### PR TITLE
test(mistral): verify prompt cache with history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -640,7 +640,11 @@ class MistralModel(Model[Mistral]):
                     # (e.g. an empty `ModelResponse` the agent graph retries). Omit it, mirroring
                     # the OpenAI and Anthropic adapters.
                     continue
-                mistral_messages.append(MistralAssistantMessage(content=content_chunks, tool_calls=tool_calls))
+                content: MistralContent = content_chunks
+                if len(message.parts) == 1 and isinstance(message.parts[0], TextPart):
+                    # Mistral returns plain assistant text as a scalar, and its prompt cache requires an identical prefix.
+                    content = message.parts[0].content
+                mistral_messages.append(MistralAssistantMessage(content=content, tool_calls=tool_calls))
             else:
                 assert_never(message)
         if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -640,11 +640,7 @@ class MistralModel(Model[Mistral]):
                     # (e.g. an empty `ModelResponse` the agent graph retries). Omit it, mirroring
                     # the OpenAI and Anthropic adapters.
                     continue
-                content: MistralContent = content_chunks
-                if len(message.parts) == 1 and isinstance(message.parts[0], TextPart):
-                    # Mistral returns plain assistant text as a scalar, and its prompt cache requires an identical prefix.
-                    content = message.parts[0].content
-                mistral_messages.append(MistralAssistantMessage(content=content, tool_calls=tool_calls))
+                mistral_messages.append(MistralAssistantMessage(content=content_chunks, tool_calls=tool_calls))
             else:
                 assert_never(message)
         if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):

--- a/tests/models/cassettes/test_mistral/test_mistral_history_uses_prompt_cache.yaml
+++ b/tests/models/cassettes/test_mistral/test_mistral_history_uses_prompt_cache.yaml
@@ -1,0 +1,172 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1758'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+    method: POST
+    parsed_body:
+      frequency_penalty: null
+      messages:
+      - content: Retain this instruction prefix for the entire conversation. Retain this instruction prefix for the entire
+          conversation. Retain this instruction prefix for the entire conversation. Retain this instruction prefix for the
+          entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction prefix
+          for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation.
+        role: system
+      - content: 'Reply with exactly: cache probe one.'
+        role: user
+      model: mistral-large-latest
+      n: 1
+      presence_penalty: null
+      prompt_cache_key: pydantic-ai-test-mistral-history-cache
+      stop: null
+      stream: false
+      top_p: 1.0
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    headers:
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '389'
+      content-type:
+      - application/json
+      mistral-correlation-id:
+      - 019f94fe-29c7-7084-bcf6-386b6baa345e
+      strict-transport-security:
+      - max-age=15552000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          content: cache probe one.
+          role: assistant
+          tool_calls: null
+      created: 1784911112
+      id: f693a0e825f04b4ba7d4fe0c132266b8
+      model: mistral-large-latest
+      object: chat.completion
+      usage:
+        completion_tokens: 5
+        prompt_tokens: 253
+        prompt_tokens_details:
+          cached_tokens: 0
+        total_tokens: 258
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1944'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+    method: POST
+    parsed_body:
+      frequency_penalty: null
+      messages:
+      - content: Retain this instruction prefix for the entire conversation. Retain this instruction prefix for the entire
+          conversation. Retain this instruction prefix for the entire conversation. Retain this instruction prefix for the
+          entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction prefix
+          for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation. Retain this instruction prefix for the entire conversation. Retain this instruction
+          prefix for the entire conversation.
+        role: system
+      - content: 'Reply with exactly: cache probe one.'
+        role: user
+      - content:
+        - text: cache probe one.
+          type: text
+        prefix: false
+        role: assistant
+        tool_calls: []
+      - content: 'Reply with exactly: cache probe two.'
+        role: user
+      model: mistral-large-latest
+      n: 1
+      presence_penalty: null
+      prompt_cache_key: pydantic-ai-test-mistral-history-cache
+      stop: null
+      stream: false
+      top_p: 1.0
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    headers:
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '391'
+      content-type:
+      - application/json
+      mistral-correlation-id:
+      - 019f94fe-2c2f-78ce-8013-ebdd056cd66e
+      strict-transport-security:
+      - max-age=15552000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          content: cache probe two.
+          role: assistant
+          tool_calls: null
+      created: 1784911113
+      id: 23271c0215f547dcb5d5e2950f354f9d
+      model: mistral-large-latest
+      object: chat.completion
+      usage:
+        completion_tokens: 5
+        prompt_tokens: 268
+        prompt_tokens_details:
+          cached_tokens: 224
+        total_tokens: 273
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -243,9 +243,6 @@ async def test_multiple_completions(allow_model_requests: None):
     assert result.output == 'hello again'
     assert result.usage.input_tokens == 1
     assert result.usage.output_tokens == 1
-    second_call_messages = get_mock_chat_completion_kwargs(mock_client)[1]['messages']
-    assert isinstance(second_call_messages[1], MistralAssistantMessage)
-    assert second_call_messages[1].content == 'world'
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
@@ -413,6 +410,27 @@ async def test_usage_with_cached_tokens(allow_model_requests: None):
     result = await agent.run('hello')
 
     assert result.usage == snapshot(RunUsage(input_tokens=1013, cache_read_tokens=1008, output_tokens=30, requests=1))
+
+
+@pytest.mark.vcr()
+async def test_mistral_history_uses_prompt_cache(allow_model_requests: None, mistral_api_key: str, vcr: Cassette):
+    instructions = ' '.join(['Retain this instruction prefix for the entire conversation.'] * 24)
+    settings = MistralModelSettings(mistral_prompt_cache_key='pydantic-ai-test-mistral-history-cache')
+    agent = Agent(
+        MistralModel('mistral-large-latest', provider=MistralProvider(api_key=mistral_api_key)),
+        instructions=instructions,
+    )
+
+    first = await agent.run('Reply with exactly: cache probe one.', model_settings=settings)
+    second = await agent.run(
+        'Reply with exactly: cache probe two.',
+        message_history=first.all_messages(),
+        model_settings=settings,
+    )
+
+    second_request = json.loads(vcr.requests[1].body)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    assert second_request['messages'][2]['content'] == [{'text': first.output, 'type': 'text'}]
+    assert second.usage.cache_read_tokens >= 64
 
 
 #####################

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -243,6 +243,9 @@ async def test_multiple_completions(allow_model_requests: None):
     assert result.output == 'hello again'
     assert result.usage.input_tokens == 1
     assert result.usage.output_tokens == 1
+    second_call_messages = get_mock_chat_completion_kwargs(mock_client)[1]['messages']
+    assert isinstance(second_call_messages[1], MistralAssistantMessage)
+    assert second_call_messages[1].content == 'world'
     assert result.all_messages() == snapshot(
         [
             ModelRequest(


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

Relates to #6653.

### Summary

- Add a two-turn Mistral VCR test using `mistral_prompt_cache_key` and real `Agent` history.
- Pin the second request's list-shaped assistant text payload, matching the reported concern.
- Pin Mistral's recorded 224-token cache hit for that request.

### Investigation

The live A/B control gave the same 224-token cache hit for both the current list-shaped assistant history and a temporary scalar representation. The reported cache regression therefore does not reproduce, so this PR intentionally contains no production-code change.

### Verification

- `source /Users/david/projects/forks/pydantic-ai-main/.env && uv run pytest tests/models/test_mistral.py::test_mistral_history_uses_prompt_cache --record-mode=new_episodes`
- `uv run pytest tests/models/test_mistral.py::test_mistral_history_uses_prompt_cache -v`
- `make format && make lint`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/models/test_mistral.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
