### PR TITLE
ci(bots): restore fork-PR auto-review broken by actions/checkout v7

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -228,7 +228,7 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -392,3 +392,15 @@ jobs:
         run: gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/auto-review" --method DELETE 2>/dev/null || true
         env:
           GH_TOKEN: ${{ github.token }}
+
+      # Without this, a review that crashed and a review that found nothing look
+      # identical from the PR: the label is gone either way and no comment lands.
+      # A silent breakage went unnoticed for three weeks that way.
+      - name: Report review failure
+        if: failure()
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body \
+            "The \`auto-review\` run ended without posting a review — see [the run](${RUN_URL}) for why. Nothing here is a verdict on this PR. If the cause was transient, re-apply the \`auto-review\` label to retry."
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -234,6 +234,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
+          # Reviewing a fork PR means reading the fork's code, so this job checks
+          # it out. v7 refuses that by default from `pull_request_target`; the
+          # pwn-request risk it guards is already covered here — no credentials
+          # persist, the reviewer only reads (never executes) the fork's code,
+          # and the guard below rejects any PR that edits the agent config this
+          # job loads. See https://gh.io/securely-using-pull_request_target.
+          allow-unsafe-pr-checkout: true
 
       - name: Check for modified config files
         # Runs for ALL PRs, not just forks: a same-repo branch (e.g. an automated


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David, who reviewed it lightly.

## What broke

The `auto-review` label reviewer (the `review` job in `bots.yml`) has posted **nothing on any fork PR since 2026-07-02**. #6196 bumped `actions/checkout` v6 → **v7.0.0**, and v7 hard-refuses to check out fork code from a `pull_request_target` workflow unless `allow-unsafe-pr-checkout: true` is set. The job dies at step 1 (checkout) on every fork PR: **17 of 17** label requests since the bump produced zero comments. Same-repo PRs were unaffected.

It stayed invisible for three weeks because `Remove auto-review label` runs `if: always()` — a crashed run and a run that found nothing look identical from the PR: the label is gone either way and no comment lands.

(Full data audit available on request — request rate, execution rate, and output rate bucketed across the window, with per-workflow comment attribution.)

## This PR

1. **`allow-unsafe-pr-checkout: true`** on the review checkout. The pwn-request risk that gate guards is already mitigated here: the checkout persists no credentials, the reviewer only *reads* the fork's code (never executes it), and the `Check for modified config files` guard rejects any PR that edits the agent config this job loads into its prompt.
2. **Fix the stale pin comment** — the SHA is `v7.0.0`; the comment still said `# v6`.
3. **Report review failures.** A new `if: failure()` step posts a comment when the job fails, so the next silent breakage announces itself instead of going unnoticed for weeks.

## Deliberately not in this PR

- **Excluding `bots.yml` from unattended Dependabot action bumps** — that's the systemic cause (a security-relevant workflow was upgraded across a breaking major with no canary), but it's a `.github/dependabot.yml` policy change with its own trade-offs; better as its own PR/discussion than bundled with the hotfix.
- **The `#6680` config-guard interaction** — commit `61d751ec` made `Check for modified config files` unconditional, so any same-repo PR editing agent config now fails auto-review by design. That's intended behavior, not a regression; noted here so it isn't mistaken for one.

CI note: this PR doesn't change any Python; the `agent` (gh-aw PR Review) check is failing env-wide today across unrelated branches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

