### PR TITLE
Remove trailing `pragma` comments and backfill `TODO(v3)` deprecation markers

### DIFF
--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -104,6 +104,7 @@
 - Remove tests when redundant, obsolete, or duplicative — each test should verify distinct, valuable behavior that currently exists — Reduces maintenance burden and keeps test suite focused on actual behavior; prevents false confidence from tests covering non-existent code paths or duplicating coverage without verifying edge cases
 <!-- rule:97 -->
 - Avoid `# pragma: no cover` — write tests instead. Only use for truly untestable code (defensive guards, platform branches, optional deps unavailable in CI) — Coverage pragmas hide gaps in test coverage; proper tests prevent regressions and document expected behavior, while pragmas should only mark code paths that cannot be executed in testing environments
+- Write nothing after a `# pragma: ...` marker on its line — no trailing prose, no second `#` comment (tooling directives like `# pyright: ignore[...]` are the exception). When the exclusion needs a rationale, put it on its own comment line above the statement — Keeps the marker itself machine-readable and uniform across the codebase, while the reason stays visible to the next reader
 
 ## Documentation
 

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -1086,7 +1086,7 @@ class _ExhaustiveProcessor(_ToolCallProcessor[DepsT, NodeRunEndT]):
                 if self.call_kinds[i] == 'output':
                     r = output_results.get(i)
                     if r is None:
-                        continue  # pragma: no cover  # every output index is populated above
+                        continue  # pragma: no cover
                     is_winner = self.final_result is not None and r.call.tool_call_id == self.final_result.tool_call_id
                     if is_winner and self.final_result_was_set_externally:
                         # Streamed-in winner: record "processed" without claiming it was selected here.

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -1085,6 +1085,7 @@ class _ExhaustiveProcessor(_ToolCallProcessor[DepsT, NodeRunEndT]):
             for i in executable_indices:
                 if self.call_kinds[i] == 'output':
                     r = output_results.get(i)
+                    # Every output index is populated above.
                     if r is None:
                         continue  # pragma: no cover
                     is_winner = self.final_result is not None and r.call.tool_call_id == self.final_result.tool_call_id

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -297,6 +297,7 @@ def raise_if_cancelling() -> None:
     try:
         task = asyncio.current_task()
     except RuntimeError:  # pragma: no cover
+        # No running asyncio loop (e.g. a Trio-backed run).
         return
     if task is not None and task.cancelling() > 0:
         raise asyncio.CancelledError('pydantic-ai: re-asserting a cancellation absorbed by a completed step')

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -296,7 +296,7 @@ def raise_if_cancelling() -> None:
         return
     try:
         task = asyncio.current_task()
-    except RuntimeError:  # pragma: no cover - no running asyncio loop (e.g. a Trio-backed run)
+    except RuntimeError:  # pragma: no cover
         return
     if task is not None and task.cancelling() > 0:
         raise asyncio.CancelledError('pydantic-ai: re-asserting a cancellation absorbed by a completed step')

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1788,12 +1788,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                             # Skip CancelledError: it's expected cancellation propagation,
                             # and setting __context__ on it causes hangs on Python 3.10.
                             if not isinstance(_wrap_exc, asyncio.CancelledError) and _wrap_exc is not _run_error:
-                                _run_error.__context__ = (
-                                    _wrap_exc  # pragma: no cover — only fires for bugs in wrap_run implementations
-                                )
-                    elif (
-                        not _wrap_task.done()
-                    ):  # pragma: no branch — _run_done.set() can't complete _wrap_task synchronously
+                                _run_error.__context__ = _wrap_exc  # pragma: no cover
+                    elif not _wrap_task.done():  # pragma: no branch
                         _wrap_task.cancel()
                         try:
                             await _wrap_task
@@ -2926,7 +2922,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             for cap_ts in cap_toolsets if cap_toolsets is not None else self._cap_toolsets:
                 if isinstance(cap_ts, AbstractToolset):
                     toolsets.append(cap_ts)  # pyright: ignore[reportUnknownArgumentType]
-                else:  # pragma: no cover — get_toolset() always returns AbstractToolset
+                else:  # pragma: no cover
                     toolsets.append(DynamicToolset(cap_ts))
 
         return toolsets

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1788,6 +1788,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                             # Skip CancelledError: it's expected cancellation propagation,
                             # and setting __context__ on it causes hangs on Python 3.10.
                             if not isinstance(_wrap_exc, asyncio.CancelledError) and _wrap_exc is not _run_error:
+                                # Only fires for bugs in `wrap_run` implementations.
                                 _run_error.__context__ = _wrap_exc  # pragma: no cover
                     # `_run_done.set()` can't complete `_wrap_task` synchronously, so the task is always still pending here.
                     elif not _wrap_task.done():  # pragma: no branch
@@ -2924,6 +2925,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 if isinstance(cap_ts, AbstractToolset):
                     toolsets.append(cap_ts)  # pyright: ignore[reportUnknownArgumentType]
                 else:  # pragma: no cover
+                    # `get_toolset()` always returns an `AbstractToolset`.
                     toolsets.append(DynamicToolset(cap_ts))
 
         return toolsets

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1789,6 +1789,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                             # and setting __context__ on it causes hangs on Python 3.10.
                             if not isinstance(_wrap_exc, asyncio.CancelledError) and _wrap_exc is not _run_error:
                                 _run_error.__context__ = _wrap_exc  # pragma: no cover
+                    # `_run_done.set()` can't complete `_wrap_task` synchronously, so the task is always still pending here.
                     elif not _wrap_task.done():  # pragma: no branch
                         _wrap_task.cancel()
                         try:

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -84,7 +84,7 @@ AgentMetadata = dict[str, Any] | Callable[[RunContext[AgentDepsT]], dict[str, An
 AgentInstructions = _instructions.AgentInstructions
 """Type alias for agent instructions — a string, `TemplateStr`, callable, or sequence thereof."""
 
-Instructions = AgentInstructions
+Instructions = AgentInstructions  # TODO(v3): remove the `Instructions` alias
 """Deprecated: use `AgentInstructions` instead."""
 
 AgentModelSettings = ModelSettings | Callable[[RunContext[AgentDepsT]], ModelSettings]
@@ -340,7 +340,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             usage: Optional usage to expose as `RunContext.usage`.
             model_settings: Optional settings to expose as `RunContext.model_settings`.
         """
-        return []  # pragma: no cover — concrete subclasses override this
+        return []  # pragma: no cover
 
     def output_json_schema(self, output_type: OutputSpec[OutputDataT | RunOutputDataT] | None = None) -> JsonSchema:
         """The output return JSON schema."""

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -340,6 +340,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             usage: Optional usage to expose as `RunContext.usage`.
             model_settings: Optional settings to expose as `RunContext.model_settings`.
         """
+        # Concrete subclasses override this.
         return []  # pragma: no cover
 
     def output_json_schema(self, output_type: OutputSpec[OutputDataT | RunOutputDataT] | None = None) -> JsonSchema:

--- a/pydantic_ai_slim/pydantic_ai/agent/spec.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/spec.py
@@ -88,7 +88,7 @@ class AgentSpec(BaseModel):
         else:
             try:
                 import yaml
-            except ImportError:  # pragma: no cover — requires PyYAML to not be installed
+            except ImportError:  # pragma: no cover
                 raise ImportError(
                     'PyYAML is required to load YAML agent specs. Install it with: pip install "pydantic-ai-slim[spec]"'
                 ) from None
@@ -146,7 +146,7 @@ class AgentSpec(BaseModel):
         if fmt == 'yaml':
             try:
                 import yaml
-            except ImportError:  # pragma: no cover — requires PyYAML to not be installed
+            except ImportError:  # pragma: no cover
                 raise ImportError(
                     'PyYAML is required to save YAML agent specs. Install it with: pip install "pydantic-ai-slim[spec]"'
                 ) from None

--- a/pydantic_ai_slim/pydantic_ai/agent/spec.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/spec.py
@@ -89,6 +89,7 @@ class AgentSpec(BaseModel):
             try:
                 import yaml
             except ImportError:  # pragma: no cover
+                # Reaching this requires PyYAML to not be installed.
                 raise ImportError(
                     'PyYAML is required to load YAML agent specs. Install it with: pip install "pydantic-ai-slim[spec]"'
                 ) from None
@@ -147,6 +148,7 @@ class AgentSpec(BaseModel):
             try:
                 import yaml
             except ImportError:  # pragma: no cover
+                # Reaching this requires PyYAML to not be installed.
                 raise ImportError(
                     'PyYAML is required to save YAML agent specs. Install it with: pip install "pydantic-ai-slim[spec]"'
                 ) from None

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -632,6 +632,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
             except (ValidationError, ModelRetry) as new_error:
                 error = new_error
             except Exception:  # pragma: no cover
+                # Defensive.
                 raise
         raise error
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -631,7 +631,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
                 )
             except (ValidationError, ModelRetry) as new_error:
                 error = new_error
-            except Exception:  # pragma: no cover — defensive
+            except Exception:  # pragma: no cover
                 raise
         raise error
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
@@ -51,6 +51,7 @@ class ReinjectSystemPrompt(AbstractCapability[AgentDepsT]):
             _strip_system_prompts(messages)
         elif _has_system_prompt(messages):
             return request_context
+        # `ctx.agent` is always set during an agent run.
         if ctx.agent is None:
             return request_context  # pragma: no cover
         sys_parts = await ctx.agent.system_prompt_parts(

--- a/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
@@ -52,7 +52,7 @@ class ReinjectSystemPrompt(AbstractCapability[AgentDepsT]):
         elif _has_system_prompt(messages):
             return request_context
         if ctx.agent is None:
-            return request_context  # pragma: no cover — ctx.agent is always set during an agent run
+            return request_context  # pragma: no cover
         sys_parts = await ctx.agent.system_prompt_parts(
             deps=ctx.deps,
             model=ctx.model,

--- a/pydantic_ai_slim/pydantic_ai/capabilities/thread_executor.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/thread_executor.py
@@ -55,6 +55,7 @@ class UseThreadExecutor(AbstractCapability[Any]):
             return await handler()
 
 
+# TODO(v3): remove the `ThreadExecutor` alias, this `__getattr__`, and the forwarding one in `capabilities/__init__.py`
 def __getattr__(name: str) -> object:
     if name == 'ThreadExecutor':
         import warnings

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -123,6 +123,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             return
 
         construction_leaves: set[int] = set()
+        # `for_agent` always binds before a run.
         if self._agent is not None:  # pragma: no branch
             for agent_toolset in self._agent.toolsets:
                 agent_toolset.apply(lambda leaf: construction_leaves.add(id(leaf)))
@@ -416,6 +417,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             return self._models_by_id['default']
         agent = run_context.agent
         root_capability = run_context.root_capability
+        # The boundary carries both.
         if agent is not None and root_capability is not None:  # pragma: no branch
             resolution_ctx = ModelResolutionContext(agent=agent, deps=run_context.deps)
             # Exceptions raised by user resolvers in the chain propagate unchanged;

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -123,7 +123,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             return
 
         construction_leaves: set[int] = set()
-        if self._agent is not None:  # pragma: no branch — `for_agent` always binds before a run
+        if self._agent is not None:  # pragma: no branch
             for agent_toolset in self._agent.toolsets:
                 agent_toolset.apply(lambda leaf: construction_leaves.add(id(leaf)))
 
@@ -416,7 +416,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             return self._models_by_id['default']
         agent = run_context.agent
         root_capability = run_context.root_capability
-        if agent is not None and root_capability is not None:  # pragma: no branch - the boundary carries both
+        if agent is not None and root_capability is not None:  # pragma: no branch
             resolution_ctx = ModelResolutionContext(agent=agent, deps=run_context.deps)
             # Exceptions raised by user resolvers in the chain propagate unchanged;
             # only the `infer_model` backstop below gets the translated error.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -492,6 +492,7 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
         if not self._in_durable_context():
             return await self._mcp_toolset.call_tool(name, tool_args, ctx, tool)
         config = self._resolve_tool_config(tool, name)
+        # No engine's resolver currently permits inline MCP tools.
         if config is False:  # pragma: no cover
             return await self._mcp_toolset.call_tool(name, tool_args, ctx, tool)
         return await self._call_tool_operation(name, tool_args, ctx, tool, config)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -492,6 +492,6 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
         if not self._in_durable_context():
             return await self._mcp_toolset.call_tool(name, tool_args, ctx, tool)
         config = self._resolve_tool_config(tool, name)
-        if config is False:  # pragma: no cover — no engine's resolver currently permits inline MCP tools
+        if config is False:  # pragma: no cover
             return await self._mcp_toolset.call_tool(name, tool_args, ctx, tool)
         return await self._call_tool_operation(name, tool_args, ctx, tool, config)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -53,6 +53,7 @@ DBOSParallelExecutionMode = Literal['sequential', 'parallel_ordered_events']
 """
 
 
+# TODO(v3): remove `DBOSAgent` in favor of the `DBOSDurability` capability.
 @deprecated(
     """`DBOSAgent` is deprecated in favor of the `DBOSDurability` capability. Migrate each constructor argument as follows:
 - With the capability, call `agent.run()` inside a `@DBOS.workflow`; the wrapper did this automatically.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -53,7 +53,7 @@ DBOSParallelExecutionMode = Literal['sequential', 'parallel_ordered_events']
 """
 
 
-# TODO(v3): remove `DBOSAgent` in favor of the `DBOSDurability` capability.
+# TODO(v3): remove `DBOSAgent` in favor of the `DBOSDurability` capability, along with `DBOSDurability(register_legacy_workflows=...)` which exists solely to migrate off it
 @deprecated(
     """`DBOSAgent` is deprecated in favor of the `DBOSDurability` capability. Migrate each constructor argument as follows:
 - With the capability, call `agent.run()` inside a `@DBOS.workflow`; the wrapper did this automatically.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 from ._types import TaskConfig, default_task_config
 
 
+# TODO(v3): remove `PrefectAgent` in favor of the `PrefectDurability` capability.
 @deprecated(
     """`PrefectAgent` is deprecated in favor of the `PrefectDurability` capability. Migrate each constructor argument as follows:
 - With the capability, call `agent.run()` inside a `@flow`; the wrapper did this automatically.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -50,6 +50,7 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
     return call_tool_operation
 
 
+# TODO(v3): remove `PrefectFunctionToolset` alongside `PrefectAgent`.
 @deprecated(
     "`PrefectFunctionToolset` is deprecated alongside `PrefectAgent`. Use the `PrefectDurability` capability, which wraps the agent's toolsets in Prefect tasks automatically.",
     category=PydanticAIDeprecationWarning,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -54,6 +54,7 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
     return call_tool_operation
 
 
+# TODO(v3): remove `PrefectMCPToolset` alongside `PrefectAgent`.
 @deprecated(
     "`PrefectMCPToolset` is deprecated alongside `PrefectAgent`. Use the `PrefectDurability` capability, which wraps the agent's toolsets in Prefect tasks automatically.",
     category=PydanticAIDeprecationWarning,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -60,6 +60,7 @@ class _EventStreamHandlerParams:
     serialized_run_context: Any
 
 
+# TODO(v3): remove `TemporalAgent` in favor of the `TemporalDurability` capability.
 @deprecated(
     """`TemporalAgent` is deprecated in favor of the `TemporalDurability` capability. Migrate each constructor argument as follows:
 - `wrapped=` → use the wrapped agent's configuration on a regular `Agent(..., capabilities=[TemporalDurability(...)])`.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
@@ -75,6 +75,7 @@ def temporalize_mcp_toolset(
 
     def resolve_tool_config(tool: ToolsetTool[Any] | None, name: str) -> ToolConfig:
         config = resolve_tool_activity_config(tool, name, tool_activity_config)
+        # The constructor-dict path raises above, so tool metadata is the only route that reaches here.
         if config is False:  # pragma: no cover
             raise UserError(
                 f'Temporal activity config for MCP tool {name!r} has been explicitly set to `False` (activity disabled), '

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
@@ -75,9 +75,7 @@ def temporalize_mcp_toolset(
 
     def resolve_tool_config(tool: ToolsetTool[Any] | None, name: str) -> ToolConfig:
         config = resolve_tool_activity_config(tool, name, tool_activity_config)
-        if (
-            config is False
-        ):  # pragma: no cover — the constructor-dict path raises above; metadata is the only route here
+        if config is False:  # pragma: no cover
             raise UserError(
                 f'Temporal activity config for MCP tool {name!r} has been explicitly set to `False` (activity disabled), '
                 'but MCP tools require the use of IO and so cannot be run outside of an activity.'

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -331,6 +331,7 @@ def _map_usage(
     if response.embeddings:  # pragma: no branch
         for emb in response.embeddings:
             if emb.statistics and emb.statistics.token_count:
+                # Requires Vertex AI.
                 total_tokens += int(emb.statistics.token_count)  # pragma: lax no cover
 
     return RequestUsage(input_tokens=total_tokens)

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -331,6 +331,6 @@ def _map_usage(
     if response.embeddings:  # pragma: no branch
         for emb in response.embeddings:
             if emb.statistics and emb.statistics.token_count:
-                total_tokens += int(emb.statistics.token_count)  # pragma: lax no cover -- requires vertexai
+                total_tokens += int(emb.statistics.token_count)  # pragma: lax no cover
 
     return RequestUsage(input_tokens=total_tokens)

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1096,6 +1096,7 @@ class CompletedStreamedResponse(StreamedResponse):
         replay_events: bool | list[ModelResponseStreamEvent] | _utils.Unset = _utils.UNSET,
         events: bool | list[ModelResponseStreamEvent] | None = None,
     ):
+        # TODO(v3): remove the `events` alias and its deprecated `__init__` overloads
         if events is not None:
             warnings.warn(
                 '`events` is deprecated; use `replay_events` instead.',
@@ -1107,6 +1108,7 @@ class CompletedStreamedResponse(StreamedResponse):
                 replay_events = events
         if isinstance(replay_events, _utils.Unset):
             replay_events = False
+        # TODO(v3): remove the positional `(model_request_parameters, response)` order and its deprecated overloads
         if isinstance(response, ModelRequestParameters):
             # The positional `(model_request_parameters, response)` order predates the move
             # from `pydantic_ai.models.wrapper` to `pydantic_ai.models`.

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3097,6 +3097,7 @@ def _finalize_streamed_tool_search_call_part(part: NativeToolSearchCallPart) -> 
         try:
             parsed: dict[str, Any] | None = cast(dict[str, Any], pydantic_core.from_json(part.args))
         except ValueError:  # pragma: no cover
+            # Malformed partial args.
             parsed = None
     else:
         parsed = None

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3096,7 +3096,7 @@ def _finalize_streamed_tool_search_call_part(part: NativeToolSearchCallPart) -> 
     if isinstance(part.args, str):
         try:
             parsed: dict[str, Any] | None = cast(dict[str, Any], pydantic_core.from_json(part.args))
-        except ValueError:  # pragma: no cover - malformed partial args
+        except ValueError:  # pragma: no cover
             parsed = None
     else:
         parsed = None

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -138,6 +138,7 @@ class InstrumentationSettings:
 
         if version not in (2, 3, 4, 5):
             raise ValueError('Instrumentation version must be one of 2, 3, 4, or 5.')
+        # TODO(v3): remove instrumentation format versions 2, 3, and 4
         if version in (2, 3, 4):
             warnings.warn(
                 'Instrumentation format versions 2, 3, and 4 are deprecated; use `version=5` instead.',

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -122,6 +122,7 @@ class WrapperModel(Model):
         return getattr(self.wrapped, item)
 
 
+# TODO(v3): remove the `CompletedStreamedResponse` re-export shim
 def __getattr__(name: str) -> Any:
     if name == 'CompletedStreamedResponse':
         warnings.warn(

--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -39,6 +39,7 @@ T_co = TypeVar('T_co', covariant=True)
 OutputDataT = TypeVar('OutputDataT', default=str, covariant=True)
 """Covariant type variable for the output data type of a run."""
 
+# TODO(v3): remove the `tool_or_text` output mode
 OutputMode = Literal['text', 'tool', 'native', 'prompted', 'tool_or_text', 'image', 'auto']
 """All output modes.
 

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -732,6 +732,7 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
         """Whether the stream has been cancelled via `cancel()`."""
         if self._stream_response is not None:
             return self._stream_response.cancelled
+        # Only reachable via a `wrap_run` short-circuit, where there is no stream.
         return False  # pragma: no cover
 
 

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -732,7 +732,7 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
         """Whether the stream has been cancelled via `cancel()`."""
         if self._stream_response is not None:
             return self._stream_response.cancelled
-        return False  # pragma: no cover -- only reachable via wrap_run short-circuit (no stream)
+        return False  # pragma: no cover
 
 
 class StreamedRunResultSync(Generic[AgentDepsT, OutputDataT]):

--- a/pydantic_ai_slim/pydantic_ai/template.py
+++ b/pydantic_ai_slim/pydantic_ai/template.py
@@ -128,7 +128,7 @@ def _import_pydantic_handlebars() -> Any:
         import pydantic_handlebars
 
         return pydantic_handlebars
-    except ImportError as e:  # pragma: no cover — optional dependency
+    except ImportError as e:  # pragma: no cover
         raise ImportError(
             'pydantic-handlebars is required for TemplateStr support. '
             'Install it with: pip install "pydantic-ai-slim[spec]"'

--- a/pydantic_ai_slim/pydantic_ai/template.py
+++ b/pydantic_ai_slim/pydantic_ai/template.py
@@ -129,6 +129,7 @@ def _import_pydantic_handlebars() -> Any:
 
         return pydantic_handlebars
     except ImportError as e:  # pragma: no cover
+        # Optional dependency.
         raise ImportError(
             'pydantic-handlebars is required for TemplateStr support. '
             'Install it with: pip install "pydantic-ai-slim[spec]"'

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -734,6 +734,7 @@ class ToolManager(Generic[AgentDepsT]):
             allow_partial=allow_partial,
             wrap_validation_errors=wrap_validation_errors,
         )
+        # The only caller (`result.py`) passes `wrap_validation_errors=False`, so validation errors are raised above.
         if not validated.args_valid:  # pragma: no cover
             assert validated.validation_error is not None
             raise validated.validation_error

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -734,7 +734,7 @@ class ToolManager(Generic[AgentDepsT]):
             allow_partial=allow_partial,
             wrap_validation_errors=wrap_validation_errors,
         )
-        if not validated.args_valid:  # pragma: no cover — caller (result.py) uses wrap_validation_errors=False
+        if not validated.args_valid:  # pragma: no cover
             assert validated.validation_error is not None
             raise validated.validation_error
         return await self.execute_output_tool_call(

--- a/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
@@ -134,6 +134,7 @@ _DEFAULT_PARAMETER_DESCRIPTION = (
 )
 
 
+# Schema source only, never invoked.
 def _search_tools_signature(
     queries: Annotated[list[str], Field(description=_DEFAULT_PARAMETER_DESCRIPTION)],
 ) -> ToolSearchReturnContent:  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
@@ -136,7 +136,7 @@ _DEFAULT_PARAMETER_DESCRIPTION = (
 
 def _search_tools_signature(
     queries: Annotated[list[str], Field(description=_DEFAULT_PARAMETER_DESCRIPTION)],
-) -> ToolSearchReturnContent:  # pragma: no cover - schema source only, never invoked
+) -> ToolSearchReturnContent:  # pragma: no cover
     """Source-of-truth signature for the `search_tools` function tool.
 
     Used by [`Tool`][pydantic_ai.tools.Tool] to derive the JSON schema and validator

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -69,7 +69,7 @@ DispatchOutputDataT = TypeVar('DispatchOutputDataT')
 """TypeVar for output data to avoid awkwardness with unbound classvar output data."""
 
 
-# TODO(v3): remove this helper along with every adapter's `preserve_file_data` argument
+# TODO(v3): remove this helper along with the Vercel AI adapter's deprecated `preserve_file_data` alias (AG-UI's `preserve_file_data` is a separate, non-deprecated setting)
 def resolve_allow_uploaded_files(
     allow_uploaded_files: bool, preserve_file_data: bool | None, *, stacklevel: int = 3
 ) -> bool:

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -69,6 +69,7 @@ DispatchOutputDataT = TypeVar('DispatchOutputDataT')
 """TypeVar for output data to avoid awkwardness with unbound classvar output data."""
 
 
+# TODO(v3): remove this helper along with every adapter's `preserve_file_data` argument
 def resolve_allow_uploaded_files(
     allow_uploaded_files: bool, preserve_file_data: bool | None, *, stacklevel: int = 3
 ) -> bool:

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -282,6 +282,7 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
         # run with no result event, flushed by `on_error`.
         self._streamed_call_parts[part.tool_call_id] = part
         return
+        # Marks this an async generator.
         yield  # pragma: no cover
 
     def _tool_input_available_chunk(self, part: ToolCallPart) -> ToolInputAvailableChunk:

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -282,7 +282,7 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
         # run with no result event, flushed by `on_error`.
         self._streamed_call_parts[part.tool_call_id] = part
         return
-        yield  # pragma: no cover  # mark this as an async generator
+        yield  # pragma: no cover
 
     def _tool_input_available_chunk(self, part: ToolCallPart) -> ToolInputAvailableChunk:
         """Build the `tool-input-available` chunk announcing a streamed tool call's input."""

--- a/pydantic_evals/pydantic_evals/_online.py
+++ b/pydantic_evals/pydantic_evals/_online.py
@@ -367,7 +367,7 @@ async def _run_and_collect(
                     target=target,
                     include_baggage=config.include_baggage,
                 )
-            except Exception as exc:  # pragma: no cover - defensive
+            except Exception as exc:  # pragma: no cover
                 # Report OTel emission failures under the `'sink'` location: it's the
                 # catch-all for "something went wrong delivering results downstream",
                 # which default-sink users and OTel users can both reason about. See

--- a/pydantic_evals/pydantic_evals/_online.py
+++ b/pydantic_evals/pydantic_evals/_online.py
@@ -368,6 +368,7 @@ async def _run_and_collect(
                     include_baggage=config.include_baggage,
                 )
             except Exception as exc:  # pragma: no cover
+                # Defensive.
                 # Report OTel emission failures under the `'sink'` location: it's the
                 # catch-all for "something went wrong delivering results downstream",
                 # which default-sink users and OTel users can both reason about. See

--- a/pydantic_evals/pydantic_evals/_otel_emit.py
+++ b/pydantic_evals/pydantic_evals/_otel_emit.py
@@ -118,6 +118,7 @@ def build_parent_context(span_reference: SpanReference | None) -> Context | None
         trace_id = int(span_reference.trace_id, 16)
         span_id = int(span_reference.span_id, 16)
     except ValueError:  # pragma: no cover
+        # Defensive against malformed hex strings.
         return None
     span_ctx = SpanContext(
         trace_id=trace_id,

--- a/pydantic_evals/pydantic_evals/_otel_emit.py
+++ b/pydantic_evals/pydantic_evals/_otel_emit.py
@@ -117,7 +117,7 @@ def build_parent_context(span_reference: SpanReference | None) -> Context | None
     try:
         trace_id = int(span_reference.trace_id, 16)
         span_id = int(span_reference.span_id, 16)
-    except ValueError:  # pragma: no cover — defensive against malformed hex strings
+    except ValueError:  # pragma: no cover
         return None
     span_ctx = SpanContext(
         trace_id=trace_id,

--- a/pydantic_evals/pydantic_evals/online.py
+++ b/pydantic_evals/pydantic_evals/online.py
@@ -687,7 +687,7 @@ def _wrap_async(
                         # observability, not a contract to fail the call.
                         try:
                             span.set_attribute('return', result)
-                        except Exception:  # pragma: no cover - defensive
+                        except Exception:  # pragma: no cover
                             pass
             except Exception as e:
                 _dispatch_on_error(e, sampled, inputs, get_eval_context_kwargs, span, target, config)
@@ -761,7 +761,7 @@ def _wrap_sync(
                         # observability, not a contract to fail the call.
                         try:
                             span.set_attribute('return', result)
-                        except Exception:  # pragma: no cover - defensive
+                        except Exception:  # pragma: no cover
                             pass
             except Exception as e:
                 _dispatch_on_error(e, sampled, inputs, get_eval_context_kwargs, span, target, config)

--- a/pydantic_evals/pydantic_evals/online.py
+++ b/pydantic_evals/pydantic_evals/online.py
@@ -688,6 +688,7 @@ def _wrap_async(
                         try:
                             span.set_attribute('return', result)
                         except Exception:  # pragma: no cover
+                            # Defensive.
                             pass
             except Exception as e:
                 _dispatch_on_error(e, sampled, inputs, get_eval_context_kwargs, span, target, config)
@@ -762,6 +763,7 @@ def _wrap_sync(
                         try:
                             span.set_attribute('return', result)
                         except Exception:  # pragma: no cover
+                            # Defensive.
                             pass
             except Exception as e:
                 _dispatch_on_error(e, sampled, inputs, get_eval_context_kwargs, span, target, config)

--- a/tests/evals/test_online.py
+++ b/tests/evals/test_online.py
@@ -2234,13 +2234,13 @@ def test_extract_args_without_logfire_raises(monkeypatch: pytest.MonkeyPatch):
     with pytest.raises(RuntimeError, match='logfire'):
 
         @online_module.evaluate(AlwaysTrue(), extract_args=True)
-        async def f(x: int) -> int:  # pragma: no cover - decorator raises before body runs
+        async def f(x: int) -> int:  # pragma: no cover
             return x
 
     with pytest.raises(RuntimeError, match='logfire'):
 
         @online_module.evaluate(AlwaysTrue(), record_return=True)
-        async def g(x: int) -> int:  # pragma: no cover - decorator raises before body runs
+        async def g(x: int) -> int:  # pragma: no cover
             return x
 
 
@@ -2250,7 +2250,7 @@ def test_extract_args_unknown_parameter_raises():
     with pytest.raises(ValueError, match='not in'):
 
         @evaluate(AlwaysTrue(), extract_args=['nonexistent'])
-        async def f(x: int) -> int:  # pragma: no cover - decorator raises before body runs
+        async def f(x: int) -> int:  # pragma: no cover
             return x
 
 

--- a/tests/evals/test_online.py
+++ b/tests/evals/test_online.py
@@ -2232,13 +2232,13 @@ def test_extract_args_without_logfire_raises(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(online_module, '_LOGFIRE_INSTALLED', False)
 
     with pytest.raises(RuntimeError, match='logfire'):
-
+        # The decorator raises before the body runs.
         @online_module.evaluate(AlwaysTrue(), extract_args=True)
         async def f(x: int) -> int:  # pragma: no cover
             return x
 
     with pytest.raises(RuntimeError, match='logfire'):
-
+        # The decorator raises before the body runs.
         @online_module.evaluate(AlwaysTrue(), record_return=True)
         async def g(x: int) -> int:  # pragma: no cover
             return x
@@ -2248,7 +2248,7 @@ def test_extract_args_without_logfire_raises(monkeypatch: pytest.MonkeyPatch):
 def test_extract_args_unknown_parameter_raises():
     """Naming an unknown parameter in `extract_args` fails at decoration time."""
     with pytest.raises(ValueError, match='not in'):
-
+        # The decorator raises before the body runs.
         @evaluate(AlwaysTrue(), extract_args=['nonexistent'])
         async def f(x: int) -> int:  # pragma: no cover
             return x

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3393,6 +3393,7 @@ async def test_bedrock_cache_write_and_read(allow_model_requests: None, bedrock_
         ),
     )
 
+    # Both tool bodies below are exercised via the agent call, not directly.
     @agent.tool_plain
     def catalog_lookup() -> str:  # pragma: no cover
         return 'catalog-ok'

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3394,11 +3394,11 @@ async def test_bedrock_cache_write_and_read(allow_model_requests: None, bedrock_
     )
 
     @agent.tool_plain
-    def catalog_lookup() -> str:  # pragma: no cover - exercised via agent call
+    def catalog_lookup() -> str:  # pragma: no cover
         return 'catalog-ok'
 
     @agent.tool_plain
-    def diagnostics() -> str:  # pragma: no cover - exercised via agent call
+    def diagnostics() -> str:  # pragma: no cover
         return 'diagnostics-ok'
 
     long_context = 'Newer response with something except single number\n' * 10

--- a/tests/models/test_continuation_stream.py
+++ b/tests/models/test_continuation_stream.py
@@ -176,6 +176,7 @@ class _FakeModel(Model):
         return None
 
 
+# Scripted responses have no delay.
 async def _no_sleep(delay: float) -> None:  # pragma: no cover
     return None
 
@@ -647,6 +648,7 @@ async def test_segment_transport_error_propagates_when_not_cancelled() -> None:
     class _ExplodingStream(_FakeStream):
         async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
             raise httpx.ReadError('boom')
+            # Unreachable; marks this a generator.
             yield  # pragma: no cover
 
     class _ExplodingModel(_FakeModel):
@@ -1018,6 +1020,7 @@ async def test_later_segment_error_cancels_suspended_job() -> None:
     class _ExplodingStream(_FakeStream):
         async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
             raise RuntimeError('segment 2 boom')
+            # Unreachable; marks this a generator.
             yield  # pragma: no cover
 
     class _SecondSegmentExplodesModel(_FakeModel):

--- a/tests/models/test_continuation_stream.py
+++ b/tests/models/test_continuation_stream.py
@@ -176,7 +176,7 @@ class _FakeModel(Model):
         return None
 
 
-async def _no_sleep(delay: float) -> None:  # pragma: no cover - scripted responses have no delay
+async def _no_sleep(delay: float) -> None:  # pragma: no cover
     return None
 
 
@@ -647,7 +647,7 @@ async def test_segment_transport_error_propagates_when_not_cancelled() -> None:
     class _ExplodingStream(_FakeStream):
         async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
             raise httpx.ReadError('boom')
-            yield  # pragma: no cover - unreachable, marks this a generator
+            yield  # pragma: no cover
 
     class _ExplodingModel(_FakeModel):
         @asynccontextmanager
@@ -1018,7 +1018,7 @@ async def test_later_segment_error_cancels_suspended_job() -> None:
     class _ExplodingStream(_FakeStream):
         async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
             raise RuntimeError('segment 2 boom')
-            yield  # pragma: no cover - unreachable, marks this a generator
+            yield  # pragma: no cover
 
     class _SecondSegmentExplodesModel(_FakeModel):
         @asynccontextmanager

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -2972,7 +2972,7 @@ def test_fallback_continuation_delay_without_pin_polls_inner_models() -> None:
     model; only the one owning the background job returns a delay (gated on the response's `background`
     marker), so the fallback surfaces it — and returns `None` when no model claims it."""
 
-    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover - never called
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
         return ModelResponse(parts=[TextPart('x')])
 
     class _DelayModel(FunctionModel):

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -2972,6 +2972,7 @@ def test_fallback_continuation_delay_without_pin_polls_inner_models() -> None:
     model; only the one owning the background job returns a delay (gated on the response's `background`
     marker), so the fallback surfaces it — and returns `None` when no model claims it."""
 
+    # Never called.
     def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
         return ModelResponse(parts=[TextPart('x')])
 

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -366,6 +366,7 @@ async def test_multiple_concurrent_tool_retries():
         if ctx.deps.run_id not in retried_run_ids:
             retried_run_ids.add(ctx.deps.run_id)
             raise ModelRetry('Fail')
+        # Won't branch if all runs happen very quickly.
         if len(retried_run_ids) == len(run_ids):  # pragma: no branch
             event.set()
         await event.wait()  # ensure a retry is done by all runs before any of them finish their flow

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -366,7 +366,7 @@ async def test_multiple_concurrent_tool_retries():
         if ctx.deps.run_id not in retried_run_ids:
             retried_run_ids.add(ctx.deps.run_id)
             raise ModelRetry('Fail')
-        if len(retried_run_ids) == len(run_ids):  # pragma: no branch  # won't branch if all runs happen very quickly
+        if len(retried_run_ids) == len(run_ids):  # pragma: no branch
             event.set()
         await event.wait()  # ensure a retry is done by all runs before any of them finish their flow
         return None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9959,9 +9959,9 @@ async def test_run_handoff_survives_absorbed_cancellation():
         # task's own cancellation still unwinds it and the run ends cancelled — contrast the streaming
         # sibling, where the model consumes the cancel on the run task itself and the run completes.
         pass
-    except (TimeoutError, asyncio.TimeoutError):  # pragma: no cover - fails only on regression
+    except (TimeoutError, asyncio.TimeoutError):  # pragma: no cover
         pytest.fail('deadlock: run task still pending after cancellation (#6422)')
-    else:  # pragma: no cover - fails only on regression
+    else:  # pragma: no cover
         pytest.fail('run completed instead of ending cancelled')
 
 
@@ -10022,7 +10022,7 @@ async def test_streaming_handoff_survives_absorbed_cancellation():
             # re-asserts the still-pending cancellation at the next step boundary: cancellation
             # always cancels...
             pass
-        else:  # pragma: no cover - fails only on regression
+        else:  # pragma: no cover
             pytest.fail('run completed instead of ending cancelled')
 
     # ...and never discards completed work: the absorbed cancel means the model request
@@ -10067,7 +10067,7 @@ async def test_run_stream_events_aclose_survives_absorbed_cancellation():
         await asyncio.wait_for(asyncio.shield(task), timeout=READINESS_WAIT_TIMEOUT)
     except asyncio.CancelledError:
         pass  # expected: teardown completed and the run ended cancelled
-    except (TimeoutError, asyncio.TimeoutError):  # pragma: no cover - fails only on regression
+    except (TimeoutError, asyncio.TimeoutError):  # pragma: no cover
         pytest.fail('deadlock: run_stream_events teardown still pending after cancellation (#6422)')
 
 
@@ -11221,7 +11221,7 @@ def test_override_none_clears_instructions():
     agent = Agent('test', instructions='BASE')
 
     @agent.instructions
-    def instr_fn() -> str:  # pragma: no cover - ignored under override
+    def instr_fn() -> str:  # pragma: no cover
         return 'ALSO_BASE'
 
     with agent.override(instructions=None):
@@ -14028,7 +14028,7 @@ class _SuspendingStreamModel(Model):
         messages: list[ModelMessage],
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-    ) -> ModelResponse:  # pragma: no cover - streaming-only helper
+    ) -> ModelResponse:  # pragma: no cover
         raise NotImplementedError
 
     @property

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9960,6 +9960,7 @@ async def test_run_handoff_survives_absorbed_cancellation():
         # sibling, where the model consumes the cancel on the run task itself and the run completes.
         pass
     except (TimeoutError, asyncio.TimeoutError):  # pragma: no cover
+        # This branch and the `else` below fail only on regression.
         pytest.fail('deadlock: run task still pending after cancellation (#6422)')
     else:  # pragma: no cover
         pytest.fail('run completed instead of ending cancelled')
@@ -10023,6 +10024,7 @@ async def test_streaming_handoff_survives_absorbed_cancellation():
             # always cancels...
             pass
         else:  # pragma: no cover
+            # Fails only on regression.
             pytest.fail('run completed instead of ending cancelled')
 
     # ...and never discards completed work: the absorbed cancel means the model request
@@ -10068,6 +10070,7 @@ async def test_run_stream_events_aclose_survives_absorbed_cancellation():
     except asyncio.CancelledError:
         pass  # expected: teardown completed and the run ended cancelled
     except (TimeoutError, asyncio.TimeoutError):  # pragma: no cover
+        # Fails only on regression.
         pytest.fail('deadlock: run_stream_events teardown still pending after cancellation (#6422)')
 
 
@@ -11220,6 +11223,7 @@ def test_override_none_clears_instructions():
     """Test that passing None for instructions clears all instructions."""
     agent = Agent('test', instructions='BASE')
 
+    # Ignored under the override.
     @agent.instructions
     def instr_fn() -> str:  # pragma: no cover
         return 'ALSO_BASE'
@@ -14023,6 +14027,7 @@ class _SuspendingStreamModel(Model):
     def continuation_delay(self, response: ModelResponse) -> float | None:
         return self._delay
 
+    # Streaming-only helper.
     async def request(
         self,
         messages: list[ModelMessage],

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -6981,7 +6981,7 @@ class TestWrapNodeRunHook:
         @dataclass
         class NodeObserverCap(AbstractCapability[Any]):
             async def wrap_node_run(self, ctx: RunContext[Any], *, node: Any, handler: Any) -> Any:
-                return await handler(node)  # pragma: no cover — bare async for doesn't call this
+                return await handler(node)  # pragma: no cover
 
         agent = Agent(FunctionModel(simple_model_function), capabilities=[NodeObserverCap()])
 
@@ -10718,7 +10718,7 @@ class TestRunErrorHooks:
                     self.log.append('wrap_run:caught')
                     return AgentRunResult(output='wrap_recovered')
 
-            async def on_run_error(  # pragma: no cover — verifying this is NOT called
+            async def on_run_error(  # pragma: no cover
                 self, ctx: RunContext[Any], *, error: BaseException
             ) -> AgentRunResult[Any]:
                 self.log.append('on_run_error')
@@ -13502,7 +13502,7 @@ class TestModelRetryFromHooks:
             ) -> ModelResponse:
                 raise ModelRetry('retry please')
 
-            async def on_model_request_error(  # pragma: no cover — verifying this is NOT called
+            async def on_model_request_error(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
                 *,
@@ -14029,7 +14029,7 @@ class TestModelRetryFromHooks:
             ) -> Any:
                 raise ModelRetry('Wrap says retry tool')
 
-            async def on_tool_execute_error(  # pragma: no cover — verifying this is NOT called
+            async def on_tool_execute_error(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
                 *,
@@ -17101,7 +17101,7 @@ class TestBeforeOutputValidate:
                 output_context: OutputContext,
                 output: str | dict[str, Any],
             ) -> str | dict[str, Any]:
-                log.append('validate')  # pragma: no cover — should NOT fire for plain text
+                log.append('validate')  # pragma: no cover
                 return output  # pragma: no cover
 
             async def before_output_process(
@@ -17571,7 +17571,7 @@ class TestModelRetryFromOutputHooks:
                     raise ModelRetry('Bad output, please try again')
                 return result
 
-            async def on_output_process_error(  # pragma: no cover — verifying this is NOT called
+            async def on_output_process_error(  # pragma: no cover
                 self, ctx: RunContext[Any], *, output_context: OutputContext, output: Any, error: Exception
             ) -> Any:
                 nonlocal error_hook_called
@@ -18333,7 +18333,7 @@ class TestToolOutputWithOutputHooks:
 
         @dataclass
         class BothHooksCap(AbstractCapability[Any]):
-            async def before_tool_validate(  # pragma: no cover — verifying this is NOT called
+            async def before_tool_validate(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
                 *,
@@ -18344,7 +18344,7 @@ class TestToolOutputWithOutputHooks:
                 log.append(f'tool_validate:{call.tool_name}')
                 return args
 
-            async def before_tool_execute(  # pragma: no cover — verifying this is NOT called
+            async def before_tool_execute(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
                 *,
@@ -20729,7 +20729,7 @@ class TestImageOutputWithHooks:
             async def before_output_validate(
                 self, ctx: RunContext[Any], *, output_context: OutputContext, output: str | dict[str, Any]
             ) -> str | dict[str, Any]:
-                log.append('validate')  # pragma: no cover — should NOT fire for images
+                log.append('validate')  # pragma: no cover
                 return output  # pragma: no cover
 
             async def before_output_process(
@@ -23226,7 +23226,7 @@ async def test_dynamic_capability_contributes_toolset_function() -> None:
 
     @toolset.tool_plain
     def func_tool() -> str:
-        return 'from func'  # pragma: no cover — the tool listing is what's asserted
+        return 'from func'  # pragma: no cover
 
     @dataclass
     class AsyncToolFuncCap(AbstractCapability):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -10718,6 +10718,7 @@ class TestRunErrorHooks:
                     self.log.append('wrap_run:caught')
                     return AgentRunResult(output='wrap_recovered')
 
+            # The uncovered body is the assertion: this hook must not be called.
             async def on_run_error(  # pragma: no cover
                 self, ctx: RunContext[Any], *, error: BaseException
             ) -> AgentRunResult[Any]:
@@ -13502,6 +13503,7 @@ class TestModelRetryFromHooks:
             ) -> ModelResponse:
                 raise ModelRetry('retry please')
 
+            # The uncovered body is the assertion: this hook must not be called.
             async def on_model_request_error(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
@@ -14029,6 +14031,7 @@ class TestModelRetryFromHooks:
             ) -> Any:
                 raise ModelRetry('Wrap says retry tool')
 
+            # The uncovered body is the assertion: this hook must not be called.
             async def on_tool_execute_error(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
@@ -17571,6 +17574,7 @@ class TestModelRetryFromOutputHooks:
                     raise ModelRetry('Bad output, please try again')
                 return result
 
+            # The uncovered body is the assertion: this hook must not be called.
             async def on_output_process_error(  # pragma: no cover
                 self, ctx: RunContext[Any], *, output_context: OutputContext, output: Any, error: Exception
             ) -> Any:
@@ -18333,6 +18337,7 @@ class TestToolOutputWithOutputHooks:
 
         @dataclass
         class BothHooksCap(AbstractCapability[Any]):
+            # The uncovered body is the assertion: this hook must not be called.
             async def before_tool_validate(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],
@@ -18344,6 +18349,7 @@ class TestToolOutputWithOutputHooks:
                 log.append(f'tool_validate:{call.tool_name}')
                 return args
 
+            # The uncovered body is the assertion: this hook must not be called.
             async def before_tool_execute(  # pragma: no cover
                 self,
                 ctx: RunContext[Any],

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -6981,6 +6981,7 @@ class TestWrapNodeRunHook:
         @dataclass
         class NodeObserverCap(AbstractCapability[Any]):
             async def wrap_node_run(self, ctx: RunContext[Any], *, node: Any, handler: Any) -> Any:
+                # A bare `async for` doesn't call this.
                 return await handler(node)  # pragma: no cover
 
         agent = Agent(FunctionModel(simple_model_function), capabilities=[NodeObserverCap()])
@@ -17104,6 +17105,7 @@ class TestBeforeOutputValidate:
                 output_context: OutputContext,
                 output: str | dict[str, Any],
             ) -> str | dict[str, Any]:
+                # The uncovered body is the assertion: this hook must not fire for plain text.
                 log.append('validate')  # pragma: no cover
                 return output  # pragma: no cover
 
@@ -20735,6 +20737,7 @@ class TestImageOutputWithHooks:
             async def before_output_validate(
                 self, ctx: RunContext[Any], *, output_context: OutputContext, output: str | dict[str, Any]
             ) -> str | dict[str, Any]:
+                # The uncovered body is the assertion: this hook must not fire for images.
                 log.append('validate')  # pragma: no cover
                 return output  # pragma: no cover
 
@@ -23232,6 +23235,7 @@ async def test_dynamic_capability_contributes_toolset_function() -> None:
 
     @toolset.tool_plain
     def func_tool() -> str:
+        # The tool listing is what's asserted.
         return 'from func'  # pragma: no cover
 
     @dataclass

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2133,9 +2133,9 @@ def test_dbos_mcp_wrapper_visit_and_replace():
 
 def _durability_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Simple model function for durability tests."""
-    for msg in reversed(messages):  # pragma: no branch - first message carries the prompt
-        for part in msg.parts:  # pragma: no branch - first part is the UserPromptPart
-            if isinstance(part, UserPromptPart):  # pragma: no branch - same reason
+    for msg in reversed(messages):  # pragma: no branch
+        for part in msg.parts:  # pragma: no branch
+            if isinstance(part, UserPromptPart):  # pragma: no branch
                 return ModelResponse(parts=[TextPart(content=f'Echo: {part.content}')])
     return ModelResponse(parts=[TextPart(content='no prompt')])  # pragma: no cover
 
@@ -2661,7 +2661,7 @@ async def test_dbos_durability_resolve_model_id_capability_is_deps_aware(dbos: D
 def _dbos_broken_resolver(ctx: ModelResolutionContext[Any], model_id: str) -> FunctionModel | None:
     if model_id == 'broken-model':
         raise ValueError('resolver exploded')
-    return None  # pragma: no cover - only 'broken-model' flows through this test
+    return None  # pragma: no cover
 
 
 async def test_dbos_durability_user_resolver_error_propagates(dbos: DBOS) -> None:
@@ -2801,9 +2801,9 @@ def test_dbos_durability_get_serialization_name() -> None:
 
 
 async def _durability_stream_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
-    for msg in reversed(messages):  # pragma: no branch - first message carries the prompt
-        for part in msg.parts:  # pragma: no branch - first part is the UserPromptPart
-            if isinstance(part, UserPromptPart):  # pragma: no branch - same reason
+    for msg in reversed(messages):  # pragma: no branch
+        for part in msg.parts:  # pragma: no branch
+            if isinstance(part, UserPromptPart):  # pragma: no branch
                 yield f'Echo: {part.content}'
                 return
     yield 'no prompt'  # pragma: no cover
@@ -3204,7 +3204,7 @@ async def test_dbos_durability_dynamic_capability_tool_runs_in_step(dbos: DBOS) 
 
 def test_dbos_durability_dynamic_capability_requires_id(dbos: DBOS) -> None:
     def factory(ctx: RunContext[Any]) -> Capability[Any]:
-        return Capability()  # pragma: no cover — construction raises before the factory can run
+        return Capability()  # pragma: no cover
 
     with pytest.raises(UserError, match=r"DynamicCapability\(\.\.\., id='user-tools'\)"):
         Agent(
@@ -3219,7 +3219,7 @@ def test_dbos_durability_bare_capability_func_requires_explicit_wrapper(dbos: DB
     so under durable execution it raises with a hint to wrap it explicitly."""
 
     def factory(ctx: RunContext[Any]) -> Capability[Any]:
-        return Capability()  # pragma: no cover — construction raises before the factory can run
+        return Capability()  # pragma: no cover
 
     with pytest.raises(UserError, match=r'wrap it explicitly'):
         Agent(
@@ -3310,7 +3310,7 @@ async def test_dbos_durability_rejects_runtime_mcp_toolset_in_iter(dbos: DBOS) -
             'Hello',
             toolsets=[MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='iter_mcp')],
         ):
-            pass  # pragma: no cover — run setup raises before any node runs
+            pass  # pragma: no cover
 
     with pytest.raises(
         UserError, match=r'MCPToolset cannot be passed to `run\(toolsets=\.\.\.\)` at runtime with DBOS'
@@ -3319,7 +3319,7 @@ async def test_dbos_durability_rejects_runtime_mcp_toolset_in_iter(dbos: DBOS) -
 
 
 def _per_run_dynamic_factory(ctx: RunContext[Any]) -> FunctionToolset[Any]:
-    return FunctionToolset()  # pragma: no cover — rejected before the factory is resolved
+    return FunctionToolset()  # pragma: no cover
 
 
 async def test_dbos_durability_rejects_per_run_capability_toolset(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2133,6 +2133,7 @@ def test_dbos_mcp_wrapper_visit_and_replace():
 
 def _durability_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Simple model function for durability tests."""
+    # The first message carries the prompt and its first part is the `UserPromptPart`, so none of these branch.
     for msg in reversed(messages):  # pragma: no branch
         for part in msg.parts:  # pragma: no branch
             if isinstance(part, UserPromptPart):  # pragma: no branch
@@ -2661,6 +2662,7 @@ async def test_dbos_durability_resolve_model_id_capability_is_deps_aware(dbos: D
 def _dbos_broken_resolver(ctx: ModelResolutionContext[Any], model_id: str) -> FunctionModel | None:
     if model_id == 'broken-model':
         raise ValueError('resolver exploded')
+    # Only 'broken-model' flows through this test.
     return None  # pragma: no cover
 
 
@@ -2801,6 +2803,7 @@ def test_dbos_durability_get_serialization_name() -> None:
 
 
 async def _durability_stream_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+    # The first message carries the prompt and its first part is the `UserPromptPart`, so none of these branch.
     for msg in reversed(messages):  # pragma: no branch
         for part in msg.parts:  # pragma: no branch
             if isinstance(part, UserPromptPart):  # pragma: no branch
@@ -3204,6 +3207,7 @@ async def test_dbos_durability_dynamic_capability_tool_runs_in_step(dbos: DBOS) 
 
 def test_dbos_durability_dynamic_capability_requires_id(dbos: DBOS) -> None:
     def factory(ctx: RunContext[Any]) -> Capability[Any]:
+        # Construction raises before the factory can run.
         return Capability()  # pragma: no cover
 
     with pytest.raises(UserError, match=r"DynamicCapability\(\.\.\., id='user-tools'\)"):
@@ -3219,6 +3223,7 @@ def test_dbos_durability_bare_capability_func_requires_explicit_wrapper(dbos: DB
     so under durable execution it raises with a hint to wrap it explicitly."""
 
     def factory(ctx: RunContext[Any]) -> Capability[Any]:
+        # Construction raises before the factory can run.
         return Capability()  # pragma: no cover
 
     with pytest.raises(UserError, match=r'wrap it explicitly'):
@@ -3310,6 +3315,7 @@ async def test_dbos_durability_rejects_runtime_mcp_toolset_in_iter(dbos: DBOS) -
             'Hello',
             toolsets=[MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='iter_mcp')],
         ):
+            # Run setup raises before any node runs.
             pass  # pragma: no cover
 
     with pytest.raises(
@@ -3319,6 +3325,7 @@ async def test_dbos_durability_rejects_runtime_mcp_toolset_in_iter(dbos: DBOS) -
 
 
 def _per_run_dynamic_factory(ctx: RunContext[Any]) -> FunctionToolset[Any]:
+    # Rejected before the factory is resolved.
     return FunctionToolset()  # pragma: no cover
 
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1867,9 +1867,9 @@ async def test_disabled_tool():
 
 def _durability_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Simple model function for durability tests."""
-    for msg in reversed(messages):  # pragma: no branch - first message carries the prompt
-        for part in msg.parts:  # pragma: no branch - first part is the UserPromptPart
-            if isinstance(part, UserPromptPart):  # pragma: no branch - same reason
+    for msg in reversed(messages):  # pragma: no branch
+        for part in msg.parts:  # pragma: no branch
+            if isinstance(part, UserPromptPart):  # pragma: no branch
                 return ModelResponse(parts=[TextPart(content=f'Echo: {part.content}')])
     return ModelResponse(parts=[TextPart(content='no prompt')])  # pragma: no cover
 
@@ -1901,7 +1901,7 @@ def test_resolve_tool_task_config_reads_metadata() -> None:
     fn_toolset = FunctionToolset[None](id='resolve_meta_toolset')
 
     def fn_tool() -> str:
-        return 'ok'  # pragma: no cover - registered with toolset; test only resolves metadata
+        return 'ok'  # pragma: no cover
 
     fn_toolset.add_function(fn_tool, metadata={'prefect': metadata_config})
     tool_def = ToolDefinition(name='fn_tool', metadata={'prefect': metadata_config})
@@ -2025,10 +2025,10 @@ async def test_prefect_durability_allows_fully_opted_out_runtime_function_toolse
 
 
 async def test_prefect_durability_rejects_partially_opted_out_runtime_function_toolset() -> None:
-    async def opted_out() -> str:  # pragma: no cover — rejected before any tool runs
+    async def opted_out() -> str:  # pragma: no cover
         return 'ok'
 
-    async def wrapped() -> str:  # pragma: no cover — rejected before any tool runs
+    async def wrapped() -> str:  # pragma: no cover
         return 'no'
 
     toolset = FunctionToolset(id='runtime')
@@ -2055,7 +2055,7 @@ async def test_prefect_durability_rejects_runtime_toolset_in_iter() -> None:
     @flow
     async def run_agent() -> None:
         async with agent.iter('Hello', toolsets=[FunctionToolset(id='iter_fn')]):
-            pass  # pragma: no cover — run setup raises before any node runs
+            pass  # pragma: no cover
 
     with pytest.raises(UserError, match='FunctionToolset cannot be passed to '):
         await run_agent()
@@ -2148,7 +2148,7 @@ async def test_prefect_durability_dynamic_capability_tool_runs_as_task() -> None
 
 def test_prefect_durability_dynamic_capability_requires_id() -> None:
     def factory(ctx: RunContext[Any]) -> Capability[Any]:
-        return Capability()  # pragma: no cover — construction raises before the factory can run
+        return Capability()  # pragma: no cover
 
     with pytest.raises(UserError, match=r"DynamicCapability\(\.\.\., id='user-tools'\)"):
         Agent(
@@ -2464,9 +2464,9 @@ async def test_prefect_durability_passes_through_non_wrappable_leaf() -> None:
 
 
 async def _durability_stream_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
-    for msg in reversed(messages):  # pragma: no branch - first message carries the prompt
-        for part in msg.parts:  # pragma: no branch - first part is the UserPromptPart
-            if isinstance(part, UserPromptPart):  # pragma: no branch - same reason
+    for msg in reversed(messages):  # pragma: no branch
+        for part in msg.parts:  # pragma: no branch
+            if isinstance(part, UserPromptPart):  # pragma: no branch
                 yield f'Echo: {part.content}'
                 return
     yield 'no prompt'  # pragma: no cover

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1867,6 +1867,7 @@ async def test_disabled_tool():
 
 def _durability_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Simple model function for durability tests."""
+    # The first message carries the prompt and its first part is the `UserPromptPart`, so none of these branch.
     for msg in reversed(messages):  # pragma: no branch
         for part in msg.parts:  # pragma: no branch
             if isinstance(part, UserPromptPart):  # pragma: no branch
@@ -1901,6 +1902,7 @@ def test_resolve_tool_task_config_reads_metadata() -> None:
     fn_toolset = FunctionToolset[None](id='resolve_meta_toolset')
 
     def fn_tool() -> str:
+        # Registered with the toolset; the test only resolves metadata.
         return 'ok'  # pragma: no cover
 
     fn_toolset.add_function(fn_tool, metadata={'prefect': metadata_config})
@@ -2025,6 +2027,7 @@ async def test_prefect_durability_allows_fully_opted_out_runtime_function_toolse
 
 
 async def test_prefect_durability_rejects_partially_opted_out_runtime_function_toolset() -> None:
+    # Both tools below are rejected before any tool runs.
     async def opted_out() -> str:  # pragma: no cover
         return 'ok'
 
@@ -2055,6 +2058,7 @@ async def test_prefect_durability_rejects_runtime_toolset_in_iter() -> None:
     @flow
     async def run_agent() -> None:
         async with agent.iter('Hello', toolsets=[FunctionToolset(id='iter_fn')]):
+            # Run setup raises before any node runs.
             pass  # pragma: no cover
 
     with pytest.raises(UserError, match='FunctionToolset cannot be passed to '):
@@ -2148,6 +2152,7 @@ async def test_prefect_durability_dynamic_capability_tool_runs_as_task() -> None
 
 def test_prefect_durability_dynamic_capability_requires_id() -> None:
     def factory(ctx: RunContext[Any]) -> Capability[Any]:
+        # Construction raises before the factory can run.
         return Capability()  # pragma: no cover
 
     with pytest.raises(UserError, match=r"DynamicCapability\(\.\.\., id='user-tools'\)"):
@@ -2464,6 +2469,7 @@ async def test_prefect_durability_passes_through_non_wrappable_leaf() -> None:
 
 
 async def _durability_stream_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+    # The first message carries the prompt and its first part is the `UserPromptPart`, so none of these branch.
     for msg in reversed(messages):  # pragma: no branch
         for part in msg.parts:  # pragma: no branch
             if isinstance(part, UserPromptPart):  # pragma: no branch

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5496,7 +5496,7 @@ async def test_run_event_stream_handler_interrupted_does_not_drain():
 
     async def counting_stream(_messages: list[ModelMessage], _: AgentInfo) -> AsyncIterator[str]:
         nonlocal pulled
-        while True:  # pragma: no cover - the test asserts this unbounded stream is never pulled
+        while True:  # pragma: no cover
             pulled += 1
             yield 'hello'
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5496,6 +5496,7 @@ async def test_run_event_stream_handler_interrupted_does_not_drain():
 
     async def counting_stream(_messages: list[ModelMessage], _: AgentInfo) -> AsyncIterator[str]:
         nonlocal pulled
+        # The test asserts this unbounded stream is never pulled.
         while True:  # pragma: no cover
             pulled += 1
             yield 'hello'

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -295,6 +295,7 @@ def _kill_leaked_temporal_server(port: int) -> None:
     except (FileNotFoundError, subprocess.TimeoutExpired):  # pragma: lax no cover
         return
 
+    # The body fires only on a real leak, so it's covered on some runs and not on others.
     for line in result.stdout.splitlines():  # pragma: lax no cover
         if 'temporal-sdk-py' not in line:
             continue

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -293,6 +293,7 @@ def _kill_leaked_temporal_server(port: int) -> None:
             timeout=2,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):  # pragma: lax no cover
+        # No `ss` on this platform, or it was unresponsive.
         return
 
     # The body fires only on a real leak, so it's covered on some runs and not on others.
@@ -5465,6 +5466,7 @@ async def test_text_content_serialization_in_workflow(client: Client):
 
 def _durability_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Simple model function for durability tests that echoes the last user prompt."""
+    # The first message always carries the prompt and its first part is always the `UserPromptPart`, so none branch.
     for msg in reversed(messages):  # pragma: no branch
         for part in msg.parts:  # pragma: no branch
             if isinstance(part, UserPromptPart):  # pragma: no branch
@@ -6280,6 +6282,7 @@ _missing_cap_agent = Agent(_durability_fn_model, name='no_cap_in_attr')
 class _MissingCapWorkflow:
     __pydantic_ai_agents__ = [_missing_cap_agent]
 
+    # `configure_worker` rejects before this can execute.
     @workflow.run
     async def run(self, prompt: str) -> str:  # pragma: no cover
         result = await _missing_cap_agent.run(prompt)
@@ -6294,6 +6297,7 @@ async def test_pydantic_ai_plugin_rejects_bare_agent_without_durability(client: 
             task_queue=TASK_QUEUE,
             workflows=[_MissingCapWorkflow],
         ):
+            # The error is raised before reaching here.
             pass  # pragma: no cover
 
 
@@ -6552,6 +6556,7 @@ def test_durability_tool_metadata_disables_activity():
     """Tool metadata={'temporal': False} disables activity wrapping for that tool."""
 
     async def slow_tool() -> str:
+        # Registered with the toolset; the test only verifies wrapping.
         return 'slow'  # pragma: no cover
 
     toolset = FunctionToolset[object](id='meta_toolset')
@@ -6581,6 +6586,7 @@ def test_resolve_tool_activity_config_reads_metadata():
     fn_toolset = FunctionToolset[None](id='resolve_meta_toolset')
 
     async def fn_tool() -> str:
+        # Registered with the toolset; the test only resolves metadata.
         return 'ok'  # pragma: no cover
 
     fn_toolset.add_function(fn_tool, metadata={'temporal': metadata_config})
@@ -7669,6 +7675,7 @@ _durability_mcp_dynamic_toolset_agent = Agent(
 
 @_durability_mcp_dynamic_toolset_agent.toolset(id='durability_mcp_toolset')
 def _durability_my_mcp_dynamic_toolset(ctx: RunContext[object]) -> MCPToolset[object]:
+    # Exercised only by the skipped test below.
     return MCPToolset('https://mcp.deepwiki.com/mcp')  # pragma: no cover
 
 
@@ -7676,6 +7683,7 @@ def _durability_my_mcp_dynamic_toolset(ctx: RunContext[object]) -> MCPToolset[ob
 class DurabilityMCPDynamicToolsetAgentWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
+        # This body runs only under the skipped test below.
         result = await _durability_mcp_dynamic_toolset_agent.run(prompt)  # pragma: no cover
         return result.output  # pragma: no cover
 
@@ -7722,6 +7730,7 @@ _durability_mcptoolset_agent = Agent(
 class DurabilityMCPToolsetAgentWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
+        # This body runs only under the skipped test below.
         result = await _durability_mcptoolset_agent.run(prompt)  # pragma: no cover
         return result.output  # pragma: no cover
 
@@ -8126,6 +8135,7 @@ async def _opted_out_runtime_tool() -> str:
     return 'tool-result'
 
 
+# Rejected before any tool runs.
 async def _not_opted_out_runtime_tool() -> str:  # pragma: no cover
     return 'other-result'
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -292,10 +292,10 @@ def _kill_leaked_temporal_server(port: int) -> None:
             check=False,
             timeout=2,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):  # pragma: lax no cover - no `ss` or unresponsive
+    except (FileNotFoundError, subprocess.TimeoutExpired):  # pragma: lax no cover
         return
 
-    for line in result.stdout.splitlines():  # pragma: lax no cover - body fires only on a real leak
+    for line in result.stdout.splitlines():  # pragma: lax no cover
         if 'temporal-sdk-py' not in line:
             continue
         match = re.search(r'pid=(\d+)', line)
@@ -5464,9 +5464,9 @@ async def test_text_content_serialization_in_workflow(client: Client):
 
 def _durability_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Simple model function for durability tests that echoes the last user prompt."""
-    for msg in reversed(messages):  # pragma: no branch - first message always carries the prompt
-        for part in msg.parts:  # pragma: no branch - first part is always the UserPromptPart
-            if isinstance(part, UserPromptPart):  # pragma: no branch - same reason
+    for msg in reversed(messages):  # pragma: no branch
+        for part in msg.parts:  # pragma: no branch
+            if isinstance(part, UserPromptPart):  # pragma: no branch
                 return ModelResponse(parts=[TextPart(content=f'Echo: {part.content}')])
     return ModelResponse(parts=[TextPart(content='no prompt')])  # pragma: no cover
 
@@ -6280,7 +6280,7 @@ class _MissingCapWorkflow:
     __pydantic_ai_agents__ = [_missing_cap_agent]
 
     @workflow.run
-    async def run(self, prompt: str) -> str:  # pragma: no cover - configure_worker rejects before exec
+    async def run(self, prompt: str) -> str:  # pragma: no cover
         result = await _missing_cap_agent.run(prompt)
         return result.output
 
@@ -6293,7 +6293,7 @@ async def test_pydantic_ai_plugin_rejects_bare_agent_without_durability(client: 
             task_queue=TASK_QUEUE,
             workflows=[_MissingCapWorkflow],
         ):
-            pass  # pragma: no cover - error raised before reaching here
+            pass  # pragma: no cover
 
 
 # --- Toolset without ID raises UserError ---
@@ -6551,7 +6551,7 @@ def test_durability_tool_metadata_disables_activity():
     """Tool metadata={'temporal': False} disables activity wrapping for that tool."""
 
     async def slow_tool() -> str:
-        return 'slow'  # pragma: no cover - registered with toolset; test only verifies wrapping
+        return 'slow'  # pragma: no cover
 
     toolset = FunctionToolset[object](id='meta_toolset')
     toolset.add_function(slow_tool, metadata={'temporal': False})
@@ -6580,7 +6580,7 @@ def test_resolve_tool_activity_config_reads_metadata():
     fn_toolset = FunctionToolset[None](id='resolve_meta_toolset')
 
     async def fn_tool() -> str:
-        return 'ok'  # pragma: no cover - registered with toolset; test only resolves metadata
+        return 'ok'  # pragma: no cover
 
     fn_toolset.add_function(fn_tool, metadata={'temporal': metadata_config})
     tool_def = ToolDefinition(name='fn_tool', metadata={'temporal': metadata_config})
@@ -7668,15 +7668,15 @@ _durability_mcp_dynamic_toolset_agent = Agent(
 
 @_durability_mcp_dynamic_toolset_agent.toolset(id='durability_mcp_toolset')
 def _durability_my_mcp_dynamic_toolset(ctx: RunContext[object]) -> MCPToolset[object]:
-    return MCPToolset('https://mcp.deepwiki.com/mcp')  # pragma: no cover - exercised only by the skipped test below
+    return MCPToolset('https://mcp.deepwiki.com/mcp')  # pragma: no cover
 
 
 @workflow.defn
 class DurabilityMCPDynamicToolsetAgentWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
-        result = await _durability_mcp_dynamic_toolset_agent.run(prompt)  # pragma: no cover - skipped test
-        return result.output  # pragma: no cover - skipped test
+        result = await _durability_mcp_dynamic_toolset_agent.run(prompt)  # pragma: no cover
+        return result.output  # pragma: no cover
 
 
 @pytest.mark.skip(
@@ -7721,8 +7721,8 @@ _durability_mcptoolset_agent = Agent(
 class DurabilityMCPToolsetAgentWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
-        result = await _durability_mcptoolset_agent.run(prompt)  # pragma: no cover - skipped test
-        return result.output  # pragma: no cover - skipped test
+        result = await _durability_mcptoolset_agent.run(prompt)  # pragma: no cover
+        return result.output  # pragma: no cover
 
 
 @pytest.mark.skip(
@@ -8125,7 +8125,7 @@ async def _opted_out_runtime_tool() -> str:
     return 'tool-result'
 
 
-async def _not_opted_out_runtime_tool() -> str:  # pragma: no cover — rejected before any tool runs
+async def _not_opted_out_runtime_tool() -> str:  # pragma: no cover
     return 'other-result'
 
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1004,6 +1004,7 @@ async def test_handle_call_raw_mode_propagates_tool_failed_from_hooks(hook_name:
         ) -> dict[str, Any]:
             if hook_name == 'execute':
                 raise ToolFailed('hook failed')
+            # Unreachable: the 'validate' hook fails before execute runs.
             return args  # pragma: no cover
 
         async def before_tool_validate(
@@ -1017,6 +1018,7 @@ async def test_handle_call_raw_mode_propagates_tool_failed_from_hooks(hook_name:
 
     @toolset.tool_plain
     def tool() -> str:
+        # Unreachable: a hook always fails before the tool body runs.
         return 'ok'  # pragma: no cover
 
     tool_manager = await ToolManager[None](toolset, root_capability=FailingCapability()).for_run_step(

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1004,7 +1004,7 @@ async def test_handle_call_raw_mode_propagates_tool_failed_from_hooks(hook_name:
         ) -> dict[str, Any]:
             if hook_name == 'execute':
                 raise ToolFailed('hook failed')
-            return args  # pragma: no cover - unreachable: the 'validate' hook fails before execute runs
+            return args  # pragma: no cover
 
         async def before_tool_validate(
             self, ctx: RunContext[None], *, call: ToolCallPart, tool_def: ToolDefinition, args: str | dict[str, Any]
@@ -1017,7 +1017,7 @@ async def test_handle_call_raw_mode_propagates_tool_failed_from_hooks(hook_name:
 
     @toolset.tool_plain
     def tool() -> str:
-        return 'ok'  # pragma: no cover - unreachable: a hook always fails before the tool body runs
+        return 'ok'  # pragma: no cover
 
     tool_manager = await ToolManager[None](toolset, root_capability=FailingCapability()).for_run_step(
         build_run_context(None)


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

David made the two convention rulings this PR implements, but has not reviewed the code.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- No linked issue — alignment of two in-repo conventions. The "no trailing prose after a `pragma` marker" rule turned out not to be written down anywhere in the repo, so this PR also lands it in `agent_docs/index.md`; everything else is comment-only.

Two conventions had drifted in the codebase.

**1. No trailing prose after a `pragma` marker.** 91 sites across `pydantic_ai_slim`, `pydantic_evals`, and `tests` had an explanatory tail appended to the marker (`# pragma: no cover — defensive`, `# pragma: no branch  # reason`). The tails move off the marker line and become standalone comments above the statement; the total count of `# pragma:` markers is unchanged, and no marker is added, moved, or deleted, so coverage behavior and the strict-pragma audit are untouched. `ruff format` collapses three statements that were only wrapped to fit the removed text. Trailing `# pyright: ignore[...]` / `# type: ignore[...]` are kept — those are directives, not comments. The rule itself is now documented under Testing in `agent_docs/index.md`.

**2. Every user-facing deprecation carries a `TODO(v3): remove ...` marker**, so the next major cut can grep for what to drop. Only 5 existed; 13 more are backfilled, one per deprecation surface, placed where the removal would happen:

| Marker | Surface |
| --- | --- |
| `durable_exec/temporal/_agent.py` | `TemporalAgent` |
| `durable_exec/dbos/_agent.py` | `DBOSAgent` (and `DBOSDurability(register_legacy_workflows=...)`, which exists only to migrate off it) |
| `durable_exec/prefect/_agent.py` | `PrefectAgent` |
| `durable_exec/prefect/_function_toolset.py` | `PrefectFunctionToolset` |
| `durable_exec/prefect/_mcp_toolset.py` | `PrefectMCPToolset` |
| `capabilities/thread_executor.py` | `ThreadExecutor` alias shim (names the forwarding `__getattr__` in `capabilities/__init__.py` too) |
| `models/wrapper.py` | `CompletedStreamedResponse` re-export shim |
| `models/__init__.py` | `CompletedStreamedResponse(events=...)` alias |
| `models/__init__.py` | `CompletedStreamedResponse` legacy positional argument order |
| `models/instrumented.py` | instrumentation format versions 2, 3, and 4 |
| `ui/_adapter.py` | `resolve_allow_uploaded_files` / the Vercel AI adapter's `preserve_file_data` |
| `agent/abstract.py` | `Instructions` type alias |
| `output.py` | `tool_or_text` output mode |

Deliberately **not** marked: the `warnings.warn` sites that emit `UserWarning` rather than a deprecation warning; the `vendor_details` / `vendor_id` / `request_tokens` / `response_tokens` deserialization aliases (back-compat for messages already persisted in a DB, not a deprecated API with a removal plan); provider-side deprecations (OpenAI/Anthropic retired model ids, `openai_prompt_cache_retention`); and anything under `tests/`. `common_tools/exa.py` already carries a module-level marker that covers its five `@deprecated` symbols.

### Review

An independent review pass verified the marker-count invariant (every `# pragma:` marker in the base is still present, none added, moved, or deleted) and produced three fixes:

- the `ui/_adapter.py` marker was scoped too widely — it read as though *every* adapter's `preserve_file_data` were deprecated, but `AGUIAdapter.preserve_file_data` is a live, non-deprecated setting with different semantics. It now names the Vercel AI alias only.
- twelve load-bearing pragma rationales are restored as standalone comment lines above the statement — the convention bans a trailing tail on the marker line, not the reason itself.

Per maintainer request, the rationale carried by every remaining tail is preserved too: all 79 are back as standalone comment lines above the statement they explain (identical reasons on consecutive sites share one grouped comment), so the convention change costs no information.
- the `DBOSAgent` marker now also names `DBOSDurability(register_legacy_workflows=...)`, public API that exists solely for migrating off the deprecated wrapper, following the `ThreadExecutor` marker's precedent of naming its forwarding shim.

Deliberately skipped: nit-tier `TODO(v3)` markers on internal branches (the `isinstance` arms in `durable_exec/temporal/__init__.py`, the Prefect fallbacks, the legacy decode arms, the `instrumented.py` validation). The grep set targets deprecation *surfaces*; those internal lines are found by usage once the surface itself is removed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

