### PR TITLE
Harden `SyncStreamBridge` GC tests against foreign xdist garbage

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -706,6 +706,10 @@ def test_sync_stream_bridge_defers_iterator_gc_from_another_thread(monkeypatch: 
     owner_thread_id = threading.get_ident()
     cleanup_thread_id: int | None = None
     unraisable: list[object] = []
+    # Flush any garbage a sibling test leaked into this xdist worker before arming the hook, so its
+    # finalizer warnings (e.g. an unclosed socket) run under the default hook instead of polluting
+    # our capture list and failing `assert not unraisable`.
+    gc.collect()
     monkeypatch.setattr(sys, 'unraisablehook', unraisable.append)
 
     @asynccontextmanager
@@ -754,6 +758,10 @@ def test_sync_stream_bridge_closes_iterator_gc_after_shutdown(monkeypatch: pytes
     asyncio.set_event_loop(loop)
     cleanup_thread_id: int | None = None
     unraisable: list[object] = []
+    # Flush any garbage a sibling test leaked into this xdist worker before arming the hook, so its
+    # finalizer warnings (e.g. an unclosed socket) run under the default hook instead of polluting
+    # our capture list and failing `assert not unraisable`.
+    gc.collect()
     monkeypatch.setattr(sys, 'unraisablehook', unraisable.append)
 
     @asynccontextmanager


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David. David directed this fix and reviewed the approach + diff, but has not reviewed it line-by-line.

Two `SyncStreamBridge` GC tests in `tests/test_streaming.py` are flaky under `pytest -n` (xdist):

- `test_sync_stream_bridge_defers_iterator_gc_from_another_thread`
- `test_sync_stream_bridge_closes_iterator_gc_after_shutdown`

Both install a **global** `sys.unraisablehook` and then force `gc.collect()`. Under xdist that collection finalizes garbage a *sibling* test leaked into the same worker process — e.g. an unclosed loopback socket — and the finalizer's `ResourceWarning` becomes an unraisable exception that the hook captures, tripping `assert not unraisable`. The bridge itself opens no sockets, so the failure is unrelated to what these tests verify.

Observed on a `test on 3.14 (lowest-versions)` shard:

```
assert not unraisable
E  assert not [UnraisableHookArgs(exc_type=<class 'ResourceWarning'>,
   exc_value=ResourceWarning("unclosed <socket.socket fd=33, family=2, type=1, proto=6,
   laddr=('127.0.0.1', 36746), raddr=('127.0.0.1', 42499)>", object=None)]
```

**Fix:** run `gc.collect()` once *before* arming the hook, so any pre-existing foreign garbage in the worker is finalized under the default hook and the capture list stays scoped to the bridge's own resources. The change is a no-op when the tests run in isolation (both still pass).

- Closes #<!-- no issue: trivial test-flake hardening -->

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

