### PR TITLE
Add `headers` and `retry_after` to `ModelHTTPError`, populate from all provider SDKs

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -192,6 +192,45 @@ attributes showing the queue depth and configured limits. The `name` parameter o
 
 <!-- TODO(Marcelo): We need to create a section in the docs about reliability. -->
 
+## Handling HTTP Errors
+
+When a provider returns a 4xx or 5xx response, Pydantic AI raises a
+[`ModelHTTPError`][pydantic_ai.exceptions.ModelHTTPError].  In addition to the
+[`status_code`][pydantic_ai.exceptions.ModelHTTPError.status_code] and
+[`body`][pydantic_ai.exceptions.ModelHTTPError.body], the exception now exposes the
+provider's **response headers** via the
+[`headers`][pydantic_ai.exceptions.ModelHTTPError.headers] attribute (a
+`dict[str, str]` with lowercase keys, or `None` for providers that don't surface headers,
+such as gRPC-based providers).
+
+The motivating use case is propagating the `Retry-After` header from a 429 response to a
+caller's own HTTP client.  A convenience property
+[`retry_after`][pydantic_ai.exceptions.ModelHTTPError.retry_after] parses that header and
+returns the number of seconds to wait as a `float`, handling both the integer
+delta-seconds and HTTP-date formats:
+
+```python {title="handle_rate_limit.py" test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelHTTPError
+
+agent = Agent('openai:gpt-4o')
+
+try:
+    result = agent.run_sync('What is the capital of France?')
+except ModelHTTPError as exc:
+    if exc.status_code == 429:
+        wait = exc.retry_after  # float | None
+        raise MyRateLimitException(
+            'AI service is rate-limited. Try again shortly.',
+            retry_after=wait,
+        )
+    raise
+```
+
+!!! note
+    `headers` is `None` for errors synthesised from a non-HTTP source (e.g. xAI's
+    gRPC transport, or OpenRouter errors parsed from a 200-OK response body).
+
 ## Fallback Model
 
 You can use [`FallbackModel`][pydantic_ai.models.fallback.FallbackModel] to attempt multiple models

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -209,7 +209,7 @@ caller's own HTTP client.  A convenience property
 returns the number of seconds to wait as a `float`, handling both the integer
 delta-seconds and HTTP-date formats:
 
-```python {title="handle_rate_limit.py" test="skip"}
+```python {title="handle_rate_limit.py" test="skip" lint="skip"}
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelHTTPError
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
@@ -658,9 +658,15 @@ class BedrockEmbeddingModel(EmbeddingModel):
                 )
             )
         except ClientError as e:
-            status_code = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
+            metadata = e.response.get('ResponseMetadata', {})
+            status_code = metadata.get('HTTPStatusCode')
             if isinstance(status_code, int):
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.response) from e
+                raise ModelHTTPError(
+                    status_code=status_code,
+                    model_name=self.model_name,
+                    body=e.response,
+                    headers=metadata.get('HTTPHeaders'),
+                ) from e
             raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
 
         # Extract input token count from HTTP headers

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -188,7 +188,9 @@ class CohereEmbeddingModel(EmbeddingModel):
             )
         except ApiError as e:
             if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+                raise ModelHTTPError(
+                    status_code=status_code, model_name=self.model_name, body=e.body, headers=e.headers
+                ) from e
             raise ModelAPIError(model_name=self.model_name, message=str(e)) from e  # pragma: no cover
 
         embeddings = response.embeddings.float_
@@ -222,7 +224,9 @@ class CohereEmbeddingModel(EmbeddingModel):
             )
         except ApiError as e:  # pragma: no cover
             if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+                raise ModelHTTPError(
+                    status_code=status_code, model_name=self.model_name, body=e.body, headers=e.headers
+                ) from e
             raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
 
         return len(result.tokens)

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -274,6 +274,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
                     status_code=status_code,
                     model_name=self._model_name,
                     body=cast(object, e.details),  # pyright: ignore[reportUnknownMemberType]
+                    headers=dict(e.response.headers) if e.response is not None else None,
                 ) from e
             raise  # pragma: no cover
 
@@ -303,6 +304,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
                     status_code=status_code,
                     model_name=self._model_name,
                     body=cast(object, e.details),  # pyright: ignore[reportUnknownMemberType]
+                    headers=dict(e.response.headers) if e.response is not None else None,
                 ) from e
             raise  # pragma: no cover
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -276,7 +276,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
                     body=cast(object, e.details),  # pyright: ignore[reportUnknownMemberType]
                     headers=dict(e.response.headers) if e.response is not None else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
                 ) from e
-            raise  # pragma: no cover
+            raise
 
         embeddings: list[list[float]] = [emb.values for emb in (response.embeddings or []) if emb.values is not None]
 
@@ -306,7 +306,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
                     body=cast(object, e.details),  # pyright: ignore[reportUnknownMemberType]
                     headers=dict(e.response.headers) if e.response is not None else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
                 ) from e
-            raise  # pragma: no cover
+            raise
 
         if response.total_tokens is None:
             raise UnexpectedModelBehavior('Token counting returned no result')  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -274,7 +274,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
                     status_code=status_code,
                     model_name=self._model_name,
                     body=cast(object, e.details),  # pyright: ignore[reportUnknownMemberType]
-                    headers=dict(e.response.headers) if e.response is not None else None,
+                    headers=dict(e.response.headers) if e.response is not None else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
                 ) from e
             raise  # pragma: no cover
 
@@ -304,7 +304,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
                     status_code=status_code,
                     model_name=self._model_name,
                     body=cast(object, e.details),  # pyright: ignore[reportUnknownMemberType]
-                    headers=dict(e.response.headers) if e.response is not None else None,
+                    headers=dict(e.response.headers) if e.response is not None else None,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
                 ) from e
             raise  # pragma: no cover
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -134,7 +134,9 @@ class OpenAIEmbeddingModel(EmbeddingModel):
             )
         except APIStatusError as e:
             if (status_code := e.status_code) >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+                raise ModelHTTPError(
+                    status_code=status_code, model_name=self.model_name, body=e.body, headers=dict(e.response.headers)
+                ) from e
             raise  # pragma: lax no cover
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -366,11 +366,11 @@ class ModelHTTPError(ModelAPIError):
 
     @property
     def retry_after(self) -> float | None:
-        """Seconds to wait before retrying, parsed from the ``Retry-After`` response header.
+        """Seconds to wait before retrying, parsed from the `Retry-After` response header.
 
-        Returns ``None`` when the header is absent or cannot be parsed.  The header value
+        Returns `None` when the header is absent or cannot be parsed. The header value
         is interpreted first as an integer number of seconds, then as an
-        `HTTP-date <https://httpwg.org/specs/rfc9110.html#http.date>`_ string.
+        [HTTP-date](https://httpwg.org/specs/rfc9110.html#http.date) string.
         """
         if self.headers is None:
             return None

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -378,8 +378,11 @@ class ModelHTTPError(ModelAPIError):
         if raw is None:
             return None
         try:
-            return float(int(raw))
-        except ValueError:
+            seconds = int(raw)
+            if seconds < 0:
+                return None
+            return float(seconds)
+        except (ValueError, OverflowError):
             pass
         try:
             retry_time = parsedate_to_datetime(raw)

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -387,6 +387,9 @@ class ModelHTTPError(ModelAPIError):
         try:
             retry_time = parsedate_to_datetime(raw)
             assert isinstance(retry_time, datetime)
+            # asctime-date format (RFC 9110 §5.6.7) carries no timezone; treat as UTC.
+            if retry_time.tzinfo is None:
+                retry_time = retry_time.replace(tzinfo=timezone.utc)
             wait = (retry_time - datetime.now(timezone.utc)).total_seconds()
             return max(0.0, wait)
         except (ValueError, TypeError, AssertionError):

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -358,10 +358,10 @@ class ModelHTTPError(ModelAPIError):
         message = f'status_code: {status_code}, model_name: {model_name}, body: {body}'
         super().__init__(model_name=model_name, message=message)
 
-    def __reduce__(self) -> tuple[type, tuple[Any, ...], dict[str, Any]]:
+    def __reduce__(self) -> tuple[type, tuple[Any, ...], dict[str, Any]]:  # pyright: ignore[reportIncompatibleMethodOverride]
         return self.__class__, (self.status_code, self.model_name, self.body), {'headers': self.headers}
 
-    def __setstate__(self, state: dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
         self.headers = state.get('headers')
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -2,6 +2,9 @@ from __future__ import annotations as _annotations
 
 import json
 import sys
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, Any
 
 import pydantic_core
@@ -333,14 +336,58 @@ class ModelHTTPError(ModelAPIError):
     body: object | None
     """The body of the response, if available."""
 
-    def __init__(self, status_code: int, model_name: str, body: object | None = None):
+    headers: dict[str, str] | None
+    """Response headers from the provider, with keys lowercased for consistent access.
+
+    For example, use `exc.headers.get('retry-after')` to read the `Retry-After` header
+    regardless of provider casing.  `None` when the provider does not supply headers
+    (e.g. gRPC-based providers or synthesised errors).
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        model_name: str,
+        body: object | None = None,
+        *,
+        headers: Mapping[str, str] | None = None,
+    ):
         self.status_code = status_code
         self.body = body
+        self.headers = {k.lower(): v for k, v in headers.items()} if headers is not None else None
         message = f'status_code: {status_code}, model_name: {model_name}, body: {body}'
         super().__init__(model_name=model_name, message=message)
 
-    def __reduce__(self) -> tuple[type, tuple[Any, ...]]:
-        return self.__class__, (self.status_code, self.model_name, self.body)
+    def __reduce__(self) -> tuple[type, tuple[Any, ...], dict[str, Any]]:
+        return self.__class__, (self.status_code, self.model_name, self.body), {'headers': self.headers}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.headers = state.get('headers')
+
+    @property
+    def retry_after(self) -> float | None:
+        """Seconds to wait before retrying, parsed from the ``Retry-After`` response header.
+
+        Returns ``None`` when the header is absent or cannot be parsed.  The header value
+        is interpreted first as an integer number of seconds, then as an
+        `HTTP-date <https://httpwg.org/specs/rfc9110.html#http.date>`_ string.
+        """
+        if self.headers is None:
+            return None
+        raw = self.headers.get('retry-after')
+        if raw is None:
+            return None
+        try:
+            return float(int(raw))
+        except ValueError:
+            pass
+        try:
+            retry_time = parsedate_to_datetime(raw)
+            assert isinstance(retry_time, datetime)
+            wait = (retry_time - datetime.now(timezone.utc)).total_seconds()
+            return max(0.0, wait)
+        except (ValueError, TypeError, AssertionError):
+            return None
 
 
 class FallbackExceptionGroup(ExceptionGroup[Any]):

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -280,7 +280,9 @@ def _map_api_errors(model_name: str) -> Generator[None]:
         yield
     except APIStatusError as e:
         if (status_code := e.status_code) >= 400:
-            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body) from e
+            raise ModelHTTPError(
+                status_code=status_code, model_name=model_name, body=e.body, headers=dict(e.response.headers)
+            ) from e
         raise ModelAPIError(model_name=model_name, message=e.message) from e  # pragma: lax no cover
     except APIConnectionError as e:
         raise ModelAPIError(model_name=model_name, message=e.message) from e

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -120,9 +120,15 @@ def _map_api_errors(model_name: str) -> Generator[None]:
     try:
         yield
     except ClientError as e:
-        status_code = e.response.get('ResponseMetadata', {}).get('HTTPStatusCode')
+        metadata = e.response.get('ResponseMetadata', {})
+        status_code = metadata.get('HTTPStatusCode')
         if isinstance(status_code, int):
-            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.response) from e
+            raise ModelHTTPError(
+                status_code=status_code,
+                model_name=model_name,
+                body=e.response,
+                headers=metadata.get('HTTPHeaders'),
+            ) from e
         raise ModelAPIError(model_name=model_name, message=str(e)) from e
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -204,7 +204,9 @@ class CohereModel(Model[AsyncClientV2]):
             )
         except ApiError as e:
             if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+                raise ModelHTTPError(
+                    status_code=status_code, model_name=self.model_name, body=e.body, headers=e.headers
+                ) from e
             raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
 
     def _get_tool_choice(

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -383,7 +383,7 @@ def _resolve_google_cloud_service_tier(model_settings: GoogleModelSettings) -> G
 def _map_api_error(e: errors.APIError, model_name: str) -> ModelAPIError:
     """Map a `google.genai` API error to the pydantic-ai exception to raise in its place."""
     if (status_code := e.code) >= 400:
-        headers = dict(e.response.headers) if e.response is not None else None
+        headers = dict(e.response.headers) if e.response is not None else None  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
         return ModelHTTPError(
             status_code=status_code,
             model_name=model_name,

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -383,10 +383,12 @@ def _resolve_google_cloud_service_tier(model_settings: GoogleModelSettings) -> G
 def _map_api_error(e: errors.APIError, model_name: str) -> ModelAPIError:
     """Map a `google.genai` API error to the pydantic-ai exception to raise in its place."""
     if (status_code := e.code) >= 400:
+        headers = dict(e.response.headers) if e.response is not None else None
         return ModelHTTPError(
             status_code=status_code,
             model_name=model_name,
             body=cast(Any, e.details),  # pyright: ignore[reportUnknownMemberType]
+            headers=headers,
         )
     return ModelAPIError(model_name=model_name, message=str(e))
 

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -83,7 +83,9 @@ def _map_api_errors(model_name: str) -> Generator[None]:
         yield
     except APIStatusError as e:
         if (status_code := e.status_code) >= 400:
-            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body) from e
+            raise ModelHTTPError(
+                status_code=status_code, model_name=model_name, body=e.body, headers=dict(e.response.headers)
+            ) from e
         raise ModelAPIError(model_name=model_name, message=e.message) from e  # pragma: lax no cover
     except APIConnectionError as e:
         raise ModelAPIError(model_name=model_name, message=e.message) from e

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -85,6 +85,7 @@ def _map_api_errors(model_name: str) -> Generator[None]:
             status_code=e.response.status_code,
             model_name=model_name,
             body=e.response.content,
+            headers=dict(e.response.headers),
         ) from e
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -116,7 +116,9 @@ def _map_api_errors(model_name: str) -> Generator[None]:
         yield
     except SDKError as e:
         if (status_code := e.status_code) >= 400:
-            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body) from e
+            raise ModelHTTPError(
+                status_code=status_code, model_name=model_name, body=e.body, headers=dict(e.headers)
+            ) from e
         raise ModelAPIError(model_name=model_name, message=e.message) from e  # pragma: lax no cover
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -200,7 +200,9 @@ def _map_api_errors(model_name: str) -> Generator[None]:
         yield
     except APIStatusError as e:
         if (status_code := e.status_code) >= 400:
-            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body) from e
+            raise ModelHTTPError(
+                status_code=status_code, model_name=model_name, body=e.body, headers=dict(e.response.headers)
+            ) from e
         raise ModelAPIError(model_name=model_name, message=e.message) from e  # pragma: lax no cover
     except APIConnectionError as e:
         raise ModelAPIError(model_name=model_name, message=e.message) from e
@@ -2009,7 +2011,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             if model_response := _check_azure_content_filter(e, self.system, self.model_name):
                 return model_response
             if (status_code := e.status_code) >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+                raise ModelHTTPError(
+                    status_code=status_code,
+                    model_name=self.model_name,
+                    body=e.body,
+                    headers=dict(e.response.headers),
+                ) from e
             raise
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -586,13 +586,19 @@ def test_model_status_error(allow_model_requests: None) -> None:
         ApiError(
             status_code=500,
             body={'error': 'test error'},
+            headers={'retry-after': '60', 'x-request-id': 'rid-1'},
         )
     )
     m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
     agent = Agent(m)
     with pytest.raises(ModelHTTPError) as exc_info:
         agent.run_sync('hello')
-    assert str(exc_info.value) == snapshot("status_code: 500, model_name: command-r, body: {'error': 'test error'}")
+    exc = exc_info.value
+    assert str(exc) == snapshot("status_code: 500, model_name: command-r, body: {'error': 'test error'}")
+    # ApiError.headers is a plain dict — verify it reaches ModelHTTPError.headers unchanged.
+    assert exc.headers is not None
+    assert exc.headers.get('retry-after') == '60'
+    assert exc.headers.get('x-request-id') == 'rid-1'
 
 
 def test_model_non_http_error(allow_model_requests: None) -> None:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -8,6 +8,7 @@ from functools import cached_property
 from typing import Any, Literal, cast
 from unittest.mock import Mock
 
+import httpx
 import pytest
 from typing_extensions import TypedDict
 
@@ -750,8 +751,6 @@ async def test_image_as_binary_content_input(
 
 
 def test_model_status_error(allow_model_requests: None) -> None:
-    import httpx
-
     error = HfHubHTTPError(
         message='test_error',
         response=Mock(status_code=500, content={'error': 'test error'}, headers=httpx.Headers({'x-request-id': 'abc'})),

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -750,13 +750,20 @@ async def test_image_as_binary_content_input(
 
 
 def test_model_status_error(allow_model_requests: None) -> None:
-    error = HfHubHTTPError(message='test_error', response=Mock(status_code=500, content={'error': 'test error'}))
+    import httpx
+
+    error = HfHubHTTPError(
+        message='test_error',
+        response=Mock(status_code=500, content={'error': 'test error'}, headers=httpx.Headers({'x-request-id': 'abc'})),
+    )
     mock_client = MockHuggingFace.create_mock(error)
     m = HuggingFaceModel('not_a_model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
     agent = Agent(m)
     with pytest.raises(ModelHTTPError) as exc_info:
         agent.run_sync('hello')
-    assert str(exc_info.value) == snapshot("status_code: 500, model_name: not_a_model, body: {'error': 'test error'}")
+    exc = exc_info.value
+    assert str(exc) == snapshot("status_code: 500, model_name: not_a_model, body: {'error': 'test error'}")
+    assert exc.headers == {'x-request-id': 'abc'}
 
 
 @pytest.mark.vcr()

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -2944,13 +2944,18 @@ async def test_uploaded_file_input(allow_model_requests: None):
 
 
 def test_model_status_error(allow_model_requests: None) -> None:
-    response = httpx.Response(500, content=b'test error')
+    response = httpx.Response(500, headers={'retry-after': '30', 'x-request-id': 'rid-1'}, content=b'test error')
     mock_client = MockMistralAI.create_mock(SDKError('test error', raw_response=response))
     m = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
     agent = Agent(m)
     with pytest.raises(ModelHTTPError) as exc_info:
         agent.run_sync('hello')
-    assert str(exc_info.value) == snapshot('status_code: 500, model_name: mistral-large-latest, body: test error')
+    exc = exc_info.value
+    assert str(exc) == snapshot('status_code: 500, model_name: mistral-large-latest, body: test error')
+    # SDKError.headers is httpx.Headers; _map_api_errors converts it with dict() — verify it lands correctly.
+    assert exc.headers is not None
+    assert exc.headers.get('retry-after') == '30'
+    assert exc.headers.get('x-request-id') == 'rid-1'
 
 
 def test_model_non_http_error(allow_model_requests: None) -> None:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1657,7 +1657,7 @@ class TestGoogle:
         req = httpx.Request('POST', 'https://generativelanguage.googleapis.com/v1beta/models')
         resp = httpx.Response(429, headers={'retry-after': '10', 'x-goog-request-id': 'rid-1'}, request=req)
         error_with_response = errors.APIError(429, {'error': {'code': 429, 'message': 'Rate limited'}})
-        error_with_response.response = resp  # type: ignore[attr-defined]
+        error_with_response.response = resp
         mocker.patch.object(model._client.aio.models, 'embed_content', side_effect=error_with_response)  # pyright: ignore[reportPrivateUsage]
 
         with pytest.raises(ModelHTTPError) as exc_info:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1609,7 +1609,7 @@ class TestGoogle:
 
         model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
         error_without_response = errors.APIError(503, {'error': {'code': 503, 'message': 'Unavailable'}})
-        mocker.patch.object(model._client.aio.models, 'embed_content', side_effect=error_without_response)
+        mocker.patch.object(model._client.aio.models, 'embed_content', side_effect=error_without_response)  # pyright: ignore[reportPrivateUsage]
 
         with pytest.raises(ModelHTTPError) as exc_info:
             await model.embed(['test'], input_type='query')
@@ -1623,13 +1623,44 @@ class TestGoogle:
 
         model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
         error_without_response = errors.APIError(503, {'error': {'code': 503, 'message': 'Unavailable'}})
-        mocker.patch.object(model._client.aio.models, 'count_tokens', side_effect=error_without_response)
+        mocker.patch.object(model._client.aio.models, 'count_tokens', side_effect=error_without_response)  # pyright: ignore[reportPrivateUsage]
 
         with pytest.raises(ModelHTTPError) as exc_info:
             await model.count_tokens('test')
 
         assert exc_info.value.status_code == 503
         assert exc_info.value.headers is None
+
+    async def test_embed_error_low_status_code(self, gemini_api_key: str, mocker: MockerFixture):
+        """An APIError with code < 400 is re-raised verbatim, not wrapped in ModelHTTPError.
+
+        GoogleEmbeddingModel only wraps errors with status_code >= 400. A code below
+        400 is a non-HTTP-error signal from the SDK; the original exception propagates.
+        This covers the `raise` (else) branch of `if (status_code := e.code) >= 400`.
+        """
+        from google.genai import errors
+
+        model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
+        low_code_error = errors.APIError(0, {'error': {'code': 0, 'message': 'Unknown'}})
+        mocker.patch.object(model._client.aio.models, 'embed_content', side_effect=low_code_error)  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(errors.APIError) as exc_info:
+            await model.embed(['test'], input_type='query')
+
+        assert exc_info.value is low_code_error
+
+    async def test_count_tokens_error_low_status_code(self, gemini_api_key: str, mocker: MockerFixture):
+        """Same as test_embed_error_low_status_code for the count_tokens path."""
+        from google.genai import errors
+
+        model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
+        low_code_error = errors.APIError(0, {'error': {'code': 0, 'message': 'Unknown'}})
+        mocker.patch.object(model._client.aio.models, 'count_tokens', side_effect=low_code_error)  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(errors.APIError) as exc_info:
+            await model.count_tokens('test')
+
+        assert exc_info.value is low_code_error
 
     async def test_query_with_task_type(self, embedder: Embedder):
         result = await embedder.embed_query(

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1217,12 +1217,19 @@ class TestBedrock:
             assert model.model_name == 'amazon.titan-embed-text-v2:0'
 
     async def test_client_error_with_status_code(self, bedrock_provider: BedrockProvider):
-        """Test error handling when ClientError is raised with HTTP status code."""
+        """Test error handling when ClientError is raised with HTTP status code.
+
+        ResponseMetadata.HTTPHeaders is the nested dict that BedrockEmbeddingModel extracts
+        via metadata.get('HTTPHeaders') — verify it reaches ModelHTTPError.headers unchanged.
+        """
         model = BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', provider=bedrock_provider)
 
         error_response = {
             'Error': {'Code': 'ValidationException', 'Message': 'Invalid input'},
-            'ResponseMetadata': {'HTTPStatusCode': 400},
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'HTTPHeaders': {'retry-after': '5', 'x-amzn-requestid': 'req-abc'},
+            },
         }
         with patch.object(
             model.client,
@@ -1232,8 +1239,12 @@ class TestBedrock:
             with pytest.raises(ExceptionGroup) as exc_info:
                 await model.embed(['test'], input_type='query')
             assert len(exc_info.value.exceptions) == 1
-            assert isinstance(exc_info.value.exceptions[0], ModelHTTPError)
-            assert exc_info.value.exceptions[0].status_code == 400
+            exc = exc_info.value.exceptions[0]
+            assert isinstance(exc, ModelHTTPError)
+            assert exc.status_code == 400
+            assert exc.headers is not None
+            assert exc.headers.get('retry-after') == '5'
+            assert exc.headers.get('x-amzn-requestid') == 'req-abc'
 
     async def test_client_error_without_status_code(self, bedrock_provider: BedrockProvider):
         """Test error handling when ClientError is raised without HTTP status code."""
@@ -1630,6 +1641,33 @@ class TestGoogle:
 
         assert exc_info.value.status_code == 503
         assert exc_info.value.headers is None
+
+    async def test_embed_error_with_http_response(self, gemini_api_key: str, mocker: MockerFixture):
+        """An APIError with a real httpx.Response propagates its headers to ModelHTTPError.
+
+        The positive path `headers=dict(e.response.headers) if e.response is not None else None`
+        converts httpx.Headers to a plain lowercased dict. Verify the value reaches
+        ModelHTTPError.headers so a wrong-attribute regression (e.g. swapping response for None)
+        would be caught.
+        """
+        import httpx
+        from google.genai import errors
+
+        model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
+        req = httpx.Request('POST', 'https://generativelanguage.googleapis.com/v1beta/models')
+        resp = httpx.Response(429, headers={'retry-after': '10', 'x-goog-request-id': 'rid-1'}, request=req)
+        error_with_response = errors.APIError(429, {'error': {'code': 429, 'message': 'Rate limited'}})
+        error_with_response.response = resp  # type: ignore[attr-defined]
+        mocker.patch.object(model._client.aio.models, 'embed_content', side_effect=error_with_response)  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(ModelHTTPError) as exc_info:
+            await model.embed(['test'], input_type='query')
+
+        exc = exc_info.value
+        assert exc.status_code == 429
+        assert exc.headers is not None
+        assert exc.headers.get('retry-after') == '10'
+        assert exc.headers.get('x-goog-request-id') == 'rid-1'
 
     async def test_embed_error_low_status_code(self, gemini_api_key: str, mocker: MockerFixture):
         """An APIError with code < 400 is re-raised verbatim, not wrapped in ModelHTTPError.

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 
 import httpx
 import pytest
+from pytest_mock import MockerFixture
 
 from ._inline_snapshot import snapshot
 
@@ -1596,6 +1597,39 @@ class TestGoogle:
         embedder = Embedder(model)
         with pytest.raises(ModelHTTPError, match='not found'):
             await embedder.count_tokens('Hello, world!')
+
+    async def test_embed_error_no_http_response(self, gemini_api_key: str, mocker: MockerFixture):
+        """An APIError with response=None (no HTTP response object) yields headers=None on ModelHTTPError.
+
+        This exercises the defensive `e.response is not None else None` branch in the embed
+        path of GoogleEmbeddingModel — the branch that handles non-HTTP errors where the SDK
+        raises an APIError without attaching an httpx.Response.
+        """
+        from google.genai import errors
+
+        model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
+        error_without_response = errors.APIError(503, {'error': {'code': 503, 'message': 'Unavailable'}})
+        mocker.patch.object(model._client.aio.models, 'embed_content', side_effect=error_without_response)
+
+        with pytest.raises(ModelHTTPError) as exc_info:
+            await model.embed(['test'], input_type='query')
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.headers is None
+
+    async def test_count_tokens_error_no_http_response(self, gemini_api_key: str, mocker: MockerFixture):
+        """Same as above for the count_tokens path."""
+        from google.genai import errors
+
+        model = GoogleEmbeddingModel('gemini-embedding-2-preview', provider=GoogleProvider(api_key=gemini_api_key))
+        error_without_response = errors.APIError(503, {'error': {'code': 503, 'message': 'Unavailable'}})
+        mocker.patch.object(model._client.aio.models, 'count_tokens', side_effect=error_without_response)
+
+        with pytest.raises(ModelHTTPError) as exc_info:
+            await model.count_tokens('test')
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.headers is None
 
     async def test_query_with_task_type(self, embedder: Embedder):
         result = await embedder.embed_query(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -413,7 +413,7 @@ def test_model_http_error_headers_provider_xai_no_headers():
 
     class _FakeRpcError(grpc.RpcError):
         def code(self) -> Any:  # grpc.StatusCode only known at runtime
-            return grpc.StatusCode.RESOURCE_EXHAUSTED  # pyright: ignore[reportUnknownMemberType]
+            return grpc.StatusCode.RESOURCE_EXHAUSTED
 
         def details(self) -> str:
             return 'quota exceeded'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -325,6 +325,30 @@ def test_model_http_error_retry_after_unparseable():
     assert exc.retry_after is None
 
 
+def test_model_http_error_retry_after_negative():
+    """retry_after returns None for a negative Retry-After value.
+
+    Negative delta-seconds are not defined by RFC 9110 — a server that sends
+    Retry-After: -1 is misbehaving, and we must not propagate a negative wait
+    time to callers who would sleep for a negative duration.
+    """
+    exc = ModelHTTPError(429, 'gpt-4', headers={'retry-after': '-1'})
+    assert exc.retry_after is None
+
+
+def test_model_http_error_retry_after_overflow():
+    """retry_after returns None for an astronomically large integer Retry-After.
+
+    float(int(very_large_string)) raises OverflowError in Python when the integer
+    cannot be represented as a finite float. The except clause must cover it so
+    callers always receive None rather than an unhandled exception.
+    """
+    # 10^309 cannot be represented as a finite double
+    huge = '1' + '0' * 309
+    exc = ModelHTTPError(429, 'gpt-4', headers={'retry-after': huge})
+    assert exc.retry_after is None
+
+
 def test_model_http_error_headers_provider_openai():
     """Headers from an openai.APIStatusError land on ModelHTTPError.
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -349,14 +349,30 @@ def test_model_http_error_retry_after_overflow():
     assert exc.retry_after is None
 
 
+def test_model_http_error_retry_after_http_date_asctime():
+    """retry_after handles the asctime HTTP-date format (RFC 9110 §5.6.7 obs-date).
+
+    Python's parsedate_to_datetime returns a *naive* datetime for the asctime
+    format because the string carries no timezone. Without the fix the subtraction
+    from an aware datetime.now(UTC) raises TypeError which is caught and silently
+    returns None — a false negative. The fix normalises the naive datetime to UTC
+    before computing the wait, so a future asctime date yields a positive float.
+    """
+    # Far-future date so the wait is always positive regardless of when the test runs.
+    exc = ModelHTTPError(429, 'gpt-4', headers={'retry-after': 'Sun Nov  6 08:49:37 2099'})
+    result = exc.retry_after
+    assert result is not None
+    assert result > 0
+
+
 def test_model_http_error_headers_provider_openai():
     """Headers from an openai.APIStatusError land on ModelHTTPError.
 
     This is a unit test — not a VCR test — because the header propagation path
     lives in our own _map_api_errors helper, not in recorded API behaviour.
     """
+    openai = pytest.importorskip('openai', reason='openai extra not installed')
     import httpx
-    import openai
 
     from pydantic_ai.models.openai import _map_api_errors  # pyright: ignore[reportPrivateUsage]
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -354,7 +354,7 @@ def test_model_http_error_headers_provider_openai():
 
 def test_model_http_error_headers_provider_anthropic():
     """Headers from an anthropic.APIStatusError land on ModelHTTPError."""
-    import anthropic
+    anthropic = pytest.importorskip('anthropic', reason='anthropic extra not installed')
     import httpx
 
     from pydantic_ai.models.anthropic import _map_api_errors
@@ -380,6 +380,7 @@ def test_model_http_error_headers_provider_anthropic():
 
 def test_model_http_error_headers_provider_bedrock():
     """Headers from a botocore.ClientError land on ModelHTTPError."""
+    pytest.importorskip('botocore', reason='botocore (bedrock extra) not installed')
     from botocore.exceptions import ClientError
 
     from pydantic_ai.models.bedrock import _map_api_errors
@@ -406,7 +407,7 @@ def test_model_http_error_headers_provider_bedrock():
 
 def test_model_http_error_headers_provider_xai_no_headers():
     """xAI errors are gRPC-based: no HTTP response headers, so ModelHTTPError.headers is None."""
-    import grpc
+    grpc = pytest.importorskip('grpc', reason='grpcio (xai extra) not installed')
 
     from pydantic_ai.models.xai import _map_api_errors
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -334,7 +334,7 @@ def test_model_http_error_headers_provider_openai():
     import httpx
     import openai
 
-    from pydantic_ai.models.openai import _map_api_errors
+    from pydantic_ai.models.openai import _map_api_errors  # pyright: ignore[reportPrivateUsage]
 
     req = httpx.Request('POST', 'https://api.openai.com/v1/chat/completions')
     resp = httpx.Response(429, headers={'retry-after': '30', 'x-request-id': 'rid-1'}, request=req)
@@ -357,7 +357,7 @@ def test_model_http_error_headers_provider_anthropic():
     anthropic = pytest.importorskip('anthropic', reason='anthropic extra not installed')
     import httpx
 
-    from pydantic_ai.models.anthropic import _map_api_errors
+    from pydantic_ai.models.anthropic import _map_api_errors  # pyright: ignore[reportPrivateUsage]
 
     req = httpx.Request('POST', 'https://api.anthropic.com/v1/messages')
     resp = httpx.Response(
@@ -383,9 +383,9 @@ def test_model_http_error_headers_provider_bedrock():
     pytest.importorskip('botocore', reason='botocore (bedrock extra) not installed')
     from botocore.exceptions import ClientError
 
-    from pydantic_ai.models.bedrock import _map_api_errors
+    from pydantic_ai.models.bedrock import _map_api_errors  # pyright: ignore[reportPrivateUsage]
 
-    error_response = {
+    error_response: Any = {
         'Error': {'Code': 'ThrottlingException', 'Message': 'Too many requests'},
         'ResponseMetadata': {
             'HTTPStatusCode': 429,
@@ -409,11 +409,11 @@ def test_model_http_error_headers_provider_xai_no_headers():
     """xAI errors are gRPC-based: no HTTP response headers, so ModelHTTPError.headers is None."""
     grpc = pytest.importorskip('grpc', reason='grpcio (xai extra) not installed')
 
-    from pydantic_ai.models.xai import _map_api_errors
+    from pydantic_ai.models.xai import _map_api_errors  # pyright: ignore[reportPrivateUsage]
 
     class _FakeRpcError(grpc.RpcError):
-        def code(self) -> grpc.StatusCode:
-            return grpc.StatusCode.RESOURCE_EXHAUSTED
+        def code(self) -> Any:  # grpc.StatusCode only known at runtime
+            return grpc.StatusCode.RESOURCE_EXHAUSTED  # pyright: ignore[reportUnknownMemberType]
 
         def details(self) -> str:
             return 'quota exceeded'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -116,10 +116,22 @@ def test_exceptions_hashable(exc_factory: Callable[[], Any]):
         ),
         (lambda: ContentFilterError('filtered'), {'message': 'filtered', 'body': None}),
         (lambda: ModelAPIError('gpt-4', 'api failed'), {'model_name': 'gpt-4', 'message': 'api failed'}),
-        (lambda: ModelHTTPError(500, 'gpt-4'), {'status_code': 500, 'model_name': 'gpt-4', 'body': None}),
+        (
+            lambda: ModelHTTPError(500, 'gpt-4'),
+            {'status_code': 500, 'model_name': 'gpt-4', 'body': None, 'headers': None},
+        ),
         (
             lambda: ModelHTTPError(429, 'gpt-4', {'error': 'rate limit'}),
-            {'status_code': 429, 'model_name': 'gpt-4', 'body': {'error': 'rate limit'}},
+            {'status_code': 429, 'model_name': 'gpt-4', 'body': {'error': 'rate limit'}, 'headers': None},
+        ),
+        (
+            lambda: ModelHTTPError(429, 'gpt-4', headers={'Retry-After': '60', 'X-Request-Id': 'abc'}),
+            {
+                'status_code': 429,
+                'model_name': 'gpt-4',
+                'body': None,
+                'headers': {'retry-after': '60', 'x-request-id': 'abc'},
+            },
         ),
         (lambda: IncompleteToolCall('incomplete'), {'message': 'incomplete', 'body': None}),
     ],
@@ -140,6 +152,7 @@ def test_exceptions_hashable(exc_factory: Callable[[], Any]):
         'ModelAPIError',
         'ModelHTTPError-no-body',
         'ModelHTTPError-with-body',
+        'ModelHTTPError-with-headers',
         'IncompleteToolCall',
     ],
 )
@@ -235,3 +248,180 @@ def test_tool_retry_error_str_with_value_error_type():
     assert str(error) == (
         "1 validation error for 'my_tool'\nfield\n  Value error, must not be foo [type=value_error, input_value='foo']"
     )
+
+
+def test_model_http_error_headers_normalized_to_lowercase():
+    """Headers passed to ModelHTTPError are stored with lowercase keys.
+
+    Providers return headers in various casings (e.g. httpx normalises to lowercase,
+    but some SDKs may preserve server casing). Requiring callers to lowercase before
+    access would be fragile, so we normalise on construction.
+    """
+    exc = ModelHTTPError(429, 'gpt-4', headers={'Retry-After': '60', 'X-Request-Id': 'abc'})
+    assert exc.headers == {'retry-after': '60', 'x-request-id': 'abc'}
+    # Access is case-insensitive only on the stored lowercase keys
+    assert exc.headers is not None
+    assert exc.headers.get('retry-after') == '60'
+
+
+def test_model_http_error_headers_default_none():
+    """headers defaults to None when not provided, keeping existing call-sites unchanged."""
+    exc = ModelHTTPError(500, 'gpt-4')
+    assert exc.headers is None
+
+
+def test_model_http_error_headers_none_explicit():
+    """Passing headers=None is equivalent to omitting it."""
+    exc = ModelHTTPError(500, 'gpt-4', headers=None)
+    assert exc.headers is None
+
+
+def test_model_http_error_headers_does_not_change_message():
+    """Adding headers must not alter the existing str() / message format.
+
+    Several places in the test suite — and downstream user code — pattern-match
+    on the message string, so this must stay stable.
+    """
+    without = ModelHTTPError(429, 'gpt-4')
+    with_headers = ModelHTTPError(429, 'gpt-4', headers={'retry-after': '60'})
+    assert str(without) == str(with_headers)
+    assert without.message == with_headers.message
+
+
+def test_model_http_error_retry_after_delta_seconds():
+    """retry_after parses an integer delta-seconds Retry-After value."""
+    exc = ModelHTTPError(429, 'gpt-4', headers={'retry-after': '42'})
+    assert exc.retry_after == 42.0
+
+
+def test_model_http_error_retry_after_missing():
+    """retry_after returns None when no Retry-After header is present."""
+    exc = ModelHTTPError(429, 'gpt-4', headers={'x-request-id': 'abc'})
+    assert exc.retry_after is None
+
+
+def test_model_http_error_retry_after_no_headers():
+    """retry_after returns None when headers is None."""
+    exc = ModelHTTPError(429, 'gpt-4')
+    assert exc.retry_after is None
+
+
+def test_model_http_error_retry_after_http_date():
+    """retry_after parses an HTTP-date Retry-After value into a non-negative float.
+
+    We can't assert the exact value without freezing time, so we just check it's
+    a non-negative float (the date is far in the future).
+    """
+    # Wed, 01 Jan 2099 00:00:00 GMT — always in the future
+    exc = ModelHTTPError(429, 'gpt-4', headers={'retry-after': 'Thu, 01 Jan 2099 00:00:00 GMT'})
+    result = exc.retry_after
+    assert result is not None
+    assert result > 0
+
+
+def test_model_http_error_retry_after_unparseable():
+    """retry_after returns None for a Retry-After value it cannot parse."""
+    exc = ModelHTTPError(429, 'gpt-4', headers={'retry-after': 'not-a-number-or-date'})
+    assert exc.retry_after is None
+
+
+def test_model_http_error_headers_provider_openai():
+    """Headers from an openai.APIStatusError land on ModelHTTPError.
+
+    This is a unit test — not a VCR test — because the header propagation path
+    lives in our own _map_api_errors helper, not in recorded API behaviour.
+    """
+    import httpx
+    import openai
+
+    from pydantic_ai.models.openai import _map_api_errors
+
+    req = httpx.Request('POST', 'https://api.openai.com/v1/chat/completions')
+    resp = httpx.Response(429, headers={'retry-after': '30', 'x-request-id': 'rid-1'}, request=req)
+    sdk_exc = openai.RateLimitError('Rate limited', response=resp, body=None)
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        with _map_api_errors('gpt-4o'):
+            raise sdk_exc
+
+    exc = exc_info.value
+    assert exc.status_code == 429
+    assert exc.headers is not None
+    assert exc.headers.get('retry-after') == '30'
+    assert exc.headers.get('x-request-id') == 'rid-1'
+    assert exc.retry_after == 30.0
+
+
+def test_model_http_error_headers_provider_anthropic():
+    """Headers from an anthropic.APIStatusError land on ModelHTTPError."""
+    import anthropic
+    import httpx
+
+    from pydantic_ai.models.anthropic import _map_api_errors
+
+    req = httpx.Request('POST', 'https://api.anthropic.com/v1/messages')
+    resp = httpx.Response(
+        429,
+        headers={'retry-after': '10', 'anthropic-ratelimit-tokens-remaining': '0'},
+        request=req,
+    )
+    sdk_exc = anthropic.RateLimitError(message='Rate limited', response=resp, body=None)
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        with _map_api_errors('claude-sonnet-4-5'):
+            raise sdk_exc
+
+    exc = exc_info.value
+    assert exc.status_code == 429
+    assert exc.headers is not None
+    assert exc.headers.get('retry-after') == '10'
+    assert exc.retry_after == 10.0
+
+
+def test_model_http_error_headers_provider_bedrock():
+    """Headers from a botocore.ClientError land on ModelHTTPError."""
+    from botocore.exceptions import ClientError
+
+    from pydantic_ai.models.bedrock import _map_api_errors
+
+    error_response = {
+        'Error': {'Code': 'ThrottlingException', 'Message': 'Too many requests'},
+        'ResponseMetadata': {
+            'HTTPStatusCode': 429,
+            'HTTPHeaders': {'retry-after': '5', 'x-amzn-requestid': 'req-abc'},
+        },
+    }
+    sdk_exc = ClientError(error_response, 'InvokeModel')
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        with _map_api_errors('amazon.nova-pro-v1:0'):
+            raise sdk_exc
+
+    exc = exc_info.value
+    assert exc.status_code == 429
+    assert exc.headers is not None
+    assert exc.headers.get('retry-after') == '5'
+    assert exc.retry_after == 5.0
+
+
+def test_model_http_error_headers_provider_xai_no_headers():
+    """xAI errors are gRPC-based: no HTTP response headers, so ModelHTTPError.headers is None."""
+    import grpc
+
+    from pydantic_ai.models.xai import _map_api_errors
+
+    class _FakeRpcError(grpc.RpcError):
+        def code(self) -> grpc.StatusCode:
+            return grpc.StatusCode.RESOURCE_EXHAUSTED
+
+        def details(self) -> str:
+            return 'quota exceeded'
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        with _map_api_errors('grok-3'):
+            raise _FakeRpcError()
+
+    exc = exc_info.value
+    assert exc.status_code == 429
+    assert exc.headers is None
+    assert exc.retry_after is None


### PR DESCRIPTION
## Motivation

David Montague (Pydantic / Logfire) raised this in Slack:

> Would it be reasonable to proxy the headers through on `ModelHTTPError`? … I can't pass through the `retry-after` in internal code because we don't forward the response details.

DouweM confirmed: *"Ah yeah agree we should, `Model{API,HTTP}Error` currently only holds body — PR welcome".*

The concrete use case is downstream code that catches a 429 and wants to honour the `Retry-After` header:

```python
try:
    result = agent.run_sync(prompt)
except ModelHTTPError as exc:
    if exc.status_code == 429:
        raise HTTPException(
            status_code=429,
            detail="The AI service is temporarily rate limited. Please try again shortly.",
            headers={"Retry-After": str(exc.headers.get("retry-after", ""))},
        )
    raise
```

## What's added

### `ModelHTTPError.headers: dict[str, str] | None`

Response headers from the provider SDK, with keys **lowercased** so `exc.headers.get('retry-after')` works predictably regardless of provider casing. `None` when the provider doesn't expose HTTP headers (gRPC-based providers, synthesised errors).

### `ModelHTTPError.retry_after: float | None`

Convenience property that parses the `Retry-After` header, handling both the integer delta-seconds form (`"60"`) and the HTTP-date form (`"Thu, 01 Jan 2099 00:00:00 GMT"`). Returns `None` when the header is absent or unparseable.

## Design decisions

**Why `ModelHTTPError` only and not `ModelAPIError`?**

`ModelAPIError` is the base for non-HTTP failures (connection errors, timeouts, DNS failures) where there is no HTTP response and therefore no response headers. Adding `headers` there would be misleading — callers would need to null-check it even for the common non-HTTP case. `ModelHTTPError` represents an actual HTTP response (4xx/5xx), which always has headers; it's the right scope. (The maintainer's Slack comment referred to both classes in passing, but the reasoning above makes `ModelHTTPError`-only the correct call.)

**Header normalisation to lowercase**

Keys are lowercased on construction (`{k.lower(): v for k, v in headers.items()}`). This makes `exc.headers.get('retry-after')` work even when a provider uses `Retry-After` or `RETRY-AFTER`. httpx already normalises to lowercase, but other SDKs (Cohere's Fern client, botocore) may differ. Lowercasing at the boundary ensures consistent behaviour everywhere.

**Backwards compatibility**

`headers` is keyword-only (`*`) with a default of `None`. All existing positional call sites (`ModelHTTPError(429, 'model-name', body)`) continue to work unchanged. The `__str__` / `message` format is untouched.

**Pickling**

`__reduce__` is updated to return a 3-tuple `(cls, positional_args, state_dict)` and `__setstate__` restores `headers` from `state`. This keeps the positional signature intact while surviving a pickle round-trip with headers.

## Provider coverage

| Provider | Headers source | Notes |
|---|---|---|
| OpenAI | `e.response.headers` (httpx) | ✅ |
| Anthropic | `e.response.headers` (httpx) | ✅ |
| Groq | `e.response.headers` (httpx) | ✅ |
| Mistral | `e.headers` (`MistralError.headers`, httpx) | ✅ |
| Cohere | `e.headers` (`ApiError.headers`, Fern) | ✅ |
| Google | `e.response.headers` (httpx, optional) | ✅ (`None` when `e.response` is `None`) |
| Bedrock | `ResponseMetadata.HTTPHeaders` (botocore) | ✅ |
| HuggingFace | `e.response.headers` (httpx) | ✅ |
| xAI | — | ❌ gRPC transport, no HTTP response |
| OpenRouter | — | ❌ errors synthesised from JSON inside a 200 body |

## Tests

- Existing pickle round-trip tests updated to assert `headers` survives (including `None` and non-`None` cases).
- New unit tests for `ModelHTTPError`: construction, lowercase normalisation, `retry_after` (delta-seconds, HTTP-date, absent, unparseable, no-headers).
- Provider integration tests (unit, no cassettes): OpenAI, Anthropic, Bedrock, xAI (verifies `headers=None` for gRPC).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

[Created via Murmur](https://cloud.murmur.dev/github_app/pydantic/task/github_app%2Fpydantic%2Fw%2Fmurmur-workspace%2Fgithub_oauth%2Fdmontagu%2Fmodelhttperror-headers)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

