### PR TITLE
Update known Cerebras model names

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -28,10 +28,7 @@ __all__ = ('CerebrasModel', 'CerebrasModelName', 'CerebrasModelSettings')
 
 LatestCerebrasModelNames = Literal[
     'gpt-oss-120b',
-    'llama-3.3-70b',
-    'llama3.1-8b',
-    'qwen-3-235b-a22b-instruct-2507',
-    'qwen-3-32b',
+    'gemma-4-31b',
     'zai-glm-4.7',
 ]
 


### PR DESCRIPTION
## Summary

- Updates LatestCerebrasModelNames to the three current public model IDs while retaining support for arbitrary model strings.
- The current public catalog is `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b`.

## Why

The previous model ID was retired or the fixed catalog was missing a currently available Cerebras model. This could produce failed requests, stale autocomplete, or misleading examples.

Fixes #6829

## Validation

- Python syntax parsing, git diff check, and an exact type-hint comparison with the live Cerebras model endpoint.
- Source of truth: https://api.cerebras.ai/public/v1/models

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

