### PR TITLE
Clarify OpenRouter Advisor observability wording

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -527,8 +527,8 @@ class _OpenRouterCostDetails:
 class _OpenRouterServerToolUseDetails:
     """Counts of OpenRouter server-side tool calls (e.g. the advisor tool).
 
-    Server tools run entirely inside the gateway, so the consultation does not appear as
-    message parts on the Chat Completions API — these counts are the only trace of it.
+    OpenRouter reports these aggregate counts in usage, including when individual server-tool
+    calls are not exposed as message parts in the Chat Completions response.
     """
 
     tool_calls_requested: int | None = None

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1112,11 +1112,9 @@ async def test_openrouter_advisor_tool_unsupported_fields(
 async def test_openrouter_advisor_tool(allow_model_requests: None, openrouter_api_key: str) -> None:
     """End-to-end advisor consult through OpenRouter, recorded live.
 
-    On the Chat Completions API the advisor runs entirely server-side: the consultation does not
-    surface as message parts (no `tool_calls` / `role:tool` blocks), only the final answer does.
-    The one observable trace that the advisor was actually invoked is the server-tool-use counts
-    in `usage`, which we surface via `provider_details['server_tool_use']` — asserted here so a
-    regression that stops sending the advisor tool (final answer still produced) fails loudly.
+    In this recorded Chat Completions response, the server-side consultation is not exposed as
+    message parts. The server-tool-use counts in `usage`, surfaced via
+    `provider_details['server_tool_use']`, verify that the advisor was invoked.
 
     The prompt explicitly asks the executor to consult so the recording reliably contains an
     advisor exchange.


### PR DESCRIPTION
## Summary

- Narrow the OpenRouter server-tool usage docstring to describe aggregate counts without claiming they are universally the only trace of a consultation.
- Make the Advisor VCR test docstring explicitly describe the recorded Chat Completions response rather than all OpenRouter responses.

## Rationale

The recorded response exposes the completed answer and aggregate server-tool usage counts without individual Advisor message parts. OpenRouter also documents response shapes that can include Advisor tool calls and results for replay, so the previous universal wording was stronger than the test evidence.

This is a documentation-only clarification; runtime behavior is unchanged.

## Validation

- `uv run pytest tests/models/test_openrouter.py -k advisor -q` — 6 passed
- pre-commit formatting, linting, type checking, and cassette checks passed

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

