### PR TITLE
Correct `after_run` docstring: called before the cancellation backstop re-check, not skipped

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -468,10 +468,13 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         *,
         result: AgentRunResult[Any],
     ) -> AgentRunResult[Any]:
-        """Called after the agent run completes. Can modify the result.
+        """Called after the agent run produces a result. Can modify the result.
 
-        Not called when the run is cancelled before completing: cancellation skips downstream
-        hooks. Put cancellation-safe cleanup in [`wrap_run`][pydantic_ai.capabilities.AbstractCapability.wrap_run]
+        Not called when the run ends without a result (e.g. a cancellation that nothing
+        recovered from). It IS called when a result was produced while a cancellation was
+        pending or absorbed upstream — but before the backstop's cancellation re-check, so the
+        cancellation still propagates after this hook returns and the run still ends cancelled.
+        Put cancellation-safe cleanup in [`wrap_run`][pydantic_ai.capabilities.AbstractCapability.wrap_run]
         (a `try`/`finally` around `handler()`), which does observe the `CancelledError`.
         """
         return result


### PR DESCRIPTION
Follow-up to #6768, fixing the one place its audit-driven docs overshot, as flagged by the [post-merge review comment](https://github.com/pydantic/pydantic-ai/pull/6768#discussion_r-latest): `after_run` is **not** skipped on cancellation. It runs whenever the run produced a result — including via `wrap_run`/`on_run_error` recovery with a cancellation pending — and the backstop's `raise_if_cancelling()` re-check in `_finalize_result` fires *after* it, so the run still ends cancelled but the hook's side effects have executed (pinned by `test_after_run_hook_cannot_convert_external_cancel_to_success`). Only `after_node_run` has the skip-before ordering. Docstring now states the actual ordering.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

