### PR TITLE
Improve wording and example model in `ModelHTTPError` docs

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -195,13 +195,12 @@ attributes showing the queue depth and configured limits. The `name` parameter o
 ## Handling HTTP Errors
 
 When a provider returns a 4xx or 5xx response, Pydantic AI raises a
-[`ModelHTTPError`][pydantic_ai.exceptions.ModelHTTPError].  In addition to the
-[`status_code`][pydantic_ai.exceptions.ModelHTTPError.status_code] and
-[`body`][pydantic_ai.exceptions.ModelHTTPError.body], the exception now exposes the
-provider's **response headers** via the
-[`headers`][pydantic_ai.exceptions.ModelHTTPError.headers] attribute (a
-`dict[str, str]` with lowercase keys, or `None` for providers that don't surface headers,
-such as gRPC-based providers).
+[`ModelHTTPError`][pydantic_ai.exceptions.ModelHTTPError]. The exception exposes the
+[`status_code`][pydantic_ai.exceptions.ModelHTTPError.status_code], the response
+[`body`][pydantic_ai.exceptions.ModelHTTPError.body], and the provider's
+**response headers** via the [`headers`][pydantic_ai.exceptions.ModelHTTPError.headers]
+attribute (a `dict[str, str]` with lowercase keys, or `None` for providers that don't
+surface headers, such as gRPC-based providers).
 
 The motivating use case is propagating the `Retry-After` header from a 429 response to a
 caller's own HTTP client.  A convenience property
@@ -213,7 +212,7 @@ delta-seconds and HTTP-date formats:
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelHTTPError
 
-agent = Agent('openai:gpt-4o')
+agent = Agent('openai:gpt-5.2')
 
 try:
     result = agent.run_sync('What is the capital of France?')


### PR DESCRIPTION
Follow-up to #6733, addressing @DouweM's docs review feedback that landed after merge:

- Drop the "the exception _now_ exposes" phrasing — the docs just list what `ModelHTTPError` exposes (`status_code`, `body`, `headers`), without assuming historical context ([comment](https://github.com/pydantic/pydantic-ai/pull/6733#discussion_r3660236947)).
- Use a modern model (`openai:gpt-5.2`, matching the rest of the docs) in the rate-limit handling example ([comment](https://github.com/pydantic/pydantic-ai/pull/6733#discussion_r3660238406)).

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

https://claude.ai/code/session_01Nyb4vskPLGprkT7ZFVYfKw

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

