### PR TITLE
docs(agents): push-and-watch rule for agent contributors

### DIFF
--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: pushing-commits-to-the-repo
+description: What to do after you push — watch CI to green, triage every review comment to a reply
+  and a reaction, and escalate genuine design trade-offs to maintainers. Use whenever you push a
+  commit to a PR.
+---
+
+# pushing-commits-to-the-repo
+
+Pushing starts a loop; it does not end the task. **Work stops only when CI is green AND no comment
+is left unresolved.**
+
+## Before you push
+- Attempt the push. If it fails, read the real error — do not preemptively decide you lack
+  permission from a flag or setting.
+- Leave nothing unstaged or uncommitted locally, unless the user's instructions override this.
+
+## After you push — the loop
+1. **Watch CI to a terminal state.** Don't idle. If it fails, diagnose: fix if the failure is
+   yours; if it's a known flake or pre-existing on main, say so with evidence.
+2. **Triage every comment** (bots and humans alike). For each one:
+   - **Valid** → fix it, then reply saying what changed, and react 👍.
+   - **Invalid** → reply explaining concretely why (with code evidence), and react 👎.
+   - Never silently ignore a comment, and never resolve a thread without a reply.
+3. **Escalate real trade-offs, don't guess.** If a comment needs a maintainer decision (a design
+   choice, an API trade-off, a behavioral default), leave a comment containing: the background,
+   your reasoning, the decision that needs making, the trade-offs (pros/cons of each option), and
+   your recommendation. Then **poll every 30 minutes for a reply** and continue when it lands.
+4. Repeat until CI is green and no comment is outstanding.

--- a/.claude/skills/pushing-commits-to-the-repo
+++ b/.claude/skills/pushing-commits-to-the-repo
@@ -1,0 +1,1 @@
+../../.agents/skills/pushing-commits-to-the-repo

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ AGENTS.override.md
 !.agents/skills/i-have-adhd/SKILL.md
 !.agents/skills/poweruser-feature-audit/
 !.agents/skills/poweruser-feature-audit/SKILL.md
+!.agents/skills/pushing-commits-to-the-repo/
+!.agents/skills/pushing-commits-to-the-repo/SKILL.md
 .claude/*
 !.claude/plans/
 !.claude/skills/
@@ -47,6 +49,7 @@ AGENTS.override.md
 !.claude/skills/testing-skill
 !.claude/skills/i-have-adhd
 !.claude/skills/poweruser-feature-audit
+!.claude/skills/pushing-commits-to-the-repo
 .github/.review-context/
 /.cursor/
 /.devcontainer/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,21 @@ PR titles feed directly into the release changelog — wrap code identifiers (cl
 
 Never add yourself (Claude) as a co-author on commits. Commits should be authored as the user only, with no `Co-Authored-By` trailer referencing Claude.
 
+## Pushing changes
+
+**A restriction is a conclusion you earn from a real failure, not a field you read.** Never report an
+operation as blocked, unavailable, or not-permitted based on a metadata flag, a config field, or a
+docs claim — attempt it and quote the actual error. (`maintainerCanModify: false` on a PR does *not*
+mean you cannot push: it governs the upstream-maintainer auto-grant, not your own access to the
+fork.) If you genuinely cannot attempt it, say "not attempted", never "we can't".
+
+**Pushing is not the end of the task.** After you push, do not go idle. The work is done when
+**CI is green and there are no unresolved comments** — see the `pushing-commits-to-the-repo` skill
+for the full loop.
+
+**Do not leave work uncommitted.** Don't end a turn with unstaged or uncommitted local changes
+unless the user's own instructions say otherwise.
+
 ## Repository structure
 
 The repo contains a `uv` workspace defining multiple Python packages:


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David. David reviewed and signed off on the exact instruction wording; the placement and `.gitignore` plumbing were not reviewed by him.

Two additions, both instruction text for agents working in this repo:

1. **`AGENTS.md` → `## Pushing changes`** — three invariants: a restriction is earned from a real failure, not read off a metadata field; pushing starts the work rather than ending it; don't end a turn with uncommitted changes.
2. **`.agents/skills/pushing-commits-to-the-repo/SKILL.md`** (+ the usual `.claude/skills/` symlink) — the actual post-push loop: watch CI to a terminal state, triage every comment to a reply and a reaction, escalate genuine design trade-offs to maintainers, repeat until green and clear.

**Why.** Two recurring agent failures: reporting an operation as blocked based on a metadata flag without ever attempting it (`maintainerCanModify: false` reads as "cannot push", when it only governs the upstream-maintainer auto-grant), and going idle right after a push instead of driving CI to green and answering review comments.

**Why split.** `AGENTS.md` is autoloaded by every agent on every task, so it carries only the short invariants. The multi-step polling procedure is a workflow, so it lives in a skill the agent invokes when it's actually pushing — keeping it out of what every task loads.

Twin PR with the same two additions on the harness repo: pydantic/pydantic-ai-harness#452.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

