### PR TITLE
Add `mistral_prediction` setting for Mistral predicted outputs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -82,6 +82,7 @@ try:
         FunctionCall as MistralFunctionCall,
         ImageURL as MistralImageURL,
         ImageURLChunk as MistralImageURLChunk,
+        PredictionTypedDict as MistralPredictionTypedDict,
         ReferenceChunk as MistralReferenceChunk,
         ResponseFormatTypedDict as MistralResponseFormatTypedDict,
         TextChunk as MistralTextChunk,
@@ -170,6 +171,13 @@ class MistralModelSettings(ModelSettings, total=False):
 
     See the [Mistral prompt caching documentation](https://docs.mistral.ai/studio-api/conversations/advanced/prompt-caching)
     for more information.
+    """
+
+    mistral_prediction: MistralPredictionTypedDict
+    """Enables [predicted outputs](https://docs.mistral.ai/capabilities/predicted_outputs/), mirroring `openai_prediction`.
+
+    Pass `{'type': 'content', 'content': ...}` with the predicted text. Useful when regenerating content with
+    only small changes, as it can reduce response latency.
     """
 
 
@@ -303,6 +311,7 @@ class MistralModel(Model[Mistral]):
                 reasoning_effort=self._translate_thinking(model_request_parameters),
                 parallel_tool_calls=model_settings.get('parallel_tool_calls'),
                 prompt_cache_key=model_settings.get('mistral_prompt_cache_key', UNSET),
+                prediction=model_settings.get('mistral_prediction'),
                 http_headers={'User-Agent': get_user_agent()},
             )
 
@@ -354,6 +363,7 @@ class MistralModel(Model[Mistral]):
             reasoning_effort=reasoning_effort,
             parallel_tool_calls=model_settings.get('parallel_tool_calls'),
             prompt_cache_key=model_settings.get('mistral_prompt_cache_key', UNSET),
+            prediction=model_settings.get('mistral_prediction'),
             http_headers={'User-Agent': get_user_agent()},
         )
         assert response, 'An unexpected empty response from Mistral.'

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -59,6 +59,7 @@ with try_import() as imports_successful:
         FunctionCall as MistralFunctionCall,
         ImageURL as MistralImageURL,
         ImageURLChunk as MistralImageURLChunk,
+        PredictionTypedDict as MistralPredictionTypedDict,
         ReferenceChunk as MistralReferenceChunk,
         TextChunk,
         TextChunk as MistralTextChunk,
@@ -3642,6 +3643,64 @@ async def test_prompt_cache_key_stream(allow_model_requests: None) -> None:
         text = await result.get_output()
     assert text == 'hello'
     assert mock_client.chat_completion_kwargs[-1]['prompt_cache_key'] == 'conv-123'
+
+
+async def test_prediction_sent(allow_model_requests: None) -> None:
+    """`mistral_prediction` reaches the SDK call when set.
+
+    Asserts on `MockMistralAI.chat_completion_kwargs` (pre-serialization SDK kwargs) rather than
+    a VCR cassette, since the cassette only captures the serialized HTTP body and can't
+    distinguish an omitted kwarg from one explicitly set to its default.
+    """
+    c = completion_message(MistralAssistantMessage(content='hello', role='assistant'))
+    mock_client = MockMistralAI(completions=c)
+    m = MistralModel('mistral-small-latest', provider=MistralProvider(mistral_client=cast(Mistral, mock_client)))
+    agent = Agent(m)
+
+    prediction: MistralPredictionTypedDict = {'type': 'content', 'content': 'hello'}
+    result = await agent.run('hello', model_settings=MistralModelSettings(mistral_prediction=prediction))
+    assert result.output == 'hello'
+    assert mock_client.chat_completion_kwargs[-1]['prediction'] == prediction
+
+
+async def test_prediction_unset_without_config(allow_model_requests: None) -> None:
+    """Without `mistral_prediction`, `prediction` is `None` (omitted by the SDK).
+
+    Asserts on `MockMistralAI.chat_completion_kwargs` (pre-serialization SDK kwargs) rather than
+    a VCR cassette, since the cassette only captures the serialized HTTP body and can't
+    distinguish an omitted kwarg from one explicitly set to its default.
+    """
+    c = completion_message(MistralAssistantMessage(content='hello', role='assistant'))
+    mock_client = MockMistralAI(completions=c)
+    m = MistralModel('mistral-small-latest', provider=MistralProvider(mistral_client=cast(Mistral, mock_client)))
+    agent = Agent(m)
+
+    result = await agent.run('hello')
+    assert result.output == 'hello'
+    assert mock_client.chat_completion_kwargs[-1]['prediction'] is None
+
+
+async def test_prediction_stream(allow_model_requests: None) -> None:
+    """`mistral_prediction` reaches the SDK call in streaming mode too, and stays `UNSET` by default.
+
+    Asserts on `MockMistralAI.chat_completion_kwargs` (pre-serialization SDK kwargs) rather than
+    a VCR cassette, since the cassette only captures the serialized HTTP body and can't
+    distinguish an omitted kwarg from one explicitly set to its default.
+    """
+    stream = [text_chunk('hello', finish_reason='stop')]
+    mock_client = MockMistralAI(stream=stream)
+    m = MistralModel('mistral-small-latest', provider=MistralProvider(mistral_client=cast(Mistral, mock_client)))
+    agent = Agent(m)
+
+    async with agent.run_stream('hello') as result:
+        await result.get_output()
+    assert mock_client.chat_completion_kwargs[-1]['prediction'] is None
+
+    prediction: MistralPredictionTypedDict = {'type': 'content', 'content': 'hello'}
+    async with agent.run_stream('hello', model_settings=MistralModelSettings(mistral_prediction=prediction)) as result:
+        text = await result.get_output()
+    assert text == 'hello'
+    assert mock_client.chat_completion_kwargs[-1]['prediction'] == prediction
 
 
 async def test_parallel_tool_calls_sent(allow_model_requests: None) -> None:


### PR DESCRIPTION
- Closes #3336

Adds a `mistral_prediction` setting to `MistralModelSettings` so you can pass Mistral's [predicted outputs](https://docs.mistral.ai/capabilities/predicted_outputs/), which speeds up responses when you're regenerating text with only small edits. It mirrors the existing `openai_prediction` setting and the recently-added `mistral_prompt_cache_key`: typed with the SDK's `PredictionTypedDict` and forwarded straight through to `complete_async`/`stream_async` in both `_completions_create` and `_stream_completions_create`, defaulting to `None` (omitted) when unset, which matches the SDK's own signature default.

Tests follow the same mock-kwargs pattern as the `mistral_prompt_cache_key` tests (asserting the pre-serialization SDK kwargs, since a VCR cassette can't tell an omitted kwarg from one set to its default): the value reaches the SDK for both non-streaming and streaming, and stays `None` by default. Ran `uv run pytest tests/models/test_mistral.py` (all green), `ruff check`/`format`, and `pyright` on both changed files.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: I built this with Claude Code's help and went through the final diff myself before pushing. apologies if I missed something obvious, I'm a freshman still learning this codebase and trying to contribute where I can, so I'd genuinely welcome any feedback.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

