### PR TITLE
Fixing issue #6684 (Change value check from truthy to None check)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -125,7 +125,7 @@ class UsageBase:
                 if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
                     continue
                 # Skipping check for value since spec implies all detail values are relevant
-                if value:
+                if value is not None:
                     result[prefix + key] = value
         return result
 


### PR DESCRIPTION
Closes #6684. 

It changes a truthy check in pydantic_ai_slim/pydantic_ai/usage.py to a None check in order to better handle 0 values.

This is a one-line change I made by hand and verified. No AI was used.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

