### PR TITLE
ci: make bots.yml agent-config guard unconditional and TOCTOU-safe

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -94,15 +94,24 @@ jobs:
       skip: ${{ steps.check-label.outputs.has_label }}
     steps:
       - name: Check for modified config files
-        if: github.event.pull_request.head.repo.fork
+        # Runs for ALL PRs, not just forks: a same-repo branch (e.g. an automated
+        # agent's branch built from an untrusted issue) can carry a poisoned
+        # CLAUDE.md/AGENTS.md/.claude just as a fork can, and this job loads that
+        # config. Compare the immutable base...head SHAs via the diff media type
+        # (not `gh pr diff`, which reads the live PR head -- a force-push could then
+        # slip a config edit past this guard while different code runs; TOCTOU) and
+        # match the per-file `diff --git` headers (the compare JSON `.files` array
+        # caps at 300 entries, so it could hide an edit in a large PR).
         run: |
-          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
-          if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then
+          CHANGED=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" -H 'Accept: application/vnd.github.v3.diff' | grep '^diff --git ')
+          if echo "$CHANGED" | grep -qiE '/(AGENTS\.md|CLAUDE\.md)( |$)|/\.claude/'; then
             echo "::error::PR modifies agent config files (AGENTS.md, CLAUDE.md, or .claude/). Skipping auto-labeling for security."
             exit 1
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Check if category label already exists
         id: check-label
@@ -227,15 +236,25 @@ jobs:
           persist-credentials: false
 
       - name: Check for modified config files
-        if: github.event.pull_request.head.repo.fork
+        # Runs for ALL PRs, not just forks: a same-repo branch (e.g. an automated
+        # agent's branch built from an untrusted issue) can carry a poisoned
+        # CLAUDE.md/AGENTS.md/.claude just as a fork can, and the review step below
+        # checks out that head and loads its root CLAUDE.md into the reviewer's
+        # system prompt. Compare the immutable base...head SHAs via the diff media
+        # type (not `gh pr diff`, which reads the live PR head -- a force-push could
+        # slip a config edit past this guard while different code runs; TOCTOU) and
+        # match the per-file `diff --git` headers (the compare JSON `.files` array
+        # caps at 300 entries, so it could hide an edit in a large PR).
         run: |
-          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
-          if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then
+          CHANGED=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" -H 'Accept: application/vnd.github.v3.diff' | grep '^diff --git ')
+          if echo "$CHANGED" | grep -qiE '/(AGENTS\.md|CLAUDE\.md)( |$)|/\.claude/'; then
             echo "::error::PR modifies agent config files (AGENTS.md, CLAUDE.md, or .claude/). Skipping auto-review for security."
             exit 1
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Select review model
         id: model


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

> AI-authored; David has reviewed lightly. Opening for the team's review.

## Problem

The agent-config guard in `bots.yml` (both the `category-classify` and the `review` jobs) — which blocks a PR from modifying `AGENTS.md` / `CLAUDE.md` / `.claude/` before those files reach a privileged automated context — only ran on **fork** PRs:

```yaml
if: github.event.pull_request.head.repo.fork
```

A **same-repo** PR branch bypasses the guard entirely. This matters because an automated agent (e.g. one that opens PRs from branches pushed into this repo, built from untrusted issue text) produces same-repo branches. The `review` job then checks out that head (`head.repo.full_name`@`head.sha`) and loads the root `CLAUDE.md` into the reviewer's system prompt — which runs with a write token + model key. A poisoned config file on a same-repo branch is therefore a prompt-injection path into the privileged reviewer that the fork-only guard never inspects.

## Fix

- **Drop the `if: …head.repo.fork` condition** so the guard runs for every PR.
- **Switch from `gh pr diff` to an immutable `compare/BASE...HEAD` check** using the diff media type. `gh pr diff` reads the *live* PR head (a force-push after the guard could slip a config edit past it while different code runs — TOCTOU), and the compare JSON `.files` array caps at 300 entries (a large PR could hide an edit). Matching the `diff --git` headers of the diff media type avoids both.

This is the **same TOCTOU-safe pattern already used in `at-claude.yml`** (lines 114-136) — this PR brings `bots.yml` to parity with a guard the repo already trusts.

Passes the repo's own `zizmor` Actions-security lint and YAML checks. No behavior change for legitimate PRs — only PRs that actually modify agent-config files are affected, and only to skip auto-labeling/auto-review (fail-closed), exactly as before for forks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

