### PR TITLE
fix: preserve `TextPart` and `ToolCallPart` metadata across AG-UI dump/load round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -88,11 +88,13 @@ try:
         FILE_ACTIVITY_TYPE,
         MULTIMODAL_VERSION,
         REASONING_VERSION,
+        TEXT_PART_ACTIVITY_TYPE,
         UPLOADED_FILE_ACTIVITY_TYPE,
         dump_tool_return_content,
         parse_ag_ui_version,
         parse_builtin_tool_call_id,
         parse_encrypted_outcome,
+        parse_encrypted_part_metadata,
         parse_encrypted_tool_kind,
         rehydrate_tool_return_content,
         thinking_encrypted_metadata,
@@ -364,6 +366,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
         builder = MessagesBuilder()
         tool_calls: dict[str, str] = {}  # Tool call ID to tool name mapping.
         tool_kinds: dict[str, ToolPartKind] = {}  # Tool call ID to `tool_kind` claim mapping.
+        # Pending TextPart metadata from a preceding ActivityMessage (TEXT_PART_ACTIVITY_TYPE).
+        pending_text_metadata: dict[str, Any] = {}
         # `ToolCall`/`ToolMessage.encrypted_value` only exists on the installed model from 0.1.11
         # onward; older versions drop the client's claim, so the field is only read when present.
         use_encrypted_value = parse_ag_ui_version(DEFAULT_AG_UI_VERSION) >= ENCRYPTED_VALUE_VERSION
@@ -425,7 +429,16 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
 
                 case AssistantMessage(content=content, tool_calls=tool_calls_list):
                     if content:
-                        builder.add(TextPart(content=content))
+                        text_meta = pending_text_metadata
+                        pending_text_metadata = {}
+                        builder.add(
+                            TextPart(
+                                content=content,
+                                id=text_meta.get('id'),
+                                provider_name=text_meta.get('provider_name'),
+                                provider_details=text_meta.get('provider_details'),
+                            )
+                        )
                     if tool_calls_list:
                         for tool_call in tool_calls_list:
                             tool_call_id = tool_call.id
@@ -441,6 +454,10 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             if tool_kind is not None:
                                 tool_kinds[tool_call_id] = tool_kind
 
+                            # Read part-level metadata (id, provider_name, provider_details) from
+                            # the encrypted_value carrier, fixing the silent field loss in #5937.
+                            part_meta = parse_encrypted_part_metadata(tool_call.encrypted_value) if use_encrypted_value else {}
+
                             builtin_id = parse_builtin_tool_call_id(tool_call_id)
                             if builtin_id is not None:
                                 provider_name, original_id = builtin_id
@@ -451,6 +468,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                         tool_call_id=original_id,
                                         provider_name=provider_name,
                                         tool_kind=tool_kind,
+                                        id=part_meta.get('id'),
+                                        provider_details=part_meta.get('provider_details'),
                                     )
                                 )
                             else:
@@ -460,6 +479,9 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                         tool_call_id=tool_call_id,
                                         args=tool_call.function.arguments,
                                         tool_kind=tool_kind,
+                                        id=part_meta.get('id'),
+                                        provider_name=part_meta.get('provider_name'),
+                                        provider_details=part_meta.get('provider_details'),
                                     )
                                 )
                 case ToolMessage() as tool_msg:
@@ -583,6 +605,9 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 ]
                             )
                         )
+                    elif activity_msg.activity_type == TEXT_PART_ACTIVITY_TYPE:
+                        # Store metadata for the next TextPart in the following AssistantMessage.
+                        pending_text_metadata = dict(activity_msg.content)
 
                 case _:
                     if TYPE_CHECKING:
@@ -753,6 +778,23 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
             if isinstance(part, TextPart):
                 if tool_calls_list:
                     flush()
+                # Carry TextPart metadata (id, provider_name, provider_details) as a preceding
+                # ActivityMessage so it survives a dump/load round-trip.  Same pattern as FilePart.
+                if use_encrypted_value and (part.id is not None or part.provider_name is not None or part.provider_details is not None):
+                    text_meta: dict[str, Any] = {}
+                    if part.id is not None:
+                        text_meta['id'] = part.id
+                    if part.provider_name is not None:
+                        text_meta['provider_name'] = part.provider_name
+                    if part.provider_details is not None:
+                        text_meta['provider_details'] = part.provider_details
+                    result.append(
+                        ActivityMessage(
+                            id=_new_message_id(),
+                            activity_type=TEXT_PART_ACTIVITY_TYPE,
+                            content=text_meta,
+                        )
+                    )
                 text_content.append(part.content)
             elif isinstance(part, ThinkingPart):
                 if use_reasoning:
@@ -772,7 +814,10 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     ToolCall(
                         id=part.tool_call_id,
                         function=FunctionCall(name=part.tool_name, arguments=part.args_as_json_str()),
-                        **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
+                        **tool_kind_encrypted_value_kwargs(
+                            part.tool_kind, supported=use_encrypted_value,
+                            part_id=part.id, provider_name=part.provider_name, provider_details=part.provider_details,
+                        ),
                     )
                 )
             elif isinstance(part, NativeToolCallPart):
@@ -781,7 +826,10 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     ToolCall(
                         id=prefixed_id,
                         function=FunctionCall(name=part.tool_name, arguments=part.args_as_json_str()),
-                        **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
+                        **tool_kind_encrypted_value_kwargs(
+                            part.tool_kind, supported=use_encrypted_value,
+                            part_id=part.id, provider_name=part.provider_name, provider_details=part.provider_details,
+                        ),
                     )
                 )
                 if builtin_return := builtin_returns.get(part.tool_call_id):

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -439,6 +439,10 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 provider_details=text_meta.get('provider_details'),
                             )
                         )
+                    else:
+                        # AssistantMessage with only tool_calls — clear any stale
+                        # pending metadata so it doesn't attach to the wrong TextPart.
+                        pending_text_metadata = {}
                     if tool_calls_list:
                         for tool_call in tool_calls_list:
                             tool_call_id = tool_call.id
@@ -780,7 +784,12 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     flush()
                 # Carry TextPart metadata (id, provider_name, provider_details) as a preceding
                 # ActivityMessage so it survives a dump/load round-trip.  Same pattern as FilePart.
+                # Flush before emitting the ActivityMessage so each metadata-bearing TextPart
+                # gets its own AssistantMessage — otherwise multiple TextParts with metadata
+                # would merge into one AssistantMessage and lose the second metadata block.
                 if use_encrypted_value and (part.id is not None or part.provider_name is not None or part.provider_details is not None):
+                    if text_content:
+                        flush()
                     text_meta: dict[str, Any] = {}
                     if part.id is not None:
                         text_meta['id'] = part.id

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -53,6 +53,15 @@ FILE_ACTIVITY_TYPE: Final[str] = 'pydantic_ai_file'
 UPLOADED_FILE_ACTIVITY_TYPE: Final[str] = 'pydantic_ai_uploaded_file'
 """Activity type for uploaded files stored as AG-UI ActivityMessages."""
 
+TEXT_PART_ACTIVITY_TYPE: Final[str] = 'pydantic_ai_text_part'
+"""Activity type for TextPart metadata (id, provider_name, provider_details) stored as AG-UI ActivityMessages.
+
+AG-UI has no generic per-part metadata carrier on AssistantMessage. TextPart fields beyond
+``content`` (``id``, ``provider_name``, ``provider_details``) are carried as a preceding
+ActivityMessage so they survive a dump/load round-trip. The same pattern is used for
+``FilePart`` (``FILE_ACTIVITY_TYPE``) and ``UploadedFile`` (``UPLOADED_FILE_ACTIVITY_TYPE``).
+"""
+
 
 class FileActivityContent(TypedDict, total=False):
     """Content schema for `ActivityMessage` with `activity_type=pydantic_ai_file`."""
@@ -130,31 +139,70 @@ _ENCRYPTED_VALUE_NAMESPACE: Final = 'pydantic_ai'
 provider blob in the same slot is never mistaken for our data."""
 
 
-def tool_kind_encrypted_value(
-    tool_kind: ToolPartKind | None, outcome: Literal['success', 'failed', 'denied', 'interrupted'] | None = None
-) -> str | None:
-    """Pack a part's `tool_kind` into an AG-UI `encrypted_value` blob, namespaced under `pydantic_ai`.
+def _part_metadata_payload(
+    *,
+    tool_kind: ToolPartKind | None = None,
+    outcome: Literal['success', 'failed', 'denied', 'interrupted'] | None = None,
+    part_id: str | None = None,
+    provider_name: str | None = None,
+    provider_details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the ``pydantic_ai``-namespaced payload for an ``encrypted_value`` blob.
 
-    AG-UI documents `encrypted_value` for opaque, client-echoed reasoning continuity, and its
-    standard reducer can attach it to a message or tool call. AG-UI has no generic per-tool metadata
-    event, so we also use that reducer-compatible carrier for Pydantic AI continuity claims. This is
-    a namespaced compatibility mechanism, not a claim that the payload is encrypted reasoning. Our
-    payload is nested under a `pydantic_ai` key so a genuine provider blob in the same slot (e.g.
-    Google's encrypted thinking on a tool call) is never read as our data. The claim is untrusted
-    coming back in: `parse_encrypted_tool_kind` returns it only when the key is present, and it
-    degrades to a plain part if it doesn't validate.
-
-    A non-`'success'` result outcome rides the same payload: a `ToolMessage` has no outcome slot,
-    so without the claim a dump/load round-trip would upgrade a failed/denied/interrupted return to
-    `'success'` — and since `outcome` can affect how a return is serialized to a provider (e.g. a
-    native error channel), that would silently change the request bytes and break the prompt-cache
-    prefix stability the repaired history is designed to keep.
+    Carries ``tool_kind``, ``outcome``, and part-level metadata (``id``, ``provider_name``,
+    ``provider_details``) so they survive a dump/load round-trip. Only non-None fields are
+    included.
     """
-    payload: dict[str, str] = {}
+    payload: dict[str, Any] = {}
     if tool_kind is not None:
         payload['tool_kind'] = tool_kind
     if outcome is not None and outcome != 'success':
         payload['outcome'] = outcome
+    if part_id is not None:
+        payload['id'] = part_id
+    if provider_name is not None:
+        payload['provider_name'] = provider_name
+    if provider_details is not None:
+        payload['provider_details'] = provider_details
+    return payload
+
+
+def tool_kind_encrypted_value(
+    tool_kind: ToolPartKind | None,
+    outcome: Literal['success', 'failed', 'denied', 'interrupted'] | None = None,
+    *,
+    part_id: str | None = None,
+    provider_name: str | None = None,
+    provider_details: dict[str, Any] | None = None,
+) -> str | None:
+    """Pack a part's metadata into an AG-UI ``encrypted_value`` blob, namespaced under ``pydantic_ai``.
+
+    AG-UI documents ``encrypted_value`` for opaque, client-echoed reasoning continuity, and its
+    standard reducer can attach it to a message or tool call. AG-UI has no generic per-tool metadata
+    event, so we also use that reducer-compatible carrier for Pydantic AI continuity claims. This is
+    a namespaced compatibility mechanism, not a claim that the payload is encrypted reasoning. Our
+    payload is nested under a ``pydantic_ai`` key so a genuine provider blob in the same slot (e.g.
+    Google's encrypted thinking on a tool call) is never read as our data. The claim is untrusted
+    coming back in: ``parse_encrypted_tool_kind`` returns it only when the key is present, and it
+    degrades to a plain part if it doesn't validate.
+
+    A non-``'success'`` result outcome rides the same payload: a ``ToolMessage`` has no outcome slot,
+    so without the claim a dump/load round-trip would upgrade a failed/denied/interrupted return to
+    ``'success'`` — and since ``outcome`` can affect how a return is serialized to a provider (e.g. a
+    native error channel), that would silently change the request bytes and break the prompt-cache
+    prefix stability the repaired history is designed to keep.
+
+    Since 0.1.11 the payload also carries part-level metadata (``id``, ``provider_name``,
+    ``provider_details``) for ``ToolCallPart`` and ``NativeToolCallPart``, fixing the silent field
+    loss reported in issue #5937.
+    """
+    payload = _part_metadata_payload(
+        tool_kind=tool_kind,
+        outcome=outcome,
+        part_id=part_id,
+        provider_name=provider_name,
+        provider_details=provider_details,
+    )
     if not payload:
         return None
     return json.dumps({_ENCRYPTED_VALUE_NAMESPACE: payload})
@@ -171,15 +219,19 @@ def tool_kind_encrypted_value_kwargs(
     *,
     supported: bool,
     outcome: Literal['success', 'failed', 'denied', 'interrupted'] | None = None,
+    part_id: str | None = None,
+    provider_name: str | None = None,
+    provider_details: dict[str, Any] | None = None,
 ) -> _EncryptedValueKwargs:
     """`ToolCall`/`ToolMessage` kwargs carrying claims as an `encrypted_value`, or empty to omit it.
 
-    Carries `tool_kind` and an `'interrupted'` result outcome (see `tool_kind_encrypted_value`).
-    Empty when the target version predates the `encrypted_value` field (`supported=False`) or the part
-    has nothing to carry, so — like the streaming carrier — the field is only ever set when there's a
-    claim to carry, never written as a bare `null` a pre-0.1.11 client wouldn't expect.
+    Carries `tool_kind`, an `'interrupted'` result outcome, and part-level metadata (see
+    `tool_kind_encrypted_value`). Empty when the target version predates the `encrypted_value` field
+    (`supported=False`) or the part has nothing to carry, so — like the streaming carrier — the field
+    is only ever set when there's a claim to carry, never written as a bare `null` a pre-0.1.11 client
+    wouldn't expect.
     """
-    value = tool_kind_encrypted_value(tool_kind, outcome) if supported else None
+    value = tool_kind_encrypted_value(tool_kind, outcome, part_id=part_id, provider_name=provider_name, provider_details=provider_details) if supported else None
     return {'encrypted_value': value} if value is not None else {}
 
 
@@ -245,6 +297,27 @@ def parse_encrypted_outcome(encrypted_value: str | None) -> Literal['failed', 'd
     if outcome == 'failed' or outcome == 'denied' or outcome == 'interrupted':
         return outcome
     return None
+
+
+def parse_encrypted_part_metadata(encrypted_value: str | None) -> dict[str, Any]:
+    """Extract part-level metadata (``id``, ``provider_name``, ``provider_details``) from an ``encrypted_value`` blob.
+
+    Returns a dict with only the fields that were present in the payload. Never returns ``None``
+    — callers can check ``.get('id')`` etc. directly.
+    """
+    namespaced = _parse_encrypted_namespace(encrypted_value)
+    if namespaced is None:
+        return {}
+    metadata: dict[str, Any] = {}
+    if 'id' in namespaced:
+        metadata['id'] = namespaced['id']
+    if 'provider_name' in namespaced:
+        metadata['provider_name'] = namespaced['provider_name']
+    if 'provider_details' in namespaced:
+        provider_details = namespaced['provider_details']
+        if isinstance(provider_details, dict):
+            metadata['provider_details'] = provider_details
+    return metadata
 
 
 def parse_builtin_tool_call_id(tool_call_id: str) -> tuple[str, str] | None:


### PR DESCRIPTION
## What this PR does

Extends the AG-UI adapter's existing carrier mechanisms to preserve part-level metadata (`id`, `provider_name`, `provider_details`) across `dump_messages()` → `load_messages()` round-trips.

## Why it's needed

When messages are round-tripped through `AGUIAdapter.dump_messages()`/`load_messages()`, seven categories of part-level fields were silently dropped because AG-UI has no generic per-part metadata carrier. The Vercel AI adapter handles all of these correctly via `provider_metadata`.

## What changed

**ToolCallPart / NativeToolCallPart** (`id`, `provider_name`, `provider_details`): carried inside the existing `pydantic_ai`-namespaced `encrypted_value` blob alongside `tool_kind`/`outcome`. On load, `parse_encrypted_part_metadata()` extracts them back.

**TextPart** (`id`, `provider_name`, `provider_details`): carried as a preceding `ActivityMessage` with `activity_type='pydantic_ai_text_part'`, the same pattern already used for `FilePart` and `UploadedFile`. On load, the metadata is buffered in `pending_text_metadata` and applied to the next `TextPart`.

## Reviewer Test Plan

### How to verify

1. Create a `TextPart` with `id`, `provider_name`, and `provider_details` set
2. Round-trip through `AGUIAdapter.dump_messages()` → `AGUIAdapter.load_messages()`
3. Before the fix: all three fields are `None` on the reloaded part
4. After the fix: all three fields are preserved

### Tested on

| OS | Status |
| :-- | :----: |
| macOS | ✅ |
| Windows | ⚠️ |
| Linux | ⚠️ |

## Risk & Scope

- **Main risk or tradeoff**: The `encrypted_value` carrier is gated on `ENCRYPTED_VALUE_VERSION` (0.1.11), so pre-0.1.11 clients continue to lose metadata (same as before). The `ActivityMessage` carrier is also gated on `use_encrypted_value` for consistency.
- **Not validated / out of scope**: `NativeToolReturnPart.provider_details` — the return part has no `encrypted_value` slot in the AG-UI protocol.
- **Breaking changes / migration notes**: None. Existing behavior for parts without metadata is unchanged.

## Linked Issues

Fixes #5937

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

