### PR TITLE
Map deferred `google-genai` stream errors in `GoogleModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -380,6 +380,17 @@ def _resolve_google_cloud_service_tier(model_settings: GoogleModelSettings) -> G
     return 'pt_then_on_demand'
 
 
+def _map_api_error(e: errors.APIError, model_name: str) -> ModelAPIError:
+    """Map a `google.genai` API error to the pydantic-ai exception to raise in its place."""
+    if (status_code := e.code) >= 400:
+        return ModelHTTPError(
+            status_code=status_code,
+            model_name=model_name,
+            body=cast(Any, e.details),  # pyright: ignore[reportUnknownMemberType]
+        )
+    return ModelAPIError(model_name=model_name, message=str(e))
+
+
 def _google_cloud_service_tier_headers(service_tier: GoogleCloudServiceTier) -> dict[str, str]:
     """HTTP headers for Google Cloud Provisioned Throughput, Flex PayGo, and Priority PayGo routing."""
     if service_tier == 'pt_then_on_demand':
@@ -784,13 +795,7 @@ class GoogleModel(Model[Client]):
         try:
             return await func(model=self._model_name, contents=contents, config=config)  # type: ignore
         except errors.APIError as e:
-            if (status_code := e.code) >= 400:
-                raise ModelHTTPError(
-                    status_code=status_code,
-                    model_name=self._model_name,
-                    body=cast(Any, e.details),  # pyright: ignore[reportUnknownMemberType]
-                ) from e
-            raise ModelAPIError(model_name=self._model_name, message=str(e)) from e
+            raise _map_api_error(e, self._model_name) from e
 
     def _translate_thinking(
         self,
@@ -1002,7 +1007,13 @@ class GoogleModel(Model[Client]):
         peekable_response: _utils.PeekableAsyncStream[
             GenerateContentResponse, AsyncIterator[GenerateContentResponse]
         ] = _utils.PeekableAsyncStream(response)
-        first_chunk = await peekable_response.peek()
+        # `generate_content_stream` doesn't issue the HTTP request until the response
+        # iterator is first advanced, so API errors surface here rather than in
+        # `_generate_content`'s try/except and need the same mapping.
+        try:
+            first_chunk = await peekable_response.peek()
+        except errors.APIError as e:
+            raise _map_api_error(e, self._model_name) from e
         if isinstance(first_chunk, _utils.Unset):
             raise UnexpectedModelBehavior('Streamed response ended without content or tool calls')  # pragma: no cover
 
@@ -1512,13 +1523,7 @@ class GeminiStreamedResponse(StreamedResponse):
                 yield self._parts_manager.handle_part(vendor_part_id=pending.tool_call_id, part=pending)
             self._pending_file_search_returns = []
         except errors.APIError as e:
-            if (status_code := e.code) >= 400:
-                raise ModelHTTPError(
-                    status_code=status_code,
-                    model_name=self._model_name,
-                    body=cast(Any, e.details),  # pyright: ignore[reportUnknownMemberType]
-                ) from e
-            raise ModelAPIError(model_name=self._model_name, message=str(e)) from e
+            raise _map_api_error(e, self._model_name) from e
 
     def _handle_file_search_grounding_metadata_streaming(
         self, grounding_metadata: GroundingMetadata | None

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -5283,6 +5283,83 @@ async def test_google_stream_api_non_http_error_is_wrapped(
     assert exc_info.value.model_name == model_name
 
 
+@pytest.mark.parametrize(
+    'error_class,error_response,expected_status',
+    [
+        (
+            errors.ClientError,
+            {
+                'error': {
+                    'code': 404,
+                    'message': 'Publisher model `gemini-1.5-flash` was not found',
+                    'status': 'NOT_FOUND',
+                }
+            },
+            404,
+        ),
+        (
+            errors.ServerError,
+            {'error': {'code': 503, 'message': 'The service is currently unavailable.', 'status': 'UNAVAILABLE'}},
+            503,
+        ),
+    ],
+)
+async def test_google_stream_api_errors_before_first_chunk_are_wrapped(
+    allow_model_requests: None,
+    google_provider: GoogleProvider,
+    mocker: MockerFixture,
+    error_class: Any,
+    error_response: dict[str, Any],
+    expected_status: int,
+):
+    """`generate_content_stream` issues the HTTP request lazily, on the first advance of the
+    response iterator, so API errors can surface before any chunk arrives. They should be
+    wrapped as ModelHTTPError like errors raised mid-stream, not bubble up raw."""
+    model_name = 'gemini-1.5-flash'
+    model = GoogleModel(model_name, provider=google_provider)
+
+    async def failing_stream():
+        raise error_class(expected_status, error_response)
+        yield  # pragma: no cover
+
+    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=failing_stream())
+
+    agent = Agent(model=model)
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        async with agent.run_stream('test') as stream:
+            async for _text in stream.stream_text():
+                pass
+
+    assert exc_info.value.status_code == expected_status
+    assert error_response['error']['message'] in str(exc_info.value.body)
+
+
+async def test_google_stream_api_non_http_error_before_first_chunk_is_wrapped(
+    allow_model_requests: None,
+    google_provider: GoogleProvider,
+    mocker: MockerFixture,
+):
+    """Non-HTTP API errors raised before the first chunk should be wrapped as ModelAPIError."""
+    model_name = 'gemini-1.5-flash'
+    model = GoogleModel(model_name, provider=google_provider)
+
+    async def failing_stream():
+        raise errors.APIError(302, {'error': {'code': 302, 'message': 'Redirect', 'status': 'REDIRECT'}})
+        yield  # pragma: no cover
+
+    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=failing_stream())
+
+    agent = Agent(model=model)
+
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('test') as stream:
+            async for _text in stream.stream_text():
+                pass
+
+    assert exc_info.value.model_name == model_name
+
+
 async def test_google_model_retrying_after_empty_response(allow_model_requests: None, google_provider: GoogleProvider):
     message_history = [
         ModelRequest(parts=[UserPromptPart(content='Hi')], timestamp=IsDatetime()),

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -5299,8 +5299,7 @@ async def test_google_stream_api_error_before_first_chunk_is_wrapped(allow_model
         )
 
         with pytest.raises(ModelHTTPError) as exc_info:
-            async with Agent(model).run_stream('test'):
-                pytest.fail('The context body should not be entered')
+            await Agent(model).run_stream('test').__aenter__()
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.model_name == model_name

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 from typing import Any, cast
 
 import pytest
-from httpx import AsyncClient as HttpxAsyncClient, Timeout
+from httpx import AsyncClient as HttpxAsyncClient, MockTransport, Request, Response, Timeout
 from pydantic import BaseModel, Field
 from pytest_mock import MockerFixture
 from typing_extensions import TypedDict
@@ -5283,81 +5283,30 @@ async def test_google_stream_api_non_http_error_is_wrapped(
     assert exc_info.value.model_name == model_name
 
 
-@pytest.mark.parametrize(
-    'error_class,error_response,expected_status',
-    [
-        (
-            errors.ClientError,
-            {
-                'error': {
-                    'code': 404,
-                    'message': 'Publisher model `gemini-1.5-flash` was not found',
-                    'status': 'NOT_FOUND',
-                }
-            },
-            404,
-        ),
-        (
-            errors.ServerError,
-            {'error': {'code': 503, 'message': 'The service is currently unavailable.', 'status': 'UNAVAILABLE'}},
-            503,
-        ),
-    ],
-)
-async def test_google_stream_api_errors_before_first_chunk_are_wrapped(
-    allow_model_requests: None,
-    google_provider: GoogleProvider,
-    mocker: MockerFixture,
-    error_class: Any,
-    error_response: dict[str, Any],
-    expected_status: int,
-):
-    """`generate_content_stream` issues the HTTP request lazily, on the first advance of the
-    response iterator, so API errors can surface before any chunk arrives. They should be
-    wrapped as ModelHTTPError like errors raised mid-stream, not bubble up raw."""
-    model_name = 'gemini-1.5-flash'
-    model = GoogleModel(model_name, provider=google_provider)
+async def test_google_stream_api_error_before_first_chunk_is_wrapped(allow_model_requests: None):
+    model_name = 'definitely-missing'
+    error_response = {'error': {'code': 404, 'message': 'Model not found', 'status': 'NOT_FOUND'}}
+    requests: list[Request] = []
 
-    async def failing_stream():
-        raise error_class(expected_status, error_response)
-        yield  # pragma: no cover
+    async def handler(request: Request) -> Response:
+        requests.append(request)
+        return Response(404, json=error_response)
 
-    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=failing_stream())
+    async with HttpxAsyncClient(transport=MockTransport(handler)) as http_client:
+        model = GoogleModel(
+            model_name,
+            provider=GoogleProvider(api_key='test-key', http_client=http_client, base_url='http://localhost'),
+        )
 
-    agent = Agent(model=model)
+        with pytest.raises(ModelHTTPError) as exc_info:
+            async with Agent(model).run_stream('test'):
+                pytest.fail('The context body should not be entered')
 
-    with pytest.raises(ModelHTTPError) as exc_info:
-        async with agent.run_stream('test') as stream:
-            async for _text in stream.stream_text():
-                pass
-
-    assert exc_info.value.status_code == expected_status
-    assert error_response['error']['message'] in str(exc_info.value.body)
-
-
-async def test_google_stream_api_non_http_error_before_first_chunk_is_wrapped(
-    allow_model_requests: None,
-    google_provider: GoogleProvider,
-    mocker: MockerFixture,
-):
-    """Non-HTTP API errors raised before the first chunk should be wrapped as ModelAPIError."""
-    model_name = 'gemini-1.5-flash'
-    model = GoogleModel(model_name, provider=google_provider)
-
-    async def failing_stream():
-        raise errors.APIError(302, {'error': {'code': 302, 'message': 'Redirect', 'status': 'REDIRECT'}})
-        yield  # pragma: no cover
-
-    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=failing_stream())
-
-    agent = Agent(model=model)
-
-    with pytest.raises(ModelAPIError) as exc_info:
-        async with agent.run_stream('test') as stream:
-            async for _text in stream.stream_text():
-                pass
-
+    assert exc_info.value.status_code == 404
     assert exc_info.value.model_name == model_name
+    assert exc_info.value.body == error_response
+    assert isinstance(exc_info.value.__cause__, errors.ClientError)
+    assert len(requests) == 1
 
 
 async def test_google_model_retrying_after_empty_response(allow_model_requests: None, google_provider: GoogleProvider):


### PR DESCRIPTION
`google-genai` can defer sending a streaming request until the returned iterator is first advanced. `GoogleModel` performs that first advance while peeking at the first response chunk, before it constructs and yields `GeminiStreamedResponse`.

If the request fails at that point, neither existing error handler covers it. `_generate_content()` has already returned the lazy iterator, while `GeminiStreamedResponse._get_event_iterator()` has not been reached. A provider error such as a 404 therefore escapes as a raw `google.genai.errors.ClientError` instead of `ModelHTTPError` or `ModelAPIError`.

This surfaced in the Logfire playground, where an unavailable Gemini model aborted the SSE stream because the caller's `except AgentRunError` did not catch the raw SDK exception.

## Changes

- Extract the existing `errors.APIError` mapping into `_map_api_error()`.
- Apply the same mapping when the first-chunk `peek()` advances the Google iterator.
- Add a credential-free regression test using the real `google-genai` SDK and an `httpx.MockTransport` 404 response.

The regression test fails on the base commit with a raw `ClientError` and passes with a `ModelHTTPError` whose cause is the original SDK exception.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the release changelog.
