### PR TITLE
Route GitHub's `openai/`-prefixed models to `openai_model_profile`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/github.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/github.py
@@ -50,6 +50,9 @@ class GitHubProvider(Provider[AsyncOpenAI]):
         provider_to_profile = {
             'xai': grok_model_profile,
             'meta': meta_model_profile,
+            # OpenAI's own models are published under `openai/`; Microsoft's Phi models under
+            # `microsoft/` share the same profile.
+            'openai': openai_model_profile,
             'microsoft': openai_model_profile,
             'mistral-ai': mistral_model_profile,
             'cohere': cohere_model_profile,

--- a/tests/providers/test_github.py
+++ b/tests/providers/test_github.py
@@ -96,6 +96,11 @@ def test_github_provider_model_profile(mocker: MockerFixture):
     assert grok_profile is not None
     assert grok_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
+    openai_profile = provider.model_profile('openai/o3')
+    openai_model_profile_mock.assert_called_with('o3')
+    assert openai_profile is not None
+    assert openai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
     microsoft_profile = provider.model_profile('microsoft/Phi-3.5-mini-instruct')
     openai_model_profile_mock.assert_called_with('phi-3.5-mini-instruct')
     assert microsoft_profile is not None
@@ -106,7 +111,37 @@ def test_github_provider_model_profile(mocker: MockerFixture):
     assert unknown_profile is not None
     assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
+    openai_model_profile_mock.reset_mock()
     unknown_profile_with_prefix = provider.model_profile('unknown-publisher/some-unknown-model')
-    openai_model_profile_mock.assert_called_with('some-unknown-model')
+    # An unrecognised publisher gets no family profile at all, only the OpenAI-compatible base.
+    # Without the reset, `assert_called_with` would pass against the previous unprefixed lookup.
+    openai_model_profile_mock.assert_not_called()
     assert unknown_profile_with_prefix is not None
     assert unknown_profile_with_prefix.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+
+# The `openai/`-prefixed names GitHub actually publishes, one per capability shape that
+# `openai_model_profile` distinguishes: a reasoning model that can't disable reasoning, one whose
+# system role is remapped, and a non-reasoning model.
+# https://models.github.ai/catalog/models
+@pytest.mark.parametrize('model_name', ['openai/o3', 'openai/o1-mini', 'openai/gpt-4.1'])
+def test_github_openai_prefixed_models_resolve_the_openai_profile(model_name: str):
+    """GitHub publishes OpenAI's own models under `openai/`, which must reach `openai_model_profile`.
+
+    The publisher map had no `openai` entry, so these fell through to the OpenAI-compatible base
+    alone and every capability flag resolved to unset. `supports_thinking` unset means the unified
+    `thinking` setting is silently dropped, so `Agent('github:openai/o3')` with `thinking='high'`
+    sent no `reasoning_effort` at all — a no-op with no error, on the largest publisher in the
+    catalog. `openai_system_prompt_role` unset means `o1-mini` keeps the `system` role its API
+    rejects.
+
+    A unit test rather than a VCR one: profile resolution happens before any request, and the
+    defect is a *missing* request field, which the cassette matchers aren't sensitive to — a
+    recording made against the broken code plays back identically.
+    """
+    profile = GitHubProvider.model_profile(model_name)
+    assert profile is not None
+    expected = openai_model_profile(model_name.removeprefix('openai/'))
+    # Compared whole rather than flag by flag so a capability added to `openai_model_profile`
+    # later is covered here without this test being updated.
+    assert {key: profile.get(key) for key in expected} == expected


### PR DESCRIPTION
Fixes #6847

`GitHubProvider.model_profile`'s publisher map had no `openai` entry, so every model GitHub publishes under the `openai/` prefix fell through to the OpenAI-compatible base profile alone and resolved *no* capability flags — 17 of the 37 models in the [catalog](https://models.github.ai/catalog/models), the largest publisher there.

```diff
 provider_to_profile = {
     'xai': grok_model_profile,
     'meta': meta_model_profile,
+    # OpenAI's own models are published under `openai/`; Microsoft's Phi models under
+    # `microsoft/` share the same profile.
+    'openai': openai_model_profile,
     'microsoft': openai_model_profile,
```

Every sibling OpenAI-compatible gateway provider already maps it — `OpenRouterProvider`, `VercelProvider` and `LiteLLMProvider` all have `'openai': openai_model_profile`. GitHub was the only one that didn't, which is why this is a one-line omission rather than a restriction to reason about.

## What was silently broken

| flag | `openai/o3` before | after |
|---|---|---|
| `supports_thinking` | `None` | `True` |
| `thinking_always_enabled` | `None` | `True` |
| `supports_json_schema_output` | `None` | `True` |
| `supports_inline_system_prompts` | `None` | `True` |
| `openai_system_prompt_role` (`o1-mini`) | `None` | `'user'` |

- **`thinking` was a no-op.** `supports_thinking` unset means the unified setting never reaches the wire, so `github:openai/o3` with `thinking='high'` sent no `reasoning_effort` — no error, no warning, just the API default at reasoning-model prices.
- **`o1-mini` sent the `system` role its API rejects.** `openai_system_prompt_role='user'` exists for exactly that (#974) and was inactive through this path.
- **`NativeOutput` raised for models that support it**, because `supports_json_schema_output` was unset.
- **Non-leading system prompts were rewritten** into `<system>`-tagged user messages for an API that accepts them inline.

All four are silent behavioral divergences between `github:openai/o3` and `openai:o3` — the same model.

## The existing test was vacuous

`test_github_provider_model_profile` looked like it covered the prefixed-fallthrough case, but all lookups share one mock and the last case asserted a call the *previous* line had made:

```python
provider.model_profile('some-unknown-model')
openai_model_profile_mock.assert_called_with('some-unknown-model')      # real call

provider.model_profile('unknown-publisher/some-unknown-model')
openai_model_profile_mock.assert_called_with('some-unknown-model')      # passes on the stale call
```

```
calls: [call('some-unknown-model')]
# assert_called_with passes even though the prefixed lookup never called it
```

So the prefixed path had never actually been asserted to route anywhere. Fixed with a `reset_mock()` + `assert_not_called()`, which now pins the real behavior (an unrecognised publisher gets only the OpenAI-compatible base) instead of accidentally passing.

## Test

`test_github_openai_prefixed_models_resolve_the_openai_profile` compares the resolved profile against `openai_model_profile` for the same name, over three models GitHub actually publishes, chosen one per capability shape the profile function distinguishes: `openai/o3` (reasoning, can't be disabled), `openai/o1-mini` (system role remapped), `openai/gpt-4.1` (non-reasoning). The comparison is whole-profile rather than flag-by-flag so a capability added to `openai_model_profile` later is covered without touching this test.

It's a unit test rather than a VCR one because profile resolution happens before any request is made, and the defect is a *missing* request field — the cassette matchers aren't sensitive to it, so a recording made against the broken code plays back identically and passes green.

Reverting only `providers/github.py` fails 4 assertions:

```
AssertionError: expected call not found.
Expected: openai_model_profile('o3')
  Actual: not called.

AssertionError: assert {'json_schema...t': None, ...} == {'json_schema...': False, ...}
  {'supports_thinking': None} != {'supports_thinking': True}
  {'openai_supports_encrypted_reasoning_content': None} != {...: True}
  ...
```

With the fix: `tests/providers/test_github.py` → 8 passed. All 17 `openai/` catalog models verified to resolve identically to their unprefixed lookup. ruff and pyright clean.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/pydantic/pydantic-ai/blob/main/CONTRIBUTING.md)
- [x] I have added tests for my changes
- [x] I have updated the documentation, if necessary


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

