### PR TITLE
Map xAI finish reasons from proto enums

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -154,9 +154,16 @@ _FINISH_REASON_PROTO_MAP: dict[int, FinishReason | None] = {
 }
 
 
-def _map_finish_reason(reason: int) -> FinishReason | None:
-    """Map an xAI proto finish reason to a pydantic-ai one, or `None` if it's unset/unrecognised."""
-    return _FINISH_REASON_PROTO_MAP.get(reason)
+def _map_finish_reason(response: chat_types.Response) -> FinishReason | None:
+    """Map an xAI response's finish reason to a pydantic-ai one, or `None` if it's unset/unrecognised.
+
+    `response.finish_reason` reflects a single output, and in multi-output responses (e.g. server-side tools) that
+    can be an intermediate `REASON_TOOL_CALLS` output rather than the final `REASON_STOP` one, so read the last
+    output instead. Streamed responses start out with a single empty output, whose `REASON_INVALID` keeps the
+    finish reason unset until the stream actually finishes.
+    """
+    outputs = response.proto.outputs
+    return _FINISH_REASON_PROTO_MAP.get(outputs[-1].finish_reason) if outputs else None
 
 
 class XaiModelSettings(ModelSettings, total=False):
@@ -867,12 +874,7 @@ class XaiModel(Model[AsyncClient]):
         # Convert usage with detailed token information
         usage = _extract_usage(response, self._model_name, self._provider.name, self._provider.base_url)
 
-        # Map finish reason.
-        #
-        # `response.finish_reason` reflects a single output, and in multi-output responses (e.g.
-        # server-side tools) that can be an intermediate TOOL_CALLS output rather than the final STOP
-        # one, so we derive the finish reason from the last output.
-        finish_reason = _map_finish_reason(outputs[-1].finish_reason) if outputs else None
+        finish_reason = _map_finish_reason(response)
 
         return ModelResponse(
             parts=parts,
@@ -959,12 +961,8 @@ class XaiStreamedResponse(StreamedResponse):
         if response.id and self.provider_response_id is None:
             self.provider_response_id = response.id
 
-        # Handle finish reason. Read it off the proto rather than `response.finish_reason`, which
-        # is the enum *name* of the same value, and take the last output for the same reason as
-        # `_process_response`. Chunks before the final one carry `REASON_INVALID`, which maps to
-        # `None` so the reason stays unset until the stream actually finishes.
-        if outputs := response.proto.outputs:
-            self.finish_reason = _map_finish_reason(outputs[-1].finish_reason)
+        # Handle finish reason
+        self.finish_reason = _map_finish_reason(response)
 
     def _collect_reasoning_events(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -140,22 +140,23 @@ def _map_reasoning_effort(thinking: ThinkingLevel, profile: GrokModelProfile) ->
         assert_never(thinking)
 
 
-_FINISH_REASON_MAP: dict[str, FinishReason] = {
-    'stop': 'stop',
-    'length': 'length',
-    'content_filter': 'content_filter',
-    'max_output_tokens': 'length',
-    'cancelled': 'error',
-    'failed': 'error',
-}
-
-# `GetChatCompletionResponse.outputs[*].finish_reason` uses the proto enum (ints), not the string values returned by
-# `Response.finish_reason`.
-_FINISH_REASON_PROTO_MAP: dict[int, FinishReason] = {
+# The xAI SDK reports finish reasons as the proto enum, both as ints on
+# `GetChatCompletionResponse.outputs[*].finish_reason` and as the enum *name* (`'REASON_STOP'`, …) from
+# `Response.finish_reason`, which is `sample_pb2.FinishReason.Name(...)` of the same value. `REASON_INVALID`
+# is the proto default for "unset" and maps to `None` so we don't claim the model stopped normally.
+_FINISH_REASON_PROTO_MAP: dict[int, FinishReason | None] = {
+    sample_pb2.FinishReason.REASON_INVALID: None,
     sample_pb2.FinishReason.REASON_STOP: 'stop',
     sample_pb2.FinishReason.REASON_MAX_LEN: 'length',
+    sample_pb2.FinishReason.REASON_MAX_CONTEXT: 'length',
     sample_pb2.FinishReason.REASON_TOOL_CALLS: 'tool_call',
+    sample_pb2.FinishReason.REASON_TIME_LIMIT: 'error',
 }
+
+
+def _map_finish_reason(reason: int) -> FinishReason | None:
+    """Map an xAI proto finish reason to a pydantic-ai one, or `None` if it's unset/unrecognised."""
+    return _FINISH_REASON_PROTO_MAP.get(reason)
 
 
 class XaiModelSettings(ModelSettings, total=False):
@@ -868,15 +869,10 @@ class XaiModel(Model[AsyncClient]):
 
         # Map finish reason.
         #
-        # The xAI SDK exposes `response.finish_reason` as a *string* for the overall response, but in
-        # multi-output responses (e.g. server-side tools) it can reflect an intermediate TOOL_CALLS
-        # output rather than the final STOP output. We derive the finish reason from the final output
-        # when available.
-        if outputs:
-            last_reason = outputs[-1].finish_reason
-            finish_reason = _FINISH_REASON_PROTO_MAP.get(last_reason, 'stop')
-        else:  # pragma: no cover
-            finish_reason = _FINISH_REASON_MAP.get(response.finish_reason, 'stop')
+        # `response.finish_reason` reflects a single output, and in multi-output responses (e.g.
+        # server-side tools) that can be an intermediate TOOL_CALLS output rather than the final STOP
+        # one, so we derive the finish reason from the last output.
+        finish_reason = _map_finish_reason(outputs[-1].finish_reason) if outputs else None
 
         return ModelResponse(
             parts=parts,
@@ -963,8 +959,12 @@ class XaiStreamedResponse(StreamedResponse):
         if response.id and self.provider_response_id is None:
             self.provider_response_id = response.id
 
-        # Handle finish reason (SDK Response always provides a finish_reason)
-        self.finish_reason = _FINISH_REASON_MAP.get(response.finish_reason, 'stop')
+        # Handle finish reason. Read it off the proto rather than `response.finish_reason`, which
+        # is the enum *name* of the same value, and take the last output for the same reason as
+        # `_process_response`. Chunks before the final one carry `REASON_INVALID`, which maps to
+        # `None` so the reason stays unset until the stream actually finishes.
+        if outputs := response.proto.outputs:
+            self.finish_reason = _map_finish_reason(outputs[-1].finish_reason)
 
     def _collect_reasoning_events(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -140,10 +140,7 @@ def _map_reasoning_effort(thinking: ThinkingLevel, profile: GrokModelProfile) ->
         assert_never(thinking)
 
 
-# The xAI SDK reports finish reasons as the proto enum, both as ints on
-# `GetChatCompletionResponse.outputs[*].finish_reason` and as the enum *name* (`'REASON_STOP'`, …) from
-# `Response.finish_reason`, which is `sample_pb2.FinishReason.Name(...)` of the same value. `REASON_INVALID`
-# is the proto default for "unset" and maps to `None` so we don't claim the model stopped normally.
+# `REASON_INVALID` is the proto default for an unfinished response.
 _FINISH_REASON_PROTO_MAP: dict[int, FinishReason | None] = {
     sample_pb2.FinishReason.REASON_INVALID: None,
     sample_pb2.FinishReason.REASON_STOP: 'stop',
@@ -155,13 +152,7 @@ _FINISH_REASON_PROTO_MAP: dict[int, FinishReason | None] = {
 
 
 def _map_finish_reason(response: chat_types.Response) -> FinishReason | None:
-    """Map an xAI response's finish reason to a pydantic-ai one, or `None` if it's unset/unrecognised.
-
-    `response.finish_reason` reflects a single output, and in multi-output responses (e.g. server-side tools) that
-    can be an intermediate `REASON_TOOL_CALLS` output rather than the final `REASON_STOP` one, so read the last
-    output instead. Streamed responses start out with a single empty output, whose `REASON_INVALID` keeps the
-    finish reason unset until the stream actually finishes.
-    """
+    """Map the final xAI output's proto finish reason."""
     outputs = response.proto.outputs
     return _FINISH_REASON_PROTO_MAP.get(outputs[-1].finish_reason) if outputs else None
 

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -65,6 +65,7 @@ from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.exceptions import UnexpectedModelBehavior
 from pydantic_ai.messages import (
     CachePoint,
+    FinishReason,
     UploadedFile,
 )
 from pydantic_ai.models import ModelRequestParameters, ToolDefinition
@@ -99,10 +100,11 @@ from .mock_xai import (
 with try_import() as imports_successful:
     import xai_sdk.chat as chat_types
     from xai_sdk.chat import required_tool
-    from xai_sdk.proto import chat_pb2, usage_pb2
+    from xai_sdk.proto import chat_pb2, sample_pb2, usage_pb2
 
     from pydantic_ai.models import xai as xai_module
     from pydantic_ai.models.xai import (
+        _FINISH_REASON_PROTO_MAP,  # pyright: ignore[reportPrivateUsage]
         XaiModel,
         XaiModelSettings,
         XaiStreamedResponse,
@@ -1399,6 +1401,89 @@ async def test_xai_stream_text_finish_reason(allow_model_requests: None):
                     finish_reason='stop',
                 )
             )
+
+
+@pytest.mark.parametrize(
+    ('proto_reason', 'expected'),
+    [
+        (sample_pb2.FinishReason.REASON_STOP, 'stop'),
+        (sample_pb2.FinishReason.REASON_MAX_LEN, 'length'),
+        (sample_pb2.FinishReason.REASON_MAX_CONTEXT, 'length'),
+        (sample_pb2.FinishReason.REASON_TOOL_CALLS, 'tool_call'),
+        (sample_pb2.FinishReason.REASON_TIME_LIMIT, 'error'),
+        # The proto default for "not set yet", which every chunk before the last one carries.
+        (sample_pb2.FinishReason.REASON_INVALID, None),
+    ],
+)
+async def test_xai_stream_finish_reason_covers_every_proto_reason(
+    allow_model_requests: None, proto_reason: int, expected: FinishReason | None
+):
+    """The streamed finish reason must come from the proto enum, not `Response.finish_reason`.
+
+    `Response.finish_reason` is `sample_pb2.FinishReason.Name(...)`, i.e. `'REASON_STOP'` /
+    `'REASON_MAX_LEN'` / … — never the lowercase `'stop'` / `'length'` spellings. Reading it through a
+    string map keyed on the lowercase names missed *every* reason and silently fell back to `'stop'`, so
+    a truncated or tool-calling stream reported a clean finish.
+    """
+    stream = [_text_chunk_with_proto_finish_reason('hello', proto_reason)]
+    mock_client = MockXai.create_mock_stream([stream])
+    m = XaiModel(XAI_NON_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))
+
+    async with m.request_stream(
+        [ModelRequest(parts=[UserPromptPart(content='')])], None, ModelRequestParameters()
+    ) as stream_response:
+        async for _ in stream_response:
+            pass
+        assert stream_response.finish_reason == expected
+
+
+def _text_chunk_with_proto_finish_reason(text: str, proto_reason: int) -> tuple[chat_types.Response, chat_types.Chunk]:
+    """Like `get_grok_text_chunk`, but sets the raw proto finish reason rather than a pydantic-ai one.
+
+    The helpers in `mock_xai` take a pydantic-ai `FinishReason` and translate it, which can't express
+    `REASON_INVALID` or `REASON_MAX_CONTEXT` and would hide the round trip under test.
+    """
+    chunk_proto = chat_pb2.GetChatCompletionChunk(id='grok-123')
+    chunk_proto.outputs.append(
+        chat_pb2.CompletionOutputChunk(
+            index=0,
+            finish_reason=proto_reason,
+            delta=chat_pb2.Delta(content=text, role=chat_pb2.MessageRole.ROLE_ASSISTANT),
+        )
+    )
+    chunk_proto.created.GetCurrentTime()
+
+    response_proto = chat_pb2.GetChatCompletionResponse(
+        id='grok-123',
+        outputs=[
+            chat_pb2.CompletionOutput(
+                index=0,
+                finish_reason=proto_reason,
+                message=chat_pb2.CompletionMessage(content=text, role=chat_pb2.MessageRole.ROLE_ASSISTANT),
+            )
+        ],
+        usage=usage_pb2.SamplingUsage(prompt_tokens=2, completion_tokens=1),
+    )
+    response_proto.created.GetCurrentTime()
+
+    return chat_types.Response(response_proto, index=None), chat_types.Chunk(chunk_proto, index=None)
+
+
+def test_xai_sdk_reports_finish_reasons_as_proto_enum_names():
+    """Pin the SDK behaviour the fix depends on, so an SDK change to lowercase strings is caught here.
+
+    If xAI ever switches `Response.finish_reason` to OpenAI-style lowercase values, this fails and points
+    at the mapping rather than leaving it to be rediscovered through a wrong `finish_reason` in the wild.
+    """
+    response, _ = _text_chunk_with_proto_finish_reason('hi', sample_pb2.FinishReason.REASON_MAX_LEN)
+    assert response.finish_reason == 'REASON_MAX_LEN'
+    # The int on the proto is what the mapping keys off.
+    assert response.proto.outputs[-1].finish_reason == sample_pb2.FinishReason.REASON_MAX_LEN
+
+
+def test_xai_finish_reason_map_covers_the_whole_proto_enum():
+    """Every value the enum can hold must be mapped, so a new xAI reason can't silently become `'stop'`."""
+    assert set(_FINISH_REASON_PROTO_MAP) == set(sample_pb2.FinishReason.values())
 
 
 class MyTypedDict(TypedDict, total=False):

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -104,7 +104,6 @@ with try_import() as imports_successful:
 
     from pydantic_ai.models import xai as xai_module
     from pydantic_ai.models.xai import (
-        _FINISH_REASON_PROTO_MAP,  # pyright: ignore[reportPrivateUsage]
         XaiModel,
         XaiModelSettings,
         XaiStreamedResponse,
@@ -1406,11 +1405,6 @@ async def test_xai_stream_text_finish_reason(allow_model_requests: None):
 def _text_chunk_with_proto_finish_reason(
     text: str, proto_reason: sample_pb2.FinishReason
 ) -> tuple[chat_types.Response, chat_types.Chunk]:
-    """Like `get_grok_text_chunk`, but sets the raw proto finish reason rather than a pydantic-ai one.
-
-    The helpers in `mock_xai` take a pydantic-ai `FinishReason` and translate it, which can't express
-    `REASON_INVALID` or `REASON_MAX_CONTEXT` and would hide the round trip under test.
-    """
     chunk_proto = chat_pb2.GetChatCompletionChunk(id='grok-123')
     chunk_proto.outputs.append(
         chat_pb2.CompletionOutputChunk(
@@ -1449,19 +1443,9 @@ def _text_chunk_with_proto_finish_reason(
         ('REASON_INVALID', None),
     ],
 )
-async def test_xai_stream_finish_reason_covers_every_proto_reason(
+async def test_xai_stream_finish_reason(
     allow_model_requests: None, proto_reason_name: str, expected: FinishReason | None
 ):
-    """The streamed finish reason must come from the proto enum, not `Response.finish_reason`.
-
-    `Response.finish_reason` is `sample_pb2.FinishReason.Name(...)`, i.e. `'REASON_STOP'` /
-    `'REASON_MAX_LEN'` / … — never the lowercase `'stop'` / `'length'` spellings. Reading it through a
-    string map keyed on the lowercase names missed *every* reason and silently fell back to `'stop'`, so
-    a truncated or tool-calling stream reported a clean finish.
-
-    Parametrized over enum *names* rather than values so the decorator doesn't touch `sample_pb2`, which
-    isn't importable in the runs where `xai-sdk` is absent and this module is skipped wholesale.
-    """
     proto_reason: sample_pb2.FinishReason = getattr(sample_pb2.FinishReason, proto_reason_name)
     stream = [_text_chunk_with_proto_finish_reason('hello', proto_reason)]
     mock_client = MockXai.create_mock_stream([stream])
@@ -1473,23 +1457,6 @@ async def test_xai_stream_finish_reason_covers_every_proto_reason(
         async for _ in stream_response:
             pass
         assert stream_response.finish_reason == expected
-
-
-def test_xai_sdk_reports_finish_reasons_as_proto_enum_names():
-    """Pin the SDK behaviour the fix depends on, so an SDK change to lowercase strings is caught here.
-
-    If xAI ever switches `Response.finish_reason` to OpenAI-style lowercase values, this fails and points
-    at the mapping rather than leaving it to be rediscovered through a wrong `finish_reason` in the wild.
-    """
-    response, _ = _text_chunk_with_proto_finish_reason('hi', sample_pb2.FinishReason.REASON_MAX_LEN)
-    assert response.finish_reason == 'REASON_MAX_LEN'
-    # The int on the proto is what the mapping keys off.
-    assert response.proto.outputs[-1].finish_reason == sample_pb2.FinishReason.REASON_MAX_LEN
-
-
-def test_xai_finish_reason_map_covers_the_whole_proto_enum():
-    """Every value the enum can hold must be mapped, so a new xAI reason can't silently become `'stop'`."""
-    assert set(_FINISH_REASON_PROTO_MAP) == set(sample_pb2.FinishReason.values())
 
 
 class MyTypedDict(TypedDict, total=False):

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -1403,6 +1403,38 @@ async def test_xai_stream_text_finish_reason(allow_model_requests: None):
             )
 
 
+def _text_chunk_with_proto_finish_reason(text: str, proto_reason: int) -> tuple[chat_types.Response, chat_types.Chunk]:
+    """Like `get_grok_text_chunk`, but sets the raw proto finish reason rather than a pydantic-ai one.
+
+    The helpers in `mock_xai` take a pydantic-ai `FinishReason` and translate it, which can't express
+    `REASON_INVALID` or `REASON_MAX_CONTEXT` and would hide the round trip under test.
+    """
+    chunk_proto = chat_pb2.GetChatCompletionChunk(id='grok-123')
+    chunk_proto.outputs.append(
+        chat_pb2.CompletionOutputChunk(
+            index=0,
+            finish_reason=proto_reason,
+            delta=chat_pb2.Delta(content=text, role=chat_pb2.MessageRole.ROLE_ASSISTANT),
+        )
+    )
+    chunk_proto.created.GetCurrentTime()
+
+    response_proto = chat_pb2.GetChatCompletionResponse(
+        id='grok-123',
+        outputs=[
+            chat_pb2.CompletionOutput(
+                index=0,
+                finish_reason=proto_reason,
+                message=chat_pb2.CompletionMessage(content=text, role=chat_pb2.MessageRole.ROLE_ASSISTANT),
+            )
+        ],
+        usage=usage_pb2.SamplingUsage(prompt_tokens=2, completion_tokens=1),
+    )
+    response_proto.created.GetCurrentTime()
+
+    return chat_types.Response(response_proto, index=None), chat_types.Chunk(chunk_proto, index=None)
+
+
 @pytest.mark.parametrize(
     ('proto_reason', 'expected'),
     [
@@ -1435,38 +1467,6 @@ async def test_xai_stream_finish_reason_covers_every_proto_reason(
         async for _ in stream_response:
             pass
         assert stream_response.finish_reason == expected
-
-
-def _text_chunk_with_proto_finish_reason(text: str, proto_reason: int) -> tuple[chat_types.Response, chat_types.Chunk]:
-    """Like `get_grok_text_chunk`, but sets the raw proto finish reason rather than a pydantic-ai one.
-
-    The helpers in `mock_xai` take a pydantic-ai `FinishReason` and translate it, which can't express
-    `REASON_INVALID` or `REASON_MAX_CONTEXT` and would hide the round trip under test.
-    """
-    chunk_proto = chat_pb2.GetChatCompletionChunk(id='grok-123')
-    chunk_proto.outputs.append(
-        chat_pb2.CompletionOutputChunk(
-            index=0,
-            finish_reason=proto_reason,
-            delta=chat_pb2.Delta(content=text, role=chat_pb2.MessageRole.ROLE_ASSISTANT),
-        )
-    )
-    chunk_proto.created.GetCurrentTime()
-
-    response_proto = chat_pb2.GetChatCompletionResponse(
-        id='grok-123',
-        outputs=[
-            chat_pb2.CompletionOutput(
-                index=0,
-                finish_reason=proto_reason,
-                message=chat_pb2.CompletionMessage(content=text, role=chat_pb2.MessageRole.ROLE_ASSISTANT),
-            )
-        ],
-        usage=usage_pb2.SamplingUsage(prompt_tokens=2, completion_tokens=1),
-    )
-    response_proto.created.GetCurrentTime()
-
-    return chat_types.Response(response_proto, index=None), chat_types.Chunk(chunk_proto, index=None)
 
 
 def test_xai_sdk_reports_finish_reasons_as_proto_enum_names():

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -1403,7 +1403,9 @@ async def test_xai_stream_text_finish_reason(allow_model_requests: None):
             )
 
 
-def _text_chunk_with_proto_finish_reason(text: str, proto_reason: int) -> tuple[chat_types.Response, chat_types.Chunk]:
+def _text_chunk_with_proto_finish_reason(
+    text: str, proto_reason: sample_pb2.FinishReason
+) -> tuple[chat_types.Response, chat_types.Chunk]:
     """Like `get_grok_text_chunk`, but sets the raw proto finish reason rather than a pydantic-ai one.
 
     The helpers in `mock_xai` take a pydantic-ai `FinishReason` and translate it, which can't express
@@ -1448,7 +1450,7 @@ def _text_chunk_with_proto_finish_reason(text: str, proto_reason: int) -> tuple[
     ],
 )
 async def test_xai_stream_finish_reason_covers_every_proto_reason(
-    allow_model_requests: None, proto_reason: int, expected: FinishReason | None
+    allow_model_requests: None, proto_reason: sample_pb2.FinishReason, expected: FinishReason | None
 ):
     """The streamed finish reason must come from the proto enum, not `Response.finish_reason`.
 

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -1438,19 +1438,19 @@ def _text_chunk_with_proto_finish_reason(
 
 
 @pytest.mark.parametrize(
-    ('proto_reason', 'expected'),
+    ('proto_reason_name', 'expected'),
     [
-        (sample_pb2.FinishReason.REASON_STOP, 'stop'),
-        (sample_pb2.FinishReason.REASON_MAX_LEN, 'length'),
-        (sample_pb2.FinishReason.REASON_MAX_CONTEXT, 'length'),
-        (sample_pb2.FinishReason.REASON_TOOL_CALLS, 'tool_call'),
-        (sample_pb2.FinishReason.REASON_TIME_LIMIT, 'error'),
+        ('REASON_STOP', 'stop'),
+        ('REASON_MAX_LEN', 'length'),
+        ('REASON_MAX_CONTEXT', 'length'),
+        ('REASON_TOOL_CALLS', 'tool_call'),
+        ('REASON_TIME_LIMIT', 'error'),
         # The proto default for "not set yet", which every chunk before the last one carries.
-        (sample_pb2.FinishReason.REASON_INVALID, None),
+        ('REASON_INVALID', None),
     ],
 )
 async def test_xai_stream_finish_reason_covers_every_proto_reason(
-    allow_model_requests: None, proto_reason: sample_pb2.FinishReason, expected: FinishReason | None
+    allow_model_requests: None, proto_reason_name: str, expected: FinishReason | None
 ):
     """The streamed finish reason must come from the proto enum, not `Response.finish_reason`.
 
@@ -1458,7 +1458,11 @@ async def test_xai_stream_finish_reason_covers_every_proto_reason(
     `'REASON_MAX_LEN'` / … — never the lowercase `'stop'` / `'length'` spellings. Reading it through a
     string map keyed on the lowercase names missed *every* reason and silently fell back to `'stop'`, so
     a truncated or tool-calling stream reported a clean finish.
+
+    Parametrized over enum *names* rather than values so the decorator doesn't touch `sample_pb2`, which
+    isn't importable in the runs where `xai-sdk` is absent and this module is skipped wholesale.
     """
+    proto_reason: sample_pb2.FinishReason = getattr(sample_pb2.FinishReason, proto_reason_name)
     stream = [_text_chunk_with_proto_finish_reason('hello', proto_reason)]
     mock_client = MockXai.create_mock_stream([stream])
     m = XaiModel(XAI_NON_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))


### PR DESCRIPTION
Fixes #6840
Fixes #6812

Map xAI proto finish reasons for streamed and non-streamed responses. `REASON_INVALID` remains unset; length, context, tool-call, and time-limit endings map to Pydantic AI finish reasons.

Focused tests cover each mapped streaming result. The linked issues report the same defect.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).