### PR TITLE
fix(providers): pass lowercased model name to family profiles in SambaNova/Heroku/Fireworks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -56,7 +56,9 @@ class FireworksProvider(Provider[AsyncOpenAI]):
 
         profile = None
         if model_name.startswith(prefix):
-            model_name = model_name[len(prefix) :]
+            # Match and dispatch on the lowercased name: the family profile functions all key off
+            # lowercase prefixes, so a mixed-case model ID would match nothing at all.
+            model_name = model_name[len(prefix) :].lower()
             for provider, profile_func in prefix_to_profile.items():
                 if model_name.startswith(provider):
                     profile = profile_func(model_name)

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -67,10 +67,12 @@ class HerokuProvider(Provider[AsyncOpenAI]):
         }
 
         profile = None
+        # The family profile functions match on lowercase prefixes, so they get the lowercased name
+        # too -- passing the original casing would defeat the detection described above.
         lower_model_name = model_name.lower()
         for prefix, profile_func in prefix_to_profile.items():
             if lower_model_name.startswith(prefix):
-                profile = profile_func(model_name)
+                profile = profile_func(lower_model_name)
                 break
 
         # As the Heroku API is OpenAI-compatible, we keep the OpenAIJsonSchemaTransformer as the base

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -65,11 +65,13 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
         }
 
         profile = None
+        # SambaNova's model names are mixed case (`DeepSeek-R1-0528`, `Qwen3-32B`), and the family
+        # profile functions match on lowercase prefixes, so they need the lowercased name too.
         model_name_lower = model_name.lower()
 
         for prefix, profile_func in prefix_to_profile.items():
             if model_name_lower.startswith(prefix):
-                profile = profile_func(model_name)
+                profile = profile_func(model_name_lower)
                 break
 
         # Wrap into OpenAIModelProfile since SambaNova is OpenAI-compatible

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -102,3 +102,19 @@ def test_fireworks_provider_model_profile(mocker: MockerFixture):
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
     assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+
+def test_fireworks_provider_model_profile_is_case_insensitive(mocker: MockerFixture):
+    """The family prefixes are lowercase, so a mixed-case model ID must be lowercased first.
+
+    Otherwise `DeepSeek-R1` matches no prefix at all and gets the bare OpenAI-compatible
+    profile -- `supports_thinking` unset, so a `thinking=True` setting is silently dropped.
+    """
+    provider = FireworksProvider(api_key='api-key')
+    deepseek_mock = mocker.patch('pydantic_ai.providers.fireworks.deepseek_model_profile', wraps=deepseek_model_profile)
+
+    profile = provider.model_profile('accounts/fireworks/models/DeepSeek-R1')
+    deepseek_mock.assert_called_with('deepseek-r1')
+    assert profile is not None
+    assert profile.get('supports_thinking') is True
+    assert profile == provider.model_profile('accounts/fireworks/models/deepseek-r1')

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -105,6 +105,23 @@ def test_heroku_model_profile_routes_thinking_capable_families():
     assert fallback.get('supports_thinking') is None
 
 
+def test_heroku_model_profile_is_case_insensitive():
+    """The prefix match is case-insensitive, so the dispatched name has to be too.
+
+    Matching on the lowercased name but handing the family profile the original casing means a
+    mixed-case model ID selects the right profile function and then detects nothing inside it --
+    every family profile keys off lowercase prefixes.
+    """
+    provider = HerokuProvider(api_key='api-key')
+
+    for model_name in ('deepseek-r1', 'claude-3-7-sonnet'):
+        assert provider.model_profile(model_name.upper()) == provider.model_profile(model_name), model_name
+
+    deepseek_profile = provider.model_profile('DeepSeek-R1')
+    assert deepseek_profile is not None
+    assert deepseek_profile.get('supports_thinking') is True
+
+
 async def test_heroku_model_provider_claude_3_7_sonnet(allow_model_requests: None, heroku_inference_key: str):
     provider = HerokuProvider(api_key=heroku_inference_key)
     m = OpenAIChatModel('claude-3-7-sonnet', provider=provider)

--- a/tests/providers/test_sambanova_provider.py
+++ b/tests/providers/test_sambanova_provider.py
@@ -8,6 +8,8 @@ from ..conftest import TestEnv, try_import
 with try_import() as imports_successful:
     import openai
 
+    from pydantic_ai.models import ModelRequestParameters
+    from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers import infer_provider
     from pydantic_ai.providers.sambanova import SambaNovaProvider
 
@@ -86,6 +88,37 @@ def test_unknown_model_profile():
     # Unknown model -> should return OpenAI compatibility wrapper with None base profile
     profile = provider.model_profile('unknown-model')
     assert isinstance(profile, dict)
+
+
+def test_model_profile_is_case_insensitive():
+    """SambaNova's model names are mixed case, and the family profiles match lowercase prefixes.
+
+    `DeepSeek-R1-0528` is a real SambaNova model ID, and `deepseek_model_profile` matches on
+    `'deepseek-r1'`, so passing the original casing through detects nothing: `supports_thinking`
+    comes back `False` and a `thinking=True` setting is silently dropped instead of sent.
+    """
+    provider = SambaNovaProvider(api_key='key')
+
+    profile = provider.model_profile('DeepSeek-R1-0528')
+    assert profile is not None
+    assert profile.get('supports_thinking') is True
+    assert profile.get('thinking_always_enabled') is True
+    assert profile.get('ignore_streamed_leading_whitespace') is True
+
+    # …and the casing must make no difference at all.
+    assert profile == provider.model_profile('deepseek-r1-0528')
+
+
+def test_model_profile_thinking_is_not_dropped_for_mixed_case_names():
+    """The user-visible symptom: `thinking=True` never reaching the wire.
+
+    `Model.prepare_request` only forwards `thinking` when the profile advertises support for it,
+    and strips it from `model_settings` either way -- so an undetected profile loses the setting
+    with no error and no warning.
+    """
+    model = OpenAIChatModel('DeepSeek-R1-0528', provider=SambaNovaProvider(api_key='key'))
+    _, params = model.prepare_request({'thinking': True}, ModelRequestParameters())
+    assert params.thinking is True
 
 
 def test_sambanova_provider_with_openai_client():


### PR DESCRIPTION
Fixes #6816

## Summary

Three providers match their family-profile prefix against the **lowercased** model name but pass the **original casing** to the profile function. Every family profile keys off lowercase prefixes, so a mixed-case model ID selects the right profile function and then detects nothing inside it — `supports_thinking` comes back `False`/unset and a `thinking=True` setting is **silently dropped**.

This is the same failure mode as #6022 / #6070, one layer down: Heroku's routing was added so capabilities "are detected instead of silently dropped", but the original casing defeats the detection it enables.

## The defect

`providers/sambanova.py`:

```python
model_name_lower = model_name.lower()

for prefix, profile_func in prefix_to_profile.items():
    if model_name_lower.startswith(prefix):
        profile = profile_func(model_name)   # <- original casing
        break
```

The profile functions it dispatches to are all case-sensitive:

| function | match |
|---|---|
| `deepseek_model_profile` | `startswith('deepseek-r1')`, `startswith('deepseek-v4-')` |
| `qwen_model_profile` | `startswith('qwen-3-coder')`, `_QWEN_3_5_RE` |
| `mistral_model_profile` | `startswith('magistral')` |
| `google_model_profile` | `'gemini-3' in`, `'gemini-2.5' in` |
| `anthropic_model_profile` | ~20 × `startswith('claude-…')` |

(`moonshotai_model_profile` and `zai_model_profile` lowercase internally, so they're immune — which is what makes the contract "the caller passes lowercase" rather than "each profile defends itself".)

SambaNova's model IDs **are** mixed case. `docs/models/openai.md` uses `sambanova:Meta-Llama-3.1-8B-Instruct`, and `DeepSeek-R1-0528` / `Qwen3-32B` are real IDs, so this fires in ordinary use:

```
model name         supports_thinking  thinking_always_enabled  ignore_streamed_leading_whitespace
DeepSeek-R1-0528   False              False                    False
deepseek-r1-0528   True               True                     True
```

## Why it's silent

`Model.prepare_request` (`models/__init__.py:418-426`) only forwards `thinking` when the profile advertises support, and strips it from `model_settings` either way:

```python
if model_settings and 'thinking' in model_settings:
    thinking_value = model_settings['thinking']
    supports_thinking = self.profile.get('supports_thinking', False)
    thinking_always_enabled = self.profile.get('thinking_always_enabled', False)
    if supports_thinking or thinking_always_enabled:
        if not (thinking_value is False and thinking_always_enabled):
            params = replace(params, thinking=thinking_value)
    stripped = {k: v for k, v in model_settings.items() if k != 'thinking'}
    model_settings = cast(ModelSettings, stripped) if stripped else None
```

So the setting is consumed and discarded — no error, no warning, nothing on the wire:

```python
for name in ('DeepSeek-R1-0528', 'deepseek-r1-0528'):
    m = OpenAIChatModel(name, provider=SambaNovaProvider(api_key='x'))
    _, params = m.prepare_request({'thinking': True}, ModelRequestParameters())
    print(name, params.thinking)

# DeepSeek-R1-0528  None      <- silently dropped
# deepseek-r1-0528  True
```

`ignore_streamed_leading_whitespace` is lost the same way, which shows up as leading whitespace in streamed DeepSeek-R1 output.

## The other two

**Heroku** has the identical shape (`profile_func(model_name)` after `lower_model_name = model_name.lower()`):

```
DeepSeek-R1   supports_thinking=False
deepseek-r1   supports_thinking=True
```

**Fireworks** never lowercases at all, so a mixed-case ID matches no prefix whatsoever and gets the bare OpenAI-compatible profile — `None` rather than `False`:

```
accounts/fireworks/models/DeepSeek-R1   supports_thinking=None
accounts/fireworks/models/deepseek-r1   supports_thinking=True
```

Heroku and Fireworks both document lowercase IDs, so those two are latent rather than currently-firing. They're the same one-line defect and fixing them together keeps the providers consistent.

## The fix

Pass the lowercased name, which is what the rest of the codebase already does:

| provider | how it gets this right |
|---|---|
| `cerebras.py:59` | `profile_func(model_name_lower)` |
| `azure.py:52` | `model_name = model_name.lower()` — rebinds, so the dispatch can't diverge |
| `ollama.py:58`, `ovhcloud.py:46` | same rebinding |
| `together.py:57` | same rebinding, then `split('/', 1)` |

Note the pattern: the four that are correct either pass the lowercased variable explicitly or rebind `model_name` itself. The three that are wrong all keep the lowercased name in a *separate* variable and then forget to use it. Rebinding would arguably be the more robust idiom, but I've kept each provider's existing structure and just corrected the argument, to keep the diff minimal and reviewable.

After the fix, all three providers give identical results for every casing of every model name.

## Tests

`tests/providers/test_sambanova_provider.py` already used the real mixed-case IDs (`DeepSeek-R1-0528`, `Qwen3-32B`, `Meta-Llama-3.1-8B-Instruct`) but only asserted `profile is not None` — it never inspected a single flag, which is why the bug was invisible to it. Added:

- **sambanova** — asserts `DeepSeek-R1-0528` resolves `supports_thinking`/`thinking_always_enabled`/`ignore_streamed_leading_whitespace`, and that the profile is *equal* to the lowercase variant's.
- **sambanova** — the user-visible symptom: `prepare_request({'thinking': True})` must yield `params.thinking is True`.
- **heroku** — `.upper()` of each model name must give an identical profile.
- **fireworks** — `assert_called_with('deepseek-r1')` on the mocked profile function, pinning the exact argument (matching the style of the existing `test_fireworks_provider_model_profile`).

## Validation

- `tests/providers/test_{sambanova_provider,heroku,fireworks}.py`: 30 → **34 passed**
- `tests/providers/ tests/profiles/`: **404 passed, 110 skipped**. One pre-existing failure, `test_anthropic_provider_pass_anthropic_client` (`AsyncAnthropicBedrock` rejecting `api_key` alongside AWS credentials) — verified to fail identically on unmodified `main`, unrelated to this change.
- **Control experiment** — reverting only the three provider files and keeping the tests fails exactly the four new tests, and nothing else:
  ```
  test_sambanova_provider.py:104: AssertionError: assert False is True
  test_sambanova_provider.py:121: assert None is True
  test_heroku.py:118: AssertionError: deepseek-r1
  test_fireworks.py:119: AssertionError: expected call not found.
  4 failed, 30 passed
  ```
- `tests/profiles/test_resolution_matrix.py` snapshots unchanged. The two entries there that use mixed-case names are `test_sambanova_llama` (`Meta-Llama-3.3-70B-Instruct`, which routes through `meta_model_profile` — it ignores the model name entirely, so casing can't affect it) and `test_together_qwen` (`Qwen/Qwen2.5-72B-Instruct-Turbo`, on `together.py`, which was already correct).
- `ruff check` / `ruff format --check` clean; `pyright` **0 errors**.
- Coverage on the three providers unchanged from baseline — the one uncovered line in each is the pre-existing `_set_http_client`.

Happy to split this into three PRs, or to narrow it to SambaNova (the only one currently reachable with documented model names), if you'd prefer.
