### PR TITLE
Capture Anthropic thinking tokens in usage details

### DIFF
--- a/docs/capabilities/thinking.md
+++ b/docs/capabilities/thinking.md
@@ -110,6 +110,8 @@ agent = Agent(model, model_settings=settings)
 ...
 ```
 
+Anthropic reports how many thinking tokens it used in [`RunUsage.details`][pydantic_ai.usage.RunUsage.details] under the `thinking_tokens` key. They are billed within `output_tokens`, so they are a readable subset of the output total rather than an addition to it, and the key is omitted entirely when a response used no thinking tokens.
+
 ### Interleaved Thinking
 
 To enable [interleaved thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#interleaved-thinking), you need to include the beta header in your model settings:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2441,6 +2441,13 @@ def _extract_usage_details(response_usage: BetaUsage | BetaMessageDeltaUsage) ->
         if isinstance((value := getattr(response_usage, key, None)), int):
             details[key] = value
 
+    # Anthropic bills thinking tokens inside `output_tokens`, so this is a readable subset of the
+    # output total rather than an additive one, matching `reasoning_tokens` on OpenAI and
+    # `thoughts_tokens` on Google.
+    output_tokens_details = response_usage.output_tokens_details
+    if output_tokens_details is not None and (thinking_tokens := output_tokens_details.thinking_tokens):
+        details['thinking_tokens'] = thinking_tokens
+
     iterations = response_usage.iterations
     if not iterations:
         return details

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4265,6 +4265,9 @@ async def test_anthropic_opus_48_features(allow_model_requests: None, anthropic_
         }
     )
     assert any(isinstance(p, TextPart) for p in response.parts)
+    # Thinking was enabled but the recording reports `thinking_tokens: 0`, which is omitted
+    # rather than written as a zero.
+    assert 'thinking_tokens' not in result.usage.details
 
 
 _REFUSAL_CASE_PARAMS = [
@@ -4844,7 +4847,11 @@ def test_streaming_usage():
 
 
 def test_streaming_usage_thinking_tokens():
-    """Streaming usage is cumulative, so `thinking_tokens` from a delta event replaces the running value."""
+    """`thinking_tokens` carried by a `message_delta` lands in the merged streaming usage.
+
+    A unit test rather than a VCR one: it pins how a delta merges into the running usage, which a
+    cassette cannot protect because the matcher replays whatever delta was recorded regardless.
+    """
     start = BetaRawMessageStartEvent(message=anth_msg(BetaUsage(input_tokens=1, output_tokens=1)), type='message_start')
     initial_usage = _map_usage(start, 'anthropic', '', 'unknown')
     delta = BetaRawMessageDeltaEvent(
@@ -7493,6 +7500,9 @@ async def test_anthropic_advisor_tool(allow_model_requests: None, anthropic_api_
     assert details['advisor_output_tokens'] > 0
     # Advisor tokens bill at the advisor model's rates and are excluded from the request totals.
     assert result.usage.input_tokens == details['input_tokens']
+    # Recorded top-level `output_tokens_details.thinking_tokens`, billed within `output_tokens`.
+    assert details['thinking_tokens'] == 28
+    assert details['thinking_tokens'] < details['output_tokens']
 
 
 @pytest.mark.vcr()
@@ -7525,6 +7535,8 @@ async def test_anthropic_advisor_tool_stream(
     content = returns[0].content
     assert isinstance(content, dict)
     assert content['type'] == 'advisor_result'
+    # Recorded on a streaming `message_delta`, which is the only place the field appears mid-stream.
+    assert agent_run.result.usage.details['thinking_tokens'] == 47
 
 
 @pytest.mark.vcr()

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -132,6 +132,7 @@ with try_import() as imports_successful:
         BetaMessageDeltaUsage,
         BetaMessageIterationUsage,
         BetaMessageTokensCount,
+        BetaOutputTokensDetails,
         BetaRawContentBlockDeltaEvent,
         BetaRawContentBlockStartEvent,
         BetaRawContentBlockStopEvent,
@@ -429,6 +430,36 @@ async def test_async_request_prompt_caching(allow_model_requests: None):
     )
     last_message = message(result.all_messages(), ModelResponse, index=-1)
     assert last_message.cost().total_price == snapshot(Decimal('0.00002688'))
+
+
+async def test_async_request_thinking_tokens(allow_model_requests: None):
+    """Anthropic reports reasoning tokens at `usage.output_tokens_details.thinking_tokens`.
+
+    They are billed within `output_tokens`, so the detail is a readable subset of the output total
+    and must not be added to it.
+    """
+    c = completion_message(
+        [BetaTextBlock(text='world', type='text')],
+        usage=BetaUsage(
+            input_tokens=3,
+            output_tokens=100,
+            output_tokens_details=BetaOutputTokensDetails(thinking_tokens=40),
+        ),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('hello')
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            input_tokens=3,
+            output_tokens=100,
+            details={'input_tokens': 3, 'output_tokens': 100, 'thinking_tokens': 40},
+        )
+    )
+    assert result.usage.total_tokens == snapshot(103)
 
 
 async def test_cache_point_adds_cache_control(allow_model_requests: None):
@@ -4809,6 +4840,25 @@ def test_streaming_usage():
     final_usage = _map_usage(delta, 'anthropic', '', 'unknown', existing_usage=initial_usage)
     assert final_usage == snapshot(
         RequestUsage(input_tokens=1, output_tokens=5, details={'input_tokens': 1, 'output_tokens': 5})
+    )
+
+
+def test_streaming_usage_thinking_tokens():
+    """Streaming usage is cumulative, so `thinking_tokens` from a delta event replaces the running value."""
+    start = BetaRawMessageStartEvent(message=anth_msg(BetaUsage(input_tokens=1, output_tokens=1)), type='message_start')
+    initial_usage = _map_usage(start, 'anthropic', '', 'unknown')
+    delta = BetaRawMessageDeltaEvent(
+        delta=Delta(),
+        usage=BetaMessageDeltaUsage(output_tokens=5, output_tokens_details=BetaOutputTokensDetails(thinking_tokens=3)),
+        type='message_delta',
+    )
+    final_usage = _map_usage(delta, 'anthropic', '', 'unknown', existing_usage=initial_usage)
+    assert final_usage == snapshot(
+        RequestUsage(
+            input_tokens=1,
+            output_tokens=5,
+            details={'input_tokens': 1, 'output_tokens': 5, 'thinking_tokens': 3},
+        )
     )
 
 


### PR DESCRIPTION
Fixes #3249

_Supersedes #6752, which the PR-checker auto-closed for not carrying a closing keyword. The GitHub API refused to reopen it (422), hence a fresh PR — same branch, same commit._

Also unblocks the Anthropic half of #6559 (referenced, not closed by this PR — the OTel `gen_ai.usage.reasoning.output_tokens` / `gen_ai.request.reasoning.level` normalization proposed there is out of scope here).

Anthropic reports reasoning tokens at `usage.output_tokens_details.thinking_tokens` (anthropic-sdk-python [v0.105.0](https://github.com/anthropics/anthropic-sdk-python/blob/main/CHANGELOG.md), 2026-05-28), but `_extract_usage_details` reads only the top-level and compaction/advisor token keys, so the count is dropped. Anthropic is currently the only frontier provider whose reasoning tokens are unobservable:

| Provider | Detail key | Source |
|---|---|---|
| OpenAI | `reasoning_tokens` | `models/openai.py` |
| xAI | `reasoning_tokens` | `models/xai.py` |
| Google | `thoughts_tokens` | `models/google.py` |
| Anthropic | — | — |

This adds the missing capture — the prerequisite #6559 identifies ("So Anthropic's `_extract_usage_details` can now capture this, unblocking #3249"). It deliberately stops there: the OTel normalization in #6559 is `needs-discussion`, and this stands alone without it.

### Notes on the implementation

- **Not additive.** Thinking tokens are billed within `output_tokens` (the SDK field docstring: *"Always ≤ output_tokens; output_tokens - thinking_tokens approximates the non-reasoning output"*), so this is a readable subset and nothing is folded into request totals or reaches genai-prices as new cost. The test asserts `total_tokens == 103` for a 3/100 response carrying 40 thinking tokens.
- **Placement matters.** The extraction sits before the `iterations` early returns, so it applies to responses without compaction or advisor iterations — i.e. the common case. Appending at the end of the function would silently skip those.
- **Covers streaming for free.** `_extract_usage_details` is the mapper both `_process_response` and the two streaming `_map_usage` call sites funnel through, and `BetaMessageDeltaUsage` declares `output_tokens_details` too. Both paths are tested.
- **Omitted when zero,** following Google's `thoughts_tokens` precedent. This keeps `thinking_tokens: 0` off every non-thinking request and leaves all existing snapshots and cassettes untouched. Happy to switch to OpenAI's always-write-`0` shape if you'd prefer the explicit form.
- No dependency change needed: the repo floor is already `anthropic>=0.108.0` (lock: 0.109.0).

### Testing

- `tests/models/test_anthropic.py`: 273 passed, including two new tests (non-streaming via `MockAnthropic`, and the cumulative streaming delta merge through `_map_usage`).
- Also ran every other test file whose cassettes contain `thinking_tokens` — `test_cache_prefix_stability.py`, `test_code_execution_files_vcr.py`, `test_thinking_native_tools.py`, plus `test_usage_limits.py`: 44 passed.
- Full suite: identical failure set before and after (195 pre-existing Bedrock/AWS-credential failures in my sandbox, unrelated), passing count +2 — exactly the new tests.
- `ruff format` / `ruff check` / `pyright` clean on both changed files.

### Context

I hit this in production: Anthropic is the primary model in a document-processing pipeline where we track per-call token accounting, and reasoning cost is the one component we can't see. We're currently carrying a local monkeypatch of this exact function as a workaround, which is what prompted looking upstream.

I know CONTRIBUTING asks for maintainer alignment before code on anything non-trivial — I've kept this to the narrow provider-parity fix rather than the broader OTel work in #6559 on the assumption that puts it near the "obvious small fix" end. Entirely happy for you to rewrite, supersede, or close it if you'd rather take the change forward yourselves or fold it into #6559; I can also validate whatever lands against our real Anthropic traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

