### PR TITLE
fix(usage): preserve zero-valued OTel details

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -237,7 +237,8 @@ class UsageBase:
                 if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
                     continue
                 # Skipping check for value since spec implies all detail values are relevant
-                if value:
+                # Provider data can contain None despite the annotation.
+                if value is not None:  # pyright: ignore[reportUnnecessaryComparison]
                     result[prefix + key] = value
         return result
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -338,6 +338,7 @@ async def test_multi_agent_usage_no_incr():
         'gen_ai.usage.output_tokens': 13,
         'gen_ai.usage.details.custom1': 10,
         'gen_ai.usage.details.custom2': 20,
+        'gen_ai.usage.details.custom3': 0,
     }
 
 
@@ -553,6 +554,22 @@ def test_usage_pydantic_core_serialization_subclass():
             'future_tokens': 42,
         }
     )
+
+
+def test_usage_opentelemetry_attributes_include_zero_details():
+    usage = RequestUsage(
+        details={
+            'reasoning_tokens': 0,
+            'accepted_prediction_tokens': 2,
+            'input_tokens': 3,
+            'output_tokens': 4,
+        }
+    )
+
+    assert usage.opentelemetry_attributes() == {
+        'gen_ai.usage.details.reasoning_tokens': 0,
+        'gen_ai.usage.details.accepted_prediction_tokens': 2,
+    }
 
 
 def test_cache_hit_ratio():


### PR DESCRIPTION
## Summary

- preserve explicitly reported zero-valued usage details in `UsageBase.opentelemetry_attributes()`
- continue excluding first-class `input_tokens` and `output_tokens` detail keys to avoid duplicate OTel attributes
- add a focused regression test for `reasoning_tokens=0` and update the existing zero-detail expectation

Fixes #6684.

## Validation

- `uv run pytest tests/test_usage_limits.py::test_usage_opentelemetry_attributes_include_zero_details` (`1 passed`)
- `uv run pytest tests/test_usage_limits.py` (`37 passed`)
- `uv run ruff check pydantic_ai_slim/pydantic_ai/usage.py tests/test_usage_limits.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/usage.py tests/test_usage_limits.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/usage.py tests/test_usage_limits.py`
- `git diff --check`

An independent audit reproduced the regression against the unpatched base (`1 failed`) and reran the focused tests and gates successfully against this patch.

## Duplicate Check

Checked before this refresh against upstream `main` at `7e3e9593df8f4f11b98c5287bccb16b7124f4893`:

- #6688 is closed and unmerged; it contains the same production-line intent but no regression test
- #6685 is merged arbitrary `RequestUsage` serialization work and does not change the `opentelemetry_attributes()` truthiness check
- #6753 captures Anthropic thinking-token details but does not change zero-value OTel filtering
- searches by issue number, symbol, behavior, affected files, and recent commits found no active equivalent fix

## Browser / Playwright

Not applicable: this is a pure Python telemetry attribute-generation change with no browser or UI behavior.
