### PR TITLE
Use UTF-8 for test config fixtures

### DIFF
--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -155,7 +155,7 @@ def test_from_file_uses_filename_as_default_name(tmp_path: Path):
     """Test that from_file uses filename stem as name."""
     yaml_content = 'cases:\n- name: test\n  inputs:\n    query: hello\n'
     yaml_path = tmp_path / 'my_dataset.yaml'
-    yaml_path.write_text(yaml_content)
+    yaml_path.write_text(yaml_content, encoding='utf-8')
 
     dataset = Dataset[TaskInput, TaskOutput, TaskMetadata].from_file(yaml_path)
     assert dataset.name == 'my_dataset'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1330,7 +1330,7 @@ class TestLoadMCPToolsets:
         }
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             toolsets = load_mcp_toolsets(config_path)
         assert len(toolsets) == 1
 
@@ -1342,7 +1342,7 @@ class TestLoadMCPToolsets:
         }
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             toolsets = load_mcp_toolsets(config_path)
         # Single server entry, wrapped with `.prefixed('alpha')`.
         assert len(toolsets) == 1
@@ -1364,7 +1364,7 @@ class TestLoadMCPToolsets:
         }
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             toolsets = load_mcp_toolsets(config_path)
         from pydantic_ai.toolsets.prefixed import PrefixedToolset
 
@@ -1390,7 +1390,7 @@ class TestLoadMCPToolsets:
         }
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             toolsets = load_mcp_toolsets(config_path)
 
         wrapped = toolsets[0].wrapped  # type: ignore[attr-defined]
@@ -1407,7 +1407,7 @@ class TestLoadMCPToolsets:
         config = {'mcpServers': {'alpha': {'url': 'https://${MCP_TEST_UNDEFINED}/mcp'}}}
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             with pytest.raises(ValueError, match=r'\$\{MCP_TEST_UNDEFINED\} is not defined'):
                 load_mcp_toolsets(config_path)
 
@@ -1415,7 +1415,7 @@ class TestLoadMCPToolsets:
         """The config root must be a JSON object; a list / scalar at the root raises a descriptive error."""
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(['not an object']))
+            config_path.write_text(json.dumps(['not an object']), encoding='utf-8')
             with pytest.raises(ValueError, match='Expected JSON object at root'):
                 load_mcp_toolsets(config_path)
 
@@ -1423,7 +1423,7 @@ class TestLoadMCPToolsets:
         """The config must have an `mcpServers` object."""
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps({'someOtherKey': {}}))
+            config_path.write_text(json.dumps({'someOtherKey': {}}), encoding='utf-8')
             with pytest.raises(ValueError, match='Expected `mcpServers` object'):
                 load_mcp_toolsets(config_path)
 
@@ -1432,7 +1432,7 @@ class TestLoadMCPToolsets:
         config = {'mcpServers': {'alpha': {'something': 'else'}}}
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             with pytest.raises(ValueError, match=r"MCP server config 'alpha' must have either"):
                 load_mcp_toolsets(config_path)
 
@@ -1453,7 +1453,7 @@ class TestLoadMCPToolsets:
         }
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
-            config_path.write_text(json.dumps(config))
+            config_path.write_text(json.dumps(config), encoding='utf-8')
             toolsets = load_mcp_toolsets(config_path)
         assert len(toolsets) == 1
 


### PR DESCRIPTION
## Summary
- Add explicit `encoding='utf-8'` to MCP config JSON fixture writes in `tests/test_mcp.py`.
- Add explicit UTF-8 encoding to the dataset YAML fixture write in `tests/evals/test_dataset.py`.

Fixes #6699

## Problem
These tests create repo-format JSON/YAML fixture files using `Path.write_text()` without an explicit encoding. Most nearby fixture reads and writes already use UTF-8, and making these remaining writes explicit avoids locale-dependent behavior on Windows or other non-UTF-8 environments.

## Before / After
Before: a small set of temporary JSON/YAML test fixtures were written with the platform default encoding.

After: those fixtures are written as UTF-8, matching the surrounding test fixture style.

## Verification
- `python -m py_compile tests/evals/test_dataset.py tests/test_mcp.py`
- `uv run pytest tests/evals/test_dataset.py::test_from_file_uses_filename_as_default_name tests/test_mcp.py::TestLoadMCPToolsets -q` (`11 passed`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

