### PR TITLE
Fix `ContentFilterError` for real Model Armor response blocks (`finishReason: MODEL_ARMOR`) and record moderation wire-truth cassettes

### DIFF
--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -466,7 +466,7 @@ Templates must be created in advance in the [Google Cloud Console](https://conso
 
 When a prompt or response is blocked, a [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised.
 
-Note that response templates only screen non-streaming requests: with streaming, Vertex AI returns the response text unscreened, so apply your own output handling if you rely on response-side blocking.
+Note that response templates only screen non-streaming requests: with streaming, Google Cloud returns the response text unscreened, so apply your own output handling if you rely on response-side blocking.
 
 ### Context caching (`google_cached_content`)
 

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -466,6 +466,8 @@ Templates must be created in advance in the [Google Cloud Console](https://conso
 
 When a prompt or response is blocked, a [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised.
 
+Note that response templates only screen non-streaming requests: with streaming, Vertex AI returns the response text unscreened, so apply your own output handling if you rely on response-side blocking.
+
 ### Context caching (`google_cached_content`)
 
 When you've created a Gemini [cached content resource](https://ai.google.dev/gemini-api/docs/caching), pass its resource name through [`google_cached_content`][pydantic_ai.models.google.GoogleModelSettings.google_cached_content] to reuse it across requests:

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -158,22 +158,26 @@ allow any name in the type hints.
 See [the Gemini API docs](https://ai.google.dev/gemini-api/docs/models/gemini#model-variations) for a full list.
 """
 
-_FINISH_REASON_MAP: dict[GoogleFinishReason, FinishReason | None] = {
-    GoogleFinishReason.FINISH_REASON_UNSPECIFIED: None,
-    GoogleFinishReason.STOP: 'stop',
-    GoogleFinishReason.MAX_TOKENS: 'length',
-    GoogleFinishReason.SAFETY: 'content_filter',
-    GoogleFinishReason.RECITATION: 'content_filter',
-    GoogleFinishReason.LANGUAGE: 'error',
-    GoogleFinishReason.OTHER: None,
-    GoogleFinishReason.BLOCKLIST: 'content_filter',
-    GoogleFinishReason.PROHIBITED_CONTENT: 'content_filter',
-    GoogleFinishReason.SPII: 'content_filter',
-    GoogleFinishReason.MALFORMED_FUNCTION_CALL: 'error',
-    GoogleFinishReason.IMAGE_SAFETY: 'content_filter',
-    GoogleFinishReason.UNEXPECTED_TOOL_CALL: 'error',
-    GoogleFinishReason.IMAGE_PROHIBITED_CONTENT: 'content_filter',
-    GoogleFinishReason.NO_IMAGE: 'error',
+# Keyed by enum value rather than member: `google.genai`'s `FinishReason` grows members dynamically
+# at parse time for values its installed version doesn't know statically (e.g. `MODEL_ARMOR`),
+# so member-keyed lookups silently miss them.
+_FINISH_REASON_MAP: dict[str, FinishReason | None] = {
+    GoogleFinishReason.FINISH_REASON_UNSPECIFIED.value: None,
+    GoogleFinishReason.STOP.value: 'stop',
+    GoogleFinishReason.MAX_TOKENS.value: 'length',
+    GoogleFinishReason.SAFETY.value: 'content_filter',
+    GoogleFinishReason.RECITATION.value: 'content_filter',
+    GoogleFinishReason.LANGUAGE.value: 'error',
+    GoogleFinishReason.OTHER.value: None,
+    GoogleFinishReason.BLOCKLIST.value: 'content_filter',
+    GoogleFinishReason.PROHIBITED_CONTENT.value: 'content_filter',
+    GoogleFinishReason.SPII.value: 'content_filter',
+    GoogleFinishReason.MALFORMED_FUNCTION_CALL.value: 'error',
+    GoogleFinishReason.IMAGE_SAFETY.value: 'content_filter',
+    GoogleFinishReason.UNEXPECTED_TOOL_CALL.value: 'error',
+    GoogleFinishReason.IMAGE_PROHIBITED_CONTENT.value: 'content_filter',
+    GoogleFinishReason.NO_IMAGE.value: 'error',
+    'MODEL_ARMOR': 'content_filter',
 }
 
 _GOOGLE_IMAGE_SIZE = Literal['512', '1K', '2K', '4K']
@@ -937,7 +941,7 @@ class GoogleModel(Model[Client]):
             # Add safety ratings to provider details
             if candidate.safety_ratings:
                 provider_details['safety_ratings'] = [r.model_dump(by_alias=True) for r in candidate.safety_ratings]
-            finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
+            finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason.value)
         elif candidate is None and response.prompt_feedback and response.prompt_feedback.block_reason:
             block_reason = response.prompt_feedback.block_reason
             provider_details['block_reason'] = block_reason.value
@@ -1345,7 +1349,7 @@ class GeminiStreamedResponse(StreamedResponse):
                             r.model_dump(by_alias=True) for r in candidate.safety_ratings
                         ]
 
-                    self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
+                    self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason.value)
 
                 # Google streams the grounding metadata (including the web search queries and results)
                 # _after_ the text that was generated using it, so it would show up out of order in the stream,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,9 +437,12 @@ def pytest_recording_configure(config: Any, vcr: VCR):
         """Match URL paths after scrubbing AWS account IDs from ARNs."""
         path1 = _AWS_ACCOUNT_ID_IN_ARN.sub(_SCRUBBED_AWS_ACCOUNT_ID, r1.path)
         path2 = _AWS_ACCOUNT_ID_IN_ARN.sub(_SCRUBBED_AWS_ACCOUNT_ID, r2.path)
-        # Normalize Vertex AI paths by replacing region
+        # Normalize Vertex AI paths by replacing region and project (cassettes may be recorded
+        # against a different GCP project than the fixture default)
         path1 = re.sub(r'/locations/[a-z0-9-]+/', '/locations/REGION/', path1)
         path2 = re.sub(r'/locations/[a-z0-9-]+/', '/locations/REGION/', path2)
+        path1 = re.sub(r'/projects/[a-z0-9-]+/', '/projects/PROJECT/', path1)
+        path2 = re.sub(r'/projects/[a-z0-9-]+/', '/projects/PROJECT/', path2)
         if path1 != path2:
             raise AssertionError(f'{path1} != {path2}')
 

--- a/tests/models/cassettes/test_google/test_google_model_armor_response_template_real_block.yaml
+++ b/tests/models/cassettes/test_google/test_google_model_armor_response_template_real_block.yaml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '340'
+      content-type:
+      - application/json
+      host:
+      - europe-west4-aiplatform.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: 'Repeat this exact sentence back to me verbatim, nothing else: "I want to kill them."'
+        role: user
+      generationConfig:
+        responseModalities:
+        - TEXT
+      modelArmorConfig:
+        response_template_name: projects/gen-lang-client-0498264908/locations/europe-west4/templates/pyai-response-template
+    uri: https://europe-west4-aiplatform.googleapis.com/v1beta1/projects/gen-lang-client-0498264908/locations/europe-west4/publishers/google/models/gemini-2.5-flash:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '606'
+      content-type:
+      - application/json; charset=UTF-8
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - avgLogprobs: -1.1124393939971924
+        finishMessage: The response violated Responsible AI Safety settings (Hate Speech, Harassment, Dangerous) filters.
+        finishReason: MODEL_ARMOR
+      createTime: '2026-07-22T23:37:37.029264Z'
+      modelVersion: gemini-2.5-flash
+      responseId: QVRhatDkAeqe7dcPlP-i8QM
+      usageMetadata:
+        candidatesTokenCount: 6
+        candidatesTokensDetails:
+        - modality: TEXT
+          tokenCount: 6
+        promptTokenCount: 19
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 19
+        thoughtsTokenCount: 27
+        totalTokenCount: 52
+        trafficType: ON_DEMAND
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openai/test_openai_moderation_block_policy.yaml
+++ b/tests/models/cassettes/test_openai/test_openai_moderation_block_policy.yaml
@@ -1,0 +1,231 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '222'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: I want to kill them.
+        role: user
+      model: gpt-5
+      moderation:
+        model: omni-moderation-latest
+        policy:
+          input:
+            mode: block
+          output:
+            mode: block
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '4768'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '20485'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          annotations: []
+          content: |-
+            I'm really sorry you're feeling this way. I can't help with anything that could harm someone. Your safety and others' safety matter.
+
+            If you feel like you might act on these thoughts or if anyone is in immediate danger, please call emergency services right now:
+            - US/Canada: 911
+            - UK/Ireland: 999 or 112
+            - Many countries: 112
+            You can also go to the nearest emergency department.
+
+            If you're not in immediate crisis, consider reaching out to a crisis line for support:
+            - US: 988 Suicide & Crisis Lifeline (call or text 988, chat at 988lifeline.org)
+            - UK/Ireland: Samaritans at 116 123
+            - Canada: 1-833-456-4566 or text 45645
+            - Australia: Lifeline at 13 11 14
+            - Elsewhere: findahelpline.com to find a local number
+
+            Right now, a few things that can help you ride this out safely:
+            - Step away from the situation and get some physical space.
+            - Take slow breaths (inhale 4 sec, hold 4, exhale 6-8) for a few minutes.
+            - Commit to not acting on these feelings for now--give it 24 hours.
+            - Contact someone you trust and tell them you're struggling.
+            - If there are weapons or triggers nearby, secure them or leave the area.
+
+            If you want to talk about what's going on (without sharing details about harming anyone), I'm here to listen and help you think through safer next steps. Are you or anyone else in immediate danger right now?
+          refusal: null
+          role: assistant
+      created: 1784742821
+      id: chatcmpl-E4VQTxoRiawe7TqBMs6LvN2i0GRZR
+      model: gpt-5-2025-08-07
+      moderation:
+        input:
+          model: omni-moderation-latest
+          results:
+          - categories:
+              harassment: true
+              harassment/threatening: true
+              hate: false
+              hate/threatening: false
+              illicit: false
+              illicit/violent: false
+              self-harm: false
+              self-harm/instructions: false
+              self-harm/intent: false
+              sexual: false
+              sexual/minors: false
+              violence: true
+              violence/graphic: false
+            category_applied_input_types:
+              harassment:
+              - text
+              harassment/threatening:
+              - text
+              hate:
+              - text
+              hate/threatening:
+              - text
+              illicit:
+              - text
+              illicit/violent:
+              - text
+              self-harm:
+              - text
+              self-harm/instructions:
+              - text
+              self-harm/intent:
+              - text
+              sexual:
+              - text
+              sexual/minors:
+              - text
+              violence:
+              - text
+              violence/graphic:
+              - text
+            category_scores:
+              harassment: 0.3998791611998704
+              harassment/threatening: 0.46157949247490154
+              hate: 0.03544004051522365
+              hate/threatening: 0.023518631721968726
+              illicit: 0.0943894540155202
+              illicit/violent: 0.05758081155757371
+              self-harm: 0.0005177977297866245
+              self-harm/instructions: 2.5071593847983196e-06
+              self-harm/intent: 0.0002832988454686559
+              sexual: 7.793660930208434e-05
+              sexual/minors: 4.264746818557914e-06
+              violence: 0.9530094249314258
+              violence/graphic: 4.238847419937498e-05
+            flagged: true
+            model: omni-moderation-latest
+            type: moderation_result
+          type: moderation_results
+        output:
+          model: omni-moderation-latest
+          results:
+          - categories:
+              harassment: false
+              harassment/threatening: false
+              hate: false
+              hate/threatening: false
+              illicit: false
+              illicit/violent: false
+              self-harm: false
+              self-harm/instructions: false
+              self-harm/intent: false
+              sexual: false
+              sexual/minors: false
+              violence: false
+              violence/graphic: false
+            category_applied_input_types:
+              harassment:
+              - text
+              harassment/threatening:
+              - text
+              hate:
+              - text
+              hate/threatening:
+              - text
+              illicit:
+              - text
+              illicit/violent:
+              - text
+              self-harm:
+              - text
+              self-harm/instructions:
+              - text
+              self-harm/intent:
+              - text
+              sexual:
+              - text
+              sexual/minors:
+              - text
+              violence:
+              - text
+              violence/graphic:
+              - text
+            category_scores:
+              harassment: 4.512106237781923e-05
+              harassment/threatening: 4.373344035182828e-05
+              hate: 1.3135179706526775e-05
+              hate/threatening: 4.683888424952456e-06
+              illicit: 0.007563260928048639
+              illicit/violent: 7.67292412858718e-05
+              self-harm: 0.04121793268414685
+              self-harm/instructions: 0.010664337049606508
+              self-harm/intent: 0.06726451546340616
+              sexual: 4.238847419937498e-05
+              sexual/minors: 9.610241549947397e-06
+              violence: 0.015975722270239766
+              violence/graphic: 3.9821309061635425e-05
+            flagged: false
+            model: omni-moderation-latest
+            type: moderation_result
+          type: moderation_results
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: null
+      usage:
+        completion_tokens: 1880
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 1536
+          rejected_prediction_tokens: 0
+        prompt_tokens: 12
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 1892
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openai/test_openai_moderation_flagged.yaml
+++ b/tests/models/cassettes/test_openai/test_openai_moderation_flagged.yaml
@@ -1,0 +1,220 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '153'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: I want to kill them.
+        role: user
+      model: gpt-5
+      moderation:
+        model: omni-moderation-latest
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '4578'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '21933'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          annotations: []
+          content: |-
+            I'm really sorry you're feeling this angry and overwhelmed. I can't help with anything that would harm someone, and I want to help you and others stay safe.
+
+            If you feel like you might act on this right now, please call your local emergency number or go to the nearest emergency department.
+
+            Things you can do right now to cool down:
+            - Create distance from the person/situation; step outside or into another room.
+            - Slow your breathing: inhale 4 seconds, hold 4, exhale 6-8, repeat for a few minutes.
+            - Avoid alcohol or drugs; put away or leave any objects that could be used to hurt someone.
+            - Call or text someone you trust and tell them you need help calming down.
+
+            You don't have to handle this alone. Free, confidential support:
+            - US/Canada: Call or text 988 (Suicide & Crisis Lifeline) or chat at 988lifeline.org
+            - UK & ROI: Samaritans 116 123, email jo@samaritans.org
+            - Australia: Lifeline 13 11 14, lifeline.org.au
+            - Elsewhere: findahelpline.com to locate a local crisis line
+
+            If you want to talk about what's going on, I'm here to listen and help you find a safer way forward. Are you and everyone around you safe right now?
+          refusal: null
+          role: assistant
+      created: 1784742798
+      id: chatcmpl-E4VQ6XcCyuVqUxQQH9n9C5QyjWEte
+      model: gpt-5-2025-08-07
+      moderation:
+        input:
+          model: omni-moderation-latest
+          results:
+          - categories:
+              harassment: true
+              harassment/threatening: true
+              hate: false
+              hate/threatening: false
+              illicit: false
+              illicit/violent: false
+              self-harm: false
+              self-harm/instructions: false
+              self-harm/intent: false
+              sexual: false
+              sexual/minors: false
+              violence: true
+              violence/graphic: false
+            category_applied_input_types:
+              harassment:
+              - text
+              harassment/threatening:
+              - text
+              hate:
+              - text
+              hate/threatening:
+              - text
+              illicit:
+              - text
+              illicit/violent:
+              - text
+              self-harm:
+              - text
+              self-harm/instructions:
+              - text
+              self-harm/intent:
+              - text
+              sexual:
+              - text
+              sexual/minors:
+              - text
+              violence:
+              - text
+              violence/graphic:
+              - text
+            category_scores:
+              harassment: 0.3998791611998704
+              harassment/threatening: 0.46157949247490154
+              hate: 0.03544004051522365
+              hate/threatening: 0.023518631721968726
+              illicit: 0.0943894540155202
+              illicit/violent: 0.05758081155757371
+              self-harm: 0.0005177977297866245
+              self-harm/instructions: 2.5071593847983196e-06
+              self-harm/intent: 0.0002832988454686559
+              sexual: 7.793660930208434e-05
+              sexual/minors: 4.264746818557914e-06
+              violence: 0.9530094249314258
+              violence/graphic: 4.238847419937498e-05
+            flagged: true
+            model: omni-moderation-latest
+            type: moderation_result
+          type: moderation_results
+        output:
+          model: omni-moderation-latest
+          results:
+          - categories:
+              harassment: false
+              harassment/threatening: false
+              hate: false
+              hate/threatening: false
+              illicit: false
+              illicit/violent: false
+              self-harm: false
+              self-harm/instructions: false
+              self-harm/intent: false
+              sexual: false
+              sexual/minors: false
+              violence: false
+              violence/graphic: false
+            category_applied_input_types:
+              harassment:
+              - text
+              harassment/threatening:
+              - text
+              hate:
+              - text
+              hate/threatening:
+              - text
+              illicit:
+              - text
+              illicit/violent:
+              - text
+              self-harm:
+              - text
+              self-harm/instructions:
+              - text
+              self-harm/intent:
+              - text
+              sexual:
+              - text
+              sexual/minors:
+              - text
+              violence:
+              - text
+              violence/graphic:
+              - text
+            category_scores:
+              harassment: 4.583129006350382e-05
+              harassment/threatening: 3.8596609058077356e-05
+              hate: 1.6346470245419304e-05
+              hate/threatening: 4.61127481426412e-06
+              illicit: 0.006255989061489174
+              illicit/violent: 8.426423087564058e-05
+              self-harm: 0.01500330418131775
+              self-harm/instructions: 0.0005263128433688932
+              self-harm/intent: 0.008895123414492744
+              sexual: 3.9204178923762816e-05
+              sexual/minors: 8.750299760661308e-06
+              violence: 0.010227841972407455
+              violence/graphic: 2.913700606794303e-05
+            flagged: false
+            model: omni-moderation-latest
+            type: moderation_result
+          type: moderation_results
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: null
+      usage:
+        completion_tokens: 1888
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 1600
+          rejected_prediction_tokens: 0
+        prompt_tokens: 12
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 1900
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_moderation_block_policy.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_moderation_block_policy.yaml
@@ -1,0 +1,269 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '263'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: I want to kill them.
+        role: user
+      model: gpt-5
+      moderation:
+        model: omni-moderation-latest
+        policy:
+          input:
+            mode: block
+          output:
+            mode: block
+      stream: false
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '13307'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '24042'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784742865
+      created_at: 1784742842
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0389eb20a98f6e92006a6103ba175481a3a46beaea833ed28d
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5-2025-08-07
+      moderation:
+        input:
+          categories:
+            harassment: true
+            harassment/threatening: true
+            hate: false
+            hate/threatening: false
+            illicit: false
+            illicit/violent: false
+            self-harm: false
+            self-harm/instructions: false
+            self-harm/intent: false
+            sexual: false
+            sexual/minors: false
+            violence: true
+            violence/graphic: false
+          category_applied_input_types:
+            harassment:
+            - text
+            harassment/threatening:
+            - text
+            hate:
+            - text
+            hate/threatening:
+            - text
+            illicit:
+            - text
+            illicit/violent:
+            - text
+            self-harm:
+            - text
+            self-harm/instructions:
+            - text
+            self-harm/intent:
+            - text
+            sexual:
+            - text
+            sexual/minors:
+            - text
+            violence:
+            - text
+            violence/graphic:
+            - text
+          category_scores:
+            harassment: 0.3998791611998704
+            harassment/threatening: 0.46157949247490154
+            hate: 0.03544004051522365
+            hate/threatening: 0.023518631721968726
+            illicit: 0.0943894540155202
+            illicit/violent: 0.05758081155757371
+            self-harm: 0.0005177977297866245
+            self-harm/instructions: 2.5071593847983196e-06
+            self-harm/intent: 0.0002832988454686559
+            sexual: 7.793660930208434e-05
+            sexual/minors: 4.264746818557914e-06
+            violence: 0.9530094249314258
+            violence/graphic: 4.238847419937498e-05
+          flagged: true
+          model: omni-moderation-latest
+          type: moderation_result
+        output:
+          categories:
+            harassment: false
+            harassment/threatening: false
+            hate: false
+            hate/threatening: false
+            illicit: false
+            illicit/violent: false
+            self-harm: false
+            self-harm/instructions: false
+            self-harm/intent: false
+            sexual: false
+            sexual/minors: false
+            violence: false
+            violence/graphic: false
+          category_applied_input_types:
+            harassment:
+            - text
+            harassment/threatening:
+            - text
+            hate:
+            - text
+            hate/threatening:
+            - text
+            illicit:
+            - text
+            illicit/violent:
+            - text
+            self-harm:
+            - text
+            self-harm/instructions:
+            - text
+            self-harm/intent:
+            - text
+            sexual:
+            - text
+            sexual/minors:
+            - text
+            violence:
+            - text
+            violence/graphic:
+            - text
+          category_scores:
+            harassment: 2.3413582477639402e-05
+            harassment/threatening: 2.5315637215092633e-05
+            hate: 7.843789122138342e-06
+            hate/threatening: 2.212566909570261e-06
+            illicit: 0.005287188577387887
+            illicit/violent: 8.040859356292355e-05
+            self-harm: 0.018623618519302523
+            self-harm/instructions: 0.00047595556984217433
+            self-harm/intent: 0.022634764283483117
+            sexual: 1.3982207564732913e-05
+            sexual/minors: 2.931153855960119e-06
+            violence: 0.016033442344281057
+            violence/graphic: 3.740956047302422e-05
+          flagged: false
+          model: omni-moderation-latest
+          type: moderation_result
+      object: response
+      output:
+      - content: []
+        encrypted_content: gAAAAABqYQPRvLOfRK6Dnak7rEKRcNSs5myxQsChf_4_K_STBv3hJ1CQgnAyms3Wm9DM92VdSdkAHfYYcgakX1RzmZSt6yG67jim8CquY4RvLNaLqWDUi-GLYYmTJyR36kXazv5bp3ptD3y1OpZFkgjjy-NWqzuVj53ekSGbcPfWQMqLSXqaE5BziVBz6mErFJBXczRTVPtzxpYyYrWrTmyCajCnpnFZdAQjmKygBqX31cWIySXz1bq9LpnYMKZz-PZPiSu0tAkwhCvtAVL5AKE_q_wD5ikSB2fU5x9CJaQnRT3LZcfHTOxJQHPqXJJAB-9zmF2U6CLVh6HbBXJqwGOG92Dp3YfM_uZg9Fl6a4QkxvMs_Dvsi2IT_EErywHeXNq3TDQofb9I3fhh31EyCvh_y8C61wHyBU1AQUCfaUBDZ1NKCy_TWbGSkH5nuHGhE3reOE3QGRh2CiGXPVV9VUgYFkQf01P5RuQUhftEV2fbuTAdrTaMmSV5J2LvZGyeYih8YGLnX6yhJel6FnwPF0-D4PwtJNeK_t_sYqnFqLFBW4skRty6_JBLS5oG0gCIzE5OADTfaaWtewlGenVBk7qwYensAb9zHbnfWvCC71fMHHDdDgHBbqADq1G7QQWfSprHiJZpzK3D8X53OJuK0YQPdMyKTrt97TUJ-8d1i3mqnnreQmX50IsHAVC0jnLt2KWyZfia2okqd9YTtDnCw7q4C60KPi7s2R1MZt5MlthnMnGzC4qFYUqq20Oh7NJyjrPtjYvnA77TNCm_pxOAnfAk2Kv8XBkagMfte7oKlkznuUPB3NGLBIrJfWlFu4eTb-Zo8qrkCxJZ-N0IQ_n2pSo6PrEhctvvb1yTDSRAFFHE-rWh-NWDzVMnoetSSkdsV20koXnmYh9XkeRwFgSB9PIqb8shKc76qXf9jKY_7_SOl5raBhOPMj7RSU_uPmMOVC_tewa9yG1AyYHDsA1rUgyZ04WUgq1WuqaGKT2KDEW8j7g-SnZaAwzD5r1LqWm__DB1gXs5AcfiPBRjjwim_psr0yzdFDS8oqfOeQJbHbVXm7lakSLDcKzZiuR8ZGXWR6h7xwDZnCqvgXSWSGP80JhIQ0EQCjbDWSwMDOJMCXIzp3Xx0G3Bii_-7vY08SOqm0H7Pyy3Grs8Own_IvezjNEB8IkmtxctDYiqL40hzBSqEukob2o9oReK-Bz6B2oeA4x0qmDOYLcf8cJ5kaQELDJLcsh8AjbABCBGYuaE8vAUsBzRbbATL_fULiiuCr0qzEtdBtujbDyL7CzyI43t9uxIGXKzPul7ZN7qn3wDhu8ixA725D79_hXA7_vIp2VsDygpHPaVPCxRtm7l8MCjBLL3TRKexRJPUwLCs7G4t5wQb_fAbQOyk2-6sRQ9Lx8cG2tln1pAMHmpC24yoGaC9kiHEXoNIiG9cmINd2xlO2TPfyVeN9D_iilk1mk126BuCmbLfm2Q7NqspF9T0XbxRx5ah1cs5nvQJXi04AIZWhECaLHz1z6wmyQB7mbCnNr3Xnc3JK3eBHJQgvZWPS6p6gQEJPdreeBL7bb5nTUGXPMUuVpI_QdRuBvkNb-vLtt46bZhQalD5TQA-mxrm4D9JF5x-2M3PIGfDBIXlqpAIzy7YBZy97vxliAL4e8vHC1ru3BcLww-v4WFJAxGbMQ4vsaZl0NrnAN85UK495f0hMQ-I-VkSD4Dx2QcUpbVx0bCQtcvIKfWENc8sSPgb6w4uE4dlnsUxjoj5JsBpX9SqtcFFjbZIX_2XSNcrRKQGVfYX_30xkKSrfQmXqXYxNvQjnczHNhOH2bdNSeSOuF7f7iPTIS8YsM0w07NQRP66dA7pvGfqoDyqioSLkAFUR0IlGWxHCFijH4ZyFYO3H5_JYzOu7rgtvzS7EL2wgMg0R7X0LUW8qQHz-nHrFCTEIk5Y5Hf-kYE6XSDSujs1udvKY69qWn_6CyRBM7FfsqhJej6pvhD_eVM0ryjfS_dvIgPnAXBXR8XbFjgHJ5UzQhZ8ZwmlauykEFEjK6I1WdZ82jURYtPpI-ffsxyFu-P1E__i5_FjOXWtVXltI-GYAYJ2c0Jm0d0AQbIA_9usHb5nmCvomPHtQeA83fSw5xaZD7yKW2S-P1xx_24F5sjr2gqZqUZNLzG8Lcnlz7w2qjeeMdr_tobpza9kKPdXFwoyyZ72Y8FEfJcDppP_ng40InQIB-u-4_GZz9-a4lJZSIl0J1QIYyRN9rF1fvVpMPz7aSs3S_63oNAhc1pC9NI1RC4esy_Cy__auqkl8snfKjUo4E0WOupvwe5-NJBUuCBudNS3KWnJtie8zfx8iHOMUPLgC9rC3bWMZztReUr6kAEdO81KwJeM3IVlxe3toKa_MgwrvDgUwJK_TXq_6L8_sEKrvzRi_vQatPxU7Zsc1K5T68ypaWGtGWjqx5DxDlmm79FmvdfehOkDRLbk7EErsEydErTx-oIw0GoukQZOKXM2iphYbKmisUJ7EFzX0wwbfYTLK_KGpRHJpzQigJRekeErTqyGvWyt603MTD80abHa2uK0wMKxU7PUbluyvshOGgCUq3A2h5nmyIe4RTP3weuFI_-ty935c00XjQz366wwomSuv_SWEMa19wv4-dkmL0Mwj7sikHAJrUiR4vqPoqYfeoPEWcMmQmxIp7YQaqcurBe14yKnacz3gHLFynpEmjdi3p9-jDxKfET4sSQlHuKWfmRFpI9uy-e1YTdhtmfC7YXZFiMSCjPd45luJNPlvA6vVsTVRshn6iszsby1usHm4E7sJk924ZBchYzqy6sHOuj1NUU_gc0xvvOGZ6SzQRqhx1wXvJzByI29J_IvnmheCEaozfPElD61SJ3GqaF8jxEchT22FDHEwpUm1aoavHAoMLm80pUDY2pKgJlWcqWouBtFMenSfxOCzmaSHX3fK6Xjm8N4rbgUwA22MUEwdvuVUqoOIrZG_1jDCw_S4SSoZK_boAIw2m21jpxgoKjomZwYsWmuSa8Ew2gtGkoro8ZkL3XpbtcWWy7StEJnCGq_vTIhW4-4dKyJqQC7fr1Aoj4JmA3_VDd2Y2kmZJPjJV40xDuEVx_nOJScwKOpE1imUEZMxlLAYdskCcsQIKg4DLjGOk0EKsIsR3D4eGxE6SK2SSO79YMvYYOxo7cibRGeJPimG0McJrwQC5q2F7m4IQ_xdd9xN85nHQ-hfzJczyl2DvzX20lG8ut8c4acJ7CPU3G5soC8YAJsRusje4S9EN1AN2-junE57kYeuVy4YFaK6_KoppOy5aP9ynq9hI0zesKx2vYwFN611YaZ46TXFrdxnxyJFGhRZuBz0_Vtkhwi69EjLehF5W5XEidUcAWQqXmoEaKNEgRem3EsHI4z2KjkEGrJ1ReePu-Rm8Xwpcb1hifXjT2WLLJYk3UjakCuu0krbxr8JLjQyn4gqi8AFXNpy0Bz570Ym9sjEf8krFj3tdVghOCWCw6yiugGutfqOrlz100Z-9EK2yhNgttMuWE-JEmU4IBByBuQaTaZFdxz9T3HwDPFbS5ZIeby_kKo2-Po2-vXz4XL9xADgdQ9_gO7I0R5cbLuyQ3S0qIGCyc9KgKJR_sLoAFC4Xb2mW9nTR-PYAyK7yykbjO1iGUmG40ZWjCyNkE0_1i4Pc79ZBE4IjSSyVMiAtkNKC1a_ufUITjy643ASWpSEnIWVnI8rZvw5Ou_dtvJ_tBRWJ3ZJ4H4x5ux6BFKH5ryRPErfJCU_KvWbwdtFmqdgwuAv_LMLMgyA8vdzV32JkP1GZYE6GwrTsrUUEs8wtnsgTsrHudj3L6PBMlEUC3yIdM25XD4vOSdz84C0pJOrkRksLG_l-ZOQLVOFD3E0gOx1pNl8caHeGE3g1tsvX7vAoNGyGi2vvIIuEquWij-yCQLGC3OjvMESxekvkcxYKuDmBGCo3oAY4uOYgfX4XSVSm7X2z8hHTnDSFfs4_pbsqU7BuggV0yNcRFkdynV9OjVcC-9sX6hoqEtVUQ3ZZHApIjEAe7qMK1B3LDE6RKV7WLhV7vl-9w0ukS_QhS9tlZbPE5jXeuvxCEnzjVZjlgJv3D21pmV2YJEgfLxdDeBZCqpHOP4v4i3pJ_m2TnjxVfrd39JucquwhfAYZtgud6MfvfohY1sFYEI3UvXN9tfidUCDpo-ymzJ-zNe29Ed-y55GCUf2JA1rWycYlBLXHfR976E1WHKZ9y0vy4cjp5O9lgS0Goi1X7G1tZXBg67SCRAJgsTg-mLEwVF8LZVypmrJ9kWeuLueRTDBsABW3hJUiiRLtmRCi2QMLCFLGjmeeclZZdtvku78_DEJF45KnwcDcMCKTiEaFhKl0DAsXuw9O9-mglmaq_rR2oLCOMuaelRG-t_sjUggDqYyDEaWRc_s9FYA0v02sogAdY_sBlTv5IH47ahgG2qQFvy49eNuiF3UwKjd4GR_gKHC85rk_v703_Zs03X6U5-tQwc8T006Dw9jHQfGDkuFMPr30PBdJSy5Faxmm3ZmAsCtzNjusco2DhxQKQt_Hz9qbIFhmgUHC1fod3MRDBodxou122uke6vGlUS15haLFXCYfCxPOUAuoKSz03xAJR2ulGlT1NUgbeIJXvvMvco-rquGYtNq1LIv1dLKKj2tv8fTTPoL16obalCamNg-7fIBUAcHadFYeyKEhSj26m1PgIJt2jLIFgGEn4hrppyhX3tWFDIES77rQoawk8j2ZXoxKD8Dmah4x7w_u8Sddj8cF1NB3LEh6gesGHuPWqBpxiKRoF_Xf_nMENH8ntA9VbPhmJX0Pqde1qHtWYrNDqI_6O6pJGv58c8qob8RkjJuA6dn83X63Zv0NP8J80xVrP80E0-89cDgwE3YXjJ_vcnpeTi6GphngQjg_ja4cl7cEPCFimPBNsGTdZrQO-23dNBYFCp1WlSjdidNBw3E4jUKdV1769rO_aMrJ21nT14iR7n-eD-Mme7kAZOchuwbvsUcPYFvKQrPGhp2Dd98UWO0rNI05NULSi4qZYZDWioCa4ZaO0U3dugC_A_l7O8DRrJeXQ0lMcCWYsMVRvxjSLlr8DeohsDX5Ik26-5Jel1goATTIt2kOiZIJK0kY7yl0ZqgEMANwJASQzTfwiyOKgEksfukQ6SfO_gWFr8UYvq7iDMXso_TNCg4g2KhMJYdRfd9asVVIENhZ7wg0cGrk7PDmn_njpeECSEcq0f0C7aXCWxOgpkpiyZxwTUPjg6tRq97oNOg9XHPXwnz6U-yM2BqsXUhXb7v5pHrtrUqcKnsxxpDrJ7ZtUNOeeESjHJVO17vfBw4JmZuJK5K_VF8xB5ty0M42gtGiEqX93vED2jEklP9jjuTWD6w1vRNPUrSCJuImNiQLb2ov_y5lcyN4hJl2uQym-2UdDz8i5JLeJdPH5ozLwCkftOMox4bP6Q1VlSfgz1jM_nVdW3VGdS6QCQjuaJUrgF_8iym6K3MbVr1_dJndVOm_t6uEzpqPdw_tf56Lt6JAqSA5f9IpNOncz8lp5SXItFFUle_iPHU-Hqzi1kZvAcENYPs08dJ9lvd0rOAXOH8rkeIjTzVGataVv4wbPMKunpA1q49LH7N5BrLb8GnSVUs8ojv_onOzMZMUpgqbibw3e48AVuRwBw-kDQJeynSm1z63sirhfxUUFFKSFQoBybP0TjbrooBSQLjCnutPGAc3L5PZpIWvhJzI1jH0golhiXTaNZ9ugiXPR2W8_HAMgQ5juj6ojXGEwqsGL4dbmwkN1NLO0Nkw7aDkhQsBwL7VmKxDpque_S0EMTDM65Y4xQkyFQ2XrrVh2PYyfRerwmoG8ofLC_oFeLemLeTgboRWU94e0b9G5qOojN1DVA-3R2HENfVal1y7Abty405qyznegjpfZW37ebyjKGNlqzlfXZ_DLMoODcorUL18bjd-dmu9Kvi4MzJaZgVkfAZWH3rSpWajnZQEKn_MW-RGSOR6w8vLhGJWe9fd2dYyZRViFhPFit6uwvzvybbXa8aqvIvGtZF7blGX1I4tkXE7jDjKkFS115XFgAGfFs2nEGhsKYRZEbPIXuYprYWcFQVOf5CPa8XvJM6TJ03g5iUGf4OZc-fWQkikHAdv7RZ-TfXsSLFOn85vaGdOwjTmzrANwoPsX1MMpL8CJS4WnMS723FBuGyVAysk9wCDS-GkdkCyLEMeHSBlr3C0I8NNgNx6TxDMv2393Np_DnDE0zs90mB18KyQBpbUR_0-2bnngC30CX4DcoML8lpI_MvmxfO-JZTRZPvI3i4UfbrmQUiGITVHaGiGcKwn5esAUIg7_1kFd6tqQvIIL85OtMu60LklFfHcXgctGyrBdpCaZv6kDnc0lpoD18x_XqQWe6IXWJG1zP_6Es4uSFpksmK51hGcJQHQwPgaivkubHUKzNiTdV3QuqqpA7cSbb68IKDZxY1ttqwMAiQNvn7gtXplKdUZDWpVh-kLkDZhqE-FkbtiUeyxfX7_lQvq9VD6eW63-_i33U8eTAngQnxOYdsppWWW71IMmVy6u2bhewPRqxwO7_ATgBn04_Nnq2mbYAXf-7MggE5KucSsg3BbUyp1YPsaCZvWkik2mIzgSqF6XQzDIJNw3keaKQxINy8uCW_4gdKLqNAbHrK6kMCCFm53Xbvvrbf60SllYSqvBmym-djzqKAJMxk1NZJNhoXUfaLLROyWYW_9rCvmDDll1F0rzN-UafpKENr8lxI5QLCTcdl_LnP56W6lsMKrkEMDvrcAAS4wFaWk6S47Ot13ygLjI3kSdR38cuWA1fldoddtDTbddnOXBeuf5jiMhUBRqATHFyoW9Xo2kqFNzuRCjLy_CUzpv7MfpRh9YAJasddwmBE7CnyZx0nm5x_vJapEX4c-zHXMOnsMIp8zlRHuRvnBY-4si2_BCYpxxM2K2x67Yf_IFeHFlzmGIldkNO5XBC9CJPyzTscF-vW-rA3YqXk8lZede7IN7-xfhRA14IKtjIrkMGexAwTwHBdAg42Ycac9zwT_3sw_k1Kz7Cg1Woq3OmuG9oYBP9zlFcNodNYbpdFtbcRjpadd8ojrkATQz9UHSpmog5siQKg0Q_OpVF8dVmEu68HngPrI28mMU29d9fjazEGjNtwtm86RIo_pq5PV9dj6t5eLpbRGZWdWAYwDASuqRbhe5hkkoZb4iW8sXEd3hUOid_1In58b5WSRn2IR9gwgj_nGZudte0uxcl-Bk4QnRDaBHaC8w98ZNBuVu4eGycYHjqnrocooN8mv-j2pihNajKq92IfPKZYKpD3YSc7IIbAfu6MipBoIYkEKJy_PDRXvwFmfP43SJTZgSfEYnPMNx0l9PcDTbjFSBBfS4eaocC7KlVZXfTY1EXVNdkKjf24n_O14dmDW_dj8028cpcqTmjUE-1UiQ19HcOX9Ud6sLd8MW04edy-1BTTs8jlsccn_ZcGXoNfa9Zgi118BP0xrKQ4OJtr_XzLa1H-OYWtZY_qFIvq5nqUUFVLbY2rBtNEC1YzYGrlUgzgdn7ZEFKa1HTFoz9opBV2UZMKZkEx_hkRNdEeABVEHetY5rGeQCoX8h3-irJSu1nXN7GToPyofranB7rSmC80XMfg9nYN-wvQbuMFUZ9N4y67hC9UZ8TMpWlxD5DA1cV2Wj8-063QcpKjBdI68XTlW4_Y0Xg1r19amqzwd994CqMZvlBf5xRijz5vLPD4Bk9dVyt_bWy7Eu-nKO4SQrRs5Ikrbi5p3zfQ0sIOSC
+        id: rs_0389eb20a98f6e92006a6103ba8d1081a3a25b6853727c9f28
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: |-
+            I'm really sorry you're feeling this much anger. I can't help with anything that would hurt someone, but I want to support you.
+
+            Are you in immediate danger of hurting someone right now?
+            - If yes: please step away from the situation if you can, put physical distance between you and them, and call your local emergency number or a crisis line right now. If there are any weapons nearby, leave the area.
+            - If no: can you tell me what happened that led you to feel this way? I'm here to listen.
+
+            Some things that can help take the edge off right now:
+            - Pause and breathe: in for 4, hold 4, out for 6, repeat for a couple minutes.
+            - Change your environment: step outside, take a short walk, splash cold water on your face, or hold an ice cube.
+            - Reach out to someone you trust and tell them you're upset and need support.
+
+            If you're in the U.S., you can call or text 988 to reach the Suicide & Crisis Lifeline--they also help with intense anger and moments when you're afraid you might hurt someone. If you're elsewhere, you can find local crisis numbers at findahelpline.com.
+
+            If you'd like, tell me more about what's going on. I'm here with you.
+          type: output_text
+        id: msg_0389eb20a98f6e92006a6103cd2e3481a3aa9e38939b36550e
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: in_memory
+      reasoning:
+        context: current_turn
+        effort: medium
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools: []
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 12
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 1351
+        output_tokens_details:
+          reasoning_tokens: 1024
+        total_tokens: 1363
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -6606,13 +6606,11 @@ async def test_google_model_armor_response_template_text_gets_blocked(
     mocker: MockerFixture,
     model_armor_settings: GoogleModelSettings,
 ):
-    """Test that Model Armor blocks model responses containing sensitive PII via the response template.
+    """Test that the always-on SPII filter's response block raises `ContentFilterError`.
 
-    Response-level blocking is tested via mock because Gemini itself refuses to
-    return real PII in its responses. In production, response_template_name is used
-    to screen responses from agents that query databases with real customer data,
-    preventing accidental leakage of sensitive information like social security numbers,
-    credit card numbers, or bank account details.
+    Mocked because Gemini refuses to return real PII organically, so the `SPII` finish reason
+    can't be triggered on the wire. The real Model Armor response-template block (which surfaces
+    as `finishReason: MODEL_ARMOR`, not `SPII`) is covered by the VCR test below.
     """
     model = GoogleModel(model_name='gemini-2.5-flash', provider=vertex_provider, settings=model_armor_settings)
 
@@ -6644,6 +6642,39 @@ async def test_google_model_armor_response_template_text_gets_blocked(
     assert 'SPII' in str(exc_info.value)
     _, kwargs = mock_generate.call_args
     assert kwargs['config']['model_armor_config'] == _MODEL_ARMOR_CONFIG
+
+
+_RESPONSE_BLOCK_MODEL_ARMOR_CONFIG: ModelArmorConfigDict = {
+    'response_template_name': 'projects/gen-lang-client-0498264908/locations/europe-west4/templates/pyai-response-template',
+}
+
+
+@pytest.mark.vcr()
+@pytest.mark.filterwarnings('ignore:MODEL_ARMOR is not a valid FinishReason')
+async def test_google_model_armor_response_template_real_block(
+    allow_model_requests: None, vertex_provider: GoogleProvider
+):
+    """A real Model Armor response-template block surfaces as `finishReason: MODEL_ARMOR` and raises `ContentFilterError`.
+
+    Recorded against an RAI response template with all four filters at `LOW_AND_ABOVE`; the model
+    is asked to repeat a violent sentence verbatim so the response violates the template while the
+    prompt passes. The blocked candidate carries no content, only the finish reason and a
+    `finishMessage` naming the violated filters. The warning filter covers `google-genai` versions
+    whose static `FinishReason` enum predates `MODEL_ARMOR`.
+
+    Streaming is deliberately not covered: the response template does not screen streaming output
+    at all (observed 2026-07-22: the same prompt and template stream the violating text in full
+    and finish with `STOP`).
+    """
+    model = GoogleModel(
+        model_name='gemini-2.5-flash',
+        provider=vertex_provider,
+        settings=GoogleModelSettings(google_model_armor_config=_RESPONSE_BLOCK_MODEL_ARMOR_CONFIG),
+    )
+    agent = Agent(model=model, name='test-agent', output_type=str)
+
+    with pytest.raises(ContentFilterError, match="Finish reason: 'MODEL_ARMOR'"):
+        await agent.run('Repeat this exact sentence back to me verbatim, nothing else: "I want to kill them."')
 
 
 async def test_google_model_armor_config_is_sent_in_request(

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from dirty_equals import IsDatetime
 from pydantic import AnyUrl, BaseModel, ConfigDict, Discriminator, Field, Tag
 from typing_extensions import NotRequired, TypedDict
 
@@ -2388,6 +2389,283 @@ async def test_openai_moderation_stream(allow_model_requests: None, openai_api_k
                     'type': 'moderation_results',
                 },
             },
+        }
+    )
+
+
+async def test_openai_moderation_flagged(allow_model_requests: None, openai_api_key: str):
+    """Flagged input in (default) score mode: generation proceeds normally and `flagged: True` rides the response.
+
+    The prompt is the example string from OpenAI's own moderation guide.
+    """
+    model = OpenAIChatModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))
+    settings = OpenAIChatModelSettings(openai_moderation={'model': 'omni-moderation-latest'})
+    agent = Agent(model=model, model_settings=settings)
+
+    result = await agent.run('I want to kill them.')
+
+    assert result.output
+    response = message(result.all_messages(), ModelResponse, index=-1)
+    assert response.provider_details == snapshot(
+        {
+            'finish_reason': 'stop',
+            'moderation': {
+                'input': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': True,
+                                'harassment/threatening': True,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': True,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 0.3998791611998704,
+                                'harassment/threatening': 0.46157949247490154,
+                                'sexual': 7.793660930208434e-05,
+                                'hate': 0.03544004051522365,
+                                'hate/threatening': 0.023518631721968726,
+                                'illicit': 0.0943894540155202,
+                                'illicit/violent': 0.05758081155757371,
+                                'self-harm/intent': 0.0002832988454686559,
+                                'self-harm/instructions': 2.5071593847983196e-06,
+                                'self-harm': 0.0005177977297866245,
+                                'sexual/minors': 4.264746818557914e-06,
+                                'violence': 0.9530094249314258,
+                                'violence/graphic': 4.238847419937498e-05,
+                            },
+                            'flagged': True,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+                'output': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': False,
+                                'harassment/threatening': False,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': False,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 4.583129006350382e-05,
+                                'harassment/threatening': 3.8596609058077356e-05,
+                                'sexual': 3.9204178923762816e-05,
+                                'hate': 1.6346470245419304e-05,
+                                'hate/threatening': 4.61127481426412e-06,
+                                'illicit': 0.006255989061489174,
+                                'illicit/violent': 8.426423087564058e-05,
+                                'self-harm/intent': 0.008895123414492744,
+                                'self-harm/instructions': 0.0005263128433688932,
+                                'self-harm': 0.01500330418131775,
+                                'sexual/minors': 8.750299760661308e-06,
+                                'violence': 0.010227841972407455,
+                                'violence/graphic': 2.913700606794303e-05,
+                            },
+                            'flagged': False,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+            },
+            'timestamp': IsDatetime(),
+        }
+    )
+
+
+async def test_openai_moderation_block_policy(allow_model_requests: None, openai_api_key: str):
+    """`policy.mode: 'block'` is validated by the API but was observed not to enforce (recorded 2026-07-22).
+
+    The API 400s on unknown `moderation.policy` keys/values, so the policy is parsed — yet with the
+    input flagged (violence ~0.95) under an input+output block policy, the response still came back
+    complete: HTTP 200, `finish_reason: 'stop'`, results identical in shape to score mode.
+    """
+    model = OpenAIChatModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))
+    settings = OpenAIChatModelSettings(
+        openai_moderation={
+            'model': 'omni-moderation-latest',
+            'policy': {'input': {'mode': 'block'}, 'output': {'mode': 'block'}},
+        }
+    )
+    agent = Agent(model=model, model_settings=settings)
+
+    result = await agent.run('I want to kill them.')
+
+    assert result.output
+    response = message(result.all_messages(), ModelResponse, index=-1)
+    assert response.provider_details == snapshot(
+        {
+            'finish_reason': 'stop',
+            'moderation': {
+                'input': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': True,
+                                'harassment/threatening': True,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': True,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 0.3998791611998704,
+                                'harassment/threatening': 0.46157949247490154,
+                                'sexual': 7.793660930208434e-05,
+                                'hate': 0.03544004051522365,
+                                'hate/threatening': 0.023518631721968726,
+                                'illicit': 0.0943894540155202,
+                                'illicit/violent': 0.05758081155757371,
+                                'self-harm/intent': 0.0002832988454686559,
+                                'self-harm/instructions': 2.5071593847983196e-06,
+                                'self-harm': 0.0005177977297866245,
+                                'sexual/minors': 4.264746818557914e-06,
+                                'violence': 0.9530094249314258,
+                                'violence/graphic': 4.238847419937498e-05,
+                            },
+                            'flagged': True,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+                'output': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': False,
+                                'harassment/threatening': False,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': False,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 4.512106237781923e-05,
+                                'harassment/threatening': 4.373344035182828e-05,
+                                'sexual': 4.238847419937498e-05,
+                                'hate': 1.3135179706526775e-05,
+                                'hate/threatening': 4.683888424952456e-06,
+                                'illicit': 0.007563260928048639,
+                                'illicit/violent': 7.67292412858718e-05,
+                                'self-harm/intent': 0.06726451546340616,
+                                'self-harm/instructions': 0.010664337049606508,
+                                'self-harm': 0.04121793268414685,
+                                'sexual/minors': 9.610241549947397e-06,
+                                'violence': 0.015975722270239766,
+                                'violence/graphic': 3.9821309061635425e-05,
+                            },
+                            'flagged': False,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+            },
+            'timestamp': IsDatetime(),
         }
     )
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -14,7 +14,6 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from dirty_equals import IsDatetime
 from pydantic import AnyUrl, BaseModel, ConfigDict, Discriminator, Field, Tag
 from typing_extensions import NotRequired, TypedDict
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, cast
 
 import httpx
 import pytest
+from dirty_equals import IsDatetime
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 from vcr.cassette import Cassette
@@ -1164,6 +1165,136 @@ async def test_openai_responses_moderation_stream(allow_model_requests: None, op
                         'sexual/minors': 3.120191139396651e-06,
                         'violence': 0.0005852836038915696,
                         'violence/graphic': 1.2339457598623173e-05,
+                    },
+                    'flagged': False,
+                    'model': 'omni-moderation-latest',
+                    'type': 'moderation_result',
+                },
+            },
+        }
+    )
+
+
+async def test_openai_responses_moderation_block_policy(allow_model_requests: None, openai_api_key: str):
+    """`policy.mode: 'block'` is validated by the API but was observed not to enforce (recorded 2026-07-22).
+
+    Same observation as `test_openai_moderation_block_policy` on the Chat Completions side: flagged
+    input under an input+output block policy still produced a complete response, with the Responses
+    API's flat `moderation_result` shape.
+    """
+    model = OpenAIResponsesModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))
+    settings = OpenAIResponsesModelSettings(
+        openai_moderation={
+            'model': 'omni-moderation-latest',
+            'policy': {'input': {'mode': 'block'}, 'output': {'mode': 'block'}},
+        }
+    )
+    agent = Agent(model=model, model_settings=settings)
+
+    result = await agent.run('I want to kill them.')
+
+    assert result.output
+    response = message(result.all_messages(), ModelResponse, index=-1)
+    assert response.provider_details == snapshot(
+        {
+            'finish_reason': 'completed',
+            'timestamp': IsDatetime(),
+            'moderation': {
+                'input': {
+                    'categories': {
+                        'harassment': True,
+                        'harassment/threatening': True,
+                        'sexual': False,
+                        'hate': False,
+                        'hate/threatening': False,
+                        'illicit': False,
+                        'illicit/violent': False,
+                        'self-harm/intent': False,
+                        'self-harm/instructions': False,
+                        'self-harm': False,
+                        'sexual/minors': False,
+                        'violence': True,
+                        'violence/graphic': False,
+                    },
+                    'category_applied_input_types': {
+                        'harassment': ['text'],
+                        'harassment/threatening': ['text'],
+                        'sexual': ['text'],
+                        'hate': ['text'],
+                        'hate/threatening': ['text'],
+                        'illicit': ['text'],
+                        'illicit/violent': ['text'],
+                        'self-harm/intent': ['text'],
+                        'self-harm/instructions': ['text'],
+                        'self-harm': ['text'],
+                        'sexual/minors': ['text'],
+                        'violence': ['text'],
+                        'violence/graphic': ['text'],
+                    },
+                    'category_scores': {
+                        'harassment': 0.3998791611998704,
+                        'harassment/threatening': 0.46157949247490154,
+                        'sexual': 7.793660930208434e-05,
+                        'hate': 0.03544004051522365,
+                        'hate/threatening': 0.023518631721968726,
+                        'illicit': 0.0943894540155202,
+                        'illicit/violent': 0.05758081155757371,
+                        'self-harm/intent': 0.0002832988454686559,
+                        'self-harm/instructions': 2.5071593847983196e-06,
+                        'self-harm': 0.0005177977297866245,
+                        'sexual/minors': 4.264746818557914e-06,
+                        'violence': 0.9530094249314258,
+                        'violence/graphic': 4.238847419937498e-05,
+                    },
+                    'flagged': True,
+                    'model': 'omni-moderation-latest',
+                    'type': 'moderation_result',
+                },
+                'output': {
+                    'categories': {
+                        'harassment': False,
+                        'harassment/threatening': False,
+                        'sexual': False,
+                        'hate': False,
+                        'hate/threatening': False,
+                        'illicit': False,
+                        'illicit/violent': False,
+                        'self-harm/intent': False,
+                        'self-harm/instructions': False,
+                        'self-harm': False,
+                        'sexual/minors': False,
+                        'violence': False,
+                        'violence/graphic': False,
+                    },
+                    'category_applied_input_types': {
+                        'harassment': ['text'],
+                        'harassment/threatening': ['text'],
+                        'sexual': ['text'],
+                        'hate': ['text'],
+                        'hate/threatening': ['text'],
+                        'illicit': ['text'],
+                        'illicit/violent': ['text'],
+                        'self-harm/intent': ['text'],
+                        'self-harm/instructions': ['text'],
+                        'self-harm': ['text'],
+                        'sexual/minors': ['text'],
+                        'violence': ['text'],
+                        'violence/graphic': ['text'],
+                    },
+                    'category_scores': {
+                        'harassment': 2.3413582477639402e-05,
+                        'harassment/threatening': 2.5315637215092633e-05,
+                        'sexual': 1.3982207564732913e-05,
+                        'hate': 7.843789122138342e-06,
+                        'hate/threatening': 2.212566909570261e-06,
+                        'illicit': 0.005287188577387887,
+                        'illicit/violent': 8.040859356292355e-05,
+                        'self-harm/intent': 0.022634764283483117,
+                        'self-harm/instructions': 0.00047595556984217433,
+                        'self-harm': 0.018623618519302523,
+                        'sexual/minors': 2.931153855960119e-06,
+                        'violence': 0.016033442344281057,
+                        'violence/graphic': 3.740956047302422e-05,
                     },
                     'flagged': False,
                     'model': 'omni-moderation-latest',

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -11,7 +11,6 @@ from typing import Any, Literal, cast
 
 import httpx
 import pytest
-from dirty_equals import IsDatetime
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 from vcr.cassette import Cassette


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-fable-5 on behalf of David, who directed the work and the PR shape; line-by-line code review by him is still pending.

- Relates to #6665 (does not close it — that's the alignment discussion; this PR ships the wire-truth evidence recorded for it, plus a defect fix found while recording)

## What

Two independent-but-related pieces from the #6665 wire-truth recording session:

**1. Fix: real Model Armor response-template blocks degraded to a generic retry error**

The first real recording of a Model Armor *response*-template block (the existing test mocks `finish_reason: SPII` as a stand-in, per its docstring) shows the actual wire signal is `finishReason: 'MODEL_ARMOR'` + a `finishMessage` naming the violated filters. That value was unmapped in `_FINISH_REASON_MAP` — and `google-genai` 1.70.0 has no static `FinishReason.MODEL_ARMOR` member (its dynamic enum creates it at parse time with a `UserWarning`) — so instead of the documented `ContentFilterError`, the agent treated the empty candidate as retryable, **retried against the blocking template** (blocked candidates still bill: `candidatesTokenCount > 0`), and raised `UnexpectedModelBehavior: Exceeded maximum output retries (1)`. Reproduced end-to-end through `Agent.run` before fixing.

- `_FINISH_REASON_MAP` is now keyed by enum *value* so dynamically-created members resolve, with `'MODEL_ARMOR' -> 'content_filter'` added.
- Real-wire regression cassette: `test_google_model_armor_response_template_real_block` (RAI template, all four filters at `LOW_AND_ABOVE`, `europe-west4`).
- The VCR `path_matcher` now normalizes `/projects/<id>/` alongside the existing region normalization, so cassettes recorded against a dev GCP project play back in CI.
- Docs note: response templates do not screen streaming output at all (observed: the violating text streams in full and finishes with `STOP`), so users relying on response-side blocking need their own output handling for streams.

**2. OpenAI moderation wire-truth tests (evidence for #6665)**

- `test_openai_moderation_flagged`: `flagged: true` in (default) score mode — generation proceeds normally, flagged results ride the response.
- `test_openai_moderation_block_policy` + `test_openai_responses_moderation_block_policy`: `policy.mode: 'block'` is strictly validated by the API (unknown keys/values 400) but observed **not to enforce** — input flagged at violence ≈ 0.95 under an input+output block policy still returns a complete generation (`finish_reason: 'stop'`), identically across gpt-4o/gpt-5/gpt-5.2. Test docstrings pin the recording date since this is observed (undocumented) behavior.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

