### PR TITLE
Fix `BedrockConverseModel` silently dropping `top_p=0.0`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -955,7 +955,7 @@ class BedrockConverseModel(Model[BaseClient]):
             inference_config['maxTokens'] = max_tokens
         if (temperature := model_settings.get('temperature')) is not None:
             inference_config['temperature'] = temperature
-        if top_p := model_settings.get('top_p'):
+        if (top_p := model_settings.get('top_p')) is not None:
             inference_config['topP'] = top_p
         if stop_sequences := model_settings.get('stop_sequences'):
             inference_config['stopSequences'] = stop_sequences

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3163,6 +3163,35 @@ async def test_bedrock_top_k_user_field_takes_precedence(
     assert kwargs['additionalModelRequestFields'] == {'top_k': 5}
 
 
+async def test_bedrock_top_p_zero_is_forwarded(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """`top_p=0.0` reaches the request as `inferenceConfig.topP` instead of being silently dropped.
+
+    `_map_inference_config` guarded `top_p` with a truthiness check, so the valid Converse
+    `topP` value `0.0` (range 0-1) never reached the request, while `temperature=0.0` two
+    lines above was forwarded via an `is not None` check.
+
+    No-network: the assertion is on the outgoing request shape, which a cassette matcher wouldn't pin.
+    """
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    agent = Agent(model, model_settings=ModelSettings(top_p=0.0, temperature=0.0))
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert kwargs['inferenceConfig']['topP'] == 0.0
+    assert kwargs['inferenceConfig']['temperature'] == 0.0
+
+
 async def test_bedrock_top_k_nova_merges_with_user_inference_config(
     allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
- Fixes #6790

## Problem

`BedrockConverseModel` silently drops `ModelSettings(top_p=0.0)` — the value never reaches the Converse request:

```python
from pydantic_ai.models.bedrock import BedrockConverseModel

print(BedrockConverseModel._map_inference_config({'temperature': 0.0, 'top_p': 0.0}))
#> {'temperature': 0.0}   # observed: topP missing
#> {'temperature': 0.0, 'topP': 0.0}   # expected
```

`top_p=0.0` is a valid `inferenceConfig.topP` value (the Converse API documents the range 0–1), and `AnthropicModel` forwards it (`top_p=model_settings.get('top_p', OMIT)` in `anthropic.py`), so the same agent code behaved differently depending only on the provider.

## Cause

`_map_inference_config` (`pydantic_ai_slim/pydantic_ai/models/bedrock.py:958`) guards `top_p` with a truthiness check, so `0.0` is treated as unset. `temperature` two lines above already uses `is not None` and correctly forwards `0.0`.

## Fix

Use the same `is not None` guard as `temperature`:

```python
if (top_p := model_settings.get('top_p')) is not None:
    inference_config['topP'] = top_p
```

The `max_tokens` and `stop_sequences` guards are unchanged: `max_tokens=0` is not a valid value and an empty `stop_sequences` list is a no-op.

## Test

`test_bedrock_top_p_zero_is_forwarded` follows the existing no-network mock pattern (`test_bedrock_top_k_user_field_takes_precedence`): it patches `client.converse`, runs an agent with `ModelSettings(top_p=0.0, temperature=0.0)`, and asserts both values appear in the outgoing `inferenceConfig`. It fails with a `KeyError` on `main` and passes with this fix; the full `tests/models/test_bedrock.py` suite passes (164 tests).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

