### PR TITLE
Handle closed event loops in synchronous APIs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,7 @@ result = agent.run_sync('Who let the dogs out?')
 
 ## `RuntimeError: Event loop is closed`
 
-Synchronous methods like [`Agent.run_sync()`][pydantic_ai.agent.AbstractAgent.run_sync] reuse the thread's current event loop, and install a fresh one if other code closed it. If this error is raised from inside `httpx` or `httpcore` during a model request, the agent was already used before its event loop was closed: the provider's HTTP connection pool still holds connections bound to the dead loop. Recreate the agent (or pass a fresh `http_client` to the provider) after the loop is closed, and avoid closing an event loop that other code is still using.
+Synchronous methods like [`Agent.run_sync()`][pydantic_ai.agent.AbstractAgent.run_sync] reuse the thread's current event loop, and install a fresh one if other code closed it. If this error is raised from inside `httpx` or `httpcore` during a model request, the agent was already used before its event loop was closed: the provider's HTTP connection pool still holds connections bound to the dead loop. Recreate the agent together with its model and provider (or pass a fresh `http_client` to the provider); reusing an existing `Model` instance keeps the dead connection pool. Avoid closing an event loop that other code is still using.
 
 ## API Key Configuration
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,6 +30,10 @@ result = agent.run_sync('Who let the dogs out?')
 
 **Note**: This also applies to Google Colab and [Marimo](https://github.com/marimo-team/marimo) environments.
 
+## `RuntimeError: Event loop is closed`
+
+Synchronous methods like [`Agent.run_sync()`][pydantic_ai.agent.AbstractAgent.run_sync] reuse the thread's current event loop, and install a fresh one if other code closed it. If this error is raised from inside `httpx` or `httpcore` during a model request, the agent was already used before its event loop was closed: the provider's HTTP connection pool still holds connections bound to the dead loop. Recreate the agent (or pass a fresh `http_client` to the provider) after the loop is closed, and avoid closing an event loop that other code is still using.
+
 ## API Key Configuration
 
 ### [`UserError`][pydantic_ai.exceptions.UserError]: Set the `[PROVIDER]_API_KEY` environment variable or pass it via the provider's `api_key=...` argument

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -871,7 +871,7 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
-    except RuntimeError:  # pragma: lax no cover
+    except RuntimeError:
         event_loop = None
 
     if event_loop is None or event_loop.is_closed():

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -872,6 +872,9 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:  # pragma: lax no cover
+        event_loop = None
+
+    if event_loop is None or event_loop.is_closed():
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -83,6 +83,9 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:  # pragma: lax no cover
+        event_loop = None
+
+    if event_loop is None or event_loop.is_closed():
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -82,7 +82,7 @@ _R = TypeVar('_R')
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
-    except RuntimeError:  # pragma: lax no cover
+    except RuntimeError:
         event_loop = None
 
     if event_loop is None or event_loop.is_closed():

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -52,6 +52,9 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:
+        event_loop = None
+
+    if event_loop is None or event_loop.is_closed():
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import re
 import secrets
 import sys
 from collections.abc import AsyncIterator, Callable, Generator, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cached_property
@@ -425,6 +425,20 @@ def closed_event_loop() -> Iterator[asyncio.AbstractEventLoop]:
         yield closed_loop
     finally:
         asyncio.get_event_loop().close()
+        asyncio.set_event_loop(original_loop)
+
+
+@pytest.fixture
+def missing_event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """Empty the thread's event loop slot, yielding the loop that was installed before."""
+    original_loop = asyncio.get_event_loop()
+    asyncio.set_event_loop(None)
+
+    try:
+        yield original_loop
+    finally:
+        with suppress(RuntimeError):
+            asyncio.get_event_loop().close()
         asyncio.set_event_loop(original_loop)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,12 +424,7 @@ def closed_event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     try:
         yield closed_loop
     finally:
-        try:
-            current_loop = asyncio.get_event_loop()
-        except RuntimeError:
-            current_loop = None
-        if current_loop is not None and current_loop is not closed_loop and current_loop is not original_loop:
-            current_loop.close()
+        asyncio.get_event_loop().close()
         asyncio.set_event_loop(original_loop)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,8 +424,11 @@ def closed_event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     try:
         yield closed_loop
     finally:
-        current_loop = asyncio.get_event_loop()
-        if current_loop is not closed_loop:
+        try:
+            current_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            current_loop = None
+        if current_loop is not None and current_loop is not closed_loop and current_loop is not original_loop:
             current_loop.close()
         asyncio.set_event_loop(original_loop)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -414,6 +414,22 @@ def event_loop() -> Iterator[None]:
     new_loop.close()
 
 
+@pytest.fixture
+def closed_event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    original_loop = asyncio.get_event_loop()
+    closed_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(closed_loop)
+    closed_loop.close()
+
+    try:
+        yield closed_loop
+    finally:
+        current_loop = asyncio.get_event_loop()
+        if current_loop is not closed_loop:
+            current_loop.close()
+        asyncio.set_event_loop(original_loop)
+
+
 @pytest.fixture(autouse=True)
 def no_instrumentation_by_default():
     Agent.instrument_all(False)

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -112,6 +112,10 @@ def test_evaluate_sync_replaces_closed_event_loop(closed_event_loop: asyncio.Abs
     assert replacement_loop is not closed_event_loop
     assert not replacement_loop.is_closed()
 
+    dataset.evaluate_sync(lambda value: value, progress=False)
+    assert asyncio.get_event_loop() is replacement_loop
+    assert not asyncio.all_tasks(replacement_loop)
+
 
 class TaskMetadata(BaseModel):
     difficulty: str = 'easy'

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -117,6 +117,18 @@ def test_evaluate_sync_replaces_closed_event_loop(closed_event_loop: asyncio.Abs
     assert not asyncio.all_tasks(replacement_loop)
 
 
+def test_evaluate_sync_creates_missing_event_loop(missing_event_loop: asyncio.AbstractEventLoop):
+    """`evaluate_sync` must create and install an event loop when the thread has none."""
+    dataset = Dataset(name='test', cases=[Case(name='case', inputs='input')])
+    report = dataset.evaluate_sync(lambda value: value, progress=False)
+    replacement_loop = asyncio.get_event_loop()
+
+    assert report.cases[0].output == 'input'
+    assert replacement_loop is not missing_event_loop
+    assert not replacement_loop.is_closed()
+    assert not asyncio.all_tasks(replacement_loop)
+
+
 class TaskMetadata(BaseModel):
     difficulty: str = 'easy'
     category: str = 'general'

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import json
 import math
 import sys
@@ -95,6 +96,21 @@ class TaskInput(BaseModel):
 class TaskOutput(BaseModel):
     answer: str
     confidence: float = 1.0
+
+
+def test_evaluate_sync_replaces_closed_event_loop(closed_event_loop: asyncio.AbstractEventLoop):
+    """`evaluate_sync` must replace a closed thread-current event loop.
+
+    This uses a local task rather than VCR because the failure occurs while scheduling the
+    evaluation coroutine, before any model request could be made.
+    """
+    dataset = Dataset(name='test', cases=[Case(name='case', inputs='input')])
+    report = dataset.evaluate_sync(lambda value: value, progress=False)
+    replacement_loop = asyncio.get_event_loop()
+
+    assert report.cases[0].output == 'input'
+    assert replacement_loop is not closed_event_loop
+    assert not replacement_loop.is_closed()
 
 
 class TaskMetadata(BaseModel):

--- a/tests/graph/builder/test_graph_execution.py
+++ b/tests/graph/builder/test_graph_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 
 import pytest
@@ -21,10 +22,32 @@ class ExecutionState:
     counter: int = 0
 
 
+def test_run_sync_replaces_closed_event_loop(closed_event_loop: asyncio.AbstractEventLoop):
+    """`Graph.run_sync` must replace a closed thread-current event loop."""
+    builder = GraphBuilder(state_type=ExecutionState, output_type=int)
+
+    @builder.step
+    async def produce_result(ctx: StepContext[ExecutionState, None, None]) -> int:
+        return 42
+
+    builder.add(
+        builder.edge_from(builder.start_node).to(produce_result),
+        builder.edge_from(produce_result).to(builder.end_node),
+    )
+    graph = builder.build()
+
+    assert graph.run_sync(state=ExecutionState()) == 42
+    replacement_loop = asyncio.get_event_loop()
+    assert replacement_loop is not closed_event_loop
+    assert not replacement_loop.is_closed()
+
+    assert graph.run_sync(state=ExecutionState()) == 42
+    assert asyncio.get_event_loop() is replacement_loop
+    assert not asyncio.all_tasks(replacement_loop)
+
+
 async def test_map_to_end_node_cancels_pending():
     """Test that mapping directly to end_node cancels pending tasks"""
-    import asyncio
-
     g = GraphBuilder(state_type=ExecutionState, output_type=int)
 
     @g.step

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -194,6 +194,20 @@ requires_task_cancelling = pytest.mark.skipif(
 READINESS_WAIT_TIMEOUT = 10
 
 
+def test_run_sync_replaces_closed_event_loop(closed_event_loop: asyncio.AbstractEventLoop):
+    """`run_sync` must replace a closed thread-current event loop.
+
+    This uses `TestModel` rather than VCR because the failure occurs while scheduling the
+    coroutine, before any model request is made.
+    """
+    result = Agent(TestModel(custom_output_text='success')).run_sync('Hello')
+    replacement_loop = asyncio.get_event_loop()
+
+    assert result.output == 'success'
+    assert replacement_loop is not closed_event_loop
+    assert not replacement_loop.is_closed()
+
+
 def test_result_tuple():
     def return_tuple(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,7 +4,7 @@ import re
 import sys
 from collections import defaultdict
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable
-from contextlib import asynccontextmanager, nullcontext, suppress
+from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, Union
@@ -213,27 +213,19 @@ def test_run_sync_replaces_closed_event_loop(closed_event_loop: asyncio.Abstract
     assert not asyncio.all_tasks(replacement_loop)
 
 
-def test_run_sync_creates_missing_event_loop():
+def test_run_sync_creates_missing_event_loop(missing_event_loop: asyncio.AbstractEventLoop):
     """`run_sync` must create and install an event loop when the thread has none.
 
     This uses `TestModel` rather than VCR because the behavior occurs before any
     model request is made.
     """
-    original_loop = asyncio.get_event_loop()
-    asyncio.set_event_loop(None)
+    result = Agent(TestModel(custom_output_text='success')).run_sync('Hello')
+    replacement_loop = asyncio.get_event_loop()
 
-    try:
-        result = Agent(TestModel(custom_output_text='success')).run_sync('Hello')
-        replacement_loop = asyncio.get_event_loop()
-
-        assert result.output == 'success'
-        assert replacement_loop is not original_loop
-        assert not replacement_loop.is_closed()
-        assert not asyncio.all_tasks(replacement_loop)
-    finally:
-        with suppress(RuntimeError):
-            asyncio.get_event_loop().close()
-        asyncio.set_event_loop(original_loop)
+    assert result.output == 'success'
+    assert replacement_loop is not missing_event_loop
+    assert not replacement_loop.is_closed()
+    assert not asyncio.all_tasks(replacement_loop)
 
 
 def test_result_tuple():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,7 +4,7 @@ import re
 import sys
 from collections import defaultdict
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable
-from contextlib import asynccontextmanager, nullcontext
+from contextlib import asynccontextmanager, nullcontext, suppress
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, Union
@@ -211,6 +211,29 @@ def test_run_sync_replaces_closed_event_loop(closed_event_loop: asyncio.Abstract
     agent.run_sync('Hello again')
     assert asyncio.get_event_loop() is replacement_loop
     assert not asyncio.all_tasks(replacement_loop)
+
+
+def test_run_sync_creates_missing_event_loop():
+    """`run_sync` must create and install an event loop when the thread has none.
+
+    This uses `TestModel` rather than VCR because the behavior occurs before any
+    model request is made.
+    """
+    original_loop = asyncio.get_event_loop()
+    asyncio.set_event_loop(None)
+
+    try:
+        result = Agent(TestModel(custom_output_text='success')).run_sync('Hello')
+        replacement_loop = asyncio.get_event_loop()
+
+        assert result.output == 'success'
+        assert replacement_loop is not original_loop
+        assert not replacement_loop.is_closed()
+        assert not asyncio.all_tasks(replacement_loop)
+    finally:
+        with suppress(RuntimeError):
+            asyncio.get_event_loop().close()
+        asyncio.set_event_loop(original_loop)
 
 
 def test_result_tuple():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -200,12 +200,17 @@ def test_run_sync_replaces_closed_event_loop(closed_event_loop: asyncio.Abstract
     This uses `TestModel` rather than VCR because the failure occurs while scheduling the
     coroutine, before any model request is made.
     """
-    result = Agent(TestModel(custom_output_text='success')).run_sync('Hello')
+    agent = Agent(TestModel(custom_output_text='success'))
+    result = agent.run_sync('Hello')
     replacement_loop = asyncio.get_event_loop()
 
     assert result.output == 'success'
     assert replacement_loop is not closed_event_loop
     assert not replacement_loop.is_closed()
+
+    agent.run_sync('Hello again')
+    assert asyncio.get_event_loop() is replacement_loop
+    assert not asyncio.all_tasks(replacement_loop)
 
 
 def test_result_tuple():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -324,6 +324,20 @@ async def test_run_stream_sync_rejects_running_event_loop():
         agent.run_stream_sync('Hello')
 
 
+def test_run_stream_sync_replaces_closed_event_loop(closed_event_loop: asyncio.AbstractEventLoop):
+    """`run_stream_sync` must replace a closed thread-current event loop.
+
+    This uses `TestModel` rather than VCR because the failure occurs while scheduling the
+    stream owner task, before any model request is made.
+    """
+    with Agent(TestModel()).run_stream_sync('Hello') as result:
+        assert result.get_output()
+
+    replacement_loop = asyncio.get_event_loop()
+    assert replacement_loop is not closed_event_loop
+    assert not replacement_loop.is_closed()
+
+
 def test_run_stream_sync_works_with_disabled_threads():
     """`run_stream_sync` does not need a worker thread.
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -330,17 +330,32 @@ def test_run_stream_sync_replaces_closed_event_loop(closed_event_loop: asyncio.A
     This uses `TestModel` rather than VCR because the failure occurs while scheduling the
     stream owner task, before any model request is made.
     """
-    agent = Agent(TestModel())
+    agent = Agent(TestModel(custom_output_text='success'))
     with agent.run_stream_sync('Hello') as result:
-        assert result.get_output()
+        assert result.get_output() == 'success'
 
     replacement_loop = asyncio.get_event_loop()
     assert replacement_loop is not closed_event_loop
     assert not replacement_loop.is_closed()
 
     with agent.run_stream_sync('Hello again') as result:
-        assert result.get_output()
+        assert result.get_output() == 'success'
     assert asyncio.get_event_loop() is replacement_loop
+    assert not asyncio.all_tasks(replacement_loop)
+
+
+def test_run_stream_sync_creates_missing_event_loop(missing_event_loop: asyncio.AbstractEventLoop):
+    """`run_stream_sync` must create and install an event loop when the thread has none.
+
+    This uses `TestModel` rather than VCR because the behavior occurs before any
+    model request is made.
+    """
+    with Agent(TestModel(custom_output_text='success')).run_stream_sync('Hello') as result:
+        assert result.get_output() == 'success'
+
+    replacement_loop = asyncio.get_event_loop()
+    assert replacement_loop is not missing_event_loop
+    assert not replacement_loop.is_closed()
     assert not asyncio.all_tasks(replacement_loop)
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -330,12 +330,18 @@ def test_run_stream_sync_replaces_closed_event_loop(closed_event_loop: asyncio.A
     This uses `TestModel` rather than VCR because the failure occurs while scheduling the
     stream owner task, before any model request is made.
     """
-    with Agent(TestModel()).run_stream_sync('Hello') as result:
+    agent = Agent(TestModel())
+    with agent.run_stream_sync('Hello') as result:
         assert result.get_output()
 
     replacement_loop = asyncio.get_event_loop()
     assert replacement_loop is not closed_event_loop
     assert not replacement_loop.is_closed()
+
+    with agent.run_stream_sync('Hello again') as result:
+        assert result.get_output()
+    assert asyncio.get_event_loop() is replacement_loop
+    assert not asyncio.all_tasks(replacement_loop)
 
 
 def test_run_stream_sync_works_with_disabled_threads():


### PR DESCRIPTION
- Closes #6849

`asyncio.get_event_loop()` can return a closed thread-current loop. The synchronous wrappers then fail while scheduling their coroutine. Replace an absent or closed loop, install the replacement, and continue reusing it while it remains live.

All sync entry points route through the three patched helpers: `Agent.run_sync`, `Agent.run_stream_sync`, `Agent.to_cli_sync`, `Graph.run_sync`, `Dataset.evaluate_sync`, `model_request_sync`, `model_request_stream_sync`, and the embeddings sync wrappers.

This is deliberately narrower than #1196: replacing the loop does not migrate resources bound to the old one. In particular, a provider's pooled HTTP connections stay bound to the loop they were opened on, so an agent that made requests before its loop was closed can still fail once from inside `httpcore` before the pool heals, and SDK retries can re-send a request whose response died with the loop. That resource-lifecycle question stays with the #1196 design discussion; a new troubleshooting entry documents the recreate-the-agent workaround.

### Tests

- `closed_event_loop` and `missing_event_loop` fixtures exercise the replace and create paths of all three helpers, so the fallback branches no longer need coverage pragmas
- 687 passed, 3 xfailed across the affected agent, streaming, graph, and eval test modules
- Pre-commit format, lint, typecheck, and cassette checks passed
- Closed-loop behavior confirmed on Python 3.10 through 3.14

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes**: we will not merge changes that break backwards compatibility unless we first deprecate the old behavior and give users a migration path.
- [x] **PR title**: remember that this will be used in the changelog, so it should be a concise description of the change, not just the issue number.
