### PR TITLE
Restore DeepSeek R1 reasoning capabilities on Bedrock

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -318,11 +318,17 @@ def bedrock_amazon_model_profile(model_name: str) -> ModelProfile | None:
 
 def bedrock_deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model used via Bedrock."""
-    profile = deepseek_model_profile(model_name)
+    # DeepSeek is the one vendor whose Bedrock model IDs drop the family name that the upstream profile
+    # matches on: Bedrock serves `deepseek.r1-v1:0`, so `split_bedrock_model_id` hands us `r1`, which
+    # `deepseek_model_profile`'s `startswith('deepseek-r1')` can't match. Restore the prefix so R1 is
+    # recognised as a reasoning model. Every other vendor's stripped name still carries its family
+    # (`claude-…`, `qwen3-…`, `kimi-…`, `glm-…`), so this is specific to DeepSeek.
+    upstream_name = model_name if model_name.startswith('deepseek-') else f'deepseek-{model_name}'
+    profile = deepseek_model_profile(upstream_name)
     if 'r1' in model_name:
         # Bedrock-specific override applies on top of the upstream DeepSeek profile.
         return merge_profile(profile, BedrockModelProfile(bedrock_send_back_thinking_parts=True))
-    return profile  # pragma: no cover
+    return profile
 
 
 def bedrock_meta_model_profile(model_name: str) -> ModelProfile | None:

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -318,11 +318,7 @@ def bedrock_amazon_model_profile(model_name: str) -> ModelProfile | None:
 
 def bedrock_deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model used via Bedrock."""
-    # DeepSeek is the one vendor whose Bedrock model IDs drop the family name that the upstream profile
-    # matches on: Bedrock serves `deepseek.r1-v1:0`, so `split_bedrock_model_id` hands us `r1`, which
-    # `deepseek_model_profile`'s `startswith('deepseek-r1')` can't match. Restore the prefix so R1 is
-    # recognised as a reasoning model. Every other vendor's stripped name still carries its family
-    # (`claude-…`, `qwen3-…`, `kimi-…`, `glm-…`), so this is specific to DeepSeek.
+    # Bedrock strips `deepseek.` from IDs such as `deepseek.r1-v1:0`.
     upstream_name = model_name if model_name.startswith('deepseek-') else f'deepseek-{model_name}'
     profile = deepseek_model_profile(upstream_name)
     if 'r1' in model_name:

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -387,23 +387,12 @@ def test_split_bedrock_model_id(model_id: str, expected: tuple[str | None, str])
 @pytest.mark.parametrize(
     ('model_id', 'is_reasoning'),
     [
-        # The IDs Bedrock actually serves, from `_known_model_names.py`. `split_bedrock_model_id` strips
-        # the `deepseek.` prefix, so the upstream profile sees `r1` / `v3.2` rather than `deepseek-r1`.
         ('deepseek.r1-v1:0', True),
         ('us.deepseek.r1-v1:0', True),
         ('deepseek.v3.2', False),
-        # The already-prefixed spelling must keep working — the prefix isn't doubled.
-        ('deepseek.deepseek-r1', True),
     ],
 )
 def test_bedrock_deepseek_reasoning_flags(env: TestEnv, model_id: str, is_reasoning: bool):
-    """R1 is a reasoning model, so the Bedrock profile must carry the flags `deepseek_model_profile` sets.
-
-    `bedrock_deepseek_model_profile` recognises R1 for `bedrock_send_back_thinking_parts` via its own
-    `'r1' in model_name` check, so a profile with that override but `supports_thinking=False` is
-    self-contradictory. `models/__init__.py` silently discards `ModelSettings(thinking=...)` when the
-    profile doesn't advertise support, so the flags being dropped is not a no-op.
-    """
     env.set('AWS_DEFAULT_REGION', 'us-east-1')
     provider = BedrockProvider()
 
@@ -412,8 +401,6 @@ def test_bedrock_deepseek_reasoning_flags(env: TestEnv, model_id: str, is_reason
     assert profile.get('supports_thinking', False) is is_reasoning
     assert profile.get('thinking_always_enabled', False) is is_reasoning
     assert profile.get('ignore_streamed_leading_whitespace', False) is is_reasoning
-    # The Bedrock-specific override keys off `'r1' in model_name` and was already correct.
-    assert profile.get('bedrock_send_back_thinking_parts', False) is is_reasoning
 
 
 @pytest.mark.parametrize('prefix', BEDROCK_GEO_PREFIXES)

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -384,6 +384,38 @@ def test_split_bedrock_model_id(model_id: str, expected: tuple[str | None, str])
     assert split_bedrock_model_id(model_id) == expected
 
 
+@pytest.mark.parametrize(
+    ('model_id', 'is_reasoning'),
+    [
+        # The IDs Bedrock actually serves, from `_known_model_names.py`. `split_bedrock_model_id` strips
+        # the `deepseek.` prefix, so the upstream profile sees `r1` / `v3.2` rather than `deepseek-r1`.
+        ('deepseek.r1-v1:0', True),
+        ('us.deepseek.r1-v1:0', True),
+        ('deepseek.v3.2', False),
+        # The already-prefixed spelling must keep working — the prefix isn't doubled.
+        ('deepseek.deepseek-r1', True),
+    ],
+)
+def test_bedrock_deepseek_reasoning_flags(env: TestEnv, model_id: str, is_reasoning: bool):
+    """R1 is a reasoning model, so the Bedrock profile must carry the flags `deepseek_model_profile` sets.
+
+    `bedrock_deepseek_model_profile` recognises R1 for `bedrock_send_back_thinking_parts` via its own
+    `'r1' in model_name` check, so a profile with that override but `supports_thinking=False` is
+    self-contradictory. `models/__init__.py` silently discards `ModelSettings(thinking=...)` when the
+    profile doesn't advertise support, so the flags being dropped is not a no-op.
+    """
+    env.set('AWS_DEFAULT_REGION', 'us-east-1')
+    provider = BedrockProvider()
+
+    profile = provider.model_profile(model_id)
+    assert profile is not None
+    assert profile.get('supports_thinking', False) is is_reasoning
+    assert profile.get('thinking_always_enabled', False) is is_reasoning
+    assert profile.get('ignore_streamed_leading_whitespace', False) is is_reasoning
+    # The Bedrock-specific override keys off `'r1' in model_name` and was already correct.
+    assert profile.get('bedrock_send_back_thinking_parts', False) is is_reasoning
+
+
 @pytest.mark.parametrize('prefix', BEDROCK_GEO_PREFIXES)
 def test_bedrock_provider_model_profile_all_geo_prefixes(env: TestEnv, prefix: str):
     """Test that all cross-region inference geo prefixes are correctly handled."""


### PR DESCRIPTION
Fixes #6831

Restore the `deepseek-` family prefix before delegating Bedrock model names to `deepseek_model_profile`.

Tests cover regional and non-regional R1 IDs plus a non-reasoning DeepSeek control.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).