### PR TITLE
Document the no-force-push rule

### DIFF
--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -15,6 +15,8 @@ is left unresolved.**
   the user's instructions override this.
 - Run `pre-push-review`. Address every finding, commit the fixes, and repeat the review until it
   returns no findings. This applies before the first PR push and between every later PR iteration.
+- Never force-push an open PR branch. Push follow-up commits so previous reviews remain valid;
+  maintainers can squash them when merging.
 - Attempt the push. If it fails, read the real error — do not preemptively decide you lack
   permission from a flag or setting.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,6 +67,8 @@ On any PR, we may push commits to your branch, open a follow-up PR that supersed
 
 Please don't spend effort chasing green CI, addressing every automated review comment, or rebasing for merge conflicts on a PR we haven't pre-aligned on. If we take the change forward, that polish gets thrown away when we rewrite. Get the approach working, then stop and ping us on Slack.
 
+Do not force-push updates to an open PR. Rewriting its commits invalidates previous reviews; push follow-up commits instead. We will squash them when merging.
+
 ### Automated review is advisory, not a gate
 
 PRs are automatically reviewed by Devin and our own tooling. These reviews are advisory:


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Context: [PR #6785 comment](https://github.com/pydantic/pydantic-ai/pull/6785#issuecomment-5109536414)

### Summary

- Tell contributors not to force-push updates to open PRs and to push follow-up commits instead.
- Add the same guard to the AICA push workflow.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

