### PR TITLE
Add telemetry.dev to alternative observability backends

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -246,6 +246,7 @@ The following providers have dedicated documentation on Pydantic AI:
 - [Laminar](https://docs.laminar.sh/tracing/integrations/pydantic-ai)
 - [Respan](https://respan.ai/docs/integrations/pydantic-ai)
 - [Raindrop](https://raindrop.ai/docs/integrations/pydantic-ai)
+- [telemetry.dev](https://telemetry.dev/integrations/pydantic-ai)
 
 ## Advanced usage
 


### PR DESCRIPTION
I added telemetry.dev to the alternative observability backends list, following the rule in the comment (bottom of the list, name with link only). It links to a setup guide for sending Pydantic AI's OpenTelemetry spans to telemetry.dev.

Disclosure: I built telemetry.dev.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

