### PR TITLE
Fix `ALLOW_MODEL_REQUESTS` guards for embeddings

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -840,6 +840,10 @@ async def test_my_rag_system():
         assert test_model.last_settings is not None
 ```
 
+Setting [`ALLOW_MODEL_REQUESTS`][pydantic_ai.models.ALLOW_MODEL_REQUESTS] to `False` also blocks embedding requests, so an embedder you forgot to override raises instead of quietly calling the provider. [`TestEmbeddingModel`][pydantic_ai.embeddings.TestEmbeddingModel] and [`SentenceTransformerEmbeddingModel`][pydantic_ai.embeddings.sentence_transformers.SentenceTransformerEmbeddingModel] are unaffected, as neither reaches a provider.
+
+This covers [`count_tokens()`][pydantic_ai.embeddings.Embedder.count_tokens] as well, but only where tokenization happens server-side: Google and Cohere count tokens through an API call and are blocked, while OpenAI tokenizes locally with `tiktoken` and is not.
+
 ## Instrumentation
 
 Enable OpenTelemetry instrumentation for debugging and monitoring:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
@@ -12,6 +12,7 @@ import anyio
 import anyio.to_thread
 
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UnexpectedModelBehavior, UserError
+from pydantic_ai.models import check_allow_model_requests
 from pydantic_ai.providers import Provider, infer_provider
 from pydantic_ai.providers.bedrock import remove_bedrock_geo_prefix
 from pydantic_ai.usage import RequestUsage
@@ -572,6 +573,7 @@ class BedrockEmbeddingModel(EmbeddingModel):
     async def embed(
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
+        check_allow_model_requests()
         inputs_list, settings_dict = self.prepare_embed(inputs, settings)
         settings_typed = cast(BedrockEmbeddingSettings, settings_dict)
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UnexpectedModelBehavior
+from pydantic_ai.models import check_allow_model_requests
 from pydantic_ai.providers import Provider, infer_provider
 from pydantic_ai.usage import RequestUsage
 
@@ -154,6 +155,7 @@ class CohereEmbeddingModel(EmbeddingModel):
     async def embed(
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
+        check_allow_model_requests()
         inputs, settings = self.prepare_embed(inputs, settings)
         settings = cast(CohereEmbeddingSettings, settings)
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -216,9 +216,11 @@ class CohereEmbeddingModel(EmbeddingModel):
         return _MAX_INPUT_TOKENS.get(self.model_name)
 
     async def count_tokens(self, text: str) -> int:
-        check_allow_model_requests()
+        # The guard goes below the capability check, not above it: without a v1 client this path never reaches
+        # Cohere, so it should report that token counting is unsupported regardless of `ALLOW_MODEL_REQUESTS`.
         if self._v1_client is None:
             raise NotImplementedError('Counting tokens requires the Cohere v1 client')
+        check_allow_model_requests()
         try:
             result = await self._v1_client.tokenize(
                 model=self.model_name,

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -216,6 +216,7 @@ class CohereEmbeddingModel(EmbeddingModel):
         return _MAX_INPUT_TOKENS.get(self.model_name)
 
     async def count_tokens(self, text: str) -> int:
+        check_allow_model_requests()
         if self._v1_client is None:
             raise NotImplementedError('Counting tokens requires the Cohere v1 client')
         try:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -295,6 +295,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
         return _MAX_INPUT_TOKENS.get(self._model_name)
 
     async def count_tokens(self, text: str) -> int:
+        check_allow_model_requests()
         try:
             response = await self._client.aio.models.count_tokens(
                 model=self._model_name,

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Literal, cast
 
 from pydantic_ai.exceptions import ModelHTTPError, UnexpectedModelBehavior
+from pydantic_ai.models import check_allow_model_requests
 from pydantic_ai.providers import Provider, infer_provider
 from pydantic_ai.usage import RequestUsage
 
@@ -212,6 +213,7 @@ class GoogleEmbeddingModel(EmbeddingModel):
     async def embed(
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
+        check_allow_model_requests()
         inputs, settings = self.prepare_embed(inputs, settings)
         settings = cast(GoogleEmbeddingSettings, settings)
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -4,6 +4,7 @@ from typing import Literal, cast
 
 from pydantic_ai import _utils
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UserError
+from pydantic_ai.models import check_allow_model_requests
 from pydantic_ai.providers import Provider, infer_provider
 from pydantic_ai.usage import RequestUsage
 
@@ -121,6 +122,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
     async def embed(
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
+        check_allow_model_requests()
         inputs, settings = self.prepare_embed(inputs, settings)
         settings = cast(OpenAIEmbeddingSettings, settings)
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Literal, cast
 
 from pydantic_ai.exceptions import ModelAPIError
+from pydantic_ai.models import check_allow_model_requests
 from pydantic_ai.providers import Provider, infer_provider
 from pydantic_ai.usage import RequestUsage
 
@@ -151,6 +152,7 @@ class VoyageAIEmbeddingModel(EmbeddingModel):
         input_type: EmbedInputType,
         settings: EmbeddingSettings | None = None,
     ) -> EmbeddingResult:
+        check_allow_model_requests()
         inputs, settings = self.prepare_embed(inputs, settings)
         settings = cast(VoyageAIEmbeddingSettings, settings)
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1192,8 +1192,11 @@ ALLOW_MODEL_REQUESTS = True
 This global setting allows you to disable request to most models, e.g. to make sure you don't accidentally
 make costly requests to a model during tests.
 
-The testing models [`TestModel`][pydantic_ai.models.test.TestModel] and
-[`FunctionModel`][pydantic_ai.models.function.FunctionModel] are no affected by this setting.
+The testing models [`TestModel`][pydantic_ai.models.test.TestModel],
+[`FunctionModel`][pydantic_ai.models.function.FunctionModel] and
+[`TestEmbeddingModel`][pydantic_ai.embeddings.TestEmbeddingModel] are not affected by this setting, nor is
+[`SentenceTransformerEmbeddingModel`][pydantic_ai.embeddings.sentence_transformers.SentenceTransformerEmbeddingModel],
+which runs locally and so has no per-call provider cost.
 """
 
 
@@ -1201,7 +1204,10 @@ def check_allow_model_requests() -> None:
     """Check if model requests are allowed.
 
     If you're defining your own models that have costs or latency associated with their use, you should call this in
-    [`Model.request`][pydantic_ai.models.Model.request] and [`Model.request_stream`][pydantic_ai.models.Model.request_stream].
+    every method that reaches the provider: [`Model.request`][pydantic_ai.models.Model.request],
+    [`Model.request_stream`][pydantic_ai.models.Model.request_stream], [`Model.count_tokens`][pydantic_ai.models.Model.count_tokens],
+    [`EmbeddingModel.embed`][pydantic_ai.embeddings.EmbeddingModel.embed] and
+    [`EmbeddingModel.count_tokens`][pydantic_ai.embeddings.EmbeddingModel.count_tokens].
 
     Raises:
         RuntimeError: If model requests are not allowed.

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1196,18 +1196,26 @@ The testing models [`TestModel`][pydantic_ai.models.test.TestModel],
 [`FunctionModel`][pydantic_ai.models.function.FunctionModel] and
 [`TestEmbeddingModel`][pydantic_ai.embeddings.TestEmbeddingModel] are not affected by this setting, nor is
 [`SentenceTransformerEmbeddingModel`][pydantic_ai.embeddings.sentence_transformers.SentenceTransformerEmbeddingModel],
-which runs locally and so has no per-call provider cost.
+which runs inference locally and so has no per-call provider cost.
 """
 
 
 def check_allow_model_requests() -> None:
     """Check if model requests are allowed.
 
-    If you're defining your own models that have costs or latency associated with their use, you should call this in
-    every method that reaches the provider: [`Model.request`][pydantic_ai.models.Model.request],
-    [`Model.request_stream`][pydantic_ai.models.Model.request_stream], [`Model.count_tokens`][pydantic_ai.models.Model.count_tokens],
+    If you're defining your own models that have costs or latency associated with their use, you should call this at the
+    top of each method that sends a request to the provider: [`Model.request`][pydantic_ai.models.Model.request],
+    [`Model.request_stream`][pydantic_ai.models.Model.request_stream],
+    [`Model.count_tokens`][pydantic_ai.models.Model.count_tokens],
+    [`Model.compact_messages`][pydantic_ai.models.Model.compact_messages],
     [`EmbeddingModel.embed`][pydantic_ai.embeddings.EmbeddingModel.embed] and
     [`EmbeddingModel.count_tokens`][pydantic_ai.embeddings.EmbeddingModel.count_tokens].
+
+    Methods that produce their result locally don't need it — for example
+    [`OpenAIEmbeddingModel`][pydantic_ai.embeddings.openai.OpenAIEmbeddingModel]'s `count_tokens`, which tokenizes with
+    `tiktoken` and never calls the provider. Neither does
+    [`Model.cancel_suspended_response`][pydantic_ai.models.Model.cancel_suspended_response], which deliberately omits it
+    so an already-started job can still be cancelled after the flag is flipped.
 
     Raises:
         RuntimeError: If model requests are not allowed.

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -635,6 +635,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
     ) -> usage.RequestUsage:
+        check_allow_model_requests()
         model_settings, model_request_parameters = self.prepare_request(
             model_settings,
             model_request_parameters,

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -681,6 +681,7 @@ class BedrockConverseModel(Model[BaseClient]):
 
         Check the actual supported models on <https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html>
         """
+        check_allow_model_requests()
         model_settings, model_request_parameters = self.prepare_request(model_settings, model_request_parameters)
         settings = cast(BedrockModelSettings, model_settings or {})
         system_prompt, bedrock_messages = await self._map_messages(messages, model_request_parameters, settings)

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -64,6 +64,7 @@ from pydantic_ai.models import (
     Model,
     ModelRequestParameters,
     StreamedResponse,
+    check_allow_model_requests,
     download_item,
 )
 from pydantic_ai.models._tool_choice import ResolvedToolChoice, resolve_tool_choice
@@ -660,6 +661,7 @@ class BedrockConverseModel(Model[BaseClient]):
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
     ) -> ModelResponse:
+        check_allow_model_requests()
         model_settings, model_request_parameters = self.prepare_request(
             model_settings,
             model_request_parameters,
@@ -714,6 +716,7 @@ class BedrockConverseModel(Model[BaseClient]):
         model_request_parameters: ModelRequestParameters,
         run_context: RunContext[Any] | None = None,
     ) -> AsyncGenerator[StreamedResponse]:
+        check_allow_model_requests()
         model_settings, model_request_parameters = self.prepare_request(
             model_settings,
             model_request_parameters,

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -10998,6 +10998,14 @@ async def test_anthropic_count_tokens_with_mock(allow_model_requests: None):
     assert 'messages' in count_tokens_kwargs
 
 
+async def test_anthropic_count_tokens_blocks_requests_when_disabled():
+    mock_client = cast(AsyncAnthropic, MockAnthropic())
+    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await m.count_tokens([ModelRequest.user_text_prompt('hello')], None, ModelRequestParameters())
+
+
 async def test_anthropic_count_tokens_with_no_messages(allow_model_requests: None):
     """Test count_tokens when messages_ is None (no exception configured)."""
     mock_client = cast(AsyncAnthropic, MockAnthropic())

--- a/tests/models/test_anthropic_bedrock_count_tokens.py
+++ b/tests/models/test_anthropic_bedrock_count_tokens.py
@@ -68,7 +68,7 @@ def bedrock_client() -> AsyncAnthropicBedrock:
     )
 
 
-async def test_anthropic_bedrock_count_tokens_unexpected_response(env: TestEnv):
+async def test_anthropic_bedrock_count_tokens_unexpected_response(allow_model_requests: None, env: TestEnv):
     """Pins the defensive `UnexpectedModelBehavior` branch for a malformed Bedrock response.
 
     Mocks `client.post` to return a body without `inputTokens` — a shape no real Bedrock

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -137,6 +137,19 @@ async def test_bedrock_client_property_can_be_reassigned(bedrock_provider: Bedro
     assert model.base_url == 'https://bedrock-runtime.example.com'
 
 
+async def test_bedrock_model_blocks_requests_when_disabled():
+    model = _bedrock_model_with_client_error(ClientError({'Error': {'Code': 'TestError'}}, 'Converse'))
+    messages: list[ModelMessage] = [ModelRequest.user_text_prompt('hello')]
+    model_request_parameters = ModelRequestParameters()
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.request(messages, None, model_request_parameters)
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        async with model.request_stream(messages, None, model_request_parameters):
+            pass
+
+
 def _bedrock_model_with_client_error(error: ClientError) -> BedrockConverseModel:
     """Instantiate a BedrockConverseModel wired to always raise the given error."""
     return BedrockConverseModel(

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -261,7 +261,7 @@ async def test_bedrock_count_tokens_error(allow_model_requests: None, bedrock_pr
     assert exc_info.value.body.get('Error', {}).get('Message') == 'The provided model identifier is invalid.'  # type: ignore[union-attr]
 
 
-async def test_bedrock_request_non_http_error():
+async def test_bedrock_request_non_http_error(allow_model_requests: None):
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'converse')
     model = _bedrock_model_with_client_error(error)
     params = ModelRequestParameters()
@@ -408,7 +408,7 @@ async def test_bedrock_count_tokens_tool_config(
     )
 
 
-async def test_bedrock_stream_non_http_error():
+async def test_bedrock_stream_non_http_error(allow_model_requests: None):
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'converse_stream')
     model = _bedrock_model_with_client_error(error)
     params = ModelRequestParameters()

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -149,6 +149,9 @@ async def test_bedrock_model_blocks_requests_when_disabled():
         async with model.request_stream(messages, None, model_request_parameters):
             pass
 
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.count_tokens(messages, None, model_request_parameters)
+
 
 def _bedrock_model_with_client_error(error: ClientError) -> BedrockConverseModel:
     """Instantiate a BedrockConverseModel wired to always raise the given error."""
@@ -274,7 +277,7 @@ async def test_bedrock_request_non_http_error(allow_model_requests: None):
     )
 
 
-async def test_bedrock_count_tokens_non_http_error():
+async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'count_tokens')
     model = _bedrock_model_with_client_error(error)
     params = ModelRequestParameters()

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -161,6 +161,37 @@ async def test_cohere_embedding_model_blocks_count_tokens_when_disabled():
             await model.count_tokens('hello')
 
 
+@pytest.mark.skipif(not openai_imports_successful(), reason='openai not installed')
+async def test_embedder_blocks_requests_when_disabled():
+    """Pins the guard on the public `Embedder` surface, which is what issue #6763 reports as leaking.
+
+    A guard that fires before the request is made can't be exercised through a VCR recording.
+    The per-model tests above prove each `embed()` guards; this proves the wrapper chain
+    (`Embedder` -> `InstrumentedEmbeddingModel` / `WrapperEmbeddingModel` -> concrete model)
+    surfaces the `RuntimeError` rather than swallowing or wrapping it.
+    """
+    embedder = Embedder(OpenAIEmbeddingModel('text-embedding-3-small', provider=OpenAIProvider(api_key='test-key')))
+
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await embedder.embed_query('hello')
+
+
+async def test_test_embedding_model_is_exempt_from_request_guard():
+    """`ALLOW_MODEL_REQUESTS`'s docstring promises `TestEmbeddingModel` is unaffected; pin that promise.
+
+    Without this, adding the guard to `TestEmbeddingModel.embed` would break every user's test
+    suite while the whole file still passed, since the module-level `allow_model_requests`
+    fixture keeps the flag on for every other test here.
+    """
+    embedder = Embedder(TestEmbeddingModel())
+
+    with pydantic_ai.models.override_allow_model_requests(False):
+        result = await embedder.embed_query('hello')
+
+    assert result.embeddings == snapshot([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]])
+
+
 STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
 # Pinned so a warm HF cache is served without revalidating files against the Hub.
 # Keep in sync with the HF cache keys and warmup commands in .github/workflows/ci.yml;
@@ -1889,6 +1920,16 @@ class TestSentenceTransformers:
     @pytest.fixture
     def embedder(self, stsb_bert_tiny_model: Any) -> Embedder:
         return Embedder(SentenceTransformerEmbeddingModel(stsb_bert_tiny_model))
+
+    async def test_embed_is_exempt_from_request_guard(self, embedder: Embedder):
+        """`ALLOW_MODEL_REQUESTS`'s docstring promises this model is unaffected; pin that promise.
+
+        Inference is local, so there's no provider call to block and no recording to make.
+        """
+        with pydantic_ai.models.override_allow_model_requests(False):
+            result = await embedder.embed_query('hello')
+
+        assert result.embeddings
 
     async def test_infer_model(self):
         model = infer_embedding_model('sentence-transformers:all-MiniLM-L6-v2')

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -143,6 +143,24 @@ async def test_voyageai_embedding_model_blocks_requests_when_disabled():
             await model.embed('hello', input_type='query')
 
 
+@pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
+async def test_google_embedding_model_blocks_count_tokens_when_disabled():
+    model = GoogleEmbeddingModel('gemini-embedding-001', provider=GoogleProvider(api_key='test-key'))
+
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.count_tokens('hello')
+
+
+@pytest.mark.skipif(not cohere_imports_successful(), reason='cohere not installed')
+async def test_cohere_embedding_model_blocks_count_tokens_when_disabled():
+    model = CohereEmbeddingModel('embed-v4.0', provider=CohereProvider(api_key='test-key'))
+
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.count_tokens('hello')
+
+
 STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
 # Pinned so a warm HF cache is served without revalidating files against the Hub.
 # Keep in sync with the HF cache keys and warmup commands in .github/workflows/ci.yml;

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -15,6 +15,8 @@ import httpx
 import pytest
 from pytest_mock import MockerFixture
 
+import pydantic_ai.models
+
 from ._inline_snapshot import snapshot
 
 if sys.version_info < (3, 11):
@@ -39,6 +41,7 @@ from .conftest import IsDatetime, IsFloat, IsInt, IsList, IsStr, try_import
 
 pytestmark = [
     pytest.mark.anyio,
+    pytest.mark.usefixtures('allow_model_requests'),
 ]
 
 with try_import() as logfire_imports_successful:
@@ -99,40 +102,45 @@ with try_import() as sentence_transformers_imports_successful:
 async def test_openai_embedding_model_blocks_requests_when_disabled():
     model = OpenAIEmbeddingModel('text-embedding-3-small', provider=OpenAIProvider(api_key='test-key'))
 
-    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
-        await model.embed('hello', input_type='query')
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.embed('hello', input_type='query')
 
 
 @pytest.mark.skipif(not cohere_imports_successful(), reason='cohere not installed')
 async def test_cohere_embedding_model_blocks_requests_when_disabled():
     model = CohereEmbeddingModel('embed-v4.0', provider=CohereProvider(api_key='test-key'))
 
-    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
-        await model.embed('hello', input_type='query')
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.embed('hello', input_type='query')
 
 
 @pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
 async def test_google_embedding_model_blocks_requests_when_disabled():
     model = GoogleEmbeddingModel('gemini-embedding-001', provider=GoogleProvider(api_key='test-key'))
 
-    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
-        await model.embed('hello', input_type='query')
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.embed('hello', input_type='query')
 
 
 @pytest.mark.skipif(not bedrock_imports_successful(), reason='bedrock not installed')
 async def test_bedrock_embedding_model_blocks_requests_when_disabled():
     model = BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', provider=BedrockProvider(bedrock_client=MagicMock()))
 
-    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
-        await model.embed('hello', input_type='query')
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.embed('hello', input_type='query')
 
 
 @pytest.mark.skipif(not voyageai_imports_successful(), reason='voyageai not installed')
 async def test_voyageai_embedding_model_blocks_requests_when_disabled():
     model = VoyageAIEmbeddingModel('voyage-4', provider=VoyageAIProvider(api_key='test-key'))
 
-    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
-        await model.embed('hello', input_type='query')
+    with pydantic_ai.models.override_allow_model_requests(False):
+        with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+            await model.embed('hello', input_type='query')
 
 
 STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -95,6 +95,46 @@ with try_import() as sentence_transformers_imports_successful:
     )
 
 
+@pytest.mark.skipif(not openai_imports_successful(), reason='openai not installed')
+async def test_openai_embedding_model_blocks_requests_when_disabled():
+    model = OpenAIEmbeddingModel('text-embedding-3-small', provider=OpenAIProvider(api_key='test-key'))
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.embed('hello', input_type='query')
+
+
+@pytest.mark.skipif(not cohere_imports_successful(), reason='cohere not installed')
+async def test_cohere_embedding_model_blocks_requests_when_disabled():
+    model = CohereEmbeddingModel('embed-v4.0', provider=CohereProvider(api_key='test-key'))
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.embed('hello', input_type='query')
+
+
+@pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
+async def test_google_embedding_model_blocks_requests_when_disabled():
+    model = GoogleEmbeddingModel('gemini-embedding-001', provider=GoogleProvider(api_key='test-key'))
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.embed('hello', input_type='query')
+
+
+@pytest.mark.skipif(not bedrock_imports_successful(), reason='bedrock not installed')
+async def test_bedrock_embedding_model_blocks_requests_when_disabled():
+    model = BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', provider=BedrockProvider(bedrock_client=MagicMock()))
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.embed('hello', input_type='query')
+
+
+@pytest.mark.skipif(not voyageai_imports_successful(), reason='voyageai not installed')
+async def test_voyageai_embedding_model_blocks_requests_when_disabled():
+    model = VoyageAIEmbeddingModel('voyage-4', provider=VoyageAIProvider(api_key='test-key'))
+
+    with pytest.raises(RuntimeError, match='Model requests are not allowed'):
+        await model.embed('hello', input_type='query')
+
+
 STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
 # Pinned so a warm HF cache is served without revalidating files against the Hub.
 # Keep in sync with the HF cache keys and warmup commands in .github/workflows/ci.yml;


### PR DESCRIPTION
## Summary

- Guard external embedding model requests when `ALLOW_MODEL_REQUESTS` is disabled.
- Guard `BedrockConverseModel` request and streaming entry points consistently with other model providers.
- Add regression coverage for each affected embedding implementation and both Bedrock request modes.

Closes #6763

## Testing

- `PYTHONUTF8=1 uv run pytest tests/test_embeddings.py::test_openai_embedding_model_blocks_requests_when_disabled tests/test_embeddings.py::test_cohere_embedding_model_blocks_requests_when_disabled tests/test_embeddings.py::test_google_embedding_model_blocks_requests_when_disabled tests/test_embeddings.py::test_bedrock_embedding_model_blocks_requests_when_disabled tests/test_embeddings.py::test_voyageai_embedding_model_blocks_requests_when_disabled tests/models/test_bedrock.py::test_bedrock_model_blocks_requests_when_disabled -q -rA`
- `PYTHONUTF8=1 uv run ruff check pydantic_ai_slim/pydantic_ai/embeddings/openai.py pydantic_ai_slim/pydantic_ai/embeddings/cohere.py pydantic_ai_slim/pydantic_ai/embeddings/google.py pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py pydantic_ai_slim/pydantic_ai/models/bedrock.py tests/test_embeddings.py tests/models/test_bedrock.py`
- `PYTHONUTF8=1 uv run ruff format --check pydantic_ai_slim/pydantic_ai/embeddings/openai.py pydantic_ai_slim/pydantic_ai/embeddings/cohere.py pydantic_ai_slim/pydantic_ai/embeddings/google.py pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py pydantic_ai_slim/pydantic_ai/models/bedrock.py tests/test_embeddings.py tests/models/test_bedrock.py`
- `PYTHONUTF8=1 PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/embeddings/openai.py pydantic_ai_slim/pydantic_ai/embeddings/google.py tests/models/test_bedrock.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

