### PR TITLE
fix(bedrock): apply strict-forcing when native output is reached via profile default

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -565,6 +565,14 @@ class BedrockConverseModel(Model[BaseClient]):
                 raise UserError(
                     f'Bedrock does not support thinking and output tools at the same time. Use `output_type={suggested_output_type}(...)` instead.'
                 )
+        # Resolve 'auto' to the profile default here (a no-op if already resolved above) so the
+        # strict-forcing check below also applies when native mode is reached via the profile default
+        # rather than an explicit `NativeOutput(...)`; `super().prepare_request()` would otherwise only
+        # resolve it after `customize_request_parameters()` has already transformed the schema.
+        model_request_parameters = model_request_parameters.with_default_output_mode(
+            self.profile.get('default_structured_output_mode', 'tool')
+        )
+
         if (
             self.profile.get('supports_json_schema_output', False)
             and model_request_parameters.output_mode == 'native'

--- a/tests/models/bedrock/test_native_output.py
+++ b/tests/models/bedrock/test_native_output.py
@@ -96,6 +96,63 @@ def test_bedrock_native_output_unsupported_model_raises(
         agent.run_sync('Tell me about Berlin')
 
 
+def test_bedrock_native_output_profile_default_transforms_schema(bedrock_provider: BedrockProvider):
+    """profile default_structured_output_mode='native' (no explicit `NativeOutput`) → schema is still transformed.
+
+    Regression test for #6523 (the Bedrock counterpart of #6471/#6521 for Anthropic):
+    `BedrockConverseModel.prepare_request` force-set `strict=True` for native structured output based on
+    `model_request_parameters.output_mode == 'native'`, checked *before* the base `Model.prepare_request()`
+    resolved `output_mode='auto'` to the profile's `default_structured_output_mode`. That meant
+    `profile={'default_structured_output_mode': 'native'}` (reaching native mode via the profile default
+    rather than an explicit `NativeOutput(...)`) skipped the strict-forcing, so the transformer ran with
+    `strict=None`/`False` and left Bedrock-incompatible constraints (`minimum`, `maximum`, `minLength`, etc.)
+    untransformed in the outgoing schema.
+
+    A direct `prepare_request` unit test, not a full agent run, because the bug is entirely in parameter
+    resolution ordering and doesn't require a live/VCR request to reproduce or verify.
+    """
+    model = BedrockConverseModel(
+        'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        provider=bedrock_provider,
+        profile={'default_structured_output_mode': 'native'},
+    )
+
+    params = ModelRequestParameters(
+        output_mode='auto',
+        output_object=OutputObjectDefinition(
+            json_schema={
+                'type': 'object',
+                'properties': {
+                    'confidence': {'type': 'number', 'minimum': 0.0, 'maximum': 1.0},
+                    'title': {'type': 'string', 'minLength': 1},
+                },
+                'required': ['confidence', 'title'],
+            },
+            name='Decision',
+        ),
+    )
+
+    _, result_params = model.prepare_request(None, params)
+
+    assert result_params.output_mode == 'native'
+    assert result_params.output_object is not None
+    assert result_params.output_object.strict is True
+
+    output_config = BedrockConverseModel._native_output_format(result_params)  # pyright: ignore[reportPrivateUsage]
+    assert output_config is not None
+    text_format = output_config.get('textFormat')
+    assert text_format is not None
+    structure = text_format.get('structure')
+    assert structure is not None
+    json_schema_field = structure.get('jsonSchema')
+    assert json_schema_field is not None
+    schema = json_schema_field.get('schema')
+    assert schema is not None
+    # The raw numeric-bound keywords must not survive untransformed into the outgoing schema.
+    assert '"minimum"' not in schema
+    assert '"maximum"' not in schema
+
+
 async def test_bedrock_native_output_qwen(
     allow_model_requests: None,
     bedrock_provider: BedrockProvider,


### PR DESCRIPTION
Fixes #6523.

## Problem

`BedrockConverseModel.prepare_request` force-sets `strict=True` for native structured output based on `model_request_parameters.output_mode == 'native'`, checked *before* the base `Model.prepare_request()` resolves `output_mode='auto'` to the profile's `default_structured_output_mode`. That means `profile={'default_structured_output_mode': 'native'}` (reaching native mode via the profile default rather than an explicit `NativeOutput(...)`) skips the strict-forcing, so the schema transformer runs with `strict=None`/`False` and leaves Bedrock-incompatible constraints (`minimum`, `maximum`, etc.) untransformed in the outgoing schema — causing a 400.

This is the Bedrock counterpart of #6471/#6521, which fixed the identical ordering defect in `AnthropicModel` (the code here already says "Mirrors Anthropic's behavior").

## Fix

Resolve `'auto'` to the profile default before the strict-forcing check runs, mirroring the fix already applied and merged for Anthropic in #6521.

## Testing

Added `test_bedrock_native_output_profile_default_transforms_schema` — a direct `prepare_request` unit test (no live/VCR request needed, since the bug is entirely in parameter resolution ordering). Verified it fails against the pre-fix code (`strict=False`, `minimum`/`maximum` survive untransformed) and passes against the fix.

- `ruff check` / `ruff format --check`: clean
- `pyright`: 0 errors
- Full `tests/models/bedrock/` + `tests/models/test_bedrock.py` suite: 188 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

