### PR TITLE
Preserve zero-valued OpenTelemetry usage details

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -236,8 +236,9 @@ class UsageBase:
                 # under `gen_ai.usage.details.*` makes consumers like Langfuse sum the two and double-count.
                 if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
                     continue
-                # Skipping check for value since spec implies all detail values are relevant
-                if value:
+                # Zero is a meaningful value, but a `None` would be an invalid OTel attribute value.
+                # Provider data can contain None despite the annotation.
+                if value is not None:  # pyright: ignore[reportUnnecessaryComparison]
                     result[prefix + key] = value
         return result
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -360,6 +360,15 @@ def test_usage_opentelemetry_attributes_include_zero_details():
         'gen_ai.usage.details.reasoning_tokens': 0,
     }
 
+    # Provider data can put a `None` in `details` despite the `dict[str, int]` annotation, and `None` is
+    # not a valid OTel attribute value, so it's the one thing the guard still drops.
+    usage.details = {'reasoning_tokens': 0, 'unreported_tokens': None}  # pyright: ignore[reportAttributeAccessIssue]
+    assert usage.opentelemetry_attributes() == {
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 50,
+        'gen_ai.usage.details.reasoning_tokens': 0,
+    }
+
 
 def test_opentelemetry_attributes_excludes_first_class_token_details():
     """`details` entries named like a first-class token attribute must never be emitted under `details.*`.

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -338,6 +338,26 @@ async def test_multi_agent_usage_no_incr():
         'gen_ai.usage.output_tokens': 13,
         'gen_ai.usage.details.custom1': 10,
         'gen_ai.usage.details.custom2': 20,
+        'gen_ai.usage.details.custom3': 0,
+    }
+
+
+def test_usage_opentelemetry_attributes_include_zero_details():
+    """A zero-valued detail is a real measurement and must survive the OTel mapping.
+
+    Providers report `reasoning_tokens=0` when a reasoning model didn't think on a given request;
+    dropping it makes "didn't reason" indistinguishable from "doesn't report reasoning tokens".
+    First-class token names stay excluded from `details.*` even at zero.
+    """
+    usage = RequestUsage(
+        input_tokens=100,
+        output_tokens=50,
+        details={'reasoning_tokens': 0, 'input_tokens': 0, 'output_tokens': 0},
+    )
+    assert usage.opentelemetry_attributes() == {
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 50,
+        'gen_ai.usage.details.reasoning_tokens': 0,
     }
 
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David reviewed this change lightly.

`opentelemetry_attributes()` guarded `gen_ai.usage.details.*` emission with `if value:`, dropping any detail whose value is `0`. OpenAI's Responses API path sets `details['reasoning_tokens'] = 0` for a model that produced no reasoning output, so "reasoned zero tokens" was indistinguishable in traces from "doesn't report reasoning tokens at all".

Guard is now `if value is not None:` — zero survives, a `None` (which providers can put in `details` despite the `dict[str, int]` annotation) is still filtered out, since it would be an invalid OTel attribute value. `_FIRST_CLASS_TOKEN_DETAIL_KEYS` still excludes `input_tokens`/`output_tokens` from `details.*`, so no double-counting. `RunUsage` inherits the fix via `UsageBase`.

Based on the approach in #6735 by @qdivan (closed in favour of this PR to avoid cross-fork coordination).

- Closes #6684

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

