### PR TITLE
Test the cancellation backstop under real Temporal: absorbed activity cancel ends `Cancelled` and replays deterministically

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import os
 import re
+import sys
 import uuid
 import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Generator, Iterator, Sequence
@@ -160,7 +161,6 @@ try:
 except ImportError:  # pragma: lax no cover
     pytest.skip('temporal not installed', allow_module_level=True)
 
-import sys
 
 if sys.version_info >= (3, 14):
     pytest.skip(
@@ -431,6 +431,10 @@ class CancellationBackstopWorkflow:
         return (await _cancellation_agent.run(prompt)).output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason='the cancellation backstop needs `Task.cancelling()` (Python 3.11+); on 3.10 the absorbed cancel legitimately completes',
+)
 async def test_temporal_cancellation_backstop_survives_absorbed_activity_cancel(client: Client) -> None:
     """A cancelled workflow cannot complete after its streaming model activity absorbs cancellation."""
     global _cancellation_activity_cancel_absorbed, _cancellation_activity_started

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -122,11 +122,11 @@ try:
     from temporalio.contrib.opentelemetry import TracingInterceptor
     from temporalio.contrib.pydantic import PydanticPayloadConverter, pydantic_data_converter
     from temporalio.converter import DataConverter, DefaultPayloadConverter, PayloadCodec
-    from temporalio.exceptions import ApplicationError
+    from temporalio.exceptions import ApplicationError, CancelledError as TemporalCancelledError
     from temporalio.testing import WorkflowEnvironment
     from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
     from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
-    from temporalio.workflow import ActivityConfig
+    from temporalio.workflow import ActivityCancellationType, ActivityConfig
 
     from pydantic_ai.durable_exec._toolset import (
         CallToolResult,
@@ -380,6 +380,92 @@ async def test_simple_agent_run_in_workflow(allow_model_requests: None, client: 
             task_queue=TASK_QUEUE,
         )
         assert output == snapshot('The capital of Mexico is Mexico City.')
+
+
+_cancellation_activity_started: asyncio.Event | None = None
+_cancellation_activity_cancel_absorbed = False
+
+
+async def _cancellation_stream_model(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+    global _cancellation_activity_cancel_absorbed
+
+    assert _cancellation_activity_started is not None
+    _cancellation_activity_started.set()
+    try:
+        while True:
+            activity.heartbeat()
+            await asyncio.sleep(0.01)
+    except asyncio.CancelledError:
+        _cancellation_activity_cancel_absorbed = True
+        yield 'completed despite activity cancellation'
+
+
+async def _cancellation_event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+    try:
+        async for _ in stream:
+            pass
+    except asyncio.CancelledError:
+        pass
+
+
+_cancellation_agent = Agent(
+    FunctionModel(stream_function=_cancellation_stream_model),
+    name='cancellation_backstop_agent',
+    deps_type=type(None),
+    capabilities=[
+        TemporalDurability(
+            event_stream_handler=_cancellation_event_stream_handler,
+            model_activity_config=ActivityConfig(
+                cancellation_type=ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+                heartbeat_timeout=timedelta(seconds=1),
+            ),
+        )
+    ],
+)
+
+
+@workflow.defn
+class CancellationBackstopWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        return (await _cancellation_agent.run(prompt)).output
+
+
+async def test_temporal_cancellation_backstop_survives_absorbed_activity_cancel(client: Client) -> None:
+    """A cancelled workflow cannot complete after its streaming model activity absorbs cancellation."""
+    global _cancellation_activity_cancel_absorbed, _cancellation_activity_started
+
+    _cancellation_activity_started = asyncio.Event()
+    _cancellation_activity_cancel_absorbed = False
+    workflow_id = f'{CancellationBackstopWorkflow.__name__}-{uuid.uuid4()}'
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[CancellationBackstopWorkflow],
+        plugins=[AgentPlugin(_cancellation_agent)],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        handle = await client.start_workflow(
+            CancellationBackstopWorkflow.run,
+            args=['cancel me'],
+            id=workflow_id,
+            task_queue=TASK_QUEUE,
+        )
+        await _cancellation_activity_started.wait()
+        await handle.cancel()
+
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await handle.result()
+        assert isinstance(exc_info.value.__cause__, TemporalCancelledError)
+        assert _cancellation_activity_cancel_absorbed
+
+        history = await handle.fetch_history()
+
+    await Replayer(
+        workflows=[CancellationBackstopWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        data_converter=pydantic_data_converter,
+    ).replay_workflow(history)
 
 
 async def _migration_event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:


### PR DESCRIPTION
Hardening follow-up to #6496 (the merged cancellation backstop), covering the contract on real Temporal rather than the plain-asyncio simulation in `tests/test_agent.py`.

One integration test, three assertions:

- a workflow cancelled while its **streaming model activity absorbs the cancellation** (`WAIT_CANCELLATION_COMPLETED`, activity-side `except CancelledError` + completes anyway — the exact #6422 shape) ends **Cancelled**, not Completed;
- the test pins that the activity really did absorb the cancel (so the assertion can't rot into testing the easy path);
- the cancelled workflow's history **replays deterministically** through `temporalio.worker.Replayer`, pinning that the backstop's `Task.cancelling()` bookkeeping is replay-safe.

Uses the `TemporalDurability` capability (not the deprecated `TemporalAgent` wrapper) and the file's existing worker/plugin/replay scaffolding. Tests only — no production code changes.

Part of #6460 (Temporal-coverage follow-up flagged in the #6497 review); the first-party-cancellation Temporal test lands with #6497 itself.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

