### PR TITLE
Clarify `BedrockMantleProvider` interface contracts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -245,7 +245,9 @@ class OpenAIModelProfile(ModelProfile, total=False):
     """Whether Responses API tool call IDs are only unique within one response. Default: `False`.
 
     When enabled, response IDs are incorporated into tool call IDs as responses are ingested so
-    normalized message history keeps the history-wide uniqueness required by Pydantic AI.
+    normalized message history keeps the history-wide uniqueness required by Pydantic AI. The qualified
+    `response_id:tool_call_id` form is replayed unchanged, so the Responses endpoint must accept
+    colon-containing tool call IDs in follow-up requests.
     """
 
     openai_supports_phase: bool

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -4,6 +4,7 @@ import os
 from typing import Literal, overload
 
 import httpx
+from typing_extensions import assert_never
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
@@ -66,10 +67,11 @@ def bedrock_mantle_model_profile(model_name: str) -> ModelProfile:
             # the base profile is resolved from (per the AWS model cards). Without this override the
             # image-output guard is bypassed and the request fails with an opaque provider error.
             supports_image_output=False,
-            # Bedrock Mantle proxies the OpenAI models but not OpenAI's server-hosted tools (web search,
-            # code interpreter, file search, image generation, ...); the AWS Mantle docs document only
-            # custom function calling, so the base profile's native tools are disabled to fail with a
-            # clean UserError rather than an opaque provider error.
+            # AWS's server-side tool integrations use Lambda or MCP rather than the OpenAI-native tools
+            # represented by Pydantic AI (web search, code interpreter, file search, image generation, ...):
+            # https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-server-side.html
+            # Disable the base profile's native tools to fail with a clean UserError rather than an opaque
+            # provider error.
             supported_native_tools=frozenset(),
         ),
     )
@@ -114,7 +116,12 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
         (GPT-OSS) are served at `/v1`. Both clients are built eagerly in `__init__` and share transport
         and auth, so this is a pure lookup.
         """
-        return self._client if interface == 'openai-responses' else self._v1_client
+        if interface == 'openai-responses':
+            return self._client
+        elif interface in ('chat', 'responses'):
+            return self._v1_client
+        else:
+            assert_never(interface)
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI) -> None: ...

--- a/tests/models/test_bedrock_mantle.py
+++ b/tests/models/test_bedrock_mantle.py
@@ -296,8 +296,9 @@ async def test_image_output_unsupported(allow_model_requests: None) -> None:
 
 
 async def test_native_tool_unsupported(allow_model_requests: None) -> None:
-    """Mantle proxies the OpenAI models but not OpenAI's server-hosted tools, so a native tool fails with a
-    clean `UserError` before any request. No cassette: the profile guard raises during request preparation.
+    """Mantle's Lambda/MCP server-side tools differ from Pydantic AI's OpenAI-native tools, so a native
+    tool fails with a clean `UserError` before any request. No cassette: the profile guard raises during
+    request preparation.
     """
     model = infer_model('bedrock-mantle:openai.gpt-5.6-luna', lambda _: _provider())
     agent = Agent(model, capabilities=[NativeTool(WebSearchTool())])

--- a/tests/models/test_bedrock_mantle.py
+++ b/tests/models/test_bedrock_mantle.py
@@ -38,6 +38,7 @@ def _provider() -> BedrockMantleProvider:
 
 
 @pytest.mark.parametrize('stream', [False, True], ids=['request', 'stream'])
+@pytest.mark.moves_cache_prefix(reason='replay uses a fresh agent without the original instructions and tools')
 async def test_reused_tool_call_ids(stream: bool, allow_model_requests: None) -> None:
     """Mantle GPT-5.6 resets Responses tool-call IDs per response; pydantic-ai must re-qualify them."""
     model = infer_model('bedrock-mantle:openai.gpt-5.6-luna', lambda _: _provider())
@@ -203,6 +204,7 @@ Second tool result: `second result`\
         assert replay_result.output == 'OK'
 
 
+@pytest.mark.moves_cache_prefix(reason='replay uses a fresh agent without the original instructions and tools')
 async def test_reused_tool_call_ids_gpt_5_5(allow_model_requests: None) -> None:
     """The Responses ID reset is a property of the `/openai/v1` endpoint, not just gpt-5.6.
 


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Follow-up to #6538 and its [late automated review](https://github.com/pydantic/pydantic-ai/pull/6538#issuecomment-5073383726).

### Summary

- Document that response-qualified tool-call IDs are replayed unchanged.
- Make `BedrockMantleProvider._client_for_interface` exhaustive.
- Clarify that AWS Lambda/MCP server-side tools differ from Pydantic AI's OpenAI-native tools.

### Validation

- Targeted Bedrock Mantle tests: passed.
- Targeted Pyright: passed.
- Formatting and lint: passed.
- Full pre-commit suite, including whole-repo Pyright and cassette validation: passed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

