### PR TITLE
Preserve `CombinedCapability` subclasses when child capabilities rebind

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
+from copy import copy
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
@@ -80,13 +81,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         new_caps = [capability.for_agent(agent) for capability in self.capabilities]
         if all(new is old for new, old in zip(new_caps, self.capabilities)):
             return self
-        return replace(self, capabilities=new_caps)
+        return _copy_with_capabilities(self, new_caps)
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractCapability[AgentDepsT]:
         new_caps = await gather(*(c.for_run(ctx) for c in self.capabilities))
         if all(new is old for new, old in zip(new_caps, self.capabilities)):
             return self
-        return replace(self, capabilities=list(new_caps))
+        return _copy_with_capabilities(self, list(new_caps))
 
     def _validate_runtime_capabilities(
         self, ctx: RunContext[AgentDepsT], capabilities: Sequence[AbstractCapability[AgentDepsT]]
@@ -844,7 +845,16 @@ def bind_capabilities_tier(
     new_caps = [c.for_agent(agent) if is_innermost(c) == innermost else c for c in combined.capabilities]
     if all(new is old for new, old in zip(new_caps, combined.capabilities, strict=True)):
         return combined
-    return replace(combined, capabilities=new_caps)
+    return _copy_with_capabilities(combined, new_caps)
+
+
+def _copy_with_capabilities(
+    combined: CombinedCapability[AgentDepsT], capabilities: Sequence[AbstractCapability[AgentDepsT]]
+) -> CombinedCapability[AgentDepsT]:
+    copied = copy(combined)
+    copied.capabilities = capabilities
+    copied.__post_init__()
+    return copied
 
 
 def _ctx_for_cap(capability: AbstractCapability[AgentDepsT], ctx: RunContext[AgentDepsT]) -> RunContext[AgentDepsT]:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -67,6 +67,7 @@ from pydantic_ai._output import (
 from pydantic_ai.agent import AgentRunResult, WrapperAgent
 from pydantic_ai.capabilities import (
     AbstractCapability,
+    CombinedCapability,
     Hooks,
     NativeTool,
     PrepareOutputTools,
@@ -11817,6 +11818,69 @@ async def test_agent_capability_for_run_called_once_per_run():
     await agent.run('Hello', capabilities=[CountingCapability('run')])
 
     assert for_run_calls == {'agent': 1, 'run': 1}
+
+
+async def test_combined_capability_custom_init_supports_rebound_children():
+    """`CombinedCapability` subclasses may expose friendly constructors that don't accept
+    `capabilities`, while child capabilities may return fresh instances for binding or
+    per-run isolation.
+
+    Unit test rather than VCR: this fails during capability binding before a provider
+    request would be made.
+    """
+    calls: list[tuple[str, str]] = []
+
+    class RebindingCapability(AbstractCapability):
+        def __init__(self, name: str, *, for_agent: bool = False, for_run: bool = False) -> None:
+            self.name = name
+            self.rebind_for_agent = for_agent
+            self.rebind_for_run = for_run
+
+        def for_agent(self, agent: Any) -> AbstractCapability:
+            calls.append(('child_for_agent', self.name))
+            if self.rebind_for_agent:
+                return RebindingCapability(f'{self.name}:agent')
+            return self
+
+        async def for_run(self, ctx: RunContext) -> AbstractCapability:
+            calls.append(('child_for_run', self.name))
+            if self.rebind_for_run:
+                return RebindingCapability(f'{self.name}:run')
+            return self
+
+    class FriendlyCombined(CombinedCapability):
+        def __init__(self, *, name: str, child: AbstractCapability) -> None:
+            self.name = name
+            super().__init__(capabilities=[child])
+
+        def for_agent(self, agent: Any) -> CombinedCapability:
+            calls.append(('combined_for_agent', self.name))
+            return super().for_agent(agent)
+
+        async def for_run(self, ctx: RunContext) -> AbstractCapability:
+            calls.append(('combined_for_run', self.name))
+            return await super().for_run(ctx)
+
+    agent = Agent(TestModel())
+    result = await agent.run(
+        'Hello',
+        capabilities=[
+            FriendlyCombined(name='for-agent', child=RebindingCapability('for-agent-child', for_agent=True)),
+            FriendlyCombined(name='for-run', child=RebindingCapability('for-run-child', for_run=True)),
+        ],
+    )
+
+    assert result.output == 'success (no tool calls)'
+    assert set(calls) == {
+        ('combined_for_agent', 'for-agent'),
+        ('combined_for_agent', 'for-run'),
+        ('child_for_agent', 'for-agent-child'),
+        ('child_for_agent', 'for-run-child'),
+        ('combined_for_run', 'for-agent'),
+        ('combined_for_run', 'for-run'),
+        ('child_for_run', 'for-agent-child:agent'),
+        ('child_for_run', 'for-run-child'),
+    }
 
 
 async def test_run_with_unapproved_tool_call_in_history():


### PR DESCRIPTION
- Closes #6674

### Summary

`CombinedCapability.for_agent()` and `for_run()` rebuilt changed children with `dataclasses.replace(...)`, which calls the concrete subclass constructor with `capabilities=...`.

That crashes for subclasses with friendly constructors that intentionally do not accept `capabilities`. This updates child rebinding to shallow-copy the current combined capability, replace its `capabilities`, and rerun `__post_init__()` so flattening and ordering still apply without invoking subclass `__init__`.

### Tests

```bash
python -m pytest tests/test_agent.py::test_agent_capability_for_run_called_once_per_run tests/test_agent.py::test_combined_capability_custom_init_supports_rebound_children -q
python -m ruff check pydantic_ai_slim/pydantic_ai/capabilities/combined.py tests/test_agent.py
python -m ruff format --check pydantic_ai_slim/pydantic_ai/capabilities/combined.py tests/test_agent.py
python -m pyright --pythonpath .venv/Scripts/python.exe pydantic_ai_slim/pydantic_ai/capabilities/combined.py tests/test_agent.py
git diff --check
```

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

