### PR TITLE
Correct xAI timeout and metadata documentation

### DIFF
--- a/docs/models/xai.md
+++ b/docs/models/xai.md
@@ -74,7 +74,10 @@ agent = Agent(model)
 ...
 ```
 
-`api_host` is the hostname of the xAI API server (the SDK connects over gRPC), and `timeout` is the default timeout in seconds applied to every request the client makes. The provider-level `timeout` is distinct from [`ModelSettings.timeout`][pydantic_ai.settings.ModelSettings.timeout], which overrides the timeout for an individual request. Both options are omitted when left unset, so the SDK's own defaults apply.
+`api_host` is the hostname of the xAI API server (the SDK connects over gRPC), and `timeout` is the default timeout in seconds applied to every request the client makes. Both options are omitted when left unset, so the SDK's own defaults apply.
+
+!!! note
+    The provider-level `timeout` is the only way to set a timeout for xAI: the SDK bakes it into the gRPC channel when the client is constructed and offers no per-request override, so [`ModelSettings.timeout`][pydantic_ai.settings.ModelSettings.timeout] is not supported. [`ModelSettings.extra_headers`][pydantic_ai.settings.ModelSettings.extra_headers] is not supported either — pass `metadata` to your own `xai_sdk.AsyncClient` (below) to send extra gRPC metadata with every request.
 
 Or with a custom `xai_sdk.AsyncClient`:
 

--- a/pydantic_ai_slim/pydantic_ai/providers/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/xai.py
@@ -92,9 +92,10 @@ class XaiProvider(Provider[AsyncClient]):
             api_key: The API key to use for authentication, if not provided, the `XAI_API_KEY` environment variable
                 will be used if available.
             api_host: The API host to use for the xAI SDK client.
-            timeout: The client-level default timeout for the xAI SDK client, in seconds, applied to all requests
-                made through it. This is distinct from `ModelSettings.timeout`, which overrides the timeout for an
-                individual request.
+            timeout: The default timeout for the xAI SDK client, in seconds, applied to all requests made through
+                it. The SDK bakes the timeout into the gRPC channel at client construction and exposes no
+                per-request override, so this is the only way to set a timeout for xAI;
+                [`ModelSettings.timeout`][pydantic_ai.settings.ModelSettings.timeout] is not supported.
             xai_client: An existing `xai_sdk.AsyncClient` to use. This takes precedence over `api_key`, `api_host`,
                 and `timeout`.
         """

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -165,7 +165,6 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI
     * Groq
     * Mistral (numeric seconds only, not `httpx.Timeout`)
-    * xAI
     """
 
     parallel_tool_calls: bool
@@ -285,7 +284,6 @@ class ModelSettings(TypedDict, total=False):
     * Anthropic
     * Gemini
     * Groq
-    * xAI
     """
 
     thinking: ThinkingLevel

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,11 +1,18 @@
 import importlib
+import inspect
 import pkgutil
+import re
 
 import pytest
 
 from pydantic_ai import Agent, models
 from pydantic_ai.models import Model
 from pydantic_ai.settings import ModelSettings, merge_model_settings
+
+from .conftest import try_import
+
+with try_import() as xai_imports_successful:
+    from pydantic_ai.models.xai import _XAI_MODEL_SETTINGS_MAPPING  # pyright: ignore[reportPrivateUsage]
 
 pytestmark = [pytest.mark.anyio, pytest.mark.vcr]
 
@@ -66,6 +73,46 @@ def test_model_settings_discovery():
     # every prefix check above silently disappears, which is what the hardcoded provider list did.
     assert len(_MODEL_MODULE_NAMES) >= 15, f'only walked {_MODEL_MODULE_NAMES}'
     assert _MODEL_SETTINGS_CLASSES, f'no settings classes found, unimportable modules: {_UNIMPORTABLE_MODEL_MODULES}'
+
+
+def _documented_supported_providers(field: str) -> set[str]:
+    """Read the `Supported by:` bullet list out of a `ModelSettings` field's docstring.
+
+    The lists are the only place a user can learn which providers honour a shared setting, and nothing
+    ties them to the code, so they can drift silently. Parsed from the source because a `TypedDict`
+    field's docstring isn't available at runtime.
+    """
+    source = inspect.getsource(ModelSettings)
+    match = re.search(rf'^    {field}: .*?\n    """(.*?)"""', source, re.DOTALL | re.MULTILINE)
+    assert match, f'no docstring found for `ModelSettings.{field}`'
+    supported = re.search(r'Supported by:\n\n((?:\s*\*.*\n)+)', match.group(1))
+    assert supported, f'`ModelSettings.{field}` has no `Supported by:` list'
+    # Bullets carry parenthesised caveats, e.g. `Gemini (numeric seconds only, ...)`.
+    return {re.sub(r'\(.*?\)', '', bullet).strip(' *') for bullet in supported.group(1).strip().split('\n')}
+
+
+# Shared settings xAI honours outside `_XAI_MODEL_SETTINGS_MAPPING`, because they need translating
+# rather than forwarding: `thinking` becomes the SDK's `reasoning_effort` and `tool_choice` is resolved
+# against the tools actually sent.
+_XAI_SETTINGS_HANDLED_SEPARATELY = frozenset({'thinking', 'tool_choice'})
+
+
+@pytest.mark.skipif(not xai_imports_successful(), reason='xai not installed')
+@pytest.mark.parametrize('field', sorted(ModelSettings.__annotations__))
+def test_xai_documented_settings_support(field: str):
+    """Every shared setting `ModelSettings` claims xAI supports must actually reach the SDK.
+
+    xAI is the one model whose shared-setting support is declarative (`_XAI_MODEL_SETTINGS_MAPPING`, plus
+    the two translated settings above), which makes the docs claim mechanically checkable: a setting in
+    neither place is dropped on the floor rather than forwarded, so documenting it sends users chasing a
+    silent no-op. A unit test rather than a VCR one because the defect is in prose — a recorded response
+    can't contradict a support claim the request never carried.
+    """
+    if 'xAI' not in _documented_supported_providers(field):
+        pytest.skip(f'`{field}` does not claim xAI support')
+    assert field in _XAI_MODEL_SETTINGS_MAPPING or field in _XAI_SETTINGS_HANDLED_SEPARATELY, (
+        f'`ModelSettings.{field}` documents xAI support but nothing in `models/xai.py` forwards it'
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,18 +1,11 @@
 import importlib
-import inspect
 import pkgutil
-import re
 
 import pytest
 
 from pydantic_ai import Agent, models
 from pydantic_ai.models import Model
 from pydantic_ai.settings import ModelSettings, merge_model_settings
-
-from .conftest import try_import
-
-with try_import() as xai_imports_successful:
-    from pydantic_ai.models.xai import _XAI_MODEL_SETTINGS_MAPPING  # pyright: ignore[reportPrivateUsage]
 
 pytestmark = [pytest.mark.anyio, pytest.mark.vcr]
 
@@ -73,46 +66,6 @@ def test_model_settings_discovery():
     # every prefix check above silently disappears, which is what the hardcoded provider list did.
     assert len(_MODEL_MODULE_NAMES) >= 15, f'only walked {_MODEL_MODULE_NAMES}'
     assert _MODEL_SETTINGS_CLASSES, f'no settings classes found, unimportable modules: {_UNIMPORTABLE_MODEL_MODULES}'
-
-
-def _documented_supported_providers(field: str) -> set[str]:
-    """Read the `Supported by:` bullet list out of a `ModelSettings` field's docstring.
-
-    The lists are the only place a user can learn which providers honour a shared setting, and nothing
-    ties them to the code, so they can drift silently. Parsed from the source because a `TypedDict`
-    field's docstring isn't available at runtime.
-    """
-    source = inspect.getsource(ModelSettings)
-    match = re.search(rf'^    {field}: .*?\n    """(.*?)"""', source, re.DOTALL | re.MULTILINE)
-    assert match, f'no docstring found for `ModelSettings.{field}`'
-    supported = re.search(r'Supported by:\n\n((?:\s*\*.*\n)+)', match.group(1))
-    assert supported, f'`ModelSettings.{field}` has no `Supported by:` list'
-    # Bullets carry parenthesised caveats, e.g. `Gemini (numeric seconds only, ...)`.
-    return {re.sub(r'\(.*?\)', '', bullet).strip(' *') for bullet in supported.group(1).strip().split('\n')}
-
-
-# Shared settings xAI honours outside `_XAI_MODEL_SETTINGS_MAPPING`, because they need translating
-# rather than forwarding: `thinking` becomes the SDK's `reasoning_effort` and `tool_choice` is resolved
-# against the tools actually sent.
-_XAI_SETTINGS_HANDLED_SEPARATELY = frozenset({'thinking', 'tool_choice'})
-
-
-@pytest.mark.skipif(not xai_imports_successful(), reason='xai not installed')
-@pytest.mark.parametrize('field', sorted(ModelSettings.__annotations__))
-def test_xai_documented_settings_support(field: str):
-    """Every shared setting `ModelSettings` claims xAI supports must actually reach the SDK.
-
-    xAI is the one model whose shared-setting support is declarative (`_XAI_MODEL_SETTINGS_MAPPING`, plus
-    the two translated settings above), which makes the docs claim mechanically checkable: a setting in
-    neither place is dropped on the floor rather than forwarded, so documenting it sends users chasing a
-    silent no-op. A unit test rather than a VCR one because the defect is in prose — a recorded response
-    can't contradict a support claim the request never carried.
-    """
-    if 'xAI' not in _documented_supported_providers(field):
-        pytest.skip(f'`{field}` does not claim xAI support')
-    assert field in _XAI_MODEL_SETTINGS_MAPPING or field in _XAI_SETTINGS_HANDLED_SEPARATELY, (
-        f'`ModelSettings.{field}` documents xAI support but nothing in `models/xai.py` forwards it'
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refs #6843

This focused documentation fix is fully included in #6857. Merge #6857 and close this PR as superseded.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).