### PR TITLE
Teach PR-monitoring agents when to apply the `auto-review` label

### DIFF
--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -27,3 +27,32 @@ is left unresolved.**
    your reasoning, the decision that needs making, the trade-offs (pros/cons of each option), and
    your recommendation. Then **poll every 30 minutes for a reply** and continue when it lands.
 4. Repeat until CI is green and no comment is outstanding.
+
+## When the loop completes — consider a deep `auto-review`
+
+Adding the `auto-review` label triggers a one-shot in-depth review (the `Review` job in
+`bots.yml`) that is significantly more expensive and thorough than the per-push CI reviewer.
+The label removes itself after the run, so each application buys exactly one review of the
+diff as it stands at that moment.
+
+Once the loop above has terminated — CI green, every comment triaged — decide whether to apply
+it before handing the PR back or requesting merge:
+
+- **Apply it last, not early.** It won't re-run on later pushes, so a deep review of a
+  still-moving PR is wasted money. Wait until CI is green and feedback from the per-push
+  reviewer and any other bots has been addressed.
+- **Use judgment on whether it's warranted.** Skip it when you're highly confident there's
+  nothing left to catch (typo fixes, dependency bumps, mechanical chores). Apply it for
+  substantive changes: new features, behavior changes, public API surface, non-trivial bug
+  fixes — and user-facing docs, where it catches things like examples using outdated models.
+  In between, weigh cost against risk; smaller PRs are cheaper to review, so lean toward
+  applying when unsure.
+- **How:** `gh pr edit <number> --add-label auto-review`. This requires triage permission on
+  the repo (Pydantic team members and their agents). If it fails, quote the actual error —
+  don't skip it based on an assumed lack of permission.
+- **Known refusal:** the review job exits without reviewing if the PR touches `AGENTS.md`,
+  `CLAUDE.md`, or anything under `.claude/` (a security guard). Don't apply the label to
+  those PRs.
+- **Afterwards, re-enter the loop.** The review posts comments that need the same triage as
+  any other. If your fixes are substantial enough to deserve another deep pass, you may
+  re-apply the label — but usually once is enough.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,13 @@ fork.) If you genuinely cannot attempt it, say "not attempted", never "we can't"
 **CI is green and there are no unresolved comments** — see the `pushing-commits-to-the-repo` skill
 for the full loop.
 
+**Consider a deep `auto-review` as the final step.** Once CI is green and every comment is
+resolved, contributors with triage permission (Pydantic team members and their agents) should use
+their judgment to add the `auto-review` label, which triggers a one-shot in-depth review that
+removes itself after running. Apply it last (it won't re-run on later pushes) and skip it only
+when you're highly confident there's nothing left to catch — see the
+`pushing-commits-to-the-repo` skill for the full criteria.
+
 **Do not leave work uncommitted.** Don't end a turn with unstaged or uncommitted local changes
 unless the user's own instructions say otherwise.
 


### PR DESCRIPTION
Encodes the team's process for the `auto-review` label into the agent-facing docs, so agents that build PRs and monitor CI (murmur etc.) apply it at the right moment without being asked:

- `AGENTS.md` (Pushing changes): once CI is green and all comments are resolved, contributors with triage permission should use judgment to add `auto-review` as the final step.
- `pushing-commits-to-the-repo` skill: full criteria — apply last since the review runs once and the label self-removes, skip only when highly confident there's nothing to catch (typos, dep bumps), definitely apply for substantive code and user-facing docs changes, and note the security refusal for PRs touching `AGENTS.md`/`CLAUDE.md`/`.claude/`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

https://claude.ai/code/session_016TixJSHWKDiP3V69kFcJ8b

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

