### PR TITLE
Support Responses API `reasoning.context` for the GPT-5.6 (luna/terra/sol) models

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -191,6 +191,24 @@ agent = Agent(model, model_settings=settings)
 
 The setting is ignored on models that don't support reasoning mode, per [`OpenAIModelProfile.openai_responses_supports_reasoning_mode`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_responses_supports_reasoning_mode].
 
+### Reasoning context
+
+Models that support it (currently the GPT-5.6 family) can control which prior-turn reasoning items are rendered back to the model on later turns using [`reasoning.context`](https://developers.openai.com/api/docs/guides/reasoning). `auto` (equivalent to omitting the setting) uses the model's default, `current_turn` makes reasoning from the active turn available without rendering reasoning from earlier turns into the next sample, and `all_turns` renders available, compatible reasoning items from earlier turns into the next sample.
+
+Configure it with [`openai_reasoning_context`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_reasoning_context]:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
+
+model = OpenAIResponsesModel('gpt-5.6-terra')
+settings = OpenAIResponsesModelSettings(openai_reasoning_context='all_turns')
+agent = Agent(model, model_settings=settings)
+...
+```
+
+`all_turns` only has an effect when the request has access to earlier response items, e.g. via [`openai_previous_response_id`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_previous_response_id] or replayed message history; on a first request it behaves the same as `current_turn`. The response's `reasoning.context` field reports the effective mode used. The setting is ignored on models that don't support reasoning context, per [`OpenAIModelProfile.openai_responses_supports_reasoning_context`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_responses_supports_reasoning_context].
+
 ### Native tools
 
 The Responses API has native tools that you can use instead of building your own:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -699,6 +699,25 @@ class OpenAIResponsesModelSettings(OpenAIChatModelSettings, total=False):
     for more details.
     """
 
+    openai_reasoning_context: Literal['auto', 'current_turn', 'all_turns']
+    """Controls which prior-turn reasoning items are rendered back to the model, for models that support it (currently the GPT-5.6 family).
+
+    `auto` uses the model's default, and is equivalent to omitting the setting. `current_turn` makes
+    reasoning from the active turn available without rendering reasoning from earlier turns into the
+    next sample. `all_turns` renders available, compatible reasoning items from earlier turns into
+    the next sample.
+
+    `all_turns` only has an effect when the request has access to earlier response items, e.g. via
+    [`openai_previous_response_id`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_previous_response_id]
+    or replayed message history; on a first request it behaves the same as `current_turn`. The
+    response's `reasoning.context` field reports the effective mode used. This setting is ignored
+    when the resolved model profile does not support reasoning context
+    ([`OpenAIModelProfile.openai_responses_supports_reasoning_context`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_responses_supports_reasoning_context]).
+
+    See [OpenAI's reasoning documentation](https://developers.openai.com/api/docs/guides/reasoning)
+    for more details.
+    """
+
     openai_reasoning_summary: Literal['detailed', 'concise', 'auto']
     """A summary of the reasoning performed by the model.
 
@@ -2660,6 +2679,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
     ) -> Reasoning | Omit:
         reasoning_effort = model_settings.get('openai_reasoning_effort', None)
         reasoning_mode = model_settings.get('openai_reasoning_mode', None)
+        reasoning_context = model_settings.get('openai_reasoning_context', None)
         reasoning_summary = model_settings.get('openai_reasoning_summary', None)
 
         # Fall back to unified thinking when openai_reasoning_effort is not set
@@ -2671,6 +2691,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             reasoning['effort'] = reasoning_effort  # type: ignore[typeddict-item]
         if reasoning_mode and self.profile.get('openai_responses_supports_reasoning_mode', False):
             reasoning['mode'] = reasoning_mode
+        if reasoning_context and self.profile.get('openai_responses_supports_reasoning_context', False):
+            reasoning['context'] = reasoning_context
         if reasoning_summary:
             reasoning['summary'] = reasoning_summary
         return reasoning or OMIT

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -67,6 +67,9 @@ class _ReasoningSupport:
     supports_mode: bool
     """The Responses API accepts `reasoning.mode` (`'standard' | 'pro'`) for the model."""
 
+    supports_context: bool = False
+    """The Responses API accepts `reasoning.context` (`'auto' | 'current_turn' | 'all_turns'`) for the model."""
+
     @property
     def supported(self) -> bool:
         """Whether the model reasons at all."""
@@ -89,8 +92,10 @@ _ALWAYS_ON_REASONING = _ReasoningSupport(enabled_by_default=True, can_be_disable
 
 _REASONING_SUPPORT_BY_PREFIX: dict[str, _ReasoningSupport] = {
     # GPT-5.6 (sol/terra/luna) reasons by default (at 'medium'), accepts `effort='none'` to turn
-    # reasoning off, and is the only family that supports `reasoning.mode`.
-    'gpt-5.6': _ReasoningSupport(enabled_by_default=True, can_be_disabled=True, supports_mode=True),
+    # reasoning off, and is the only family that supports `reasoning.mode` and `reasoning.context`.
+    'gpt-5.6': _ReasoningSupport(
+        enabled_by_default=True, can_be_disabled=True, supports_mode=True, supports_context=True
+    ),
     # gpt-5.5 reasons by default like gpt-5.6, but has no `reasoning.mode`.
     'gpt-5.5-pro': _ALWAYS_ON_REASONING,
     'gpt-5.5': _ReasoningSupport(enabled_by_default=True, can_be_disabled=True, supports_mode=False),
@@ -234,6 +239,11 @@ class OpenAIModelProfile(ModelProfile, total=False):
 
     Currently only supported by the GPT-5.6 family."""
 
+    openai_responses_supports_reasoning_context: bool
+    """Whether the Responses API supports `reasoning.context` (`'auto' | 'current_turn' | 'all_turns'`) for this model. Default: `False`.
+
+    Currently only supported by the GPT-5.6 family."""
+
     openai_responses_requires_function_call_status_none: bool
     """Whether the Responses API requires the `status` field on function tool calls to be `None`. Default: `False`.
 
@@ -339,6 +349,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
         openai_reasoning_enabled_by_default=reasoning.enabled_by_default,
         openai_supports_reasoning_effort_none=reasoning.can_be_disabled,
         openai_responses_supports_reasoning_mode=reasoning.supports_mode,
+        openai_responses_supports_reasoning_context=reasoning.supports_context,
         openai_supports_phase=supports_phase,
         openai_supports_prompt_cache_breakpoints=supports_prompt_cache_breakpoints,
         supported_native_tools=supported_native_tools,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -215,6 +215,75 @@ async def test_openai_responses_reasoning_mode(
     assert get_mock_responses_kwargs(mock_client)[0]['reasoning'] == expected_reasoning
 
 
+@pytest.mark.parametrize(
+    ('model_settings', 'expected_reasoning'),
+    [
+        ({'openai_reasoning_context': 'auto'}, {'context': 'auto'}),
+        ({'openai_reasoning_context': 'current_turn'}, {'context': 'current_turn'}),
+        ({'openai_reasoning_context': 'all_turns'}, {'context': 'all_turns'}),
+        (
+            {
+                'openai_reasoning_effort': 'high',
+                'openai_reasoning_mode': 'pro',
+                'openai_reasoning_context': 'all_turns',
+                'openai_reasoning_summary': 'concise',
+            },
+            {'effort': 'high', 'mode': 'pro', 'context': 'all_turns', 'summary': 'concise'},
+        ),
+    ],
+)
+async def test_openai_responses_reasoning_context(
+    allow_model_requests: None,
+    model_settings: 'OpenAIResponsesModelSettings',
+    expected_reasoning: dict[str, str],
+) -> None:
+    """Not a VCR test: this pins the exact typed `reasoning` request object."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.6-sol', provider=OpenAIProvider(openai_client=mock_client))
+
+    await Agent(model=model, model_settings=model_settings).run('Solve this carefully.')
+
+    assert get_mock_responses_kwargs(mock_client)[0]['reasoning'] == expected_reasoning
+
+
+@pytest.mark.parametrize('provider_name', ['openai', 'openrouter'])
+async def test_openai_responses_reasoning_context_omitted_when_unsupported(
+    allow_model_requests: None, provider_name: Literal['openai', 'openrouter']
+):
+    """Not a VCR test: unsupported paths must omit `reasoning.context` before sending."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    if provider_name == 'openai':
+        model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    else:
+        model = OpenAIResponsesModel('openai/gpt-5.4', provider=OpenRouterProvider(openai_client=mock_client))
+
+    await Agent(model, model_settings=OpenAIResponsesModelSettings(openai_reasoning_context='all_turns')).run('Hello')
+
+    assert 'reasoning' not in get_mock_responses_kwargs(mock_client)[0]
+
+
 async def test_openrouter_responses_reasoning_mode(allow_model_requests: None) -> None:
     """Not a VCR test: exact request kwargs prove the OpenRouter Responses profile enables mode."""
     c = response_message(

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -3,7 +3,7 @@
 Tests verify model profile detection for different OpenAI models, particularly the full desired
 reasoning-flag matrix per model version: `openai_supports_reasoning`,
 `openai_reasoning_enabled_by_default`, `openai_supports_reasoning_effort_none`, and
-`openai_responses_supports_reasoning_mode`.
+`openai_responses_supports_reasoning_mode`, and `openai_responses_supports_reasoning_context`.
 """
 
 from __future__ import annotations as _annotations
@@ -43,6 +43,8 @@ class ReasoningCase:
     """The model accepts `reasoning_effort='none'`, which also allows sampling params."""
     supports_mode: bool = False
     """The Responses API accepts `reasoning.mode` ('standard' | 'pro')."""
+    supports_context: bool = False
+    """The Responses API accepts `reasoning.context` ('auto' | 'current_turn' | 'all_turns')."""
 
 
 # Every cell verified against the live Responses API (2026-07): "enabled by default" = sampling
@@ -84,9 +86,16 @@ REASONING_CASES = [
     # gpt-5.5: reasons by default AND can be turned off, like gpt-5.6 but without `reasoning.mode`
     ReasoningCase(model='gpt-5.5', enabled_by_default=True, can_be_disabled=True),
     # gpt-5.6: reasons by default AND can be turned off; the only family with `reasoning.mode`
-    ReasoningCase(model='gpt-5.6-sol', enabled_by_default=True, can_be_disabled=True, supports_mode=True),
-    ReasoningCase(model='gpt-5.6-terra', enabled_by_default=True, can_be_disabled=True, supports_mode=True),
-    ReasoningCase(model='gpt-5.6-luna', enabled_by_default=True, can_be_disabled=True, supports_mode=True),
+    # and `reasoning.context`
+    ReasoningCase(
+        model='gpt-5.6-sol', enabled_by_default=True, can_be_disabled=True, supports_mode=True, supports_context=True
+    ),
+    ReasoningCase(
+        model='gpt-5.6-terra', enabled_by_default=True, can_be_disabled=True, supports_mode=True, supports_context=True
+    ),
+    ReasoningCase(
+        model='gpt-5.6-luna', enabled_by_default=True, can_be_disabled=True, supports_mode=True, supports_context=True
+    ),
     # no reasoning
     ReasoningCase(model='gpt-5-chat'),
     ReasoningCase(model='gpt-4o'),
@@ -106,6 +115,7 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('openai_reasoning_enabled_by_default', False) is case.enabled_by_default
     assert profile.get('openai_supports_reasoning_effort_none', False) is case.can_be_disabled
     assert profile.get('openai_responses_supports_reasoning_mode', False) is case.supports_mode
+    assert profile.get('openai_responses_supports_reasoning_context', False) is case.supports_context
     assert profile.get('supports_thinking', False) is supports_reasoning
     assert profile.get('thinking_always_enabled', False) is (case.enabled_by_default and not case.can_be_disabled)
 

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -121,6 +121,7 @@ _CANONICAL_DEFAULTS: dict[str, Any] = {
     'openai_reasoning_enabled_by_default': False,
     'openai_supports_reasoning_effort_none': False,
     'openai_responses_supports_reasoning_mode': False,
+    'openai_responses_supports_reasoning_context': False,
     'openai_responses_requires_function_call_status_none': False,
     'openai_supports_phase': False,
     'openai_supports_prompt_cache_breakpoints': False,
@@ -308,6 +309,7 @@ def test_openai_gpt_5_6():
             'openai_reasoning_enabled_by_default': True,
             'openai_supports_reasoning_effort_none': True,
             'openai_responses_supports_reasoning_mode': True,
+            'openai_responses_supports_reasoning_context': True,
             'openai_supports_phase': True,
             'openai_supports_prompt_cache_breakpoints': True,
         }
@@ -322,6 +324,7 @@ def test_openai_gpt_5_6_reasoning_mode(model_name: str):
     profile = OpenAIProvider.model_profile(model_name)
     assert profile is not None
     assert profile.get('openai_responses_supports_reasoning_mode') is True
+    assert profile.get('openai_responses_supports_reasoning_context') is True
 
 
 @pytest.mark.parametrize(
@@ -335,6 +338,7 @@ def test_openrouter_openai_gpt_5_6_reasoning_mode(model_name: str):
     profile = OpenRouterProvider.model_profile(model_name)
     assert profile is not None
     assert profile.get('openai_responses_supports_reasoning_mode') is True
+    assert profile.get('openai_responses_supports_reasoning_context') is True
 
 
 @pytest.mark.parametrize('model_name', ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
@@ -345,6 +349,7 @@ def test_azure_gpt_5_6_reasoning_mode(model_name: str):
     profile = AzureProvider.model_profile(model_name)
     assert profile is not None
     assert profile.get('openai_responses_supports_reasoning_mode') is True
+    assert profile.get('openai_responses_supports_reasoning_context') is True
 
 
 def test_openai_gpt_4o():


### PR DESCRIPTION
Adds support for the Responses API `reasoning.context` field (`'auto' | 'current_turn' | 'all_turns'`), which controls which prior-turn reasoning items are rendered back to the model on later turns. Support is model-dependent, currently the GPT-5.6 family (`gpt-5.6-luna` / `gpt-5.6-terra` / `gpt-5.6-sol`).

This mirrors the existing `reasoning.mode` pattern one-to-one:

- `openai_reasoning_context` setting on `OpenAIResponsesModelSettings`
- gated by a new `openai_responses_supports_reasoning_context` profile flag (a `supports_context` fact on `_ReasoningSupport`, enabled for the `gpt-5.6` prefix) and omitted from the request when the resolved profile doesn't support it
- pinned in the reasoning matrix in `tests/profiles/test_openai.py` and the resolution matrix (OpenAI, OpenRouter, and Azure providers), with mock request-shape tests for the sent and omitted paths
- documented in a "Reasoning context" section of `docs/models/openai.md`, alongside "Reasoning mode"

No `type: ignore` is needed: `openai` 2.47.0 already types `Reasoning.context`.

One gap versus the `reasoning.mode` tests: there's no live VCR cassette yet (the mode feature has `test_openai_responses_reasoning_mode_pro`). Happy to record one mirroring it for `context='all_turns'` if desired.

- Closes #6672

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

