### PR TITLE
Enforce specific rule codes on type-ignore comments with ruff `PGH003`

### DIFF
--- a/examples/pydantic_ai_examples/chat_app.py
+++ b/examples/pydantic_ai_examples/chat_app.py
@@ -212,10 +212,10 @@ class Database:
     async def _asyncify(
         self, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs
     ) -> R:
-        return await self._loop.run_in_executor(  # type: ignore
+        return await self._loop.run_in_executor(  # pyright: ignore[reportUnknownVariableType]
             self._executor,
             partial(func, **kwargs),
-            *args,  # type: ignore
+            *args,  # pyright: ignore[reportCallIssue]
         )
 
 

--- a/examples/pydantic_ai_examples/evals/agent.py
+++ b/examples/pydantic_ai_examples/evals/agent.py
@@ -5,7 +5,12 @@ from datetime import datetime
 
 from pydantic_ai import Agent, RunContext
 
-from .models import TimeRangeInputs, TimeRangeResponse
+from .models import (
+    TimeRangeBuilderError,
+    TimeRangeBuilderSuccess,
+    TimeRangeInputs,
+    TimeRangeResponse,
+)
 
 
 @dataclass
@@ -21,13 +26,14 @@ class TimeRangeDeps:
 
 
 time_range_agent = Agent[TimeRangeDeps, TimeRangeResponse](
-    'gpt-5.2',
-    output_type=TimeRangeResponse,  # type: ignore  # we can't yet annotate something as receiving a TypeForm
+    'openai:gpt-5.2',
+    # pass the union members directly: a `TimeRangeResponse` type alias isn't yet accepted as a `TypeForm` value (PEP-747)
+    output_type=TimeRangeBuilderSuccess | TimeRangeBuilderError,
     deps_type=TimeRangeDeps,
     system_prompt="Convert the user's request into a structured time range.",
     retries=1,
-    instrument=True,
 )
+time_range_agent.instrument = True
 
 
 @time_range_agent.tool

--- a/examples/pydantic_ai_examples/flight_booking.py
+++ b/examples/pydantic_ai_examples/flight_booking.py
@@ -50,7 +50,8 @@ class Deps:
 # This agent is responsible for controlling the flow of the conversation.
 search_agent = Agent[Deps, FlightDetails | NoFlightFound](
     'openai:gpt-5.2',
-    output_type=FlightDetails | NoFlightFound,  # type: ignore
+    output_type=FlightDetails | NoFlightFound,
+    deps_type=Deps,
     retries=4,
     system_prompt=(
         'Your job is to find the cheapest flight for the user on the given date. '

--- a/examples/pydantic_ai_examples/slack_lead_qualifier/modal.py
+++ b/examples/pydantic_ai_examples/slack_lead_qualifier/modal.py
@@ -32,7 +32,7 @@ def setup_logfire():
 
 ### [web_app]
 @app.function(min_containers=1)
-@modal.asgi_app()  # type: ignore
+@modal.asgi_app()  # pyright: ignore[reportUnknownMemberType]
 def web_app():
     setup_logfire()
 

--- a/examples/pydantic_ai_examples/slack_lead_qualifier/store.py
+++ b/examples/pydantic_ai_examples/slack_lead_qualifier/store.py
@@ -28,4 +28,4 @@ class AnalysisStore:
 
     @classmethod
     def _get_store(cls) -> modal.Dict:
-        return modal.Dict.from_name('analyses', create_if_missing=True)  # type: ignore ### [/analysis_store]
+        return modal.Dict.from_name('analyses', create_if_missing=True)  # pyright: ignore[reportUnknownMemberType] ### [/analysis_store]

--- a/examples/pydantic_ai_examples/sql_gen.py
+++ b/examples/pydantic_ai_examples/sql_gen.py
@@ -93,8 +93,8 @@ class InvalidRequest(BaseModel):
 Response: TypeAlias = Success | InvalidRequest
 agent = Agent[Deps, Response](
     'google:gemini-3-flash-preview',
-    # Type ignore while we wait for PEP-0747, nonetheless unions will work fine everywhere else
-    output_type=Response,  # type: ignore
+    # Pass the union members directly: a `Response` type alias isn't yet accepted as a `TypeForm` value (PEP-747)
+    output_type=Success | InvalidRequest,
     deps_type=Deps,
 )
 

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -118,7 +118,7 @@ async def task_group_gather(tasks: Sequence[Callable[[], Awaitable[T]]]) -> list
     Returns:
         A list of results in the same order as the input tasks.
     """
-    results: list[T] = [None] * len(tasks)  # type: ignore
+    results: list[T] = [None] * len(tasks)  # pyright: ignore[reportAssignmentType]
 
     async def _run_task(tsk: Callable[[], Awaitable[T]], index: int) -> None:
         """Helper function to run a task and store the result in the correct index."""

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -551,7 +551,7 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
                 f' when serializing or deserializing.',
                 UserWarning,
             )
-            return Any, Any, Any  # type: ignore
+            return Any, Any, Any  # pyright: ignore[reportReturnType]
 
     @classmethod
     def from_file(
@@ -828,15 +828,15 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
             metadata: meta_type | None = None  # pyright: ignore[reportInvalidTypeForm]
             expected_output: out_type | None = None  # pyright: ignore[reportInvalidTypeForm]
             if evaluator_schema_types:  # pragma: no branch
-                evaluators: list[Union[tuple(evaluator_schema_types)]] = []  # pyright: ignore  # noqa: UP007
+                evaluators: list[Union[tuple(evaluator_schema_types)]] = []  # pyright: ignore[reportInvalidTypeArguments, reportInvalidTypeForm, reportUnknownVariableType]  # noqa: UP007
 
         class Dataset(BaseModel, extra='forbid'):
             name: str | None = None
             cases: list[Case]
             if evaluator_schema_types:  # pragma: no branch
-                evaluators: list[Union[tuple(evaluator_schema_types)]] = []  # pyright: ignore  # noqa: UP007
+                evaluators: list[Union[tuple(evaluator_schema_types)]] = []  # pyright: ignore[reportInvalidTypeArguments, reportInvalidTypeForm, reportUnknownVariableType]  # noqa: UP007
             if report_evaluator_schema_types:  # pragma: no branch
-                report_evaluators: list[Union[tuple(report_evaluator_schema_types)]] = []  # pyright: ignore  # noqa: UP007
+                report_evaluators: list[Union[tuple(report_evaluator_schema_types)]] = []  # pyright: ignore[reportInvalidTypeArguments, reportInvalidTypeForm, reportUnknownVariableType]  # noqa: UP007
 
         json_schema = Dataset.model_json_schema()
         # See `_add_json_schema` below, since `$schema` is added to the JSON, it has to be supported in the JSON
@@ -1297,7 +1297,7 @@ def _get_span_duration(span: logfire_api.LogfireSpan, fallback: float) -> float:
         The duration of the span in seconds.
     """
     try:
-        return (span.end_time - span.start_time) / 1_000_000_000  # type: ignore
+        return (span.end_time - span.start_time) / 1_000_000_000  # pyright: ignore[reportOperatorIssue, reportUnknownVariableType]
     except (AttributeError, TypeError):  # pragma: lax no cover
         return fallback
 

--- a/pydantic_evals/pydantic_evals/otel/_context_in_memory_span_exporter.py
+++ b/pydantic_evals/pydantic_evals/otel/_context_in_memory_span_exporter.py
@@ -14,7 +14,7 @@ from opentelemetry.trace import ProxyTracerProvider, get_tracer_provider
 
 try:
     from logfire._internal.tracer import (
-        ProxyTracerProvider as LogfireProxyTracerProvider,  # pyright: ignore
+        ProxyTracerProvider as LogfireProxyTracerProvider,  # pyright: ignore[reportAssignmentType]
     )
 
     _LOGFIRE_IS_INSTALLED = True
@@ -165,5 +165,5 @@ def _add_context_span_exporter() -> _ContextInMemorySpanExporter | SpanTreeRecor
     exporter = _ContextInMemorySpanExporter()
     _context_in_memory_providers[cache_id] = exporter
     processor = SimpleSpanProcessor(exporter)
-    tracer_provider.add_span_processor(processor)  # type: ignore
+    tracer_provider.add_span_processor(processor)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
     return exporter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ extend-select = [
     "D",
     "TID251",
     "PLW1514", # https://docs.astral.sh/ruff/rules/unspecified-encoding/
+    "PGH003", # https://docs.astral.sh/ruff/rules/blanket-type-ignore/
 ]
 flake8-quotes = { inline-quotes = "single", multiline-quotes = "double" }
 mccabe = { max-complexity = 15 }


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

David directed this work and reviewed the approach; the individual diffs have had a light review.

Follow-up to #6646, which cleaned up bare type-ignore comments by hand. This adds the lint rule so they can't come back, and resolves the remaining occurrences.

## Why

`# type: ignore` and `# pyright: ignore` without a rule code suppress *every* diagnostic on that line, so an unrelated error introduced later is silently swallowed. Ruff's [`PGH003`](https://docs.astral.sh/ruff/rules/blanket-type-ignore/) catches exactly that, and the pre-commit ruff hook already runs on every commit, so enabling it costs nothing new.

Most sites become `# pyright: ignore[<code>]`. That form matters: Pyright does **not** parse rule codes inside `# type: ignore[<code>]`, so the code there is decorative and the suppression stays blanket. With `# pyright: ignore[<code>]` the code is validated, and `reportUnnecessaryTypeIgnoreComment` (already enabled in `pyproject.toml`) flags it once the underlying typing improves. `tests/typed_agent.py` keeps mypy-style codes, since it is the only file `[tool.mypy] files` covers.

## Example agents fixed at the source

Three example agents passing a union `output_type` are fixed rather than suppressed, so they now type-check with **no ignore at all**:

- **`flight_booking`** — `search_agent` is declared `Agent[Deps, ...]` and its tools take `RunContext[Deps]`, but it never passed `deps_type=Deps`.
- **`sql_gen`** — pass the union members directly; a type alias isn't yet accepted as a `TypeForm` value ([PEP-747](https://peps.python.org/pep-0747/)).
- **`evals/agent`** — the same alias fix, plus two stale v2 leftovers: `instrument=` was removed from `Agent.__init__` (it's now a property), and the model id lacked the `openai:` prefix its sibling examples (`example_01`, `example_04`) use. Run as-is, the example raised `TypeError: Agent.__init__() got an unexpected keyword argument 'instrument'` and then `UserError: Unknown model: gpt-5.2`.

That last one is worth calling out: `examples/pydantic_ai_examples/evals/agent.py` has no test or doc coverage anywhere in the repo — `tests/import_examples.py` globs only the top level, so it never reaches the `evals/` subpackage. The breakage was surfaced by this lint pass, not by CI. Widening that glob is left out of scope here.

## Test plan

- [x] `make lint` / `make format` (full pre-commit suite, including whole-repo Pyright)
- [x] `uv run mypy`
- [x] `tests/test_examples.py -k "output or flight or sql"`
- [x] `tests/evals/`
- [x] `tests/import_examples.py` (the script CI runs) — imports all example modules cleanly
- [x] Direct import of `pydantic_ai_examples.evals.agent` + the `example_0*` modules that depend on it
- [ ] CI green

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

