### PR TITLE
Allow maintainer PRs to bypass agent-config guards

### DIFF
--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -36,7 +36,7 @@ jobs:
       pr_head_repo: ${{ steps.pr-info.outputs.pr_head_repo }}
       pr_head_sha: ${{ steps.pr-info.outputs.pr_head_sha }}
       pr_base_sha: ${{ steps.pr-info.outputs.pr_base_sha }}
-      pr_author_role: ${{ steps.pr-info.outputs.pr_author_role }}
+      pr_author_permission: ${{ steps.pr-info.outputs.pr_author_permission }}
     steps:
       - name: Get PR info
         if: github.event.issue.pull_request || github.event.pull_request
@@ -49,8 +49,8 @@ jobs:
           echo "pr_base_sha=$(echo "$PR_DATA" | jq -r '.base.sha')" >> $GITHUB_OUTPUT
           echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
           PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.user.login')
-          PR_AUTHOR_ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
-          echo "pr_author_role=${PR_AUTHOR_ROLE}" >> $GITHUB_OUTPUT
+          PR_AUTHOR_PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "unknown")
+          echo "pr_author_permission=${PR_AUTHOR_PERMISSION}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -117,8 +117,10 @@ jobs:
 
       - name: Check for modified config files
         # Maintainers are trusted to change agent config in their own PRs. Use
-        # their actual repository role rather than `author_association`, which can
-        # report `CONTRIBUTOR` for maintainers with private org membership.
+        # their actual repository permission rather than `author_association`,
+        # which can report `CONTRIBUTOR` for maintainers with private org
+        # membership. The API's `.permission` maps maintain and custom roles onto
+        # their stable base access level.
         #
         # Compare the exact immutable SHAs captured in get-pr-info (and checked
         # out above) rather than the live PR head. Using `gh pr diff` would read
@@ -133,9 +135,9 @@ jobs:
         # emits a `diff --git a/<old> b/<new>` header for every changed file,
         # including renames, so matching those lines cannot miss a path.
         run: |
-          case "$AUTHOR_ROLE" in
-            write | maintain | admin)
-              echo "PR author has ${AUTHOR_ROLE} access; skipping agent-config guard."
+          case "$AUTHOR_PERMISSION" in
+            write | admin)
+              echo "PR author has ${AUTHOR_PERMISSION} access; skipping agent-config guard."
               exit 0
               ;;
           esac
@@ -149,7 +151,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_SHA: ${{ needs.get-pr-info.outputs.pr_base_sha }}
           HEAD_SHA: ${{ needs.get-pr-info.outputs.pr_head_sha }}
-          AUTHOR_ROLE: ${{ needs.get-pr-info.outputs.pr_author_role }}
+          AUTHOR_PERMISSION: ${{ needs.get-pr-info.outputs.pr_author_permission }}
 
       - name: Install bubblewrap
         run: sudo apt-get install -y bubblewrap

--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -36,6 +36,7 @@ jobs:
       pr_head_repo: ${{ steps.pr-info.outputs.pr_head_repo }}
       pr_head_sha: ${{ steps.pr-info.outputs.pr_head_sha }}
       pr_base_sha: ${{ steps.pr-info.outputs.pr_base_sha }}
+      pr_author_role: ${{ steps.pr-info.outputs.pr_author_role }}
     steps:
       - name: Get PR info
         if: github.event.issue.pull_request || github.event.pull_request
@@ -47,6 +48,9 @@ jobs:
           echo "pr_head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
           echo "pr_base_sha=$(echo "$PR_DATA" | jq -r '.base.sha')" >> $GITHUB_OUTPUT
           echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.user.login')
+          PR_AUTHOR_ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
+          echo "pr_author_role=${PR_AUTHOR_ROLE}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -112,6 +116,10 @@ jobs:
           persist-credentials: false
 
       - name: Check for modified config files
+        # Maintainers are trusted to change agent config in their own PRs. Use
+        # their actual repository role rather than `author_association`, which can
+        # report `CONTRIBUTOR` for maintainers with private org membership.
+        #
         # Compare the exact immutable SHAs captured in get-pr-info (and checked
         # out above) rather than the live PR head. Using `gh pr diff` would read
         # whatever the PR points at now, so a force-push after get-pr-info could
@@ -125,6 +133,13 @@ jobs:
         # emits a `diff --git a/<old> b/<new>` header for every changed file,
         # including renames, so matching those lines cannot miss a path.
         run: |
+          case "$AUTHOR_ROLE" in
+            write | maintain | admin)
+              echo "PR author has ${AUTHOR_ROLE} access; skipping agent-config guard."
+              exit 0
+              ;;
+          esac
+
           CHANGED=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" -H 'Accept: application/vnd.github.v3.diff' | grep '^diff --git ')
           if echo "$CHANGED" | grep -qiE '/(AGENTS\.md|CLAUDE\.md)( |$)|/\.claude/'; then
             echo "::error::PR modifies agent config files (AGENTS.md, CLAUDE.md, or .claude/). Skipping for security."
@@ -134,6 +149,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_SHA: ${{ needs.get-pr-info.outputs.pr_base_sha }}
           HEAD_SHA: ${{ needs.get-pr-info.outputs.pr_head_sha }}
+          AUTHOR_ROLE: ${{ needs.get-pr-info.outputs.pr_author_role }}
 
       - name: Install bubblewrap
         run: sudo apt-get install -y bubblewrap

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -272,9 +272,11 @@ jobs:
         # review, where injected text carries the authority of the system prompt
         # instead of having to argue against it.
         #
-        # Runs for ALL PRs, not just forks: a same-repo branch (e.g. an automated
-        # agent's branch built from an untrusted issue) can carry a poisoned
-        # instruction file just as a fork can.
+        # Runs for all PRs not authored by a repository maintainer: a same-repo
+        # branch (e.g. an automated agent's branch built from an untrusted issue)
+        # can carry a poisoned instruction file just as a fork can. Resolve the
+        # actual repository role rather than trusting `author_association`, which
+        # can report `CONTRIBUTOR` for maintainers with private org membership.
         #
         # The path list is that instruction layer, which is wider than what Claude
         # Code autoloads: the root `CLAUDE.md` (system prompt) and `.claude/`, but
@@ -291,6 +293,14 @@ jobs:
         # 300 entries, so it could hide an edit in a large PR). Paths with spaces
         # come through quoted, hence the `"` terminator.
         run: |
+          AUTHOR_ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
+          case "$AUTHOR_ROLE" in
+            write | maintain | admin)
+              echo "PR author ${PR_AUTHOR} has ${AUTHOR_ROLE} access; skipping agent-config guard."
+              exit 0
+              ;;
+          esac
+
           CHANGED=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" -H 'Accept: application/vnd.github.v3.diff' | grep '^diff --git ')
           if echo "$CHANGED" | grep -qiE '/(AGENTS\.md|CLAUDE\.md|CLAUDE\.local\.md|\.mcp\.json)( |"|$)|/(\.claude|\.agents|agent_docs)/'; then
             echo "::error::PR modifies agent config the reviewer loads (AGENTS.md, CLAUDE.md, CLAUDE.local.md, .mcp.json, .claude/, .agents/, agent_docs/). Skipping douwebot for security."
@@ -300,6 +310,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
       - name: Gather PR context
         # Runs from the workspace root, i.e. the BASE checkout, so the guidance

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -275,8 +275,10 @@ jobs:
         # Runs for all PRs not authored by a repository maintainer: a same-repo
         # branch (e.g. an automated agent's branch built from an untrusted issue)
         # can carry a poisoned instruction file just as a fork can. Resolve the
-        # actual repository role rather than trusting `author_association`, which
-        # can report `CONTRIBUTOR` for maintainers with private org membership.
+        # actual repository permission rather than trusting `author_association`,
+        # which can report `CONTRIBUTOR` for maintainers with private org
+        # membership. The API's `.permission` maps maintain and custom roles onto
+        # their stable base access level.
         #
         # The path list is that instruction layer, which is wider than what Claude
         # Code autoloads: the root `CLAUDE.md` (system prompt) and `.claude/`, but
@@ -293,10 +295,10 @@ jobs:
         # 300 entries, so it could hide an edit in a large PR). Paths with spaces
         # come through quoted, hence the `"` terminator.
         run: |
-          AUTHOR_ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
-          case "$AUTHOR_ROLE" in
-            write | maintain | admin)
-              echo "PR author ${PR_AUTHOR} has ${AUTHOR_ROLE} access; skipping agent-config guard."
+          AUTHOR_PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "unknown")
+          case "$AUTHOR_PERMISSION" in
+            write | admin)
+              echo "PR author ${PR_AUTHOR} has ${AUTHOR_PERMISSION} access; skipping agent-config guard."
               exit 0
               ;;
           esac


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

### Summary

- bypass the `douwebot` and `at-claude-fork` agent-config guards when the PR author has confirmed `write` or `admin` base access
- resolve the author’s actual repository permission instead of relying on `author_association`; GitHub’s `.permission` field maps maintain and custom write-or-higher roles onto stable base levels
- fail closed: unknown and lower-trust roles still run the existing immutable-SHA config-path checks

### Why

The guard rejected [PR #6770](https://github.com/pydantic/pydantic-ai/pull/6770), authored by repository maintainer DouweM, before `douwebot` could review it. The root cause was that the guard applied unconditionally, including to authors already trusted to modify repository agent configuration.

### Validation

- `uv run pre-commit run --files .github/workflows/bots.yml .github/workflows/at-claude.yml`
- `make format && make lint`
- verified the trusted-permission matrix and live repository permissions for DouweM (`admin`) and dsfaccini (`write`)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).