### PR TITLE
Expose OpenAI Responses phase on the streamed `PartStartEvent`

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -364,6 +364,40 @@ The mode is inferred from which parameters you pass: supplying `message_count_th
 
 For lower-level use cases, you can call [`compact_messages`][pydantic_ai.models.openai.OpenAIResponsesModel.compact_messages] directly on the model.
 
+### Text phases
+
+Models that support it label each assistant message with a `phase`: `commentary` for the preamble the model writes while it works, and `final_answer` for the answer itself. Pydantic AI surfaces it as `'phase'` in [`TextPart.provider_details`][pydantic_ai.messages.TextPart.provider_details], and sends it back on the next request so the model keeps the distinction across turns.
+
+When [streaming](../agent.md#streaming-all-events), the phase is set on the [`PartStartEvent`][pydantic_ai.messages.PartStartEvent] that opens each text part (including its first content chunk), so you can route commentary and the final answer differently as they're generated. Prefer [`run_stream_events`][pydantic_ai.agent.AbstractAgent.run_stream_events] for this: [`run_stream`][pydantic_ai.agent.AbstractAgent.run_stream] treats the first text part as the final output, which is often `commentary` on models that emit a preamble.
+
+```python {title="openai_phase.py"}
+from pydantic_ai import Agent, PartDeltaEvent, PartStartEvent, TextPart, TextPartDelta
+
+agent = Agent('openai:gpt-5.5')
+
+
+async def main():
+    final_answer_indexes: set[int] = set()
+    async with agent.run_stream_events('What is the capital of France?') as events:
+        async for event in events:
+            if isinstance(event, PartStartEvent):
+                # Indexes are scoped to a single model response and start over on the
+                # next one, so a new part at an index supersedes what was there before.
+                final_answer_indexes.discard(event.index)
+                if isinstance(event.part, TextPart):
+                    phase = (event.part.provider_details or {}).get('phase')
+                    if phase == 'final_answer':
+                        final_answer_indexes.add(event.index)
+                        print(event.part.content)
+            elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                if event.index in final_answer_indexes:
+                    print(event.delta.content_delta)
+```
+
+_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+
+On models that don't label their output, per [`OpenAIModelProfile.openai_supports_phase`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_supports_phase], `provider_details` has no `'phase'` key and nothing is sent back.
+
 ### Background mode
 
 For long-running requests, such as large reasoning or tool-heavy jobs that may exceed the practical duration of a synchronous request, OpenAI's Responses API offers a [background mode](https://platform.openai.com/docs/guides/background) that runs the request server-side and lets you retrieve the result once it's ready. Enable it with [`openai_background`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_background]:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3828,7 +3828,9 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             _annotations_by_item: dict[str, list[Any]] = {}
             # Track `phase` (commentary | final_answer) on assistant message items, captured
             # from the `output_item.added` event and merged into the corresponding
-            # `TextPart.provider_details` on `output_text.done`.
+            # `TextPart.provider_details` on the first `output_text.delta` (so consumers can
+            # filter commentary from final-answer text as it streams, rather than having to
+            # buffer the whole part), or on `output_text.done` if no delta was received.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
             mcp_list_tools_return_ids: set[str] = set()
 
@@ -4223,11 +4225,17 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                 elif isinstance(chunk, responses.ResponseTextDeltaEvent):
                     # Guard against delta=null from OpenAI-compatible gateways (e.g. Bifrost).
                     if chunk.delta is not None:  # pyright: ignore[reportUnnecessaryComparison]
+                        # Pop so the phase rides along with the `PartStartEvent` for the new text part
+                        # and isn't repeated on every subsequent delta.
+                        delta_provider_details: dict[str, Any] | None = None
+                        if (phase := _phase_by_item.pop(chunk.item_id, None)) is not None:
+                            delta_provider_details = {'phase': phase}
                         for event in self._parts_manager.handle_text_delta(
                             vendor_part_id=chunk.item_id,
                             content=chunk.delta,
                             id=chunk.item_id,
                             provider_name=self.provider_name,
+                            provider_details=delta_provider_details,
                         ):
                             yield event
 

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_phase_streamed_on_part_start.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_phase_streamed_on_part_start.yaml
@@ -1,0 +1,311 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '497'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: What is the capital of PotatoLand?
+        role: user
+      instructions: Briefly narrate what you are about to do before calling each tool.
+      model: gpt-5.5
+      stream: true
+      tool_choice: auto
+      tools:
+      - description: null
+        name: get_capital
+        parameters:
+          additionalProperties: false
+          properties:
+            country:
+              type: string
+          required:
+          - country
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_0fabc13af1ee0049006a691dfdab8881a1a75f2db7ff78cb83","object":"response","created_at":1785273853,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Briefly narrate what you are about to do before calling each tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5-2026-04-23","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_0fabc13af1ee0049006a691dfdab8881a1a75f2db7ff78cb83","object":"response","created_at":1785273853,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Briefly narrate what you are about to do before calling each tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5-2026-04-23","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"rs_0fabc13af1ee0049006a691dfe60b081a1baa444d3cf19afba","type":"reasoning","content":[],"encrypted_content":"gAAAAABqaR3--246DyIVMWvEVGOZxZzu8KicoiWrYVUA3zi-CnAt4ZOmD8TsCbgeSmNkgIgpgey1TXV58HPbf6xHsXNY9u1Y8-A_I4VEwUzlyXWc_Q9IRl-scw8EAW0iTN0p0xsRDN98d7ZT6AxoXdJcKVAcffirwOZwn-qBtIlO7s8UIVafiDwPvh_KsEilJ_JH4JyW-wUFaEoXNFHGjQgmC7F20ekwrnuK3FqW61NMgTOCOu5cjS0rUefrwrzscDThEY8KAxr4Yk0caYlnYuHvluAbjFlfbu5Dl0uFbUJhoyu3DVOtkhomADS68YaP0zKlgbRw7F6wOvAPsixB7RBIN7KvkzBzuiVci64qm4UKJfR0RR2l4H2TjyXjHT-C0pmOpYbf0P7kZg1jr85rwv_aHHiXnJfzLBADnhqGLp2_2LU-m9vZHIgzq0U50RthYAz7JaVqmdmK7Z9adNuIoicpJH-tCvdOjBQkfOlBhqcqGP9CKZF2faGdBL3oZdx-8e3H-AMKaU7jjVv_oew8V3aiOJY5AQHDMxm-qWr1tuY-uXd5_bG41YvlQFWdqmqasrSmlpi6SKfLqrIW_B-tTxi0UwATjWfiGjGF4hlenv984Crku09rhzSWkhHI7cvylUTcaQBRCGoLWI2mfuCHtuOiq7iP1aelPD1tRDUl0bOh2Ejimti1gFNfSLEZcuWC48WtsbUpAUaEQezPDdJrEPBFr8ZbPCwPla5miUJJUX9q29RzUdcIb4C6YOqMG3YqpT5DJXm2REfqX90H3vRARUaTniYIy4j4aQOvXG4ev6K0PXJ8MNlGWMw1Oyl5xj55ESmWDYKB9pchjSXngIGqrM2E7gyKa3BNEsRNMlCAznJJw12Z1lWqGnK7PpGom0VZFrqGLeSuVB91NvHlP7Ph-DE5Y-ft04ZDvQ==","summary":[]},"output_index":0,"sequence_number":2}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"rs_0fabc13af1ee0049006a691dfe60b081a1baa444d3cf19afba","type":"reasoning","content":[],"encrypted_content":"gAAAAABqaR3-pGgSyJcPT3y2_26v61vCZmE9M2P6q5LyFcAkcT7vldTwqVUWc757s4uFB6vneHEoMEnkg-fXJlIWoxAM9ZP5ZehA4u0By_HQz7X5TqeAu4UNdryzz-x3Ks0uWUqT710mc2sH145ky0kHIJgDlX-aYjSV5tkfRqhNcoQgYz8lUIvkYQ0CJDAFEFWnriCziPD9SvN_jxGnrCGE5GDqY_m1AQOd1lVfCiIq1MLWyhCXy9eK81a8ZdKAJxOZEgdCfX-oCQXR_FXuNkW4_O0hdlEzNRhBZwc2ysJn30E7Vr8u-KJcULRUmtKriMiiu2K9FjZyQ8_xXUlcCUWPGsr-KhpW_BHO9nL8X_aj3M6wUvDDNpQWUgiKMT2gOYgtVLQfM8f1nWlIfFdWEhZCMThp7oW3FZccA3tHOBE9_TR4UcmrQwHTR3zBA4KHx3QXiPI7zuExP1UAkQClqZsS-h7uAPHqegpyOe6oL0DpoMbl6Mps1xiwewe8jKH_Aus4XvWBsOdpuFPkEOVY9Pe1C-OEVeT5Qmzcm3KuZok_sakubBCc9FRiKaNPAej8xQg-YXJX1j9ZYK2vHJG-pu4ZLd2gIcI87X11xdUyMUmD1T66pe8JZwUskoLxLtkFefILyn8DoMJQkZ9IO2gdsHMsrFzJNfpst0u9KC5Wp3Y687Rh4vN4AlWFsCDYhhats5XcJU3TlpvTuVqacE2_FE_n6zUpr6mtB6sG_qHaeLwQJdaBs_09SzHmTcTPQ_DLrQvKu2UNebLgI7WWOTBjOD7UcZKj5Sd_F6LvAEvh8a_LwCz-oX_Nd87MfVRFmuKklzWMYMEKo1ocgsAoJOaawHdBMultF0o_01shTly4iYVBoBkki4uxmP_ORd0LQsV4o6A_Eiwqk8qEnI4_7D2tzIRsrfDxlEaP17-_IRHTdHw4Ax2FwKYbMyM3KZdtYnZ0eeDaT0z24RfqwL2WX8gH3bRMVr8KDNeapLG8EF3z9oK9sjeOTIo-3fXyY_ZEMBEvq5dzsZfosl_9EyRon0TlCVC7IUPEPgeI-QScqnYrFieJls_UcqGK8PU=","summary":[]},"output_index":0,"sequence_number":3}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","type":"message","status":"in_progress","content":[],"phase":"commentary","role":"assistant"},"output_index":1,"sequence_number":4}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"I","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"RvoJ43TaUvnCS8e","output_index":1,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"’ll","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"r8neEDaEcJNme","output_index":1,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" check","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"VXalrhZ6zy","output_index":1,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"9Zf24FhMep0e","output_index":1,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" capital","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"h5gFh9sx","output_index":1,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" lookup","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"lVzTC1xsa","output_index":1,"sequence_number":11}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" tool","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"qAsRuc3WojZ","output_index":1,"sequence_number":12}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" for","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"rwG0LEhExYtm","output_index":1,"sequence_number":13}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" “","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"dUoYwOQ4dfFeje","output_index":1,"sequence_number":14}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Pot","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"xUkBI4RasjkyL","output_index":1,"sequence_number":15}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ato","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"24UfxKNMJvXH8","output_index":1,"sequence_number":16}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Land","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"3jva13uFw78n","output_index":1,"sequence_number":17}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".”","item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"obfuscation":"5TofRiKodIdPpO","output_index":1,"sequence_number":18}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","logprobs":[],"output_index":1,"sequence_number":19,"text":"I’ll check the capital lookup tool for “PotatoLand.”"}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I’ll check the capital lookup tool for “PotatoLand.”"},"sequence_number":20}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I’ll check the capital lookup tool for “PotatoLand.”"}],"phase":"commentary","role":"assistant"},"output_index":1,"sequence_number":21}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","type":"function_call","status":"in_progress","arguments":"","call_id":"call_LabG58Uhrq9kZvR52BYKjToD","name":"get_capital"},"output_index":2,"sequence_number":22}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"{\"","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"g1Ne32Jx8rlULp","output_index":2,"sequence_number":23}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"country","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"AmOdvnmX8","output_index":2,"sequence_number":24}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"SMzhllJ9VGnZZ","output_index":2,"sequence_number":25}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"Pot","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"MH6kpuS15K3BS","output_index":2,"sequence_number":26}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"ato","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"9wk8Fv9cjKIt9","output_index":2,"sequence_number":27}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"Land","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"oa7lbiqVGWuC","output_index":2,"sequence_number":28}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"\"}","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","obfuscation":"tQ82OoCsyGFMKn","output_index":2,"sequence_number":29}
+
+        event: response.function_call_arguments.done
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"country\":\"PotatoLand\"}","item_id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","output_index":2,"sequence_number":30}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","type":"function_call","status":"completed","arguments":"{\"country\":\"PotatoLand\"}","call_id":"call_LabG58Uhrq9kZvR52BYKjToD","name":"get_capital"},"output_index":2,"sequence_number":31}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_0fabc13af1ee0049006a691dfdab8881a1a75f2db7ff78cb83","object":"response","created_at":1785273853,"status":"completed","background":false,"completed_at":1785273855,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Briefly narrate what you are about to do before calling each tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5-2026-04-23","moderation":null,"output":[{"id":"rs_0fabc13af1ee0049006a691dfe60b081a1baa444d3cf19afba","type":"reasoning","content":[],"encrypted_content":"gAAAAABqaR3__TqUW4ueyUvYUej-l5gdC3W09mBYrf9eLkskOF32uIzNBnMyNXDqwI6MUXPMTnwY4SMzMvjW3yH8w6pQmnwHqeUFVNNZ6593jvbO5_9zI_LeyrJFMb25ZVDLl-q-Othxb_da-txY6goPp3o2Xg9yeJNtroz4yltx2wURqV8IBHW0Qmt4mLNJItm7cysEZeh0oz7yRkRu604YZp79E2rkCd1Y4O_q-JqNsIaDuBQc81nPaWngHGQM9QPXOrAunHpogNL03vYYjat0__ceKR2vEWXwzl-70ZT-izvCL297yLIg1oDI8Ko2OoQ927qr4ZlhKk5YWQhfvKO0qjqKfveUB74wAusY6bO0jlR3Vimjj4NUCNCyfA4rK0xBCSkQryzo_9DOZVYQwcrHC399nvF1vrOe_vLeLEs9Re-BSh2nSKR4258m79oJycYdhxK3KpxJK7mg_sUgUbfCx9ZmOMzf_i458ZLct5tNLoq6xygZymTVkHfhkgOaHQDnlKlv-mmS7xsUwyscVcTq7-qW78UjOLGvs0iN2-lfrgSZA264-w10c1HgaghOGktySbZcBnflcy2_-USawD15BwGMMImfY_ygDlTfOKgTOxdsgDpv4R6dBZGTnmiTW47A0OQuiaaiihAtZcmflO6-rDO7fQ2THihkKwo2RvbsUQFpZrcBrihmH3lZk9_XtAVivuNnMf4AwtKaaxjKTmsKaZM-sCi2ndqlqy9kEaV2vg2r6Jjx7Qexj9gVDHuw0WsUefU8qbfq5S__xUE9nEjyiMgPFtFcYQjF1OBjT10RjxL_GkmzboNoqf47-R486zdb2BFuU2KZKqZ5nJno0I8UY2i3huE35GWtBIC-5soeHUh5fS-qnv6apbxu27Uxel2Ai1p6Uz7efDKxi5wHB7hJmy2S5ZEGT58ZbiolX7UYcqQrmhARV3hhlTORBg0_YAKwh-VrtrCEc6BbFwRtCGo6Vsro6KjXaWLI5ZfKL_xch_mecxKSSm2U7ammORDqHjB6emarduJeT11jPNBDyzdTR7Ub4pecFavyrKm0OkZXb05ZS775tX0=","summary":[]},{"id":"msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I’ll check the capital lookup tool for “PotatoLand.”"}],"phase":"commentary","role":"assistant"},{"id":"fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb","type":"function_call","status":"completed","arguments":"{\"country\":\"PotatoLand\"}","call_id":"call_LabG58Uhrq9kZvR52BYKjToD","name":"get_capital"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":63,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":69,"output_tokens_details":{"reasoning_tokens":26},"total_tokens":132},"user":null,"metadata":{}},"sequence_number":32}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '399'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '2283'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: What is the capital of PotatoLand?
+        role: user
+      - encrypted_content: gAAAAABqaR3-pGgSyJcPT3y2_26v61vCZmE9M2P6q5LyFcAkcT7vldTwqVUWc757s4uFB6vneHEoMEnkg-fXJlIWoxAM9ZP5ZehA4u0By_HQz7X5TqeAu4UNdryzz-x3Ks0uWUqT710mc2sH145ky0kHIJgDlX-aYjSV5tkfRqhNcoQgYz8lUIvkYQ0CJDAFEFWnriCziPD9SvN_jxGnrCGE5GDqY_m1AQOd1lVfCiIq1MLWyhCXy9eK81a8ZdKAJxOZEgdCfX-oCQXR_FXuNkW4_O0hdlEzNRhBZwc2ysJn30E7Vr8u-KJcULRUmtKriMiiu2K9FjZyQ8_xXUlcCUWPGsr-KhpW_BHO9nL8X_aj3M6wUvDDNpQWUgiKMT2gOYgtVLQfM8f1nWlIfFdWEhZCMThp7oW3FZccA3tHOBE9_TR4UcmrQwHTR3zBA4KHx3QXiPI7zuExP1UAkQClqZsS-h7uAPHqegpyOe6oL0DpoMbl6Mps1xiwewe8jKH_Aus4XvWBsOdpuFPkEOVY9Pe1C-OEVeT5Qmzcm3KuZok_sakubBCc9FRiKaNPAej8xQg-YXJX1j9ZYK2vHJG-pu4ZLd2gIcI87X11xdUyMUmD1T66pe8JZwUskoLxLtkFefILyn8DoMJQkZ9IO2gdsHMsrFzJNfpst0u9KC5Wp3Y687Rh4vN4AlWFsCDYhhats5XcJU3TlpvTuVqacE2_FE_n6zUpr6mtB6sG_qHaeLwQJdaBs_09SzHmTcTPQ_DLrQvKu2UNebLgI7WWOTBjOD7UcZKj5Sd_F6LvAEvh8a_LwCz-oX_Nd87MfVRFmuKklzWMYMEKo1ocgsAoJOaawHdBMultF0o_01shTly4iYVBoBkki4uxmP_ORd0LQsV4o6A_Eiwqk8qEnI4_7D2tzIRsrfDxlEaP17-_IRHTdHw4Ax2FwKYbMyM3KZdtYnZ0eeDaT0z24RfqwL2WX8gH3bRMVr8KDNeapLG8EF3z9oK9sjeOTIo-3fXyY_ZEMBEvq5dzsZfosl_9EyRon0TlCVC7IUPEPgeI-QScqnYrFieJls_UcqGK8PU=
+        id: rs_0fabc13af1ee0049006a691dfe60b081a1baa444d3cf19afba
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          text: I'll check the capital lookup tool for "PotatoLand."
+          type: output_text
+        id: msg_0fabc13af1ee0049006a691dfebdc881a1ae18d027c313d8ce
+        phase: commentary
+        role: assistant
+        status: completed
+        type: message
+      - arguments: '{"country":"PotatoLand"}'
+        call_id: call_LabG58Uhrq9kZvR52BYKjToD
+        id: fc_0fabc13af1ee0049006a691dff0c1481a1b4a0eec7e3c753bb
+        name: get_capital
+        type: function_call
+      - call_id: call_LabG58Uhrq9kZvR52BYKjToD
+        output: Potato City
+        type: function_call_output
+      instructions: Briefly narrate what you are about to do before calling each tool.
+      model: gpt-5.5
+      stream: true
+      tool_choice: auto
+      tools:
+      - description: null
+        name: get_capital
+        parameters:
+          additionalProperties: false
+          properties:
+            country:
+              type: string
+          required:
+          - country
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_0fabc13af1ee0049006a691dffc71481a18c5ea1841dec14ce","object":"response","created_at":1785273855,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Briefly narrate what you are about to do before calling each tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5-2026-04-23","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_0fabc13af1ee0049006a691dffc71481a18c5ea1841dec14ce","object":"response","created_at":1785273855,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Briefly narrate what you are about to do before calling each tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5-2026-04-23","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"Ui6T7ZRgUUHBz","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" capital","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"3Vbd90o7","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"D6RJdU3OHhKTE","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Potato","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"wfqdpfkMO","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Land","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"HfD2B013s6FN","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"W6N1UIm4Qt3dA","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"91k0pkdZ2nnWB","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Pot","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"ZJYTsesUghvqw","output_index":0,"sequence_number":11}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ato","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"GycOpttcNksPB","output_index":0,"sequence_number":12}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" City","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"TqedTSxPH1Z","output_index":0,"sequence_number":13}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"**","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"yrlt8ddq3uYAAj","output_index":0,"sequence_number":14}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"obfuscation":"TjfPckiH3wfWnRn","output_index":0,"sequence_number":15}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","logprobs":[],"output_index":0,"sequence_number":16,"text":"The capital of PotatoLand is **Potato City**."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of PotatoLand is **Potato City**."},"sequence_number":17}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of PotatoLand is **Potato City**."}],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":18}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_0fabc13af1ee0049006a691dffc71481a18c5ea1841dec14ce","object":"response","created_at":1785273855,"status":"completed","background":false,"completed_at":1785273856,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"Briefly narrate what you are about to do before calling each tool.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5-2026-04-23","moderation":null,"output":[{"id":"msg_0fabc13af1ee0049006a691e008ed881a19fb315ceb267e808","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of PotatoLand is **Potato City**."}],"phase":"final_answer","role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":147,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":16,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":163},"user":null,"metadata":{}},"sequence_number":19}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '418'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -12895,6 +12895,236 @@ async def test_openai_responses_phase_streamed(allow_model_requests: None):
     assert text_parts[0].provider_details == snapshot({'phase': 'final_answer'})
 
 
+async def test_openai_responses_phase_streamed_on_part_start(allow_model_requests: None):
+    """`phase` is on the `PartStartEvent`, so commentary can be filtered out as it streams.
+
+    Not a VCR test: this pins the exact event ordering within a single text part, which a cassette
+    replay can't hold stable — a re-recording chunks the deltas differently and the assertion is
+    about which event carries `phase`, not about the wire format.
+    """
+    base_response = resp.Response(
+        id='resp_001',
+        model='gpt-5.5',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+
+    def message_events(
+        item_id: str,
+        phase: Literal['commentary', 'final_answer'],
+        deltas: list[str],
+        output_index: int,
+    ) -> list[resp.ResponseStreamEvent]:
+        text = ''.join(deltas)
+        return [
+            resp.ResponseOutputItemAddedEvent(
+                item=ResponseOutputMessage.model_construct(
+                    id=item_id,
+                    content=[],
+                    role='assistant',
+                    status='in_progress',
+                    type='message',
+                    phase=phase,
+                ),
+                output_index=output_index,
+                type='response.output_item.added',
+                sequence_number=0,
+            ),
+            *[
+                resp.ResponseTextDeltaEvent(
+                    content_index=0,
+                    delta=delta,
+                    item_id=item_id,
+                    output_index=output_index,
+                    type='response.output_text.delta',
+                    sequence_number=0,
+                    logprobs=[],
+                )
+                for delta in deltas
+            ],
+            resp.ResponseTextDoneEvent(
+                content_index=0,
+                item_id=item_id,
+                output_index=output_index,
+                text=text,
+                type='response.output_text.done',
+                sequence_number=0,
+                logprobs=[],
+            ),
+            resp.ResponseOutputItemDoneEvent(
+                item=ResponseOutputMessage.model_construct(
+                    id=item_id,
+                    content=cast(list[Content], [ResponseOutputText(text=text, type='output_text', annotations=[])]),
+                    role='assistant',
+                    status='completed',
+                    type='message',
+                    phase=phase,
+                ),
+                output_index=output_index,
+                type='response.output_item.done',
+                sequence_number=0,
+            ),
+        ]
+
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        *message_events('msg_001', 'commentary', ['Let me ', 'think.'], output_index=0),
+        *message_events('msg_002', 'final_answer', ['Paris', '.'], output_index=1),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(update={'status': 'completed'}),
+            type='response.completed',
+            sequence_number=0,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    events: list[Any] = []
+    async with agent.iter(user_prompt='What is the capital of France?') as agent_run:
+        async for node in agent_run:
+            if Agent.is_model_request_node(node):
+                async with node.stream(agent_run.ctx) as request_stream:
+                    async for event in request_stream:
+                        events.append(event)
+
+    # Each part's `phase` is on its `PartStartEvent`, so a consumer can decide whether to forward
+    # the deltas that follow without buffering the whole part.
+    assert events == snapshot(
+        [
+            PartStartEvent(
+                index=0,
+                part=TextPart(
+                    content='Let me ', id='msg_001', provider_name='openai', provider_details={'phase': 'commentary'}
+                ),
+            ),
+            FinalResultEvent(tool_name=None, tool_call_id=None),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta='think.')),
+            PartEndEvent(
+                index=0,
+                part=TextPart(
+                    content='Let me think.',
+                    id='msg_001',
+                    provider_name='openai',
+                    provider_details={'phase': 'commentary'},
+                ),
+                next_part_kind='text',
+            ),
+            PartStartEvent(
+                index=1,
+                part=TextPart(
+                    content='Paris', id='msg_002', provider_name='openai', provider_details={'phase': 'final_answer'}
+                ),
+                previous_part_kind='text',
+            ),
+            PartDeltaEvent(index=1, delta=TextPartDelta(content_delta='.')),
+            PartEndEvent(
+                index=1,
+                part=TextPart(
+                    content='Paris.', id='msg_002', provider_name='openai', provider_details={'phase': 'final_answer'}
+                ),
+            ),
+        ]
+    )
+
+
+async def test_openai_responses_phase_streamed_without_deltas(allow_model_requests: None):
+    """`phase` is still captured when a gateway emits `output_text.done` without any deltas.
+
+    Not a VCR test: OpenAI always sends deltas, so this fallback exists for OpenAI-compatible
+    gateways whose streams we can't record.
+    """
+    base_response = resp.Response(
+        id='resp_001',
+        model='gpt-5.5',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        resp.ResponseOutputItemAddedEvent(
+            item=ResponseOutputMessage.model_construct(
+                id='msg_001',
+                content=[],
+                role='assistant',
+                status='in_progress',
+                type='message',
+                phase='final_answer',
+            ),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=1,
+        ),
+        resp.ResponseTextDoneEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            text='Paris.',
+            type='response.output_text.done',
+            sequence_number=2,
+            logprobs=[],
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=ResponseOutputMessage.model_construct(
+                id='msg_001',
+                content=cast(list[Content], [ResponseOutputText(text='Paris.', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+                phase='final_answer',
+            ),
+            output_index=0,
+            type='response.output_item.done',
+            sequence_number=3,
+        ),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(update={'status': 'completed'}),
+            type='response.completed',
+            sequence_number=4,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    events: list[Any] = []
+    async with agent.iter(user_prompt='What is the capital of France?') as agent_run:
+        async for node in agent_run:
+            if Agent.is_model_request_node(node):
+                async with node.stream(agent_run.ctx) as request_stream:
+                    async for event in request_stream:
+                        events.append(event)
+                # The run would go on to retry this text-less response; only the stream matters here.
+                break
+
+    # Same contract as the delta path: the phase arrives on the `PartStartEvent` that opens the
+    # part, and the completed part carries it too.
+    assert events == snapshot(
+        [
+            PartStartEvent(
+                index=0,
+                part=TextPart(content='', provider_name='openai', provider_details={'phase': 'final_answer'}),
+            ),
+            FinalResultEvent(tool_name=None, tool_call_id=None),
+            PartEndEvent(
+                index=0,
+                part=TextPart(content='', provider_name='openai', provider_details={'phase': 'final_answer'}),
+            ),
+        ]
+    )
+
+
 async def test_openai_responses_phase_round_trip(allow_model_requests: None):
     """When the profile supports phase, it's sent back on the assistant ResponseOutputMessageParam."""
     mock_client = MockOpenAIResponses.create_mock(

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -12895,149 +12895,47 @@ async def test_openai_responses_phase_streamed(allow_model_requests: None):
     assert text_parts[0].provider_details == snapshot({'phase': 'final_answer'})
 
 
-async def test_openai_responses_phase_streamed_on_part_start(allow_model_requests: None):
-    """`phase` is on the `PartStartEvent`, so commentary can be filtered out as it streams.
+async def test_openai_responses_phase_streamed_on_part_start(allow_model_requests: None, openai_api_key: str):
+    """Real cassette: `phase` rides the `PartStartEvent`, so commentary can be filtered as it streams.
 
-    Not a VCR test: this pins the exact event ordering within a single text part, which a cassette
-    replay can't hold stable — a re-recording chunks the deltas differently and the assertion is
-    about which event carries `phase`, not about the wire format.
+    The API announces `phase` on `output_item.added` — before the first delta — so a consumer knows
+    what kind of text a part holds the moment it opens, without buffering the part to find out.
     """
-    base_response = resp.Response(
-        id='resp_001',
-        model='gpt-5.5',
-        object='response',
-        created_at=1704067200,
-        output=[],
-        parallel_tool_calls=True,
-        tool_choice='auto',
-        tools=[],
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(
+        model=model,
+        instructions='Briefly narrate what you are about to do before calling each tool.',
     )
 
-    def message_events(
-        item_id: str,
-        phase: Literal['commentary', 'final_answer'],
-        deltas: list[str],
-        output_index: int,
-    ) -> list[resp.ResponseStreamEvent]:
-        text = ''.join(deltas)
-        return [
-            resp.ResponseOutputItemAddedEvent(
-                item=ResponseOutputMessage.model_construct(
-                    id=item_id,
-                    content=[],
-                    role='assistant',
-                    status='in_progress',
-                    type='message',
-                    phase=phase,
-                ),
-                output_index=output_index,
-                type='response.output_item.added',
-                sequence_number=0,
-            ),
-            *[
-                resp.ResponseTextDeltaEvent(
-                    content_index=0,
-                    delta=delta,
-                    item_id=item_id,
-                    output_index=output_index,
-                    type='response.output_text.delta',
-                    sequence_number=0,
-                    logprobs=[],
-                )
-                for delta in deltas
-            ],
-            resp.ResponseTextDoneEvent(
-                content_index=0,
-                item_id=item_id,
-                output_index=output_index,
-                text=text,
-                type='response.output_text.done',
-                sequence_number=0,
-                logprobs=[],
-            ),
-            resp.ResponseOutputItemDoneEvent(
-                item=ResponseOutputMessage.model_construct(
-                    id=item_id,
-                    content=cast(list[Content], [ResponseOutputText(text=text, type='output_text', annotations=[])]),
-                    role='assistant',
-                    status='completed',
-                    type='message',
-                    phase=phase,
-                ),
-                output_index=output_index,
-                type='response.output_item.done',
-                sequence_number=0,
-            ),
-        ]
+    @agent.tool_plain
+    async def get_capital(country: str) -> str:
+        return 'Potato City'
 
-    stream: list[resp.ResponseStreamEvent] = [
-        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
-        *message_events('msg_001', 'commentary', ['Let me ', 'think.'], output_index=0),
-        *message_events('msg_002', 'final_answer', ['Paris', '.'], output_index=1),
-        resp.ResponseCompletedEvent(
-            response=base_response.model_copy(update={'status': 'completed'}),
-            type='response.completed',
-            sequence_number=0,
-        ),
-    ]
+    text_part_starts: list[tuple[str, Any]] = []
+    text_delta_count = 0
+    deltas_carrying_phase: list[dict[str, Any]] = []
+    async with agent.run_stream_events('What is the capital of PotatoLand?') as event_stream:
+        async for event in event_stream:
+            if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+                text_part_starts.append((event.part.content, (event.part.provider_details or {}).get('phase')))
+            elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                text_delta_count += 1
+                if event.delta.provider_details is not None:
+                    deltas_carrying_phase.append(event.delta.provider_details)
 
-    mock_client = MockOpenAIResponses.create_mock_stream(stream)
-    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(openai_client=mock_client))
-    agent = Agent(model=model)
-
-    events: list[Any] = []
-    async with agent.iter(user_prompt='What is the capital of France?') as agent_run:
-        async for node in agent_run:
-            if Agent.is_model_request_node(node):
-                async with node.stream(agent_run.ctx) as request_stream:
-                    async for event in request_stream:
-                        events.append(event)
-
-    # Each part's `phase` is on its `PartStartEvent`, so a consumer can decide whether to forward
-    # the deltas that follow without buffering the whole part.
-    assert events == snapshot(
-        [
-            PartStartEvent(
-                index=0,
-                part=TextPart(
-                    content='Let me ', id='msg_001', provider_name='openai', provider_details={'phase': 'commentary'}
-                ),
-            ),
-            FinalResultEvent(tool_name=None, tool_call_id=None),
-            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta='think.')),
-            PartEndEvent(
-                index=0,
-                part=TextPart(
-                    content='Let me think.',
-                    id='msg_001',
-                    provider_name='openai',
-                    provider_details={'phase': 'commentary'},
-                ),
-                next_part_kind='text',
-            ),
-            PartStartEvent(
-                index=1,
-                part=TextPart(
-                    content='Paris', id='msg_002', provider_name='openai', provider_details={'phase': 'final_answer'}
-                ),
-                previous_part_kind='text',
-            ),
-            PartDeltaEvent(index=1, delta=TextPartDelta(content_delta='.')),
-            PartEndEvent(
-                index=1,
-                part=TextPart(
-                    content='Paris.', id='msg_002', provider_name='openai', provider_details={'phase': 'final_answer'}
-                ),
-            ),
-        ]
-    )
+    # Each part's phase is known as it opens, and the content is only the first chunk, not the whole part.
+    assert text_part_starts == snapshot([('I', 'commentary'), ('The', 'final_answer')])
+    # The phase opens the part and is not repeated on any of the deltas that follow.
+    assert text_delta_count == snapshot(23)
+    assert deltas_carrying_phase == []
 
 
 async def test_openai_responses_phase_streamed_without_deltas(allow_model_requests: None):
     """`phase` is still captured when a gateway emits `output_text.done` without any deltas.
 
-    Not a VCR test: OpenAI always sends deltas, so this fallback exists for OpenAI-compatible
-    gateways whose streams we can't record.
+    Not a VCR test: OpenAI itself always sends deltas — `test_openai_responses_phase_streamed_on_part_start`
+    records them for every text part — so this fallback only ever runs against OpenAI-compatible gateways
+    whose streams we have no way to record.
     """
     base_response = resp.Response(
         id='resp_001',

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -12913,21 +12913,20 @@ async def test_openai_responses_phase_streamed_on_part_start(allow_model_request
 
     text_part_starts: list[tuple[str, Any]] = []
     text_delta_count = 0
-    deltas_carrying_phase: list[dict[str, Any]] = []
+    delta_phases: set[Any] = set()
     async with agent.run_stream_events('What is the capital of PotatoLand?') as event_stream:
         async for event in event_stream:
             if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
                 text_part_starts.append((event.part.content, (event.part.provider_details or {}).get('phase')))
             elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
                 text_delta_count += 1
-                if event.delta.provider_details is not None:
-                    deltas_carrying_phase.append(event.delta.provider_details)
+                delta_phases.add((event.delta.provider_details or {}).get('phase'))
 
     # Each part's phase is known as it opens, and the content is only the first chunk, not the whole part.
     assert text_part_starts == snapshot([('I', 'commentary'), ('The', 'final_answer')])
     # The phase opens the part and is not repeated on any of the deltas that follow.
     assert text_delta_count == snapshot(23)
-    assert deltas_carrying_phase == []
+    assert delta_phases == snapshot({None})
 
 
 async def test_openai_responses_phase_streamed_without_deltas(allow_model_requests: None):


### PR DESCRIPTION
The `phase` (`commentary` | `final_answer`) announced on `output_item.added` was only merged into `TextPart.provider_details` on `output_text.done`, so consumers had to buffer a whole text part before they could tell whether to show it. Attach it to the part as it's created on the first `output_text.delta` instead, keeping the `output_text.done` path as a fallback for gateways that don't send deltas.

Closes #6718<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->


### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

