### PR TITLE
docs: add Modelsell OpenAI-compatible configuration

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -1027,6 +1027,28 @@ agent = Agent(model)
 ...
 ```
 
+### Modelsell
+
+[Modelsell](https://modelsell.com/) provides an OpenAI-compatible Chat Completions API for models available to your account. Create an [API key](https://modelsell.com/console/token), get an available model ID from [`GET /v1/models`](https://modelsell.com/docs/api-reference), and configure [`OpenAIProvider`][pydantic_ai.providers.openai.OpenAIProvider] with the Modelsell API base:
+
+```python {test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    os.environ['MODELSELL_MODEL'],
+    provider=OpenAIProvider(
+        base_url='https://modelsell.com/v1',
+        api_key=os.environ['MODELSELL_API_KEY'],
+    ),
+)
+agent = Agent(model)
+...
+```
+
 ### Rapid-MLX (Apple Silicon)
 
 [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an OpenAI-compatible inference server for Apple Silicon, built on Apple's MLX framework.


### PR DESCRIPTION
## Summary

Add a Modelsell section to the OpenAI-compatible model documentation, showing how to configure `OpenAIProvider` with the Modelsell API base URL and credentials.

The example uses a model ID supplied through `MODELSELL_MODEL` because available models are credential-scoped and should be discovered dynamically through `GET /v1/models` rather than hard-coded in the documentation.

This follows the contribution guidance for providers that only require a custom URL and API key, so no dedicated provider class is added.

Disclosure: I represent Modelsell.

No live authenticated Modelsell API call was performed.

## Validation

- `git diff --check`
- `uvx pre-commit run --files docs/models/openai.md` (all applicable text, whitespace, and spelling checks passed; the unrelated `clai-help` hook could not construct the workspace because this sparse checkout does not include `pydantic-ai-slim`)
- `make docs` (same sparse-checkout workspace limitation)
- Verified the Modelsell homepage, token console, and API reference return HTTP 200; unauthenticated `GET /v1/models` returns HTTP 401 as expected

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

