### PR TITLE
Honour `ignore_streamed_leading_whitespace` in Bedrock streams

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -729,6 +729,7 @@ class BedrockConverseModel(Model[BaseClient]):
         yield BedrockStreamedResponse(
             model_request_parameters=model_request_parameters,
             _model_name=self.model_name,
+            _model_profile=self.profile,
             _event_stream=response['stream'],
             _provider_name=self._provider.name,
             _provider_url=self.base_url,
@@ -1547,6 +1548,7 @@ class BedrockStreamedResponse(StreamedResponse):
     """Implementation of `StreamedResponse` for Bedrock models."""
 
     _model_name: BedrockModelName
+    _model_profile: BedrockModelProfile
     _event_stream: EventStream[ConverseStreamOutputTypeDef]
     _provider_name: str
     _provider_url: str
@@ -1647,7 +1649,13 @@ class BedrockStreamedResponse(StreamedResponse):
                                 ):
                                     yield event
                         if text := delta.get('text'):
-                            for event in self._parts_manager.handle_text_delta(vendor_part_id=index, content=text):
+                            for event in self._parts_manager.handle_text_delta(
+                                vendor_part_id=index,
+                                content=text,
+                                ignore_leading_whitespace=self._model_profile.get(
+                                    'ignore_streamed_leading_whitespace', False
+                                ),
+                            ):
                                 yield event
                         if 'toolUse' in delta:
                             tool_use = delta['toolUse']

--- a/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
@@ -114,7 +114,7 @@ class ModelProfile(TypedDict, total=False):
     This is a workaround for models that emit `<think>\n</think>\n\n` or an empty text part ahead of tool calls (e.g. Ollama + Qwen3),
     which we don't want to end up treating as a final result when using `run_stream` with `str` a valid `output_type`.
 
-    This is currently only used by `OpenAIChatModel`, `HuggingFaceModel`, and `GroqModel`.
+    This is currently only used by `OpenAIChatModel`, `HuggingFaceModel`, `GroqModel`, and `BedrockConverseModel`.
     """
 
     supported_native_tools: frozenset[type[AbstractNativeTool]]

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3302,6 +3302,57 @@ async def test_bedrock_model_stream_empty_text_delta(allow_model_requests: None,
     )
 
 
+@pytest.mark.parametrize(
+    'model_id,expect_whitespace_part',
+    [
+        # `qwen_model_profile` and `moonshotai_model_profile` both set
+        # `ignore_streamed_leading_whitespace`, and Bedrock serves both families
+        # (`bedrock:qwen.qwen3-coder-next`, `bedrock:moonshot.kimi-k2-thinking`).
+        ('qwen.qwen3-coder-next', False),
+        ('moonshot.kimi-k2-thinking', False),
+        # Nova doesn't set the flag, so a whitespace-only delta is still a legitimate text part.
+        ('us.amazon.nova-micro-v1:0', True),
+    ],
+)
+async def test_bedrock_stream_whitespace_only_leading_delta(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    mocker: MockerFixture,
+    model_id: str,
+    expect_whitespace_part: bool,
+):
+    """A whitespace-only first delta must not become a `TextPart` when the profile opts out.
+
+    `test_bedrock_model_stream_empty_text_delta` covers `text=''`, which the `if text :=` truthiness
+    check already drops. `'\\n\\n'` is truthy, so it reaches `handle_text_delta` and — without
+    `ignore_leading_whitespace` — creates a whitespace-only `TextPart` that `run_stream` with a `str`
+    output type resolves as the final result, ahead of the real content.
+    """
+    model = BedrockConverseModel(model_id, provider=bedrock_provider)
+    agent = Agent(model=model)
+
+    def _stream() -> Iterator[dict[str, Any]]:
+        yield {'messageStart': {'role': 'assistant'}}
+        # Qwen3/Kimi emit a leading newline run before the substantive content.
+        yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': '\n\n'}}}
+        yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'Paris'}}}
+        yield {'contentBlockStop': {'contentBlockIndex': 0}}
+        yield {'messageStop': {'stopReason': 'end_turn'}}
+
+    mock_converse_stream = mocker.patch.object(model.client, 'converse_stream')
+    mock_converse_stream.return_value = {'stream': _stream(), 'ResponseMetadata': {'RequestId': 'stub'}}
+
+    async with agent.run_stream('What is the capital of France?') as result:
+        output = await result.get_output()
+
+    text_parts = [p for p in result.response.parts if isinstance(p, TextPart)]
+    assert len(text_parts) == 1
+    if expect_whitespace_part:
+        assert output == '\n\nParis'
+    else:
+        assert output == 'Paris'
+
+
 @pytest.mark.vcr()
 async def test_bedrock_error(allow_model_requests: None, bedrock_provider: BedrockProvider):
     """Test that errors convert to ModelHTTPError."""

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3303,15 +3303,11 @@ async def test_bedrock_model_stream_empty_text_delta(allow_model_requests: None,
 
 
 @pytest.mark.parametrize(
-    'model_id,expect_whitespace_part',
+    ('model_id', 'expected_output'),
     [
-        # `qwen_model_profile` and `moonshotai_model_profile` both set
-        # `ignore_streamed_leading_whitespace`, and Bedrock serves both families
-        # (`bedrock:qwen.qwen3-coder-next`, `bedrock:moonshot.kimi-k2-thinking`).
-        ('qwen.qwen3-coder-next', False),
-        ('moonshot.kimi-k2-thinking', False),
-        # Nova doesn't set the flag, so a whitespace-only delta is still a legitimate text part.
-        ('us.amazon.nova-micro-v1:0', True),
+        ('qwen.qwen3-coder-next', 'Paris'),
+        ('moonshot.kimi-k2-thinking', 'Paris'),
+        ('us.amazon.nova-micro-v1:0', '\n\nParis'),
     ],
 )
 async def test_bedrock_stream_whitespace_only_leading_delta(
@@ -3319,21 +3315,13 @@ async def test_bedrock_stream_whitespace_only_leading_delta(
     bedrock_provider: BedrockProvider,
     mocker: MockerFixture,
     model_id: str,
-    expect_whitespace_part: bool,
+    expected_output: str,
 ):
-    """A whitespace-only first delta must not become a `TextPart` when the profile opts out.
-
-    `test_bedrock_model_stream_empty_text_delta` covers `text=''`, which the `if text :=` truthiness
-    check already drops. `'\\n\\n'` is truthy, so it reaches `handle_text_delta` and — without
-    `ignore_leading_whitespace` — creates a whitespace-only `TextPart` that `run_stream` with a `str`
-    output type resolves as the final result, ahead of the real content.
-    """
     model = BedrockConverseModel(model_id, provider=bedrock_provider)
     agent = Agent(model=model)
 
     def _stream() -> Iterator[dict[str, Any]]:
         yield {'messageStart': {'role': 'assistant'}}
-        # Qwen3/Kimi emit a leading newline run before the substantive content.
         yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': '\n\n'}}}
         yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'Paris'}}}
         yield {'contentBlockStop': {'contentBlockIndex': 0}}
@@ -3345,12 +3333,7 @@ async def test_bedrock_stream_whitespace_only_leading_delta(
     async with agent.run_stream('What is the capital of France?') as result:
         output = await result.get_output()
 
-    text_parts = [p for p in result.response.parts if isinstance(p, TextPart)]
-    assert len(text_parts) == 1
-    if expect_whitespace_part:
-        assert output == '\n\nParis'
-    else:
-        assert output == 'Paris'
+    assert output == expected_output
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
Fixes #6827

Pass the resolved Bedrock model profile into `BedrockStreamedResponse` and honor `ignore_streamed_leading_whitespace` while processing text deltas.

Tests cover two opted-in model families and one unaffected control.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).