### PR TITLE
Use Ubicloud runners for CI on `push` and tag runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,15 @@ jobs:
     name: test on ${{ matrix.python-version }} (${{ matrix.install.name }})
     # Use Ubicloud 4-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
+    # `github.event.pull_request` is null on push/tag runs, so those need their own clause to
+    # reach Ubicloud -- without it main and release runs silently fall back to `ubuntu-latest`.
     runs-on: >-
       ${{
         !contains(github.event.pull_request.labels.*.name, 'ci:slow')
         && matrix.install.name == 'all-extras'
         && (
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'push'
+          || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
         && 'ubicloud-premium-4'
@@ -244,11 +247,13 @@ jobs:
     name: test on ${{ matrix.python-version }} (lowest-versions)
     # Use Ubicloud 4-core runners for maintainers or opted in via 'ci:fast' label
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
+    # See the note on the `test` job for why push/tag runs need their own clause.
     runs-on: >-
       ${{
         !contains(github.event.pull_request.labels.*.name, 'ci:slow')
         && (
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'push'
+          || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
         && 'ubicloud-premium-4'


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David approved the change in concept but has not reviewed the diff line-by-line.

<!-- Trivial CI-infra change, no issue. -->

`runs-on` on the `test` (all-extras) and `test-lowest-versions` jobs selects `ubicloud-premium-4` via a condition that only ever inspects `github.event.pull_request`. On `push` (main) and tag runs that object is null, so the condition collapses to false and both jobs silently fall back to `ubuntu-latest`.

Measured on two recent runs of the same job:

| run | event | runner | `test on 3.12 (all-extras)` |
|---|---|---|---|
| [30156719488](https://github.com/pydantic/pydantic-ai/actions/runs/30156719488) (`ed0f40c0`, main) | `push` | GitHub-hosted | **627s** |
| [30297959757](https://github.com/pydantic/pydantic-ai/actions/runs/30297959757) | `pull_request` | Ubicloud | **414s** |

Adding `github.event_name == 'push'` to the existing OR group restores the intended runner for main and tag runs. The `ci:slow` escape hatch still applies (it also reads a null `pull_request` on push, evaluating false, so push runs get Ubicloud unconditionally — same as any maintainer PR).

Worth a maintainer's call: this trades Ubicloud minutes for ~35% faster main/tag CI. Main runs aren't latency-critical, but tag runs gate `release-build` → PyPI publish, so the release path is the one that actually benefits. If the cost isn't wanted for plain main pushes, the narrower version is `startsWith(github.ref, 'refs/tags/')` instead of `github.event_name == 'push'`.

**Verification limit:** the PR check run exercises the `pull_request` path, which is unchanged. The `push` path cannot be exercised before merge — `ci.yml`'s push trigger is `branches: [main]` / `tags: ['**']`, and pushing a throwaway tag would fire `release-build` and `release`. First real exercise is the merge commit on `main`; if it's wrong, the symptom is a main run on `ubuntu-latest`, which is today's behavior anyway.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

