### PR TITLE
Make `RequestUsage` and `RunUsage` support arbitrary fields for upcoming genai-prices

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 from copy import copy
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import Annotated, Any
 
 from genai_prices.data_snapshot import get_snapshot
@@ -143,7 +143,7 @@ class UsageBase:
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""
-        return any(self.details.values()) or any(getattr(self, f.name) for f in fields(self) if f.name != 'details')
+        return any(self.details.values()) or any(v for k, v in self.__dict__.items() if k != 'details')
 
 
 @dataclass(repr=False, init=False)

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -273,7 +273,7 @@ def _incr_usage_tokens(slf: RunUsage | RequestUsage, incr_usage: RunUsage | Requ
         slf: The usage to increment.
         incr_usage: The usage to increment by.
     """
-    for k in slf.__dict__.keys() | incr_usage.__dict__.keys():
+    for k in (slf.__dict__.keys() | incr_usage.__dict__.keys()) - {'requests', 'tool_calls', 'details'}:
         slf_value = getattr(slf, k, 0)
         incr_value = getattr(incr_usage, k, 0)
         if isinstance(slf_value, (int, float)) and isinstance(incr_value, (int, float)):

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -21,7 +21,7 @@ and cost. Adapters that stash these keys in `details` (e.g. Anthropic's streamin
 billed units) keep them accessible on `RequestUsage.details`; only the ambiguous OTel emission is dropped."""
 
 
-@dataclass(repr=False, kw_only=True)
+@dataclass(repr=False, init=False)
 class UsageBase:
     input_tokens: Annotated[
         int,
@@ -64,6 +64,11 @@ class UsageBase:
         BeforeValidator(lambda d: d or {}),
     ] = dataclasses.field(default_factory=dict[str, int])
     """Any extra details returned by the model."""
+
+    def __init__(self, *, details: dict[str, int] | None = None, **kwargs: Any):
+        self.details = details or {}
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     def __copy__(self) -> UsageBase:
         """Shallow copy that also copies mutable fields like `details`."""
@@ -130,7 +135,7 @@ class UsageBase:
         return result
 
     def __repr__(self):
-        kv_pairs = (f'{f.name}={value!r}' for f in fields(self) if (value := getattr(self, f.name)))
+        kv_pairs = (f'{name}={value!r}' for name, value in sorted(self.__dict__.items()) if value)
         return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
     def has_values(self) -> bool:
@@ -138,7 +143,7 @@ class UsageBase:
         return any(self.details.values()) or any(getattr(self, f.name) for f in fields(self) if f.name != 'details')
 
 
-@dataclass(repr=False, kw_only=True)
+@dataclass(repr=False, init=False)
 class RequestUsage(UsageBase):
     """LLM usage associated with a single request.
 
@@ -203,7 +208,7 @@ class RequestUsage(UsageBase):
         return cls(details=details)
 
 
-@dataclass(repr=False, kw_only=True)
+@dataclass(repr=False, init=False)
 class RunUsage(UsageBase):
     """LLM usage associated with an agent run.
 

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -139,7 +139,11 @@ class UsageBase:
         return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
     def __eq__(self, value: object, /) -> bool:
-        return type(self) is type(value) and self.__dict__ == value.__dict__
+        if type(self) is type(value):
+            missing = object()
+            keys = self.__dict__.keys() | value.__dict__.keys()
+            return all(getattr(self, key, missing) == getattr(value, key, missing) for key in keys)
+        return NotImplemented
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -273,13 +273,11 @@ def _incr_usage_tokens(slf: RunUsage | RequestUsage, incr_usage: RunUsage | Requ
         slf: The usage to increment.
         incr_usage: The usage to increment by.
     """
-    slf.input_tokens += incr_usage.input_tokens
-    slf.cache_write_tokens += incr_usage.cache_write_tokens
-    slf.cache_read_tokens += incr_usage.cache_read_tokens
-    slf.input_audio_tokens += incr_usage.input_audio_tokens
-    slf.cache_audio_read_tokens += incr_usage.cache_audio_read_tokens
-    slf.output_audio_tokens += incr_usage.output_audio_tokens
-    slf.output_tokens += incr_usage.output_tokens
+    for k in slf.__dict__.keys() | incr_usage.__dict__.keys():
+        slf_value = getattr(slf, k, 0)
+        incr_value = getattr(incr_usage, k, 0)
+        if isinstance(slf_value, (int, float)) and isinstance(incr_value, (int, float)):
+            setattr(slf, k, slf_value + incr_value)
 
     for key, value in incr_usage.details.items():
         # Note: value can be None at runtime from model responses despite the type annotation

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -21,7 +21,7 @@ and cost. Adapters that stash these keys in `details` (e.g. Anthropic's streamin
 billed units) keep them accessible on `RequestUsage.details`; only the ambiguous OTel emission is dropped."""
 
 
-@dataclass(repr=False, init=False)
+@dataclass(repr=False, init=False, eq=False)
 class UsageBase:
     input_tokens: Annotated[
         int,
@@ -146,7 +146,7 @@ class UsageBase:
         return any(self.details.values()) or any(v for k, v in self.__dict__.items() if k != 'details')
 
 
-@dataclass(repr=False, init=False)
+@dataclass(repr=False, init=False, eq=False)
 class RequestUsage(UsageBase):
     """LLM usage associated with a single request.
 
@@ -211,7 +211,7 @@ class RequestUsage(UsageBase):
         return cls(details=details)
 
 
-@dataclass(repr=False, init=False)
+@dataclass(repr=False, init=False, eq=False)
 class RunUsage(UsageBase):
     """LLM usage associated with an agent run.
 

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -138,6 +138,9 @@ class UsageBase:
         kv_pairs = (f'{name}={value!r}' for name, value in sorted(self.__dict__.items()) if value)
         return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
+    def __eq__(self, value: object, /) -> bool:
+        return type(self) is type(value) and self.__dict__ == value.__dict__
+
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""
         return any(self.details.values()) or any(getattr(self, f.name) for f in fields(self) if f.name != 'details')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -722,6 +722,7 @@ def tiny_video() -> BinaryContent:
 
 os.environ.pop('OPENAI_BASE_URL', None)
 os.environ.pop('ANTHROPIC_BASE_URL', None)
+os.environ.pop('LOGFIRE_EMIT_CONFIGURATION_SPAN', None)
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -803,7 +803,7 @@ def test_prompted_output_schema_instructions_do_not_set_variable_instructions(
     )
 
     result = my_agent.run_sync('Tell me about Paris')
-    assert result.output == snapshot(City(name='Paris', population=2148000))
+    assert result.output == City(name='Paris', population=2148000)
 
     summary = get_logfire_summary()
     agent_run_attrs = summary.attributes[0]

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -432,6 +432,16 @@ def test_request_usage_basics():
     assert usage.requests == 1
 
 
+def test_usage_arbitrary_fields():
+    usage = RequestUsage(future_tokens=1, label='original')
+
+    assert usage == RequestUsage(future_tokens=1, label='original')
+    assert usage != RequestUsage(future_tokens=2, label='original')
+
+    result = usage + RequestUsage(future_tokens=2, label='increment')
+    assert result == RequestUsage(future_tokens=3, label='original')
+
+
 def test_cache_hit_ratio():
     """Pure arithmetic on usage fields -- no model request to record."""
     assert RequestUsage(input_tokens=1000, cache_read_tokens=900).cache_hit_ratio == 0.9

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -437,6 +437,8 @@ def test_usage_arbitrary_fields():
 
     assert usage == RequestUsage(future_tokens=1, label='original')
     assert usage != RequestUsage(future_tokens=2, label='original')
+    assert usage != object()
+    assert RunUsage(requests=0) == RunUsage()
 
     result = usage + RequestUsage(future_tokens=2, label='increment')
     assert result == RequestUsage(future_tokens=3, label='original')


### PR DESCRIPTION
Needed to support new units in https://github.com/pydantic/genai-prices/pull/351

This doesn't solve (de)serializing arbitrary fields yet, but for now the scope is just that the genai-prices change shouldn't break anything here.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
