### PR TITLE
Recognise `kimi-k2-thinking` and Heroku's `kimi-k2-5` as Kimi reasoning models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
@@ -1,18 +1,6 @@
 from __future__ import annotations as _annotations
 
-import re
-
 from . import ModelProfile
-
-# Kimi reasoning models (kimi-k2.5/k2.6/k2.7-code, kimi-k2-thinking, kimi-k3, …) accept
-# reasoning_effort and emit reasoning_content; the moonshot-v1 and non-thinking k2 models don't.
-#
-# Gateways disagree on how to punctuate the minor version: MoonshotAI, OpenRouter and Bedrock serve
-# `kimi-k2.5`, while Heroku serves `kimi-k2-5` (see `heroku:kimi-k2-5` in `_known_model_names.py`),
-# so accept either separator. `kimi-k2-thinking` is matched separately: it is a distinct reasoning
-# model rather than a minor version, and it must not widen the match to plain `kimi-k2` /
-# `kimi-k2-0905`, which do not support reasoning.
-_KIMI_REASONING_RE = re.compile(r'^kimi-(k2[.\-](5|6|7)|k2-thinking|k3|thinking)')
 
 
 def moonshotai_model_profile(model_name: str) -> ModelProfile | None:
@@ -20,7 +8,9 @@ def moonshotai_model_profile(model_name: str) -> ModelProfile | None:
     # `thinking_always_enabled` is left to the direct provider, since the `reasoning_effort='none'`
     # quirk is specific to the `api.moonshot.ai` endpoint and this profile is also routed through
     # OpenRouter, Heroku and Bedrock.
-    is_reasoning = bool(_KIMI_REASONING_RE.match(model_name.lower()))
+    is_reasoning = model_name.lower().startswith(
+        ('kimi-k2.5', 'kimi-k2-5', 'kimi-k2.6', 'kimi-k2.7', 'kimi-k2-thinking', 'kimi-k3', 'kimi-thinking')
+    )
     return ModelProfile(
         ignore_streamed_leading_whitespace=True,
         supports_thinking=is_reasoning,

--- a/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
@@ -5,9 +5,10 @@ from . import ModelProfile
 
 def moonshotai_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a MoonshotAI model."""
-    # `thinking_always_enabled` is left to the direct provider, since the `reasoning_effort='none'`
-    # quirk is specific to the `api.moonshot.ai` endpoint and this profile is also routed through
-    # OpenRouter, Heroku and Bedrock.
+    # Kimi reasoning models (kimi-k2.5/k2.6/k2.7-code, …) accept reasoning_effort and emit
+    # reasoning_content; the moonshot-v1/instruct models don't. `thinking_always_enabled` is left
+    # to the direct provider, since the `reasoning_effort='none'` quirk is specific to the
+    # `api.moonshot.ai` endpoint and this profile is also routed through OpenRouter, Heroku and Bedrock.
     is_reasoning = model_name.lower().startswith(
         ('kimi-k2.5', 'kimi-k2-5', 'kimi-k2.6', 'kimi-k2.7', 'kimi-k2-thinking', 'kimi-k3', 'kimi-thinking')
     )

--- a/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
@@ -1,15 +1,26 @@
 from __future__ import annotations as _annotations
 
+import re
+
 from . import ModelProfile
+
+# Kimi reasoning models (kimi-k2.5/k2.6/k2.7-code, kimi-k2-thinking, kimi-k3, …) accept
+# reasoning_effort and emit reasoning_content; the moonshot-v1 and non-thinking k2 models don't.
+#
+# Gateways disagree on how to punctuate the minor version: MoonshotAI, OpenRouter and Bedrock serve
+# `kimi-k2.5`, while Heroku serves `kimi-k2-5` (see `heroku:kimi-k2-5` in `_known_model_names.py`),
+# so accept either separator. `kimi-k2-thinking` is matched separately: it is a distinct reasoning
+# model rather than a minor version, and it must not widen the match to plain `kimi-k2` /
+# `kimi-k2-0905`, which do not support reasoning.
+_KIMI_REASONING_RE = re.compile(r'^kimi-(k2[.\-](5|6|7)|k2-thinking|k3|thinking)')
 
 
 def moonshotai_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a MoonshotAI model."""
-    # Kimi reasoning models (kimi-k2.5/k2.6/k2.7-code, …) accept reasoning_effort and emit
-    # reasoning_content; the moonshot-v1/instruct models don't. `thinking_always_enabled` is left
-    # to the direct provider, since the `reasoning_effort='none'` quirk is specific to the
-    # `api.moonshot.ai` endpoint and this profile is also routed through OpenRouter and Heroku.
-    is_reasoning = model_name.lower().startswith(('kimi-k2.5', 'kimi-k2.6', 'kimi-k2.7', 'kimi-k3', 'kimi-thinking'))
+    # `thinking_always_enabled` is left to the direct provider, since the `reasoning_effort='none'`
+    # quirk is specific to the `api.moonshot.ai` endpoint and this profile is also routed through
+    # OpenRouter, Heroku and Bedrock.
+    is_reasoning = bool(_KIMI_REASONING_RE.match(model_name.lower()))
     return ModelProfile(
         ignore_streamed_leading_whitespace=True,
         supports_thinking=is_reasoning,

--- a/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
@@ -10,7 +10,7 @@ def moonshotai_model_profile(model_name: str) -> ModelProfile | None:
     # to the direct provider, since the `reasoning_effort='none'` quirk is specific to the
     # `api.moonshot.ai` endpoint and this profile is also routed through OpenRouter, Heroku and Bedrock.
     is_reasoning = model_name.lower().startswith(
-        ('kimi-k2.5', 'kimi-k2-5', 'kimi-k2.6', 'kimi-k2.7', 'kimi-k2-thinking', 'kimi-k3', 'kimi-thinking')
+        ('kimi-k2.5', 'kimi-k2.6', 'kimi-k2.7', 'kimi-k2-thinking', 'kimi-k3', 'kimi-thinking')
     )
     return ModelProfile(
         ignore_streamed_leading_whitespace=True,

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -31,6 +31,14 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
+def _heroku_kimi_model_profile(model_name: str) -> ModelProfile | None:
+    # Heroku spells the Kimi 2.5 minor version with a hyphen (`kimi-k2-5`) where MoonshotAI's
+    # native id uses a dot (`kimi-k2.5`), which is what `moonshotai_model_profile` matches.
+    if model_name.lower() == 'kimi-k2-5':
+        model_name = 'kimi-k2.5'
+    return moonshotai_model_profile(model_name)
+
+
 class HerokuProvider(Provider[AsyncOpenAI]):
     """Provider for Heroku API."""
 
@@ -58,7 +66,7 @@ class HerokuProvider(Provider[AsyncOpenAI]):
             'gpt-oss': harmony_model_profile,
             'qwen': qwen_model_profile,
             'deepseek': deepseek_model_profile,
-            'kimi': moonshotai_model_profile,
+            'kimi': _heroku_kimi_model_profile,
             'glm': moonshotai_model_profile,
             'mistral': mistral_model_profile,
             'nova': amazon_model_profile,

--- a/tests/profiles/test_moonshotai.py
+++ b/tests/profiles/test_moonshotai.py
@@ -1,11 +1,3 @@
-"""Tests for MoonshotAI (Kimi) model profile detection.
-
-Gateways disagree on how to punctuate a Kimi minor version: MoonshotAI, OpenRouter and Bedrock
-serve `kimi-k2.5`, while Heroku serves `kimi-k2-5`. `kimi-k2-thinking` is a distinct reasoning
-model rather than a minor version. Every one of these must resolve `supports_thinking=True`, or
-`ModelSettings['thinking']` is silently dropped for them.
-"""
-
 from __future__ import annotations as _annotations
 
 import pytest
@@ -15,63 +7,19 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 
 @pytest.mark.parametrize(
     'model_name',
-    [
-        # MoonshotAI's own IDs (`moonshotai:…` in `_known_model_names.py`).
-        'kimi-k2.5',
-        'kimi-k2.6',
-        'kimi-k2.7-code',
-        'kimi-k2.7-code-highspeed',
-        'kimi-k3',
-        'kimi-thinking-preview',
-        # Heroku punctuates the minor version with a hyphen (`heroku:kimi-k2-5`).
-        'kimi-k2-5',
-        # `kimi-k2-thinking` (`heroku:kimi-k2-thinking`, `bedrock:moonshot.kimi-k2-thinking`, and
-        # OpenRouter's `moonshotai/kimi-k2-thinking`, which reports `reasoning` in
-        # `supported_parameters`).
-        'kimi-k2-thinking',
-        # Case is normalised, since gateways such as Nebius serve mixed-case IDs.
-        'Kimi-K2-Thinking',
-        'Kimi-K2.5',
-    ],
+    ['kimi-k2.5', 'kimi-k2-5', 'kimi-k2-thinking', 'Kimi-K2-Thinking'],
 )
 def test_kimi_reasoning_models_support_thinking(model_name: str):
-    """Every real Kimi reasoning ID must advertise `supports_thinking`.
-
-    `models/__init__.py` strips `thinking` from `model_settings` unconditionally but only forwards
-    it when the profile advertises support, so a missed match discards the setting with no error.
-    """
     profile = moonshotai_model_profile(model_name)
     assert profile is not None
-    assert profile.get('supports_thinking') is True, model_name
+    assert profile.get('supports_thinking') is True
 
 
 @pytest.mark.parametrize(
     'model_name',
-    [
-        # Plain K2 and its dated snapshots are not reasoning models — OpenRouter reports no
-        # `reasoning` in `supported_parameters` for `moonshotai/kimi-k2` or `kimi-k2-0905`. The
-        # `k2-thinking` alternative must not widen to these.
-        'kimi-k2',
-        'kimi-k2-0905',
-        'kimi-k2-0711-preview',
-        'kimi-k2-instruct',
-        # `kimi-latest` currently points at a non-thinking model.
-        'kimi-latest',
-        # The moonshot-v1 family predates reasoning entirely.
-        'moonshot-v1-8k',
-        'moonshot-v1-128k',
-    ],
+    ['kimi-k2', 'kimi-k2-0905'],
 )
 def test_non_reasoning_moonshot_models_do_not_support_thinking(model_name: str):
-    """`supports_thinking` must not leak onto models that reject `reasoning_effort`."""
     profile = moonshotai_model_profile(model_name)
     assert profile is not None
-    assert profile.get('supports_thinking') is False, model_name
-
-
-def test_all_moonshot_models_ignore_streamed_leading_whitespace():
-    """The shared quirk applies regardless of the reasoning branch."""
-    for model_name in ('kimi-k2-thinking', 'kimi-k2', 'moonshot-v1-8k'):
-        profile = moonshotai_model_profile(model_name)
-        assert profile is not None
-        assert profile.get('ignore_streamed_leading_whitespace') is True, model_name
+    assert profile.get('supports_thinking') is False

--- a/tests/profiles/test_moonshotai.py
+++ b/tests/profiles/test_moonshotai.py
@@ -1,0 +1,77 @@
+"""Tests for MoonshotAI (Kimi) model profile detection.
+
+Gateways disagree on how to punctuate a Kimi minor version: MoonshotAI, OpenRouter and Bedrock
+serve `kimi-k2.5`, while Heroku serves `kimi-k2-5`. `kimi-k2-thinking` is a distinct reasoning
+model rather than a minor version. Every one of these must resolve `supports_thinking=True`, or
+`ModelSettings['thinking']` is silently dropped for them.
+"""
+
+from __future__ import annotations as _annotations
+
+import pytest
+
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        # MoonshotAI's own IDs (`moonshotai:…` in `_known_model_names.py`).
+        'kimi-k2.5',
+        'kimi-k2.6',
+        'kimi-k2.7-code',
+        'kimi-k2.7-code-highspeed',
+        'kimi-k3',
+        'kimi-thinking-preview',
+        # Heroku punctuates the minor version with a hyphen (`heroku:kimi-k2-5`).
+        'kimi-k2-5',
+        # `kimi-k2-thinking` (`heroku:kimi-k2-thinking`, `bedrock:moonshot.kimi-k2-thinking`, and
+        # OpenRouter's `moonshotai/kimi-k2-thinking`, which reports `reasoning` in
+        # `supported_parameters`).
+        'kimi-k2-thinking',
+        # Case is normalised, since gateways such as Nebius serve mixed-case IDs.
+        'Kimi-K2-Thinking',
+        'Kimi-K2.5',
+    ],
+)
+def test_kimi_reasoning_models_support_thinking(model_name: str):
+    """Every real Kimi reasoning ID must advertise `supports_thinking`.
+
+    `models/__init__.py` strips `thinking` from `model_settings` unconditionally but only forwards
+    it when the profile advertises support, so a missed match discards the setting with no error.
+    """
+    profile = moonshotai_model_profile(model_name)
+    assert profile is not None
+    assert profile.get('supports_thinking') is True, model_name
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        # Plain K2 and its dated snapshots are not reasoning models — OpenRouter reports no
+        # `reasoning` in `supported_parameters` for `moonshotai/kimi-k2` or `kimi-k2-0905`. The
+        # `k2-thinking` alternative must not widen to these.
+        'kimi-k2',
+        'kimi-k2-0905',
+        'kimi-k2-0711-preview',
+        'kimi-k2-instruct',
+        # `kimi-latest` currently points at a non-thinking model.
+        'kimi-latest',
+        # The moonshot-v1 family predates reasoning entirely.
+        'moonshot-v1-8k',
+        'moonshot-v1-128k',
+    ],
+)
+def test_non_reasoning_moonshot_models_do_not_support_thinking(model_name: str):
+    """`supports_thinking` must not leak onto models that reject `reasoning_effort`."""
+    profile = moonshotai_model_profile(model_name)
+    assert profile is not None
+    assert profile.get('supports_thinking') is False, model_name
+
+
+def test_all_moonshot_models_ignore_streamed_leading_whitespace():
+    """The shared quirk applies regardless of the reasoning branch."""
+    for model_name in ('kimi-k2-thinking', 'kimi-k2', 'moonshot-v1-8k'):
+        profile = moonshotai_model_profile(model_name)
+        assert profile is not None
+        assert profile.get('ignore_streamed_leading_whitespace') is True, model_name

--- a/tests/profiles/test_moonshotai.py
+++ b/tests/profiles/test_moonshotai.py
@@ -7,7 +7,7 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 
 @pytest.mark.parametrize(
     'model_name',
-    ['kimi-k2.5', 'kimi-k2-5', 'kimi-k2-thinking', 'Kimi-K2-Thinking'],
+    ['kimi-k2.5', 'kimi-k2-thinking', 'Kimi-K2-Thinking'],
 )
 def test_kimi_reasoning_models_support_thinking(model_name: str):
     profile = moonshotai_model_profile(model_name)

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -105,6 +105,15 @@ def test_heroku_model_profile_routes_thinking_capable_families():
     assert fallback.get('supports_thinking') is None
 
 
+@pytest.mark.parametrize('model_name', ['kimi-k2-5', 'kimi-k2-thinking'])
+def test_heroku_kimi_reasoning_models_support_thinking(model_name: str):
+    provider = HerokuProvider(api_key='api-key')
+
+    profile = provider.model_profile(model_name)
+    assert profile is not None
+    assert profile.get('supports_thinking') is True
+
+
 async def test_heroku_model_provider_claude_3_7_sonnet(allow_model_requests: None, heroku_inference_key: str):
     provider = HerokuProvider(api_key=heroku_inference_key)
     m = OpenAIChatModel('claude-3-7-sonnet', provider=provider)


### PR DESCRIPTION
Fixes #6822

`moonshotai_model_profile` only matched MoonshotAI's dotted reasoning-model ids, so two names the library itself registers in `KnownModelName` resolved with `supports_thinking=False` and silently dropped the `thinking` setting:

- `kimi-k2-thinking` (served as `heroku:kimi-k2-thinking` and `bedrock:moonshot.kimi-k2-thinking`) is added to the profile's prefix tuple — it is a native MoonshotAI id that was missing.
- `heroku:kimi-k2-5` is Heroku's hyphenated spelling of `kimi-k2.5`; following the convention that family profiles match native ids only (see `zai_model_profile`), `HerokuProvider` now renames it before delegating.

Plain `kimi-k2` and `kimi-k2-0905` intentionally keep `supports_thinking=False`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
