### PR TITLE
Add the `zai` optional group to `docs/install.md`

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -52,6 +52,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `bedrock-mantle` - installs [Bedrock Mantle Model](models/bedrock.md#bedrock-mantle) dependencies `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"} and `botocore` [PyPI ↗](https://pypi.org/project/botocore){:target="_blank"}
 * `xai` - installs [xAI Model](models/xai.md) dependency `xai-sdk` [PyPI ↗](https://pypi.org/project/xai-sdk){:target="_blank"}
 * `openrouter` - installs the [OpenRouter](models/openrouter.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
+* `zai` - installs the [Z.AI](models/zai.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `huggingface` - installs [Hugging Face Model](models/huggingface.md) dependency `huggingface-hub` [PyPI ↗](https://pypi.org/project/huggingface-hub){:target="_blank"}
 * `sentence-transformers` - installs [Sentence Transformers Embedding Model](embeddings.md#sentence-transformers-local) dependency `sentence-transformers` [PyPI ↗](https://pypi.org/project/sentence-transformers){:target="_blank"}
 * `voyageai` - installs [VoyageAI Embedding Model](embeddings.md#voyageai) dependency `voyageai` [PyPI ↗](https://pypi.org/project/voyageai){:target="_blank"}


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Not reviewed by David: he has not read this diff, it was written and verified by the agent.

No linked issue — maintainer bypass on `pr-guard`. Trivial docs fix.

`pydantic_ai_slim/pyproject.toml` carries `# WARNING if you add optional groups, please update docs/install.md` above the extras table. `zai` was added without that update, so the "`pydantic-ai-slim` has the following optional groups" list in [`docs/install.md`](https://github.com/pydantic/pydantic-ai/blob/main/docs/install.md) was missing it, even though [`docs/models/zai.md`](https://github.com/pydantic/pydantic-ai/blob/main/docs/models/zai.md) tells you to install `pydantic-ai-slim[zai]`.

Swept every optional group in `pydantic_ai_slim/pyproject.toml` against that list: `zai` was the only one missing, and no documented group is stale. `docs/install.md` is also the only page in `docs/` that enumerates the groups — everywhere else names its own extra inline.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

