### PR TITLE
Harden the cancellation backstop: honest `raise_if_cancelling` policy docs, informative re-raise, Trio guard, hook-skip contract

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -275,11 +275,18 @@ def raise_if_cancelling() -> None:
     completes the awaiting task too. Either way the cancellation is an edge the framework never
     sees, and without a re-check the run would complete as if it was never cancelled.
 
-    `Task.cancelling()` stays elevated in exactly those cases (well-behaved consumers of their
-    own cancellation, like `asyncio.timeout()` and AnyIO cancel scopes, balance it back down
-    with `Task.uncancel()`), so a positive count at a step boundary means an external cancel is
-    still pending and must be re-raised. Call this only after the just-completed step's results
-    have been recorded to message history, so cancellation never discards completed work.
+    Well-behaved consumers of their own cancellation, like `asyncio.timeout()` and AnyIO cancel
+    scopes, balance `Task.cancelling()` back down with `Task.uncancel()`, so a positive count at
+    a step boundary is treated as a still-pending cancellation of the run and re-raised. This is
+    deliberately a *policy*, not a proof of external intent: code awaited by the run that cancels
+    its own task as an internal wake-up and suppresses the `CancelledError` without calling
+    `Task.uncancel()` (a pre-3.11 idiom) will be read as a cancelled run. Call this only after
+    the just-completed step's results have been recorded to message history, so cancellation
+    never discards completed work.
+
+    The re-raise is a fresh `CancelledError`: the originally-injected exception object (and any
+    message it carried) was consumed by whatever absorbed it and cannot be recovered — the
+    cancellation *state* is re-asserted, not the original exception.
 
     On Python 3.10 `Task.cancelling()` does not exist and this is a no-op: an absorbed external
     cancellation cannot be reliably detected there, so the cancellation guarantee is documented
@@ -287,9 +294,12 @@ def raise_if_cancelling() -> None:
     """
     if sys.version_info < (3, 11):  # pragma: lax no cover
         return
-    task = asyncio.current_task()
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:  # pragma: no cover - no running asyncio loop (e.g. a Trio-backed run)
+        return
     if task is not None and task.cancelling() > 0:
-        raise asyncio.CancelledError()
+        raise asyncio.CancelledError('pydantic-ai: re-asserting a cancellation absorbed by a completed step')
 
 
 class Unset:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -468,7 +468,12 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         *,
         result: AgentRunResult[Any],
     ) -> AgentRunResult[Any]:
-        """Called after the agent run completes. Can modify the result."""
+        """Called after the agent run completes. Can modify the result.
+
+        Not called when the run is cancelled before completing: cancellation skips downstream
+        hooks. Put cancellation-safe cleanup in [`wrap_run`][pydantic_ai.capabilities.AbstractCapability.wrap_run]
+        (a `try`/`finally` around `handler()`), which does observe the `CancelledError`.
+        """
         return result
 
     async def wrap_run(
@@ -532,7 +537,14 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         node: AgentNode[AgentDepsT],
         result: NodeResult[AgentDepsT],
     ) -> NodeResult[AgentDepsT]:
-        """Called after each graph node succeeds. Can modify the result (next node or `End`)."""
+        """Called after each graph node succeeds. Can modify the result (next node or `End`).
+
+        Not called for a node interrupted by cancellation — including a cancellation the node
+        itself absorbed and completed through, which the framework re-asserts at the node
+        boundary: cancellation skips downstream hooks. Put cancellation-safe cleanup in
+        [`wrap_node_run`][pydantic_ai.capabilities.AbstractCapability.wrap_node_run]
+        (a `try`/`finally` around `handler()`), which does observe the `CancelledError`.
+        """
         return result
 
     async def wrap_node_run(


### PR DESCRIPTION
Post-merge hardening of #6496's cancellation backstop, from an adversarial after-the-fact audit. No behavior change to the contract — three sharpenings:

- **Honest policy wording** on `raise_if_cancelling()`: an unbalanced `Task.cancelling()` count is *treated as* cancellation of the run — it is a policy, not a proof of external intent. Code awaited by the run that self-cancels as an internal wake-up and suppresses the `CancelledError` without `Task.uncancel()` (a pre-3.11 idiom) will be read as a cancelled run; the docstring previously overclaimed "exactly these cases". Also documents that the re-raise is a *fresh* `CancelledError` — the absorbed original (and any message it carried) is unrecoverable; the cancellation state is re-asserted, not the exception object.
- **Informative re-raise**: the backstop's `CancelledError` now carries a message identifying it as a pydantic-ai re-assertion, so it's distinguishable in tracebacks from a directly-injected cancel (whose own message the absorbing code consumed).
- **Trio guard**: `asyncio.current_task()` raises `RuntimeError` (rather than returning `None`) with no running asyncio loop, so the helper was not a harmless no-op under a Trio-backed event loop; it now is.
- **Hook contract documented**: `after_run`/`after_node_run` docstrings now state that cancellation skips downstream hooks — including a cancellation the node absorbed, which the backstop re-asserts at the boundary — and point cancellation-safe cleanup at the `wrap_*` hooks' `try/finally`. (This was already the behavior for un-absorbed cancellation; the audit flagged it as an undocumented lifecycle asymmetry. The only shipped `after_node_run`, the pending-message drain, must *not* run on a cancelled run — it would redirect the run into further model requests.)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

