### PR TITLE
feat(TestModel): add output_tool_name to select a specific output tool (#2199)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -80,6 +80,13 @@ class TestModel(Model):
     """If set, this text is returned as the final output."""
     custom_output_args: Any | None = None
     """If set, these args will be passed to the output tool."""
+    output_tool_name: str | None = None
+    """If set, the output tool with this name is called instead of selecting one based on `seed`.
+
+    This is the output-tool equivalent of `call_tools` for function tools. When unset (the default),
+    the output tool is selected with `seed % len(output_tools)`. Raises `UserError` if no output tool
+    with this name is available.
+    """
     seed: int = 0
     """Seed for generating random data."""
     last_model_request_parameters: ModelRequestParameters | None = field(default=None, init=False)
@@ -98,6 +105,7 @@ class TestModel(Model):
         call_tools: list[str] | Literal['all'] = 'all',
         custom_output_text: str | None = None,
         custom_output_args: Any | None = None,
+        output_tool_name: str | None = None,
         seed: int = 0,
         model_name: str = 'test',
         profile: ModelProfileSpec | None = None,
@@ -107,6 +115,7 @@ class TestModel(Model):
         self.call_tools = call_tools
         self.custom_output_text = custom_output_text
         self.custom_output_args = custom_output_args
+        self.output_tool_name = output_tool_name
         self.seed = seed
         self.last_model_request_parameters = None
         self._model_name = model_name
@@ -187,6 +196,19 @@ class TestModel(Model):
             tools_to_call = (function_tools_lookup[name] for name in self.call_tools)
             return [(r.name, r) for r in tools_to_call]
 
+    def _select_output_tool(self, output_tools: list[ToolDefinition]) -> ToolDefinition:
+        """Select which output tool to call.
+
+        Honors `output_tool_name` when set, otherwise falls back to the seed-based selection.
+        """
+        if self.output_tool_name is None:
+            return output_tools[self.seed % len(output_tools)]
+        for tool in output_tools:
+            if tool.name == self.output_tool_name:
+                return tool
+        available = ', '.join(repr(tool.name) for tool in output_tools)
+        raise UserError(f'Output tool {self.output_tool_name!r} not found. Available output tools: {available}.')
+
     def _get_output(self, model_request_parameters: ModelRequestParameters) -> _WrappedTextOutput | _WrappedToolOutput:
         if self.custom_output_text is not None:
             assert model_request_parameters.output_mode != 'tool', (
@@ -198,7 +220,7 @@ class TestModel(Model):
             assert model_request_parameters.output_tools is not None, (
                 'No output tools provided, but `custom_output_args` is set.'
             )
-            output_tool = model_request_parameters.output_tools[0]
+            output_tool = self._select_output_tool(model_request_parameters.output_tools)
 
             if k := output_tool.outer_typed_dict_key:
                 return _WrappedToolOutput({k: self.custom_output_args})
@@ -287,7 +309,7 @@ class TestModel(Model):
         else:
             assert output_tools, 'No output tools provided'
             custom_output_args = output_wrapper.value
-            output_tool = output_tools[self.seed % len(output_tools)]
+            output_tool = self._select_output_tool(output_tools)
             if custom_output_args is not None:
                 return ModelResponse(
                     parts=[

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -25,11 +25,12 @@ from pydantic_ai import (
     RunContext,
     TextPart,
     ToolCallPart,
+    ToolOutput,
     ToolReturnPart,
     UserPromptPart,
     VideoUrl,
 )
-from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
 from pydantic_ai.models.test import TestModel, _chars, _JsonSchemaTestData  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai.usage import RequestUsage, RunUsage
 
@@ -521,3 +522,58 @@ def test_different_content_input(content: AudioUrl | VideoUrl | ImageUrl | Binar
     result = agent.run_sync(['x', content], model=TestModel(custom_output_text='custom'))
     assert result.output == snapshot('custom')
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=51, output_tokens=1))
+
+
+class _Foo(BaseModel):
+    x: int
+
+
+class _Bar(BaseModel):
+    y: int
+
+
+def _multi_output_agent() -> Agent[None, Any]:
+    return Agent(output_type=[ToolOutput(_Foo, name='foo_tool'), ToolOutput(_Bar, name='bar_tool')])
+
+
+def test_output_tool_name_selects_named_output_tool():
+    """`output_tool_name` calls the requested output tool instead of the seed-based one."""
+    agent = _multi_output_agent()
+    result = agent.run_sync('x', model=TestModel(output_tool_name='bar_tool'))
+    assert isinstance(result.output, _Bar)
+    response = result.all_messages()[1]
+    assert isinstance(response, ModelResponse)
+    part = response.parts[0]
+    assert isinstance(part, ToolCallPart)
+    assert part.tool_name == 'bar_tool'
+
+
+def test_output_tool_name_defaults_to_seed_selection():
+    """Unset `output_tool_name` preserves the existing `seed % len(output_tools)` behavior."""
+    agent = _multi_output_agent()
+    result = agent.run_sync('x', model=TestModel(seed=0))
+    assert isinstance(result.output, _Foo)
+    response = result.all_messages()[1]
+    assert isinstance(response, ModelResponse)
+    part = response.parts[0]
+    assert isinstance(part, ToolCallPart)
+    assert part.tool_name == 'foo_tool'
+
+
+def test_output_tool_name_with_custom_output_args():
+    """`output_tool_name` and `custom_output_args` compose: named tool, given args."""
+    agent = _multi_output_agent()
+    result = agent.run_sync('x', model=TestModel(output_tool_name='bar_tool', custom_output_args={'y': 7}))
+    assert result.output == _Bar(y=7)
+    response = result.all_messages()[1]
+    assert isinstance(response, ModelResponse)
+    part = response.parts[0]
+    assert isinstance(part, ToolCallPart)
+    assert part.tool_name == 'bar_tool'
+
+
+def test_output_tool_name_unknown_raises_user_error():
+    """An unknown `output_tool_name` raises a clear `UserError`."""
+    agent = _multi_output_agent()
+    with pytest.raises(UserError, match=re.escape("Output tool 'nope' not found.")):
+        agent.run_sync('x', model=TestModel(output_tool_name='nope'))


### PR DESCRIPTION
Fixes #2199.

`TestModel` can already target a specific *function* tool via `TestModel(call_tools=['tool_name'])`, but there was no equivalent for *output* tools — when an agent has multiple output tools it always picked one via `seed % len(output_tools)`, so a test couldn't deterministically exercise a particular one. (@DouweM invited a PR for this in the issue.)

## Change

Add an optional `output_tool_name` to `TestModel`:

- When set, the output tool with that name is called; if no output tool matches, a clear `UserError` is raised listing the available names.
- When unset, behavior is unchanged — the existing `seed % len(output_tools)` selection.

Both the wrapper-key computation (for `custom_output_args`) and the emitted tool call now go through a single `_select_output_tool` helper, so they stay consistent (previously the key came from `output_tools[0]` while the call used `output_tools[seed % len]`; they now agree, and are identical to before at the default `seed=0`).

Scope is `ToolOutput` only, as discussed in the thread — `NativeOutput` uses a different path (no output tool to select) and is intentionally left out.

## Tests

Added to `tests/models/test_model_test.py` (all offline — `TestModel` is the built-in mock, no network/API key):

- named selection calls the requested output tool,
- unset `output_tool_name` still uses seed-based selection (regression),
- `output_tool_name` composes with `custom_output_args`,
- an unknown name raises `UserError`.

`pytest tests/models/test_model_test.py` → 23 passed; broader `tests/test_agent.py tests/test_streaming.py` → 615 passed, no regressions. `ruff check`/`ruff format` clean; `pyright` clean.
