### PR TITLE
Add Nimble common tools (`nimble_search_tool`, extract/map/crawl, Agent API, `NimbleToolset`)

### DIFF
--- a/docs/api/common_tools.md
+++ b/docs/api/common_tools.md
@@ -4,6 +4,8 @@
 
 ::: pydantic_ai.common_tools.exa
 
+::: pydantic_ai.common_tools.nimble
+
 ::: pydantic_ai.common_tools.tavily
 
 ::: pydantic_ai.common_tools.web_fetch

--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -209,27 +209,67 @@ Here are some recent papers about transformer architectures from arxiv.org:
 """
 ```
 
-## Nimble Search Tool
+## Nimble Tools
 
 !!! info
     Nimble is a paid service, but they have free credits to explore their product.
 
-    You need to [sign up for an account](https://online.nimbleway.com/account-settings/api-keys) and get an API key to use the Nimble search tool.
+    You need to [sign up for an account](https://online.nimbleway.com/account-settings/api-keys) and get an API key to use the Nimble tools.
 
-The Nimble search tool allows you to search the web for information. It is built on top of the [Nimble Search API](https://www.nimbleway.com/) via the [`nimble_python`](https://pypi.org/project/nimble_python/) SDK.
+The Nimble common tools cover web search, page extract, site map, crawl job control, and [Agent API V2](https://docs.nimbleway.com/) run lifecycle. They are built on the [`nimble_python`](https://pypi.org/project/nimble_python/) SDK.
 
 ### Installation
 
-To use [`nimble_search_tool`][pydantic_ai.common_tools.nimble.nimble_search_tool], you need to install
-[`pydantic-ai-slim`](install.md#slim-install) with the `nimble` optional group:
+To use the Nimble tools, install [`pydantic-ai-slim`](install.md#slim-install) with the `nimble` optional group:
 
 ```bash
 pip/uv-add "pydantic-ai-slim[nimble]"
 ```
 
-### Usage
+### Recommended: `NimbleToolset`
 
-Here's an example of how you can use the Nimble search tool with an agent:
+Prefer [`NimbleToolset`][pydantic_ai.common_tools.nimble.NimbleToolset] when you want several Nimble tools that share one client. By default it includes search and extract; map, crawl, and Agent API tools are opt-in:
+
+```py {title="nimble_toolset.py" test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.nimble import NimbleToolset
+
+api_key = os.getenv('NIMBLE_API_KEY')
+assert api_key is not None
+
+agent = Agent(
+    'openai:gpt-5.2',
+    toolsets=[
+        NimbleToolset(
+            api_key,
+            include_map=True,
+            include_crawl=True,
+            include_agents=True,
+        )
+    ],
+    instructions='Use Nimble tools to research the web and return sources.',
+)
+
+result = agent.run_sync('Summarize the top GenAI news with links.')
+print(result.output)
+```
+
+Crawl and Agent API tools are intentionally **non-blocking**: start a job, then poll status (and fetch agent results) across later turns. Do not expect a single tool call to wait until a multi-minute crawl or agent run finishes.
+
+### Individual tools
+
+In addition to the toolset, you can register factories one at a time:
+
+| Factory | Purpose |
+| --- | --- |
+| [`nimble_search_tool`][pydantic_ai.common_tools.nimble.nimble_search_tool] | Web search |
+| [`nimble_extract_tool`][pydantic_ai.common_tools.nimble.nimble_extract_tool] | URL → markdown |
+| [`nimble_map_tool`][pydantic_ai.common_tools.nimble.nimble_map_tool] | Discover links on a site |
+| [`nimble_crawl_start_tool`][pydantic_ai.common_tools.nimble.nimble_crawl_start_tool] / [`nimble_crawl_status_tool`][pydantic_ai.common_tools.nimble.nimble_crawl_status_tool] | Start and poll a crawl job |
+| [`nimble_agents_list_tool`][pydantic_ai.common_tools.nimble.nimble_agents_list_tool] / [`nimble_agent_templates_list_tool`][pydantic_ai.common_tools.nimble.nimble_agent_templates_list_tool] | Discover agents and templates |
+| [`nimble_agent_run_start_tool`][pydantic_ai.common_tools.nimble.nimble_agent_run_start_tool] / [`nimble_agent_run_status_tool`][pydantic_ai.common_tools.nimble.nimble_agent_run_status_tool] / [`nimble_agent_run_result_tool`][pydantic_ai.common_tools.nimble.nimble_agent_run_result_tool] | Agent API V2 run lifecycle |
 
 ```py {title="nimble_search.py" test="skip"}
 import os
@@ -250,7 +290,7 @@ result = agent.run_sync('Tell me the top news in the GenAI world, give me links.
 print(result.output)
 ```
 
-### Configuring Parameters
+### Configuring search parameters
 
 The `nimble_search_tool` factory accepts optional parameters that control search behavior. `max_results` is always developer-controlled and never appears in the LLM tool schema. Other parameters, when provided, are fixed for all searches and hidden from the LLM's tool schema. Parameters left unset remain available for the LLM to set per-call.
 

--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -209,6 +209,80 @@ Here are some recent papers about transformer architectures from arxiv.org:
 """
 ```
 
+## Nimble Search Tool
+
+!!! info
+    Nimble is a paid service, but they have free credits to explore their product.
+
+    You need to [sign up for an account](https://online.nimbleway.com/account-settings/api-keys) and get an API key to use the Nimble search tool.
+
+The Nimble search tool allows you to search the web for information. It is built on top of the [Nimble Search API](https://www.nimbleway.com/) via the [`nimble_python`](https://pypi.org/project/nimble_python/) SDK.
+
+### Installation
+
+To use [`nimble_search_tool`][pydantic_ai.common_tools.nimble.nimble_search_tool], you need to install
+[`pydantic-ai-slim`](install.md#slim-install) with the `nimble` optional group:
+
+```bash
+pip/uv-add "pydantic-ai-slim[nimble]"
+```
+
+### Usage
+
+Here's an example of how you can use the Nimble search tool with an agent:
+
+```py {title="nimble_search.py" test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.nimble import nimble_search_tool
+
+api_key = os.getenv('NIMBLE_API_KEY')
+assert api_key is not None
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[nimble_search_tool(api_key)],
+    instructions='Search Nimble for the given query and return the results.',
+)
+
+result = agent.run_sync('Tell me the top news in the GenAI world, give me links.')
+print(result.output)
+```
+
+### Configuring Parameters
+
+The `nimble_search_tool` factory accepts optional parameters that control search behavior. `max_results` is always developer-controlled and never appears in the LLM tool schema. Other parameters, when provided, are fixed for all searches and hidden from the LLM's tool schema. Parameters left unset remain available for the LLM to set per-call.
+
+For example, you can lock in `max_results` and `include_domains` at tool creation time while still letting the LLM control `exclude_domains`:
+
+```py {title="nimble_domain_filtering.py"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.nimble import nimble_search_tool
+
+api_key = os.getenv('NIMBLE_API_KEY')
+assert api_key is not None
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[nimble_search_tool(api_key, max_results=5, include_domains=['arxiv.org'])],
+    instructions='Search for information and return the results.',
+)
+
+result = agent.run_sync(
+    'Find recent papers about transformer architectures'
+)
+print(result.output)
+"""
+Here are some recent papers about transformer architectures from arxiv.org:
+
+1. "Attention Is All You Need" - The foundational paper on the Transformer model.
+2. "FlashAttention: Fast and Memory-Efficient Exact Attention" - Proposes an IO-aware attention algorithm.
+"""
+```
+
 ## Exa Search Tool
 
 !!! warning "Deprecated"

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,7 +58,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `duckduckgo` - installs [DuckDuckGo Search Tool](common-tools.md#duckduckgo-search-tool) dependency `ddgs` [PyPI ↗](https://pypi.org/project/ddgs){:target="_blank"}
 * `tavily` - installs [Tavily Search Tool](common-tools.md#tavily-search-tool) dependency `tavily-python` [PyPI ↗](https://pypi.org/project/tavily-python){:target="_blank"}
 * `exa` - installs [Exa Search Tool](common-tools.md#exa-search-tool) dependency `exa-py` [PyPI ↗](https://pypi.org/project/exa-py){:target="_blank"}
-* `nimble` - installs [Nimble Search Tool](common-tools.md#nimble-search-tool) dependency `nimble_python` [PyPI ↗](https://pypi.org/project/nimble_python){:target="_blank"}
+* `nimble` - installs [Nimble Tools](common-tools.md#nimble-tools) dependency `nimble_python` [PyPI ↗](https://pypi.org/project/nimble_python){:target="_blank"}
 * `web-fetch` - installs [Web Fetch Tool](common-tools.md#web-fetch-tool) dependency `markdownify` [PyPI ↗](https://pypi.org/project/markdownify){:target="_blank"}
 * `cli` - installs [CLI](cli.md) dependencies `rich` [PyPI ↗](https://pypi.org/project/rich){:target="_blank"}, `prompt-toolkit` [PyPI ↗](https://pypi.org/project/prompt-toolkit){:target="_blank"}, and `argcomplete` [PyPI ↗](https://pypi.org/project/argcomplete){:target="_blank"}
 * `mcp` - installs [MCP](mcp/client.md) dependency `fastmcp-slim[client]` [PyPI ↗](https://pypi.org/project/fastmcp-slim){:target="_blank"}

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,6 +58,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `duckduckgo` - installs [DuckDuckGo Search Tool](common-tools.md#duckduckgo-search-tool) dependency `ddgs` [PyPI ↗](https://pypi.org/project/ddgs){:target="_blank"}
 * `tavily` - installs [Tavily Search Tool](common-tools.md#tavily-search-tool) dependency `tavily-python` [PyPI ↗](https://pypi.org/project/tavily-python){:target="_blank"}
 * `exa` - installs [Exa Search Tool](common-tools.md#exa-search-tool) dependency `exa-py` [PyPI ↗](https://pypi.org/project/exa-py){:target="_blank"}
+* `nimble` - installs [Nimble Search Tool](common-tools.md#nimble-search-tool) dependency `nimble_python` [PyPI ↗](https://pypi.org/project/nimble_python){:target="_blank"}
 * `web-fetch` - installs [Web Fetch Tool](common-tools.md#web-fetch-tool) dependency `markdownify` [PyPI ↗](https://pypi.org/project/markdownify){:target="_blank"}
 * `cli` - installs [CLI](cli.md) dependencies `rich` [PyPI ↗](https://pypi.org/project/rich){:target="_blank"}, `prompt-toolkit` [PyPI ↗](https://pypi.org/project/prompt-toolkit){:target="_blank"}, and `argcomplete` [PyPI ↗](https://pypi.org/project/argcomplete){:target="_blank"}
 * `mcp` - installs [MCP](mcp/client.md) dependency `fastmcp-slim[client]` [PyPI ↗](https://pypi.org/project/fastmcp-slim){:target="_blank"}

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
@@ -38,9 +38,9 @@ Read [Enable Thinking Across Providers](./CAPABILITIES-AND-HOOKS.md#enable-think
 
 Read [Use MCP Servers](./TOOLS-CORE.md#use-mcp-servers).
 
-## Search with DuckDuckGo, Tavily, or Exa
+## Search with DuckDuckGo, Tavily, Nimble, or Exa
 
-Read [Search with DuckDuckGo, Tavily, or Exa](./TOOLS-CORE.md#search-with-duckduckgo-tavily-or-exa).
+Read [Search with DuckDuckGo, Tavily, Nimble, or Exa](./TOOLS-CORE.md#search-with-duckduckgo-tavily-nimble-or-exa).
 
 ## Require Tool Approval (Human in the Loop)
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -91,7 +91,7 @@ agent = Agent(
 
 When you need to manage the toolset lifecycle yourself, share an MCP server across multiple agents, or use FastMCP-specific configuration that doesn't fit the capability shape, use [`MCPToolset`](https://ai.pydantic.dev/mcp/client/) directly and pass it via `toolsets=[...]`. Its `tool_error_behavior` controls how a tool error from the server surfaces: `'retry'` (default) raises `ModelRetry`, `'failed'` raises `ToolFailed` (recorded as `outcome='failed'`), and `'error'` raises the raw `fastmcp` `ToolError`.
 
-## Search with DuckDuckGo, Tavily, or Exa
+## Search with DuckDuckGo, Tavily, Nimble, or Exa
 
 Use common tools when the user wants explicit search tools rather than provider-adaptive capabilities.
 
@@ -107,7 +107,9 @@ agent = Agent(
 )
 ```
 
+For Nimble, prefer `NimbleToolset` (`pydantic-ai-slim[nimble]`) when the user wants search plus extract (and optionally map, crawl, or Agent API V2). Crawl and agent runs are resumable start/status/result tools — do not poll inside a single tool call.
+
 Good default split:
 
 - use `WebSearch()` capability when the user wants model-agnostic search with native fallback
-- use `duckduckgo_search_tool()` / Tavily / Exa when the user explicitly wants those engines as tools
+- use `duckduckgo_search_tool()` / Tavily / Nimble / Exa when the user explicitly wants those engines as tools

--- a/pydantic_ai_slim/pydantic_ai/common_tools/nimble.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/nimble.py
@@ -1,3 +1,13 @@
+"""Nimble common tools for Pydantic AI agents.
+
+Provides web search, page extract, site map, crawl job control, and Agent API V2
+run lifecycle tools via the official [`nimble_python`](https://pypi.org/project/nimble_python/)
+SDK.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
 from dataclasses import KW_ONLY, dataclass
 from functools import partial
 from inspect import signature
@@ -6,23 +16,65 @@ from typing import Literal, overload
 from pydantic import TypeAdapter
 from typing_extensions import Any, TypedDict
 
+from pydantic_ai import FunctionToolset
 from pydantic_ai.tools import Tool
 
 try:
     from nimble_python import AsyncNimble
 except ImportError as _import_error:
     raise ImportError(
-        'Please install `nimble_python` to use the Nimble search tool, '
+        'Please install `nimble_python` to use the Nimble tools, '
         'you can use the `nimble` optional group — `pip install "pydantic-ai-slim[nimble]"`'
     ) from _import_error
 
-__all__ = ('nimble_search_tool',)
+__all__ = (
+    'NimbleToolset',
+    'nimble_agent_run_result_tool',
+    'nimble_agent_run_start_tool',
+    'nimble_agent_run_status_tool',
+    'nimble_agents_list_tool',
+    'nimble_agent_templates_list_tool',
+    'nimble_crawl_start_tool',
+    'nimble_crawl_status_tool',
+    'nimble_extract_tool',
+    'nimble_map_tool',
+    'nimble_search_tool',
+)
 
 _CLIENT_SOURCE = 'pydantic-ai'
 """Stable attribution slug sent as `X-Client-Source` on every Nimble request."""
 
 _UNSET: Any = object()
 """Sentinel to distinguish "not provided" from None in factory kwargs."""
+
+
+def _resolve_client(api_key: str | None, client: AsyncNimble | None) -> AsyncNimble:
+    if client is not None:
+        return client
+    if api_key is None:
+        raise ValueError('Either api_key or client must be provided')
+    return AsyncNimble(api_key=api_key, client_source=_CLIENT_SOURCE)
+
+
+def _bind_tool_params(func: Callable[..., Any], kwargs: dict[str, Any]) -> Callable[..., Any]:
+    if not kwargs:
+        return func
+    original = func
+    bound = partial(func, **kwargs)
+    bound.__name__ = original.__name__  # type: ignore[attr-defined]
+    bound.__qualname__ = original.__qualname__
+    # partial with keyword args only updates defaults, not removes params.
+    # Set __signature__ explicitly to exclude bound params from the tool schema.
+    orig_sig = signature(original)
+    bound.__signature__ = orig_sig.replace(  # type: ignore[attr-defined]
+        parameters=[p for name, p in orig_sig.parameters.items() if name not in kwargs]
+    )
+    return bound
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
 
 
 class NimbleSearchResult(TypedDict):
@@ -148,12 +200,8 @@ def nimble_search_tool(
         include_domains: List of domains to specifically include in the search results.
         exclude_domains: List of domains to specifically exclude from the search results.
     """
-    if client is None:
-        if api_key is None:
-            raise ValueError('Either api_key or client must be provided')
-        client = AsyncNimble(api_key=api_key, client_source=_CLIENT_SOURCE)
-    func = NimbleSearchTool(client=client, max_results=max_results).__call__
-
+    resolved = _resolve_client(api_key, client)
+    func = NimbleSearchTool(client=resolved, max_results=max_results).__call__
     kwargs: dict[str, Any] = {}
     if search_depth is not _UNSET:
         kwargs['search_depth'] = search_depth
@@ -163,21 +211,639 @@ def nimble_search_tool(
         kwargs['include_domains'] = include_domains
     if exclude_domains is not _UNSET:
         kwargs['exclude_domains'] = exclude_domains
-
-    if kwargs:
-        original = func
-        func = partial(func, **kwargs)
-        func.__name__ = original.__name__  # type: ignore[union-attr]
-        func.__qualname__ = original.__qualname__
-        # partial with keyword args only updates defaults, not removes params.
-        # Set __signature__ explicitly to exclude bound params from the tool schema.
-        orig_sig = signature(original)
-        func.__signature__ = orig_sig.replace(  # type: ignore[attr-defined]
-            parameters=[p for name, p in orig_sig.parameters.items() if name not in kwargs]
-        )
-
     return Tool[Any](
-        func,  # pyright: ignore[reportArgumentType]
+        _bind_tool_params(func, kwargs),
         name='nimble_search',
         description='Searches Nimble for the given query and returns the results.',
     )
+
+
+# ---------------------------------------------------------------------------
+# Extract
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NimbleExtractTool:
+    """The Nimble extract tool."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(self, url: str) -> str:
+        """Extracts page content as markdown from a URL.
+
+        Args:
+            url: The URL to extract content from.
+
+        Returns:
+            The page content as markdown, or an empty string when unavailable.
+        """
+        response = await self.client.extract.run(url=url, formats=['markdown'])
+        if response.data and response.data.markdown:
+            return response.data.markdown
+        return ''
+
+
+@overload
+def nimble_extract_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_extract_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_extract_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a Nimble extract tool that returns page content as markdown.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleExtractTool(client=resolved).__call__,
+        name='nimble_extract',
+        description='Extract page content as markdown from a URL. Use after search to read a specific page.',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Map
+# ---------------------------------------------------------------------------
+
+
+class NimbleMapLink(TypedDict):
+    """A link discovered by Nimble Map."""
+
+    url: str
+    """The discovered URL."""
+    title: str | None
+    """The link title, if available."""
+    description: str | None
+    """The link description, if available."""
+
+
+nimble_map_ta = TypeAdapter(list[NimbleMapLink])
+
+
+@dataclass
+class NimbleMapTool:
+    """The Nimble map tool."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(
+        self,
+        url: str,
+        limit: int | None = None,
+        domain_filter: Literal['domain', 'subdomain', 'all'] | None = None,
+        sitemap: Literal['skip', 'include', 'only'] | None = None,
+    ) -> list[NimbleMapLink]:
+        """Discovers links on a website.
+
+        Args:
+            url: The website URL to map.
+            limit: Maximum number of links to return.
+            domain_filter: Scope of domains to include (`domain`, `subdomain`, or `all`).
+            sitemap: Sitemap handling strategy (`skip`, `include`, or `only`).
+
+        Returns:
+            Discovered links with optional titles and descriptions.
+        """
+        map_kwargs: dict[str, Any] = {'url': url}
+        if limit is not None:
+            map_kwargs['limit'] = limit
+        if domain_filter is not None:
+            map_kwargs['domain_filter'] = domain_filter
+        if sitemap is not None:
+            map_kwargs['sitemap'] = sitemap
+        response = await self.client.map(**map_kwargs)
+        projected = [
+            {
+                'url': link.url,
+                'title': link.title,
+                'description': link.description,
+            }
+            for link in response.links
+        ]
+        return nimble_map_ta.validate_python(projected)
+
+
+@overload
+def nimble_map_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_map_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_map_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a Nimble map tool for discovering links on a website.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleMapTool(client=resolved).__call__,
+        name='nimble_map',
+        description='Discover links on a website. Use to understand site structure before crawling or extracting pages.',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Crawl (resumable: start + status, no long polling)
+# ---------------------------------------------------------------------------
+
+
+class NimbleCrawlJob(TypedDict):
+    """A Nimble crawl job snapshot."""
+
+    crawl_id: str
+    """The crawl job id."""
+    status: str
+    """The crawl job status."""
+    url: str
+    """The start URL for the crawl."""
+    completed: float | None
+    """Number of completed page tasks."""
+    failed: float | None
+    """Number of failed page tasks."""
+    pending: float | None
+    """Number of pending page tasks."""
+    total: float | None
+    """Total number of page tasks."""
+
+
+def _crawl_job_from_response(response: Any) -> NimbleCrawlJob:
+    return NimbleCrawlJob(
+        crawl_id=response.crawl_id,
+        status=response.status,
+        url=response.url,
+        completed=response.completed,
+        failed=response.failed,
+        pending=response.pending,
+        total=response.total,
+    )
+
+
+@dataclass
+class NimbleCrawlStartTool:
+    """Starts a Nimble crawl job without waiting for completion."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(
+        self,
+        url: str,
+        limit: int | None = None,
+        max_discovery_depth: int | None = None,
+        include_paths: list[str] | None = None,
+        exclude_paths: list[str] | None = None,
+        sitemap: Literal['skip', 'include', 'only'] | None = None,
+        name: str | None = None,
+    ) -> NimbleCrawlJob:
+        """Starts a crawl job and returns its id/status.
+
+        Args:
+            url: The URL to start crawling from.
+            limit: Maximum number of pages to crawl.
+            max_discovery_depth: Maximum link-following depth from the start URL.
+            include_paths: URL path patterns to include.
+            exclude_paths: URL path patterns to exclude.
+            sitemap: Sitemap handling strategy.
+            name: Optional name for the crawl job.
+
+        Returns:
+            A crawl job snapshot including `crawl_id` for later status checks.
+        """
+        crawl_kwargs: dict[str, Any] = {'url': url}
+        if limit is not None:
+            crawl_kwargs['limit'] = limit
+        if max_discovery_depth is not None:
+            crawl_kwargs['max_discovery_depth'] = max_discovery_depth
+        if include_paths is not None:
+            crawl_kwargs['include_paths'] = include_paths
+        if exclude_paths is not None:
+            crawl_kwargs['exclude_paths'] = exclude_paths
+        if sitemap is not None:
+            crawl_kwargs['sitemap'] = sitemap
+        if name is not None:
+            crawl_kwargs['name'] = name
+        response = await self.client.crawl.run(**crawl_kwargs)
+        return _crawl_job_from_response(response)
+
+
+@dataclass
+class NimbleCrawlStatusTool:
+    """Fetches status for a Nimble crawl job."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(self, crawl_id: str) -> NimbleCrawlJob:
+        """Gets the current status of a crawl job.
+
+        Args:
+            crawl_id: The crawl job id returned by `nimble_crawl_start`.
+
+        Returns:
+            The latest crawl job snapshot.
+        """
+        response = await self.client.crawl.status(crawl_id)
+        return _crawl_job_from_response(response)
+
+
+@overload
+def nimble_crawl_start_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_crawl_start_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_crawl_start_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that starts a Nimble crawl job (does not poll for completion).
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleCrawlStartTool(client=resolved).__call__,
+        name='nimble_crawl_start',
+        description=(
+            'Start a Nimble crawl job and return its crawl_id immediately. '
+            'Use nimble_crawl_status to poll progress across agent turns.'
+        ),
+    )
+
+
+@overload
+def nimble_crawl_status_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_crawl_status_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_crawl_status_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that fetches Nimble crawl job status.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleCrawlStatusTool(client=resolved).__call__,
+        name='nimble_crawl_status',
+        description='Get the status of a Nimble crawl job by crawl_id.',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent API V2 (list + start / status / result)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NimbleAgentsListTool:
+    """Lists Nimble agents."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(self, limit: int | None = None, offset: int | None = None) -> list[dict[str, Any]]:
+        """Lists available Nimble agents.
+
+        Args:
+            limit: Maximum number of agents to return.
+            offset: Pagination offset.
+
+        Returns:
+            Agent records as dictionaries.
+        """
+        list_kwargs: dict[str, Any] = {}
+        if limit is not None:
+            list_kwargs['limit'] = limit
+        if offset is not None:
+            list_kwargs['offset'] = offset
+        response = await self.client.agents.list(**list_kwargs)
+        return [item.model_dump(mode='json') for item in response.items]
+
+
+@dataclass
+class NimbleAgentTemplatesListTool:
+    """Lists Nimble agent templates."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(self, limit: int | None = None, offset: int | None = None) -> list[dict[str, Any]]:
+        """Lists available Nimble agent templates.
+
+        Args:
+            limit: Maximum number of templates to return.
+            offset: Pagination offset.
+
+        Returns:
+            Template records as dictionaries.
+        """
+        list_kwargs: dict[str, Any] = {}
+        if limit is not None:
+            list_kwargs['limit'] = limit
+        if offset is not None:
+            list_kwargs['offset'] = offset
+        response = await self.client.agents.templates.list(**list_kwargs)
+        return [item.model_dump(mode='json') for item in response.items]
+
+
+@dataclass
+class NimbleAgentRunStartTool:
+    """Starts an Agent API V2 run."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(
+        self,
+        agent_id: str,
+        input: str,
+        effort: Literal['low', 'medium', 'high', 'x-high', 'max'] | None = None,
+    ) -> dict[str, Any]:
+        """Starts an agent run and returns run metadata.
+
+        Args:
+            agent_id: The Nimble agent id to run.
+            input: The prompt / input for the agent run.
+            effort: Optional effort level for the run.
+
+        Returns:
+            Run metadata including `id` and `status` for later status/result calls.
+        """
+        run_kwargs: dict[str, Any] = {'agent_id': agent_id, 'input': input}
+        if effort is not None:
+            run_kwargs['effort'] = effort
+        response = await self.client.agents.runs.create(**run_kwargs)
+        return response.model_dump(mode='json')
+
+
+@dataclass
+class NimbleAgentRunStatusTool:
+    """Fetches Agent API V2 run status."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(self, agent_id: str, run_id: str) -> dict[str, Any]:
+        """Gets the status of an agent run.
+
+        Args:
+            agent_id: The Nimble agent id.
+            run_id: The run id returned by `nimble_agent_run_start`.
+
+        Returns:
+            Run status metadata.
+        """
+        response = await self.client.agents.runs.get(run_id, agent_id=agent_id)
+        return response.model_dump(mode='json')
+
+
+@dataclass
+class NimbleAgentRunResultTool:
+    """Fetches Agent API V2 run result."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    async def __call__(self, agent_id: str, run_id: str) -> dict[str, Any]:
+        """Gets the result of a completed agent run.
+
+        Args:
+            agent_id: The Nimble agent id.
+            run_id: The run id returned by `nimble_agent_run_start`.
+
+        Returns:
+            The run result payload (text/JSON output and trust metadata when present).
+        """
+        response = await self.client.agents.runs.result(run_id, agent_id=agent_id)
+        if hasattr(response, 'model_dump'):
+            return response.model_dump(mode='json')
+        return {'result': response}  # pragma: no cover
+
+
+@overload
+def nimble_agents_list_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_agents_list_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_agents_list_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that lists Nimble agents.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleAgentsListTool(client=resolved).__call__,
+        name='nimble_agents_list',
+        description='List available Nimble agents. Use an agent id with nimble_agent_run_start.',
+    )
+
+
+@overload
+def nimble_agent_templates_list_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_agent_templates_list_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_agent_templates_list_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that lists Nimble agent templates.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleAgentTemplatesListTool(client=resolved).__call__,
+        name='nimble_agent_templates_list',
+        description='List available Nimble agent templates (research / enrichment starting points).',
+    )
+
+
+@overload
+def nimble_agent_run_start_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_agent_run_start_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_agent_run_start_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that starts an Agent API V2 run (does not wait for completion).
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleAgentRunStartTool(client=resolved).__call__,
+        name='nimble_agent_run_start',
+        description=(
+            'Start a Nimble agent run and return run id/status immediately. '
+            'Use nimble_agent_run_status and nimble_agent_run_result across turns.'
+        ),
+    )
+
+
+@overload
+def nimble_agent_run_status_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_agent_run_status_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_agent_run_status_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that fetches Agent API V2 run status.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleAgentRunStatusTool(client=resolved).__call__,
+        name='nimble_agent_run_status',
+        description='Get the status of a Nimble agent run by agent_id and run_id.',
+    )
+
+
+@overload
+def nimble_agent_run_result_tool(api_key: str) -> Tool[Any]: ...
+
+
+@overload
+def nimble_agent_run_result_tool(*, client: AsyncNimble) -> Tool[Any]: ...
+
+
+def nimble_agent_run_result_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+) -> Tool[Any]:
+    """Creates a tool that fetches Agent API V2 run results.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+    """
+    resolved = _resolve_client(api_key, client)
+    return Tool[Any](
+        NimbleAgentRunResultTool(client=resolved).__call__,
+        name='nimble_agent_run_result',
+        description='Get the result of a completed Nimble agent run by agent_id and run_id.',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Toolset
+# ---------------------------------------------------------------------------
+
+
+class NimbleToolset(FunctionToolset[Any]):
+    """A toolset that provides Nimble tools with a shared client.
+
+    By default includes search and extract. Map, crawl, and Agent API tools are opt-in.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        max_results: int | None = None,
+        include_search: bool = True,
+        include_extract: bool = True,
+        include_map: bool = False,
+        include_crawl: bool = False,
+        include_agents: bool = False,
+        id: str | None = None,
+    ):
+        """Creates a Nimble toolset with a shared client.
+
+        Args:
+            api_key: The Nimble API key.
+            max_results: Developer-controlled max results for search.
+            include_search: Whether to include `nimble_search`.
+            include_extract: Whether to include `nimble_extract`.
+            include_map: Whether to include `nimble_map`.
+            include_crawl: Whether to include crawl start/status tools.
+            include_agents: Whether to include Agent API V2 tools.
+            id: Optional ID for the toolset, used for durable execution environments.
+        """
+        client = AsyncNimble(api_key=api_key, client_source=_CLIENT_SOURCE)
+        tools: list[Tool[Any]] = []
+
+        if include_search:
+            tools.append(nimble_search_tool(client=client, max_results=max_results))
+        if include_extract:
+            tools.append(nimble_extract_tool(client=client))
+        if include_map:
+            tools.append(nimble_map_tool(client=client))
+        if include_crawl:
+            tools.append(nimble_crawl_start_tool(client=client))
+            tools.append(nimble_crawl_status_tool(client=client))
+        if include_agents:
+            tools.append(nimble_agents_list_tool(client=client))
+            tools.append(nimble_agent_templates_list_tool(client=client))
+            tools.append(nimble_agent_run_start_tool(client=client))
+            tools.append(nimble_agent_run_status_tool(client=client))
+            tools.append(nimble_agent_run_result_tool(client=client))
+
+        super().__init__(tools, id=id)

--- a/pydantic_ai_slim/pydantic_ai/common_tools/nimble.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/nimble.py
@@ -1,0 +1,183 @@
+from dataclasses import KW_ONLY, dataclass
+from functools import partial
+from inspect import signature
+from typing import Literal, overload
+
+from pydantic import TypeAdapter
+from typing_extensions import Any, TypedDict
+
+from pydantic_ai.tools import Tool
+
+try:
+    from nimble_python import AsyncNimble
+except ImportError as _import_error:
+    raise ImportError(
+        'Please install `nimble_python` to use the Nimble search tool, '
+        'you can use the `nimble` optional group — `pip install "pydantic-ai-slim[nimble]"`'
+    ) from _import_error
+
+__all__ = ('nimble_search_tool',)
+
+_CLIENT_SOURCE = 'pydantic-ai'
+"""Stable attribution slug sent as `X-Client-Source` on every Nimble request."""
+
+_UNSET: Any = object()
+"""Sentinel to distinguish "not provided" from None in factory kwargs."""
+
+
+class NimbleSearchResult(TypedDict):
+    """A Nimble search result.
+
+    See [Nimble Search API documentation](https://docs.nimbleway.com/)
+    for more information.
+    """
+
+    title: str
+    """The title of the search result."""
+    url: str
+    """The URL of the search result."""
+    content: str
+    """The result content, or the description when content is empty (e.g. `lite` depth)."""
+
+
+nimble_search_ta = TypeAdapter(list[NimbleSearchResult])
+
+
+@dataclass
+class NimbleSearchTool:
+    """The Nimble search tool."""
+
+    client: AsyncNimble
+    """The Nimble async client."""
+
+    _: KW_ONLY
+
+    max_results: int | None = None
+    """The maximum number of results. If None, the Nimble default is used."""
+
+    async def __call__(
+        self,
+        query: str,
+        search_depth: Literal['lite', 'fast', 'deep'] = 'lite',
+        time_range: Literal['hour', 'day', 'week', 'month', 'year'] | None = None,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+    ) -> list[NimbleSearchResult]:
+        """Searches Nimble for the given query and returns the results.
+
+        Args:
+            query: The search query to execute with Nimble.
+            search_depth: Controls content richness and latency of search results.
+            time_range: The time range back from the current date to filter results.
+            include_domains: List of domains to specifically include in the search results.
+            exclude_domains: List of domains to specifically exclude from the search results.
+
+        Returns:
+            A list of search results from Nimble.
+        """
+        search_kwargs: dict[str, Any] = {
+            'query': query,
+            'search_depth': search_depth,
+            'time_range': time_range,
+            'include_domains': include_domains,
+            'exclude_domains': exclude_domains,
+        }
+        if self.max_results is not None:
+            search_kwargs['max_results'] = self.max_results
+        response = await self.client.search(**search_kwargs)
+        projected = [
+            {
+                'title': result.title,
+                'url': result.url,
+                'content': result.content or result.description,
+            }
+            for result in response.results
+        ]
+        return nimble_search_ta.validate_python(projected)
+
+
+@overload
+def nimble_search_tool(
+    api_key: str,
+    *,
+    max_results: int | None = None,
+    search_depth: Literal['lite', 'fast', 'deep'] = _UNSET,
+    time_range: Literal['hour', 'day', 'week', 'month', 'year'] | None = _UNSET,
+    include_domains: list[str] | None = _UNSET,
+    exclude_domains: list[str] | None = _UNSET,
+) -> Tool[Any]: ...
+
+
+@overload
+def nimble_search_tool(
+    *,
+    client: AsyncNimble,
+    max_results: int | None = None,
+    search_depth: Literal['lite', 'fast', 'deep'] = _UNSET,
+    time_range: Literal['hour', 'day', 'week', 'month', 'year'] | None = _UNSET,
+    include_domains: list[str] | None = _UNSET,
+    exclude_domains: list[str] | None = _UNSET,
+) -> Tool[Any]: ...
+
+
+def nimble_search_tool(
+    api_key: str | None = None,
+    *,
+    client: AsyncNimble | None = None,
+    max_results: int | None = None,
+    search_depth: Literal['lite', 'fast', 'deep'] = _UNSET,
+    time_range: Literal['hour', 'day', 'week', 'month', 'year'] | None = _UNSET,
+    include_domains: list[str] | None = _UNSET,
+    exclude_domains: list[str] | None = _UNSET,
+) -> Tool[Any]:
+    """Creates a Nimble search tool.
+
+    `max_results` is always developer-controlled and does not appear in the LLM tool schema.
+    Other parameters, when provided, are fixed for all searches and hidden from the LLM's
+    tool schema. Parameters left unset remain available for the LLM to set per-call.
+
+    Args:
+        api_key: The Nimble API key. Required if `client` is not provided.
+
+            You can get one from [Nimble's dashboard](https://online.nimbleway.com/account-settings/api-keys).
+        client: An existing `AsyncNimble` client. If provided, `api_key` is ignored.
+            This is useful for sharing a client across multiple tool instances.
+        max_results: The maximum number of results. If None, the Nimble default is used.
+        search_depth: Controls content richness and latency of search results.
+        time_range: The time range back from the current date to filter results.
+        include_domains: List of domains to specifically include in the search results.
+        exclude_domains: List of domains to specifically exclude from the search results.
+    """
+    if client is None:
+        if api_key is None:
+            raise ValueError('Either api_key or client must be provided')
+        client = AsyncNimble(api_key=api_key, client_source=_CLIENT_SOURCE)
+    func = NimbleSearchTool(client=client, max_results=max_results).__call__
+
+    kwargs: dict[str, Any] = {}
+    if search_depth is not _UNSET:
+        kwargs['search_depth'] = search_depth
+    if time_range is not _UNSET:
+        kwargs['time_range'] = time_range
+    if include_domains is not _UNSET:
+        kwargs['include_domains'] = include_domains
+    if exclude_domains is not _UNSET:
+        kwargs['exclude_domains'] = exclude_domains
+
+    if kwargs:
+        original = func
+        func = partial(func, **kwargs)
+        func.__name__ = original.__name__  # type: ignore[union-attr]
+        func.__qualname__ = original.__qualname__
+        # partial with keyword args only updates defaults, not removes params.
+        # Set __signature__ explicitly to exclude bound params from the tool schema.
+        orig_sig = signature(original)
+        func.__signature__ = orig_sig.replace(  # type: ignore[attr-defined]
+            parameters=[p for name, p in orig_sig.parameters.items() if name not in kwargs]
+        )
+
+    return Tool[Any](
+        func,  # pyright: ignore[reportArgumentType]
+        name='nimble_search',
+        description='Searches Nimble for the given query and returns the results.',
+    )

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -98,6 +98,7 @@ voyageai = ["voyageai>=0.3.7; python_version < '3.14'"]
 duckduckgo = ["ddgs>=9.0.0"]
 tavily = ["tavily-python>=0.5.0"]
 exa = ["exa-py>=2.0.0"]
+nimble = ["nimble_python>=1.0.0"]
 web-fetch = ["markdownify>=1.2"]
 # CLI
 cli = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ ui = ["pydantic-ai-slim[ui]=={{ version }}"]
 duckduckgo = ["pydantic-ai-slim[duckduckgo]=={{ version }}"]
 tavily = ["pydantic-ai-slim[tavily]=={{ version }}"]
 exa = ["pydantic-ai-slim[exa]=={{ version }}"]
+nimble = ["pydantic-ai-slim[nimble]=={{ version }}"]
 web-fetch = ["pydantic-ai-slim[web-fetch]=={{ version }}"]
 temporal = ["pydantic-ai-slim[temporal]=={{ version }}"]
 spec = ["pydantic-ai-slim[spec]=={{ version }}"]
@@ -151,6 +152,7 @@ dev = [
     "pydocket>=0.20.2",
     "exa-py>=2.0.0",
     "tavily-python>=0.5.0",
+    "nimble_python>=1.0.0",
     "markdownify>=1.2",
     "inline-snapshot>=0.32.5",
     "pytest>=9.0.3",

--- a/tests/cassettes/test_nimble/test_agent_calls_nimble_search.yaml
+++ b/tests/cassettes/test_nimble/test_agent_calls_nimble_search.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains: null
+      include_domains: null
+      max_results: 2
+      query: a
+      search_depth: lite
+      time_range: null
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '742'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '20'
+      ratelimit-remaining:
+      - '19'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: 9c0c9c1d-a952-456d-976c-528668b8992c
+      results:
+      - content: ''
+        description: 'A (minuscule: a) is the first letter and the first vowel letter of the Latin alphabet, used in the modern
+          English alphabet, and others worldwide.'
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 1
+        title: A - Wikipedia
+        url: https://en.wikipedia.org/wiki/A
+      - content: ''
+        description: Free shipping on millions of items. Enjoy low prices and great deals. Shop clothing, shoes, and more
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 2
+        title: Amazon.com. Spend less. Smile more.
+        url: https://www.amazon.com/
+      total_results: 2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_nimble/test_basic_search.yaml
+++ b/tests/cassettes/test_nimble/test_basic_search.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '145'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains: null
+      include_domains: null
+      max_results: 3
+      query: What is Pydantic AI?
+      search_depth: lite
+      time_range: null
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '1225'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '20'
+      ratelimit-remaining:
+      - '19'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: 9fda41d7-5663-4022-9a89-1c88d248eab2
+      results:
+      - content: ''
+        description: Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build
+          production grade applications and workflows with...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 1
+        title: Pydantic AI | Pydantic Docs
+        url: https://pydantic.dev/docs/ai/overview/
+      - content: ''
+        description: Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build
+          production grade applications and workflows with...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 2
+        title: AI Agent Framework, the Pydantic way
+        url: https://github.com/pydantic/pydantic-ai
+      - content: ''
+        description: 2 days ago -- Pydantic is the AI engineering stack for teams building with AI. Build in Python, TypeScript,
+          Rust, and Go. Observe and optimize on the cloud ...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 3
+        title: Pydantic | The end-to-end AI engineering stack
+        url: https://pydantic.dev/
+      total_results: 3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_nimble/test_factory_with_bound_params.yaml
+++ b/tests/cassettes/test_nimble/test_factory_with_bound_params.yaml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '154'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains: null
+      include_domains:
+      - arxiv.org
+      max_results: 2
+      query: attention mechanisms
+      search_depth: lite
+      time_range: null
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '927'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '20'
+      ratelimit-remaining:
+      - '19'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: 65099ec7-673d-4cd1-a683-f7a091453703
+      results:
+      - content: ''
+        description: by H Hays · 2026 · Cited by 4 -- Attention mechanisms represent a fundamental paradigm shift in neural
+          network architectures, enabling models to selectively focus on relevant ...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 1
+        title: Attention mechanisms in neural networks
+        url: https://arxiv.org/pdf/2601.03329
+      - content: ''
+        description: by H Hays · 2026 · Cited by 4 -- :Attention mechanisms represent a fundamental paradigm shift in neural
+          network architectures, enabling models to selectively focus on relevant ...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 2
+        title: '[2601.03329] Attention mechanisms in neural networks'
+        url: https://arxiv.org/abs/2601.03329
+      total_results: 2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_nimble/test_search_with_exclude_domains.yaml
+++ b/tests/cassettes/test_nimble/test_search_with_exclude_domains.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '146'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains:
+      - medium.com
+      include_domains: null
+      max_results: 3
+      query: Pydantic AI
+      search_depth: lite
+      time_range: null
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '1211'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '20'
+      ratelimit-remaining:
+      - '19'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: 17a17d17-2451-490b-a5e4-b2e3298d4ba1
+      results:
+      - content: ''
+        description: Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build
+          production grade applications and workflows with...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 1
+        title: AI Agent Framework, the Pydantic way
+        url: https://github.com/pydantic/pydantic-ai
+      - content: ''
+        description: Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build
+          production grade applications and workflows with...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 2
+        title: Pydantic AI | Pydantic Docs
+        url: https://pydantic.dev/docs/ai/overview/
+      - content: ''
+        description: 2 days ago -- Pydantic is the AI engineering stack for teams building with AI. Build in Python, TypeScript,
+          Rust, and Go. the cloud or self-host.
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 3
+        title: Pydantic | The end-to-end AI engineering stack
+        url: https://pydantic.dev/
+      total_results: 3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_nimble/test_search_with_include_domains.yaml
+++ b/tests/cassettes/test_nimble/test_search_with_include_domains.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '159'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains: null
+      include_domains:
+      - arxiv.org
+      max_results: 3
+      query: transformer architectures
+      search_depth: lite
+      time_range: null
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '1313'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '20'
+      ratelimit-remaining:
+      - '19'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: 3eed6afc-0036-4276-ac5f-d704bec641a0
+      results:
+      - content: ''
+        description: by RE Turner · 2023 · Cited by 96 -- In this note we aim for a mathematically precise, intuitive, and
+          clean description of the transformer architecture.
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 1
+        title: '[2304.10557] An Introduction to Transformers'
+        url: https://arxiv.org/abs/2304.10557
+      - content: ''
+        description: by HH Samson · 2026 · Cited by 11 -- This comprehensive survey examines lightweight transformer architectures
+          specifically designed for edge deployment, analyzing recent advances ...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 2
+        title: Lightweight Transformer Architectures for Edge Devices in ...
+        url: https://arxiv.org/abs/2601.03290
+      - content: ''
+        description: Feb 15, 2026 -- Transformer architectures have revolutionized machine learning across a wide range of
+          domains, from natural language processing to scientific ...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 3
+        title: In Transformer We Trust? A Perspective on ...
+        url: https://arxiv.org/html/2602.14318v1
+      total_results: 3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_nimble/test_search_with_search_depth.yaml
+++ b/tests/cassettes/test_nimble/test_search_with_search_depth.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '145'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains: null
+      include_domains: null
+      max_results: 2
+      query: What is Pydantic AI?
+      search_depth: fast
+      time_range: null
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '4090'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '10'
+      ratelimit-remaining:
+      - '9'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: e200b9e4-0391-47fa-ad59-bbda57a75aad
+      results:
+      - content: ''
+        description: "Pydantic AI ships the agent loop, a composable capabilities system, and built-in capabilities for thinking,
+          web search, web fetch, image generation, MCP, tool search, and more; Pydantic AI Harness is our official library
+          of ready-made capabilities -- code execution, file access, guardrails, sub-agent orchestration, and more -- that
+          you pick and choose to build coding agents, research assistants, and anything in between. Built by the Pydantic
+          Team: Pydantic Validation is the validation layer of the OpenAI SDK, the Google ADK, the Anthropic SDK, LangChain,
+          LlamaIndex, AutoGPT, Transformers, CrewAI, Instructor and many more. Why use the derivative when you can go straight
+          to the source? \U0001F603 · Model-agnostic: Supports virtually every model and provider: OpenAI, Anthropic, Gemini,
+          DeepSeek, Grok, Cohere, Mistral, and Perplexity; Azure AI Foundry, Amazon Bedrock, Google Cloud, Ollama, LiteLLM,
+          Groq, OpenRouter, Together AI, Fireworks AI, Cerebras, Hugging Face, GitHub, Heroku, Vercel, Nebius, OVHcloud, Alibaba
+          Cloud, SambaNova, and Z.AI. If your favorite model or provider is not listed, you can easily implement a custom
+          model. Seamless Observability: Tightly integrates with Pydantic Logfire, our general-purpose OpenTelemetry observability
+          platform, for real-time debugging, evals-based performance monitoring, and behavior, tracing, and cost tracking.
+          If you already have an observability platform that supports OTel, you can use that too. Fully Type-safe: Designed
+          to give your IDE or AI coding agent as much context as possible for auto-completion and type checking, moving entire
+          classes of errors from runtime to write-time for a bit of that Rust \"if it compiles, it works\" feel. The SupportDependencies
+          dataclass is used to pass data, connections, and logic into the model that will be needed when running instructions
+          and tool functions. Pydantic AI's system of dependency injection provides a type-safe way to customise the behavior
+          of your agents, and can be especially useful when running unit tests and evals."
+        metadata:
+          country: US
+          entity_type: SearchResult
+          locale: en
+          position: 1
+        title: Pydantic AI | Pydantic Docs
+        url: https://pydantic.dev/docs/ai/overview/
+      - content: ''
+        description: 'We built Pydantic AI with one simple aim: to bring that FastAPI feeling to GenAI app and agent development.
+          Built by the Pydantic Team: Pydantic Validation is the validation layer of the OpenAI SDK, the Google ADK, the Anthropic
+          SDK, LangChain, LlamaIndex, AutoGPT, Transformers, CrewAI, Instructor and many more. Model-agnostic: Supports virtually
+          every model and provider: OpenAI, Anthropic, Gemini, DeepSeek, Grok, Cohere, Mistral, and Perplexity; Azure AI Foundry,
+          Amazon Bedrock, Google Cloud, Ollama, LiteLLM, Groq, OpenRouter, Together AI, Fireworks AI, Cerebras, Hugging Face,
+          GitHub, Heroku, Vercel, Nebius, OVHcloud, Alibaba Cloud, SambaNova, and Z.AI. If your favorite model or provider
+          is not listed, you can easily implement a custom model. Seamless Observability: Tightly integrates with Pydantic
+          Logfire, our general-purpose OpenTelemetry observability platform, for real-time debugging, evals-based performance
+          monitoring, and behavior, tracing, and cost tracking. Realistically though, no list is going to be as convincing
+          as giving it a try and seeing how it makes you feel! ... from pydantic_ai import Agent # Define a very simple agent
+          including the model to use, you can also set the model when running the agent. agent = Agent( ''anthropic:claude-sonnet-4-6'',
+          # Register static instructions using a keyword argument to the agent. Read the API Reference to understand Pydantic
+          AI''s interface. Join Slack or file an issue on GitHub if you have any questions.'
+        metadata:
+          country: US
+          entity_type: SearchResult
+          locale: en
+          position: 2
+        title: 'GitHub - pydantic/pydantic-ai: AI Agent Framework, the Pydantic ...'
+        url: https://github.com/pydantic/pydantic-ai
+      total_results: 2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_nimble/test_search_with_time_range.yaml
+++ b/tests/cassettes/test_nimble/test_search_with_time_range.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '145'
+      content-type:
+      - application/json
+      host:
+      - sdk.nimbleway.com
+    method: POST
+    parsed_body:
+      exclude_domains: null
+      include_domains: null
+      max_results: 3
+      query: generative AI news
+      search_depth: lite
+      time_range: week
+    uri: https://sdk.nimbleway.com/v2/search
+  response:
+    headers:
+      content-length:
+      - '1420'
+      content-type:
+      - application/json
+      ratelimit-limit:
+      - '20'
+      ratelimit-remaining:
+      - '19'
+      ratelimit-reset:
+      - '1'
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      request_id: 3772ba83-a1f5-4c6d-9f86-09d8ad0fec2a
+      results:
+      - content: ''
+        description: 5 days ago -- AI reduced excessive brain stress and unnecessary processes that occur during problem-solving,
+          thereby drastically increasing learning efficiency.
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 1
+        title: Uncovering Multidimensional Effects of Generative AI on ...
+        url: https://www.newswise.com/articles/uncovering-multidimensional-effects-of-generative-ai-on-learning-high-dependency-lowers-actual-test-scores
+      - content: ''
+        description: 18 hours ago -- All the latest content about Artificial intelligence from the BBC. Man sues ChatGPT for
+          near-fatal medical advice. Chinese AI companies are facing increased US ...
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 2
+        title: Artificial intelligence - BBC News
+        url: https://www.bbc.com/news/topics/ce1qrvleleqt
+      - content: ''
+        description: 2 days ago -- OpenAI and other companies have warned that their new A.I. systems could be powerful hacking
+          tools. CreditAaron Wojack for The New York Times.
+        metadata:
+          country: US
+          entity_type: OrganicResult
+          locale: en
+          position: 3
+        title: Artificial Intelligence - The New York ...
+        url: https://www.nytimes.com/spotlight/artificial-intelligence
+      total_results: 3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -884,6 +884,11 @@ def tavily_api_key() -> str:
 
 
 @pytest.fixture(scope='session')
+def nimble_api_key() -> str:
+    return os.getenv('NIMBLE_API_KEY', 'mock-api-key')
+
+
+@pytest.fixture(scope='session')
 def zai_api_key() -> str:
     return os.getenv('ZAI_API_KEY', 'mock-api-key')
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -221,6 +221,7 @@ def test_docs_examples(
     env.set('VOYAGE_API_KEY', 'testing')
     env.set('XAI_API_KEY', 'testing')
     env.set('TAVILY_API_KEY', 'testing')
+    env.set('NIMBLE_API_KEY', 'testing')
     env.set('ZAI_API_KEY', 'testing')
 
     prefix_settings = example.prefix_settings()

--- a/tests/test_nimble.py
+++ b/tests/test_nimble.py
@@ -1,0 +1,308 @@
+"""Tests for the Nimble search tool."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import json
+import sys
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from inline_snapshot import snapshot
+from nimble_python import AsyncNimble
+from nimble_python.types.search_response import Result, ResultMetadataSerpMetadata, SearchResponse
+
+from pydantic_ai import Agent
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.common_tools.nimble import NimbleSearchTool, nimble_search_tool
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from .conftest import IsStr
+
+pytestmark = [pytest.mark.anyio]
+
+
+@pytest.mark.vcr()
+async def test_basic_search(nimble_api_key: str):
+    """Test basic search with default parameters."""
+    tool = NimbleSearchTool(
+        client=AsyncNimble(api_key=nimble_api_key, client_source='pydantic-ai'),
+        max_results=3,
+    )
+    results = await tool('What is Pydantic AI?')
+    assert len(results) == 3
+    assert results == snapshot(
+        [
+            {'title': IsStr(), 'url': IsStr(), 'content': IsStr()},
+            {'title': IsStr(), 'url': IsStr(), 'content': IsStr()},
+            {'title': IsStr(), 'url': IsStr(), 'content': IsStr()},
+        ]
+    )
+
+
+@pytest.mark.vcr()
+async def test_search_with_include_domains(nimble_api_key: str):
+    """Test search with include_domains filtering."""
+    tool = NimbleSearchTool(client=AsyncNimble(api_key=nimble_api_key, client_source='pydantic-ai'), max_results=3)
+    results = await tool('transformer architectures', include_domains=['arxiv.org'])
+    assert len(results) == 3
+    assert all('arxiv.org' in r['url'] for r in results)
+    assert results == snapshot(
+        [
+            {'title': IsStr(), 'url': IsStr(), 'content': IsStr()},
+            {'title': IsStr(), 'url': IsStr(), 'content': IsStr()},
+            {'title': IsStr(), 'url': IsStr(), 'content': IsStr()},
+        ]
+    )
+
+
+@pytest.mark.vcr()
+async def test_search_with_exclude_domains(nimble_api_key: str):
+    """Test search with exclude_domains filtering."""
+    tool = NimbleSearchTool(client=AsyncNimble(api_key=nimble_api_key, client_source='pydantic-ai'), max_results=3)
+    results = await tool('Pydantic AI', exclude_domains=['medium.com'])
+    assert len(results) >= 1
+    assert all('medium.com' not in r['url'] for r in results)
+
+
+@pytest.mark.vcr()
+async def test_search_with_time_range(nimble_api_key: str):
+    """Test search with time_range filtering."""
+    tool = NimbleSearchTool(client=AsyncNimble(api_key=nimble_api_key, client_source='pydantic-ai'), max_results=3)
+    results = await tool('generative AI news', time_range='week')
+    assert len(results) >= 1
+    assert all(r['title'] and r['url'] for r in results)
+
+
+@pytest.mark.vcr()
+async def test_search_with_search_depth(nimble_api_key: str):
+    """Test search with a non-default search_depth."""
+    tool = NimbleSearchTool(client=AsyncNimble(api_key=nimble_api_key, client_source='pydantic-ai'), max_results=2)
+    results = await tool('What is Pydantic AI?', search_depth='fast')
+    assert len(results) >= 1
+    assert all(r['content'] for r in results)
+
+
+@pytest.mark.vcr()
+async def test_factory_with_bound_params(nimble_api_key: str):
+    """Test factory-bound params are forwarded through FunctionSchema.call."""
+    tool = nimble_search_tool(nimble_api_key, max_results=2, include_domains=['arxiv.org'])
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    results = await tool.function_schema.call({'query': 'attention mechanisms'}, ctx)
+    assert len(results) >= 1
+    assert all('arxiv.org' in r['url'] for r in results)
+
+
+@pytest.mark.vcr()
+async def test_agent_calls_nimble_search(nimble_api_key: str):
+    """Public-API path: Agent + TestModel invokes nimble_search and hits Nimble over VCR."""
+    agent = Agent(
+        TestModel(call_tools=['nimble_search']),
+        tools=[nimble_search_tool(nimble_api_key, max_results=2)],
+    )
+    result = await agent.run('Search for Pydantic AI')
+    assert result.output
+    tool_calls = [
+        p
+        for m in result.all_messages()
+        for p in getattr(m, 'parts', [])
+        if getattr(p, 'part_kind', None) == 'tool-call'
+    ]
+    assert any(getattr(p, 'tool_name', None) == 'nimble_search' for p in tool_calls)
+
+
+def test_client_source_header(monkeypatch: pytest.MonkeyPatch):
+    """VCR matchers do not fail if X-Client-Source is dropped — pin factory client_source."""
+    import pydantic_ai.common_tools.nimble as nimble_mod
+
+    captured: dict[str, Any] = {}
+    real_client = nimble_mod.AsyncNimble
+
+    def tracking_client(*args: Any, **kwargs: Any) -> AsyncNimble:
+        captured.update(kwargs)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(nimble_mod, 'AsyncNimble', tracking_client)
+    tool = nimble_search_tool('test-key')
+    assert tool.name == 'nimble_search'
+    assert captured.get('client_source') == 'pydantic-ai'
+    assert captured.get('api_key') == 'test-key'
+
+
+async def test_request_body_defaults(nimble_api_key: str):
+    """Cassette match-on may ignore body drift — pin lite default and max_results via httpx mock."""
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured['headers'] = dict(request.headers)
+        captured['body'] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                'request_id': '00000000-0000-0000-0000-000000000001',
+                'results': [
+                    {
+                        'title': 'Example',
+                        'url': 'https://example.com',
+                        'content': 'body',
+                        'description': 'desc',
+                        'metadata': {
+                            'country': 'US',
+                            'entity_type': 'organic',
+                            'locale': 'en',
+                            'position': 1,
+                        },
+                    }
+                ],
+                'total_results': 1,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = AsyncNimble(
+        api_key=nimble_api_key,
+        client_source='pydantic-ai',
+        http_client=httpx.AsyncClient(transport=transport),
+    )
+    tool = NimbleSearchTool(client=client, max_results=3)
+    results = await tool('hello world')
+    assert results == [{'title': 'Example', 'url': 'https://example.com', 'content': 'body'}]
+    assert captured['body']['query'] == 'hello world'
+    assert captured['body']['search_depth'] == 'lite'
+    assert captured['body']['max_results'] == 3
+    assert captured['headers'].get('x-client-source') == 'pydantic-ai'
+
+
+async def test_result_content_fallback():
+    """Empty content should fall back to description (lite depth) without a network call."""
+    response = SearchResponse(
+        request_id='00000000-0000-0000-0000-000000000002',
+        total_results=1,
+        results=[
+            Result(
+                title='Lite Result',
+                url='https://example.com/lite',
+                content='',
+                description='snippet only',
+                metadata=ResultMetadataSerpMetadata(
+                    country='US',
+                    entity_type='organic',
+                    locale='en',
+                    position=1,
+                ),
+            )
+        ],
+    )
+    client = AsyncMock()
+    client.search = AsyncMock(return_value=response)
+    tool = NimbleSearchTool(client=cast(AsyncNimble, client))
+    results = await tool('q')
+    assert results == [
+        {
+            'title': 'Lite Result',
+            'url': 'https://example.com/lite',
+            'content': 'snippet only',
+        }
+    ]
+
+
+def test_no_params_bound_exposes_all_in_schema(nimble_api_key: str):
+    """Test that with no factory params, all parameters appear in the tool schema."""
+    tool = nimble_search_tool(nimble_api_key)
+    assert tool.name == snapshot('nimble_search')
+    assert tool.function_schema.json_schema == snapshot(
+        {
+            'additionalProperties': False,
+            'properties': {
+                'query': {
+                    'description': 'The search query to execute with Nimble.',
+                    'type': 'string',
+                },
+                'search_depth': {
+                    'default': 'lite',
+                    'description': 'Controls content richness and latency of search results.',
+                    'enum': ['lite', 'fast', 'deep'],
+                    'type': 'string',
+                },
+                'time_range': {
+                    'anyOf': [
+                        {'enum': ['hour', 'day', 'week', 'month', 'year'], 'type': 'string'},
+                        {'type': 'null'},
+                    ],
+                    'default': None,
+                    'description': 'The time range back from the current date to filter results.',
+                },
+                'include_domains': {
+                    'anyOf': [{'items': {'type': 'string'}, 'type': 'array'}, {'type': 'null'}],
+                    'default': None,
+                    'description': 'List of domains to specifically include in the search results.',
+                },
+                'exclude_domains': {
+                    'anyOf': [{'items': {'type': 'string'}, 'type': 'array'}, {'type': 'null'}],
+                    'default': None,
+                    'description': 'List of domains to specifically exclude from the search results.',
+                },
+            },
+            'required': ['query'],
+            'type': 'object',
+        }
+    )
+
+
+def test_bound_params_hidden_from_schema(nimble_api_key: str):
+    """Test that factory-provided params are excluded from the tool schema."""
+    tool = nimble_search_tool(
+        nimble_api_key,
+        search_depth='deep',
+        time_range='week',
+        include_domains=['arxiv.org'],
+        exclude_domains=['medium.com'],
+    )
+    assert tool.function_schema.json_schema == snapshot(
+        {
+            'additionalProperties': False,
+            'properties': {
+                'query': {
+                    'description': 'The search query to execute with Nimble.',
+                    'type': 'string',
+                },
+            },
+            'required': ['query'],
+            'type': 'object',
+        }
+    )
+
+
+def test_factory_requires_api_key_or_client():
+    """Test that nimble_search_tool raises when neither api_key nor client is provided."""
+    with pytest.raises(ValueError, match='Either api_key or client must be provided'):
+        nimble_search_tool()  # pyright: ignore[reportCallIssue]
+
+
+def test_factory_with_client():
+    """Test that nimble_search_tool accepts a pre-built client."""
+    client = AsyncNimble(api_key='test-key', client_source='custom')
+    tool = nimble_search_tool(client=client)
+    assert tool.name == 'nimble_search'
+    # Pre-built client attribution is left untouched.
+    assert client.client_source == 'custom'
+
+
+def test_import_error_mentions_nimble_extra(monkeypatch: pytest.MonkeyPatch):
+    """Missing nimble_python should raise ImportError pointing at pydantic-ai-slim[nimble]."""
+    real_import = builtins.__import__
+
+    def mock_import(name: str, *args: Any, **kwargs: Any):
+        if name == 'nimble_python' or name.startswith('nimble_python.'):
+            raise ImportError('mocked missing nimble_python')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', mock_import)
+    sys.modules.pop('pydantic_ai.common_tools.nimble', None)
+    sys.modules.pop('nimble_python', None)
+    with pytest.raises(ImportError, match=r'pydantic-ai-slim\[nimble\]'):
+        importlib.import_module('pydantic_ai.common_tools.nimble')

--- a/tests/test_nimble.py
+++ b/tests/test_nimble.py
@@ -17,7 +17,21 @@ from nimble_python.types.search_response import Result, ResultMetadataSerpMetada
 
 from pydantic_ai import Agent
 from pydantic_ai._run_context import RunContext
-from pydantic_ai.common_tools.nimble import NimbleSearchTool, nimble_search_tool
+from pydantic_ai.common_tools.nimble import (
+    NimbleAgentRunResultTool,
+    NimbleAgentRunStartTool,
+    NimbleAgentRunStatusTool,
+    NimbleAgentsListTool,
+    NimbleAgentTemplatesListTool,
+    NimbleCrawlStartTool,
+    NimbleCrawlStatusTool,
+    NimbleExtractTool,
+    NimbleMapTool,
+    NimbleSearchTool,
+    NimbleToolset,
+    nimble_extract_tool,
+    nimble_search_tool,
+)
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
@@ -306,3 +320,226 @@ def test_import_error_mentions_nimble_extra(monkeypatch: pytest.MonkeyPatch):
     sys.modules.pop('nimble_python', None)
     with pytest.raises(ImportError, match=r'pydantic-ai-slim\[nimble\]'):
         importlib.import_module('pydantic_ai.common_tools.nimble')
+
+
+async def test_extract_returns_markdown():
+    """Extract projects markdown from SDK response without a network call."""
+    data = AsyncMock()
+    data.markdown = '# Hello'
+    response = AsyncMock()
+    response.data = data
+    client = AsyncMock()
+    client.extract = AsyncMock()
+    client.extract.run = AsyncMock(return_value=response)
+    tool = NimbleExtractTool(client=cast(AsyncNimble, client))
+    assert await tool('https://example.com') == '# Hello'
+    client.extract.run.assert_awaited_once_with(url='https://example.com', formats=['markdown'])
+
+
+async def test_extract_empty_when_no_markdown():
+    """Extract returns empty string when markdown is missing."""
+    response = AsyncMock()
+    response.data = None
+    client = AsyncMock()
+    client.extract = AsyncMock()
+    client.extract.run = AsyncMock(return_value=response)
+    tool = NimbleExtractTool(client=cast(AsyncNimble, client))
+    assert await tool('https://example.com') == ''
+
+
+async def test_map_projects_links():
+    """Map projects link fields from the SDK response."""
+    link = AsyncMock()
+    link.url = 'https://example.com/a'
+    link.title = 'A'
+    link.description = 'desc'
+    response = AsyncMock()
+    response.links = [link]
+    client = AsyncMock()
+    client.map = AsyncMock(return_value=response)
+    tool = NimbleMapTool(client=cast(AsyncNimble, client))
+    assert await tool(
+        'https://example.com',
+        limit=10,
+        domain_filter='domain',
+        sitemap='include',
+    ) == [{'url': 'https://example.com/a', 'title': 'A', 'description': 'desc'}]
+    client.map.assert_awaited_once_with(
+        url='https://example.com',
+        limit=10,
+        domain_filter='domain',
+        sitemap='include',
+    )
+
+
+async def test_map_omits_unset_optional_kwargs():
+    """Map only forwards optional kwargs that the caller sets."""
+    response = AsyncMock()
+    response.links = []
+    client = AsyncMock()
+    client.map = AsyncMock(return_value=response)
+    await NimbleMapTool(client=cast(AsyncNimble, client))('https://example.com')
+    client.map.assert_awaited_once_with(url='https://example.com')
+
+
+async def test_crawl_start_and_status():
+    """Crawl start/status are separate tools and do not poll."""
+    start_response = AsyncMock()
+    start_response.crawl_id = 'crawl_1'
+    start_response.status = 'queued'
+    start_response.url = 'https://example.com'
+    start_response.completed = 0
+    start_response.failed = 0
+    start_response.pending = 1
+    start_response.total = 1
+    status_response = AsyncMock()
+    status_response.crawl_id = 'crawl_1'
+    status_response.status = 'running'
+    status_response.url = 'https://example.com'
+    status_response.completed = 0
+    status_response.failed = 0
+    status_response.pending = 1
+    status_response.total = 1
+    client = AsyncMock()
+    client.crawl = AsyncMock()
+    client.crawl.run = AsyncMock(return_value=start_response)
+    client.crawl.status = AsyncMock(return_value=status_response)
+
+    started = await NimbleCrawlStartTool(client=cast(AsyncNimble, client))(
+        'https://example.com',
+        limit=5,
+        max_discovery_depth=2,
+        include_paths=['/docs'],
+        exclude_paths=['/admin'],
+        sitemap='skip',
+        name='docs-crawl',
+    )
+    assert started['crawl_id'] == 'crawl_1'
+    assert started['status'] == 'queued'
+    client.crawl.run.assert_awaited_once_with(
+        url='https://example.com',
+        limit=5,
+        max_discovery_depth=2,
+        include_paths=['/docs'],
+        exclude_paths=['/admin'],
+        sitemap='skip',
+        name='docs-crawl',
+    )
+    status = await NimbleCrawlStatusTool(client=cast(AsyncNimble, client))('crawl_1')
+    assert status['status'] == 'running'
+    client.crawl.status.assert_awaited_once_with('crawl_1')
+
+
+async def test_crawl_start_omits_unset_optional_kwargs():
+    """Crawl start only forwards optional kwargs that the caller sets."""
+    start_response = AsyncMock()
+    start_response.crawl_id = 'crawl_2'
+    start_response.status = 'queued'
+    start_response.url = 'https://example.com'
+    start_response.completed = 0
+    start_response.failed = 0
+    start_response.pending = 1
+    start_response.total = 1
+    client = AsyncMock()
+    client.crawl = AsyncMock()
+    client.crawl.run = AsyncMock(return_value=start_response)
+    await NimbleCrawlStartTool(client=cast(AsyncNimble, client))('https://example.com')
+    client.crawl.run.assert_awaited_once_with(url='https://example.com')
+
+
+async def test_agent_api_lifecycle_tools():
+    """Agent list/start/status/result tools map onto SDK Agent API V2 methods."""
+    item = AsyncMock()
+    item.model_dump = lambda mode='json': {'id': 'agent_1', 'name': 'Research'}
+    list_response = AsyncMock()
+    list_response.items = [item]
+    template_item = AsyncMock()
+    template_item.model_dump = lambda mode='json': {'template_name': 'research'}
+    templates_response = AsyncMock()
+    templates_response.items = [template_item]
+    start_response = AsyncMock()
+    start_response.model_dump = lambda mode='json': {'id': 'run_1', 'status': 'queued'}
+    status_response = AsyncMock()
+    status_response.model_dump = lambda mode='json': {'id': 'run_1', 'status': 'running'}
+    result_response = AsyncMock()
+    result_response.model_dump = lambda mode='json': {'id': 'run_1', 'output': 'done'}
+
+    client = AsyncMock()
+    client.agents = AsyncMock()
+    client.agents.list = AsyncMock(return_value=list_response)
+    client.agents.templates = AsyncMock()
+    client.agents.templates.list = AsyncMock(return_value=templates_response)
+    client.agents.runs = AsyncMock()
+    client.agents.runs.create = AsyncMock(return_value=start_response)
+    client.agents.runs.get = AsyncMock(return_value=status_response)
+    client.agents.runs.result = AsyncMock(return_value=result_response)
+
+    assert await NimbleAgentsListTool(client=cast(AsyncNimble, client))() == [{'id': 'agent_1', 'name': 'Research'}]
+    client.agents.list.assert_awaited_once_with()
+    assert await NimbleAgentsListTool(client=cast(AsyncNimble, client))(limit=10, offset=5) == [
+        {'id': 'agent_1', 'name': 'Research'}
+    ]
+    client.agents.list.assert_awaited_with(limit=10, offset=5)
+    assert await NimbleAgentTemplatesListTool(client=cast(AsyncNimble, client))() == [{'template_name': 'research'}]
+    client.agents.templates.list.assert_awaited_once_with()
+    assert await NimbleAgentTemplatesListTool(client=cast(AsyncNimble, client))(limit=3, offset=1) == [
+        {'template_name': 'research'}
+    ]
+    client.agents.templates.list.assert_awaited_with(limit=3, offset=1)
+    assert await NimbleAgentRunStartTool(client=cast(AsyncNimble, client))('agent_1', 'Find AI news') == {
+        'id': 'run_1',
+        'status': 'queued',
+    }
+    client.agents.runs.create.assert_awaited_once_with(agent_id='agent_1', input='Find AI news')
+    assert await NimbleAgentRunStartTool(client=cast(AsyncNimble, client))('agent_1', 'Find AI news', effort='low') == {
+        'id': 'run_1',
+        'status': 'queued',
+    }
+    client.agents.runs.create.assert_awaited_with(agent_id='agent_1', input='Find AI news', effort='low')
+    assert await NimbleAgentRunStatusTool(client=cast(AsyncNimble, client))('agent_1', 'run_1') == {
+        'id': 'run_1',
+        'status': 'running',
+    }
+    assert await NimbleAgentRunResultTool(client=cast(AsyncNimble, client))('agent_1', 'run_1') == {
+        'id': 'run_1',
+        'output': 'done',
+    }
+    client.agents.runs.get.assert_awaited_once_with('run_1', agent_id='agent_1')
+    client.agents.runs.result.assert_awaited_once_with('run_1', agent_id='agent_1')
+
+
+def test_toolset_default_and_full_surface(nimble_api_key: str):
+    """NimbleToolset defaults to search+extract; opt-in flags add the rest."""
+    default = NimbleToolset(nimble_api_key)
+    assert sorted(default.tools) == ['nimble_extract', 'nimble_search']
+
+    full = NimbleToolset(
+        nimble_api_key,
+        include_map=True,
+        include_crawl=True,
+        include_agents=True,
+    )
+    assert sorted(full.tools) == [
+        'nimble_agent_run_result',
+        'nimble_agent_run_start',
+        'nimble_agent_run_status',
+        'nimble_agent_templates_list',
+        'nimble_agents_list',
+        'nimble_crawl_start',
+        'nimble_crawl_status',
+        'nimble_extract',
+        'nimble_map',
+        'nimble_search',
+    ]
+
+    extract_only = NimbleToolset(nimble_api_key, include_search=False, include_extract=True)
+    assert sorted(extract_only.tools) == ['nimble_extract']
+
+    search_only = NimbleToolset(nimble_api_key, include_search=True, include_extract=False)
+    assert sorted(search_only.tools) == ['nimble_search']
+
+
+def test_extract_factory_name():
+    """Extract factory returns a named tool."""
+    tool = nimble_extract_tool('test-key')
+    assert tool.name == 'nimble_extract'

--- a/uv.lock
+++ b/uv.lock
@@ -1360,7 +1360,7 @@ name = "cuda-bindings"
 version = "13.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/63/579402b642f5b9b8ceb79e456b39b5771f27e132a8af3b140e54d69790fc/cuda_bindings-13.1.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4400370a83f1538e25ed4c18c34a0e9d5fad39741e282e69ce24d1479a11017d", size = 15777291, upload-time = "2025-12-09T22:05:41.109Z" },
@@ -1395,43 +1395,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -1898,7 +1898,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future" },
+    { name = "future", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -2589,16 +2589,16 @@ resolution-markers = [
     "python_full_version == '3.14.*'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "shellingham" },
-    { name = "tqdm" },
-    { name = "typer-slim" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version >= '3.14'" },
+    { name = "fsspec", marker = "python_full_version >= '3.14'" },
+    { name = "hf-xet", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine == 'AMD64') or (python_full_version >= '3.14' and platform_machine == 'aarch64') or (python_full_version >= '3.14' and platform_machine == 'amd64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version >= '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.14'" },
+    { name = "shellingham", marker = "python_full_version >= '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.14'" },
+    { name = "typer-slim", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/25/74af9d16cd59ae15b12467a79a84aa0fe24be4aba68fc4da0c1864d49c17/huggingface_hub-1.3.4.tar.gz", hash = "sha256:c20d5484a611b7b7891d272e8fc9f77d5de025b0480bdacfa858efb3780b455f", size = 627683, upload-time = "2026-01-26T14:05:10.656Z" }
 wheels = [
@@ -2616,15 +2616,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", version = "1.4.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "hf-xet", version = "1.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
@@ -2997,15 +2997,15 @@ name = "langchain-core"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpatch" },
-    { name = "langchain-protocol" },
-    { name = "langsmith" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "uuid-utils" },
+    { name = "jsonpatch", marker = "python_full_version < '3.14'" },
+    { name = "langchain-protocol", marker = "python_full_version < '3.14'" },
+    { name = "langsmith", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tenacity", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "uuid-utils", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
@@ -3017,7 +3017,7 @@ name = "langchain-protocol"
 version = "0.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
@@ -3029,7 +3029,7 @@ name = "langchain-text-splitters"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
+    { name = "langchain-core", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
 wheels = [
@@ -3041,20 +3041,20 @@ name = "langsmith"
 version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-    { name = "uuid-utils" },
-    { name = "websockets" },
-    { name = "xxhash" },
-    { name = "zstandard" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
+    { name = "distro", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "orjson", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "requests-toolbelt", marker = "python_full_version < '3.14'" },
+    { name = "sniffio", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "uuid-utils", marker = "python_full_version < '3.14'" },
+    { name = "websockets", marker = "python_full_version < '3.14'" },
+    { name = "xxhash", marker = "python_full_version < '3.14'" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/b7/43f80940a758ceb48714ccc10c7acb9564be4f0d4786e8ed5d46deb0be39/langsmith-0.9.3.tar.gz", hash = "sha256:868a007b3ecda002914b21212a953c77fcb1d71a8a09a94562c3b57941d3df3a", size = 4577380, upload-time = "2026-06-26T15:56:30.45Z" }
 wheels = [
@@ -3969,6 +3969,23 @@ wheels = [
 ]
 
 [[package]]
+name = "nimble-python"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/70/b64449e47ba0998ff4ef29ca53149b819b7fe58fefe0e59cb3589da4cfbf/nimble_python-1.1.0.tar.gz", hash = "sha256:1560b706b23e85c98833afcf1fab955e185f28f143f97b387589c1d72054470c", size = 322741, upload-time = "2026-07-21T19:17:43.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/d9/c83717e864eb6fd5cc8eb198652f00000e462fa6a9044bf55c6ab4d6de73/nimble_python-1.1.0-py3-none-any.whl", hash = "sha256:deb4f8441e888b32ea55edda41c1efefc5c64c9146eb43d98310a76c16a5abbb", size = 260984, upload-time = "2026-07-21T19:17:45.05Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4105,7 +4122,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -4144,7 +4161,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -4156,7 +4173,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -4186,9 +4203,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-cusparse", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -4200,7 +4217,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4673,8 +4690,8 @@ name = "pendulum"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/7c/009c12b86c7cc6c403aec80f8a4308598dfc5995e5c523a5491faaa3952e/pendulum-3.1.0.tar.gz", hash = "sha256:66f96303560f41d097bee7d2dc98ffca716fbb3a832c4b3062034c2d45865015", size = 85930, upload-time = "2025-04-19T14:30:01.675Z" }
 wheels = [
@@ -5361,6 +5378,9 @@ huggingface = [
 mistral = [
     { name = "pydantic-ai-slim", extra = ["mistral"] },
 ]
+nimble = [
+    { name = "pydantic-ai-slim", extra = ["nimble"] },
+]
 openrouter = [
     { name = "pydantic-ai-slim", extra = ["openrouter"] },
 ]
@@ -5408,6 +5428,7 @@ dev = [
     { name = "genai-prices" },
     { name = "inline-snapshot" },
     { name = "markdownify" },
+    { name = "nimble-python" },
     { name = "pip" },
     { name = "pydocket" },
     { name = "pytest" },
@@ -5454,6 +5475,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["groq"], marker = "extra == 'groq'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["huggingface"], marker = "extra == 'huggingface'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["mistral"], marker = "extra == 'mistral'", editable = "pydantic_ai_slim" },
+    { name = "pydantic-ai-slim", extras = ["nimble"], marker = "extra == 'nimble'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["openrouter"], marker = "extra == 'openrouter'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["prefect"], marker = "extra == 'prefect'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["sentence-transformers"], marker = "extra == 'sentence-transformers'", editable = "pydantic_ai_slim" },
@@ -5465,7 +5487,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["web-fetch"], marker = "extra == 'web-fetch'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["xai"], marker = "extra == 'xai'", editable = "pydantic_ai_slim" },
 ]
-provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "exa", "examples", "groq", "huggingface", "mistral", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
+provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "exa", "examples", "groq", "huggingface", "mistral", "nimble", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5483,6 +5505,7 @@ dev = [
     { name = "genai-prices", specifier = ">=0.0.69" },
     { name = "inline-snapshot", specifier = ">=0.32.5" },
     { name = "markdownify", specifier = ">=1.2" },
+    { name = "nimble-python", specifier = ">=1.0.0" },
     { name = "pip", specifier = ">=26.1" },
     { name = "pydocket", specifier = ">=0.20.2" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -5631,6 +5654,9 @@ mcp = [
 mistral = [
     { name = "mistralai" },
 ]
+nimble = [
+    { name = "nimble-python" },
+]
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
@@ -5702,6 +5728,7 @@ requires-dist = [
     { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.16.0" },
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
+    { name = "nimble-python", marker = "extra == 'nimble'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'bedrock-mantle'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openrouter'", specifier = ">=2.45.0" },
@@ -5730,7 +5757,7 @@ requires-dist = [
     { name = "voyageai", marker = "python_full_version < '3.14' and extra == 'voyageai'", specifier = ">=0.3.7" },
     { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.14.0" },
 ]
-provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
+provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "nimble", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
 
 [[package]]
 name = "pydantic-core"
@@ -6508,7 +6535,7 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -6826,10 +6853,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -6875,10 +6902,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -6928,7 +6955,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6989,7 +7016,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -7153,16 +7180,16 @@ name = "sentence-transformers"
 version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "torch" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "transformers", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/bc/0bc9c0ec1cf83ab2ec6e6f38667d167349b950fff6dd2086b79bd360eeca/sentence_transformers-5.2.2.tar.gz", hash = "sha256:7033ee0a24bc04c664fd490abf2ef194d387b3a58a97adcc528783ff505159fa", size = 381607, upload-time = "2026-01-27T11:11:02.658Z" }
 wheels = [
@@ -7328,7 +7355,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -7353,8 +7380,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [
@@ -7593,21 +7620,21 @@ name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "cuda-bindings", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "nvidia-cudnn-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "triton", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/e7/19894fdb51c7dbaf94f5a79bb0871da0992e8e4241e579cb006da46d2e58/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", size = 111178962, upload-time = "2026-07-08T16:05:49.855Z" },
@@ -7653,15 +7680,15 @@ name = "transformers"
 version = "5.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "safetensors" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "regex", marker = "python_full_version < '3.14'" },
+    { name = "safetensors", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/418169401560cec2b61512e6bf37b0cfb4c8e27700cfa868a1de073cb65d/transformers-5.13.1.tar.gz", hash = "sha256:1e2452d6778a7482158df5d5dacf6bf775d5b2fdcfce33caaf7f6b0e5f3e3397", size = 9196891, upload-time = "2026-07-11T09:15:50.845Z" }
 wheels = [
@@ -7720,10 +7747,10 @@ resolution-markers = [
     "python_full_version == '3.14.*'",
 ]
 dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "python_full_version >= '3.14'" },
+    { name = "rich", marker = "python_full_version >= '3.14'" },
+    { name = "shellingham", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
 wheels = [
@@ -7741,10 +7768,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "python_full_version < '3.14'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "rich", marker = "python_full_version < '3.14'" },
+    { name = "shellingham", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
@@ -7942,16 +7969,16 @@ name = "voyageai"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "aiolimiter" },
-    { name = "ffmpeg-python" },
-    { name = "langchain-text-splitters" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "tenacity" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "aiolimiter", marker = "python_full_version < '3.14'" },
+    { name = "ffmpeg-python", marker = "python_full_version < '3.14'" },
+    { name = "langchain-text-splitters", marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pillow", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "tenacity", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/16/1b46b3cd401e1717a68197c1fe336d7bb4e0a1833f8105e1738f5b1add05/voyageai-0.3.7.tar.gz", hash = "sha256:826cd97f97223f42b5babc5c459c9c80f3a8215ce5c0e007b0b276550f790d24", size = 26485, upload-time = "2025-12-16T18:43:05.26Z" }
 wheels = [
@@ -8175,7 +8202,7 @@ name = "whenever"
 version = "0.8.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/67/cfc23dfe54ced1e4388826b29db9b9ab2c70a342b33b7e92cf15866f35a6/whenever-0.8.10.tar.gz", hash = "sha256:5e2a3da71527e299f98eec5bb38c4e79d9527a127107387456125005884fb235", size = 240223, upload-time = "2025-10-16T20:31:23.538Z" }
 wheels = [


### PR DESCRIPTION
- Closes #6746

### Summary

Partner contribution from [`Nimbleway/pydantic-ai`](https://github.com/Nimbleway/pydantic-ai) (replaces closed personal-fork PR #6747).

Adds Nimble common tools via `nimble_python` (`AsyncNimble`), installable as `pydantic-ai-slim[nimble]` / `pydantic-ai[nimble]`:

- `nimble_search_tool` — Tavily-shaped web search (`lite`/`fast`/`deep`, time/domain filters, factory-only `max_results`)
- `nimble_extract_tool` — URL → markdown
- `nimble_map_tool` — site link discovery
- `nimble_crawl_start_tool` / `nimble_crawl_status_tool` — resumable crawl (no long-polling in one tool call)
- Agent API V2 — list/templates + run start/status/result
- `NimbleToolset` — shared client; search+extract by default; map/crawl/agents opt-in

Hardcoded attribution: `client_source='pydantic-ai'` → `X-Client-Source: pydantic-ai`.

Docs: `common-tools.md`, `api/common_tools.md`, `install.md`, and agent skill refs.

### Non-goals

- Extract Templates (`/v2/extract/templates/run`)
- Deprecated one-shot `/v1/agent`
- Wiring into `WebSearch(local=...)` / Harness

### Tests

- VCR: search matrix + Agent/`TestModel` path
- Units: attribution, request-body defaults, result projection, schema/factory validation, import guard
- Mocks: extract/map/crawl/agents lifecycle + toolset opt-ins (100% coverage of `nimble.py`)
- Docs example via `test_examples` (`nimble_domain_filtering.py`)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

