### PR TITLE
fix(_parts_manager): fix part lookup and update in `apply_event` for replayed stream deltas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -535,5 +535,16 @@ class ModelResponsePartsManager:
         if isinstance(event, PartStartEvent):
             self.handle_part(vendor_part_id=event.index, part=event.part)
         elif isinstance(event, PartDeltaEvent):
-            part = self.get_parts()[event.index]
-            self.handle_part(vendor_part_id=event.index, part=event.delta.apply(part))
+            existing_part = self._parts[event.index]
+            delta = event.delta
+            if isinstance(delta, TextPartDelta) and isinstance(existing_part, TextPart):
+                self._parts[event.index] = delta.apply(existing_part)
+            elif isinstance(delta, ThinkingPartDelta) and isinstance(existing_part, ThinkingPart):
+                self._parts[event.index] = delta.apply(existing_part)
+            elif isinstance(delta, ToolCallPartDelta) and isinstance(
+                existing_part, ToolCallPartDelta | ToolCallPart | NativeToolCallPart
+            ):
+                updated_part = delta.apply(existing_part)
+                if isinstance(updated_part, ToolCallPart):
+                    updated_part = self._typed_call_part(updated_part)
+                self._parts[event.index] = updated_part

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -708,3 +708,26 @@ def test_get_part_by_vendor_id():
     assert part == snapshot(TextPart(content='hello', part_kind='text'))
 
     assert manager.get_part_by_vendor_id('missing') is None
+
+
+def test_apply_event_with_tool_call_delta_and_dovetailed_parts():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+
+    # Create an incomplete ToolCallPartDelta at index 0 (not in get_parts())
+    manager.handle_tool_call_delta(vendor_part_id='tool_0', args='{"arg":')
+
+    # Create TextPart at index 1
+    event_text_start = next(manager.handle_text_delta(vendor_part_id='text_1', content='hello '))
+    assert event_text_start.index == 1
+
+    # Update TextPart at index 1
+    event_text_delta = next(manager.handle_text_delta(vendor_part_id='text_1', content='world'))
+    assert event_text_delta.index == 1
+
+    # Replay on a new manager
+    replay_manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    replay_manager.handle_tool_call_delta(vendor_part_id='tool_0', args='{"arg":')
+    replay_manager.apply_event(event_text_start)
+    replay_manager.apply_event(event_text_delta)
+
+    assert replay_manager.get_parts() == snapshot([TextPart(content='hello world', part_kind='text')])


### PR DESCRIPTION
Fixes #6731

### Summary

Fixes an indexing defect in `ModelResponsePartsManager.apply_event` when replaying stream events.

### Problem & Root Cause

When `apply_event` received a `PartDeltaEvent`, it previously looked up the target part using `self.get_parts()[event.index]`.

However, `event.index` on stream events (`PartStartEvent`, `PartDeltaEvent`) represents the index of the part in `self._parts` (which includes incomplete `ToolCallPartDelta` items). `self.get_parts()` returns a filtered list containing only completed `ModelResponsePart` objects.

When `self._parts` contains any `ToolCallPartDelta` (or when `event.index` is greater than or equal to `len(get_parts())`), `apply_event`:
1. Raised an `IndexError: list index out of range` if `event.index >= len(get_parts())`.
2. Updated the wrong part if `get_parts()` had fewer elements than `_parts` due to preceding `ToolCallPartDelta` items.

### Solution

In `ModelResponsePartsManager.apply_event`:
1. Retrieve the existing part directly from `self._parts[event.index]`.
2. Narrow delta and part types to apply the delta accurately and preserve typed promotion for `ToolCallPart` instances.
3. Update `self._parts[event.index]` directly.

### Regression Coverage

Added `test_apply_event_with_tool_call_delta_and_dovetailed_parts` in `tests/test_parts_manager.py` to verify that stream replay succeeds when `_parts` contains `ToolCallPartDelta` instances and multiple dovetailed parts.

### Validation

- `uv run pytest tests/test_parts_manager.py` (35 passed)
- `uv run pytest tests/test_streaming.py` (177 passed, 3 xfailed as expected)
- `uv run pytest tests/test_messages.py` (171 passed)
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_parts_manager.py tests/test_parts_manager.py` (All checks passed)
- `uv run pyright pydantic_ai_slim/pydantic_ai/_parts_manager.py` (0 errors, 0 warnings)
- `git diff --check` (clean)