### PR TITLE
Allow `MCPToolset` clients to skip optional MCP tasks via `prefer_tasks`

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -346,19 +346,23 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 MCP tools can include metadata that provides additional information about the tool's characteristics, which can be useful when [filtering tools][pydantic_ai.toolsets.FilteredToolset]. The `meta` and `annotations` fields can be found on the `metadata` dict on the [`ToolDefinition`][pydantic_ai.tools.ToolDefinition] object that's passed to filter functions, and the tool's output schema (if any) is available as the `return_schema` field.
 
-[`MCPToolset`][pydantic_ai.mcp.MCPToolset] additionally exposes a `task: bool` flag indicating whether the server declares support for [task-augmented execution](#background-tasks) on the tool.
+[`MCPToolset`][pydantic_ai.mcp.MCPToolset] additionally exposes a `task: bool` flag indicating whether the toolset will use [task-augmented execution](#background-tasks) for the tool. For tools where task support is optional, this reflects the `prefer_tasks` setting.
 
 ## Background tasks
 
-[`MCPToolset`][pydantic_ai.mcp.MCPToolset] supports MCP [task-augmented execution](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) (SEP-1686). Servers can declare per-tool task support via `execution.taskSupport`, and `MCPToolset` routes calls accordingly:
+[`MCPToolset`][pydantic_ai.mcp.MCPToolset] supports MCP [task-augmented execution](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) (SEP-1686). Servers using SEP-1686, including FastMCP 3 servers, can declare per-tool task support via `execution.taskSupport`, and `MCPToolset` routes calls accordingly:
 
 | `execution.taskSupport` | Behavior |
 | --- | --- |
 | `"required"` | Always calls with `task=True`. The server creates a task and the client awaits the final result via `tasks/result`. |
-| `"optional"` | Always calls with `task=True` to opt in to durability, cancellation, and progress notifications. |
+| `"optional"` | Calls with `task=True` by default. Set [`prefer_tasks=False`][pydantic_ai.mcp.MCPToolset.prefer_tasks] to call normally instead. |
 | `"forbidden"` or absent | Calls normally. |
 
-For [FastMCP](https://gofastmcp.com/) servers, declare task support per tool with `task=TaskConfig(mode=...)`:
+The newer MCP [Tasks extension](https://tasks.extensions.modelcontextprotocol.io/seps/2663-tasks-extension) (SEP-2663) uses server-directed task creation instead, so this client-side preference does not apply.
+
+For [FastMCP 3](https://gofastmcp.com/v3/servers/tasks) servers, install the tasks extra with
+`pip install "fastmcp[tasks]>=3,<4"` and declare task support per tool with
+`task=TaskConfig(mode=...)`:
 
 ```python {title="background_task_server.py" dunder_name="not_main"}
 from fastmcp import FastMCP
@@ -367,7 +371,7 @@ from fastmcp.server.tasks import TaskConfig
 mcp = FastMCP('long_running_server')
 
 
-@mcp.tool(task=TaskConfig(mode='required'))
+@mcp.tool(task=TaskConfig(mode='optional'))
 async def deep_research(topic: str) -> str:
     import asyncio
     await asyncio.sleep(0)
@@ -378,13 +382,13 @@ if __name__ == '__main__':
     mcp.run(transport='streamable-http')
 ```
 
-The client side needs no extra configuration — `MCPToolset` sends `task=True` automatically based on the server's declaration:
+By default, [`MCPToolset`][pydantic_ai.mcp.MCPToolset] uses task-augmented execution when a tool supports it. A client that prefers normal calls for tools where task support is optional can set [`prefer_tasks=False`][pydantic_ai.mcp.MCPToolset.prefer_tasks]. This setting does not affect tools where task support is required:
 
 ```python {title="background_task_client.py"}
 from pydantic_ai import Agent
 from pydantic_ai.mcp import MCPToolset
 
-toolset = MCPToolset('http://localhost:8000/mcp')
+toolset = MCPToolset('http://localhost:8000/mcp', prefer_tasks=False)
 agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 ```
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -89,7 +89,7 @@ agent = Agent(
 )
 ```
 
-When you need to manage the toolset lifecycle yourself, share an MCP server across multiple agents, or use FastMCP-specific configuration that doesn't fit the capability shape, use [`MCPToolset`](https://ai.pydantic.dev/mcp/client/) directly and pass it via `toolsets=[...]`. Its `tool_error_behavior` controls how a tool error from the server surfaces: `'retry'` (default) raises `ModelRetry`, `'failed'` raises `ToolFailed` (recorded as `outcome='failed'`), and `'error'` raises the raw `fastmcp` `ToolError`.
+When you need to manage the toolset lifecycle yourself, share an MCP server across multiple agents, or use FastMCP-specific configuration that doesn't fit the capability shape, use [`MCPToolset`](https://ai.pydantic.dev/mcp/client/) directly and pass it via `toolsets=[...]`. Its `tool_error_behavior` controls how a tool error from the server surfaces: `'retry'` (default) raises `ModelRetry`, `'failed'` raises `ToolFailed` (recorded as `outcome='failed'`), and `'error'` raises the raw `fastmcp` `ToolError`. For SEP-1686 tools with optional task support, set `prefer_tasks=False` to use normal calls; required tasks still use task-augmented execution.
 
 ## Search with DuckDuckGo, Tavily, or Exa
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -730,6 +730,13 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     `None` (default) inherits the agent's retry count at runtime. Set explicitly to override.
     """
 
+    prefer_tasks: bool
+    """Whether to prefer task-augmented execution (SEP-1686) for tools that support it optionally.
+
+    Defaults to `True`. Tools that require task-augmented execution always use it, while tools that
+    forbid it never do.
+    """
+
     cache_tools: bool
     """Whether to cache the list of tools across `get_tools()` calls.
 
@@ -818,6 +825,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         max_retries: int | None = None,
         tool_error_behavior: Literal['retry', 'error', 'failed'] = 'retry',
         process_tool_call: ProcessToolCallback | None = None,
+        prefer_tasks: bool = True,
         cache_tools: bool = True,
         cache_resources: bool = True,
         cache_prompts: bool = True,
@@ -857,6 +865,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] so the model can see the error.
             process_tool_call: Hook to wrap tool calls. See
                 [`ProcessToolCallback`][pydantic_ai.mcp.ProcessToolCallback].
+            prefer_tasks: Whether to prefer task-augmented execution (SEP-1686) for tools that
+                support it optionally. Tools that require task-augmented execution always use it,
+                while tools that forbid it never do.
             cache_tools: Whether to cache the list of tools. See
                 [`MCPToolset.cache_tools`][pydantic_ai.mcp.MCPToolset.cache_tools].
             cache_resources: Whether to cache the list of resources. See
@@ -978,6 +989,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self.max_retries = max_retries
         self.tool_error_behavior = tool_error_behavior
         self.process_tool_call = process_tool_call
+        self.prefer_tasks = prefer_tasks
         self.cache_tools = cache_tools
         self.cache_resources = cache_resources
         self.cache_prompts = cache_prompts
@@ -1150,7 +1162,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                     metadata={
                         'meta': mcp_tool.meta,
                         'annotations': mcp_tool.annotations.model_dump() if mcp_tool.annotations else None,
-                        'task': task_support in ('required', 'optional'),
+                        'task': task_support == 'required' or (task_support == 'optional' and self.prefer_tasks),
                     },
                     return_schema=mcp_tool.outputSchema or None,
                     include_return_schema=self.include_return_schema,
@@ -1275,8 +1287,8 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         ctx: RunContext[Any],
         tool: ToolsetTool[Any],
     ) -> Any:
-        # Server-side task-augmented execution per MCP SEP-1686 is governed entirely by the tool's
-        # `execution.taskSupport`: 'required'/'optional' → task path; 'forbidden' or absent → regular path.
+        # `get_tools()` resolves the server's `execution.taskSupport` and the client's
+        # `prefer_tasks` preference into the effective task path for this tool.
         use_task = bool((tool.tool_def.metadata or {}).get('task'))
         if self.process_tool_call is not None:
             return await self.process_tool_call(

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -598,7 +598,7 @@ class ToolDefinition:
     metadata: dict[str, Any] | None = None
     """Tool metadata that can be set by the toolset this tool came from. It is not sent to the model, but can be used for filtering and tool behavior customization.
 
-    For MCP tools, this contains the `meta` and `annotations` fields from the tool definition, as well as a `task` flag indicating whether the server declares support for task-augmented execution.
+    For MCP tools, this contains the `meta` and `annotations` fields from the tool definition, as well as a `task` flag indicating whether the toolset will use task-augmented execution for the tool.
     """
 
     timeout: float | None = None

--- a/tests/mcp_task_server.py
+++ b/tests/mcp_task_server.py
@@ -1,0 +1,18 @@
+from fastmcp.server import Context, FastMCP
+from fastmcp.server.tasks import TaskConfig
+
+mcp: FastMCP[None] = FastMCP('Pydantic AI MCP Task Server')
+
+
+@mcp.tool(task=TaskConfig(mode='required'))
+async def required_task_tool() -> str:
+    return 'required_completed'
+
+
+@mcp.tool(task=TaskConfig(mode='optional'))
+async def optional_task_tool(ctx: Context) -> str:
+    return 'optional_task' if ctx.is_background_task else 'optional_sync'
+
+
+if __name__ == '__main__':
+    mcp.run()

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2053,6 +2053,29 @@ async def test_dbos_mcptoolset_returns_cached_tool_defs(dbos: DBOS):
     assert tools['foo'].tool_def.name == 'foo'
 
 
+_mcp_task_dbos_agent = DBOSAgent(  # pyright: ignore[reportDeprecated]
+    Agent(
+        TestModel(call_tools=['required_task_tool', 'optional_task_tool']),
+        name='mcp_task_dbos_agent',
+        toolsets=[
+            MCPToolset(
+                StdioTransport(command='python', args=['-m', 'tests.mcp_task_server']),
+                id='mcp_tasks',
+                init_timeout=20,
+                prefer_tasks=False,
+            )
+        ],
+    )
+)
+
+
+async def test_dbos_mcptoolset_preserves_task_routing(dbos: DBOS):
+    """Effective task routing in `ToolDefinition.metadata` survives DBOS steps."""
+    result = await _mcp_task_dbos_agent.run('Call both tools')
+
+    assert result.output == '{"required_task_tool":"required_completed","optional_task_tool":"optional_sync"}'
+
+
 def _call_mcp_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Two model steps: call an MCP tool on the first request, return text on the second.
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -23,11 +23,12 @@ import httpx
 import pytest
 from inline_snapshot import snapshot
 
-from pydantic_ai import models
+from pydantic_ai import Agent, ToolsetTool, models
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import BaseExceptionGroup
 from pydantic_ai.exceptions import ModelRetry, ToolFailed
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
 
 from .conftest import try_import
@@ -41,7 +42,7 @@ with try_import() as imports_successful:
     )
     from fastmcp.exceptions import ToolError
     from fastmcp.prompts import Message
-    from fastmcp.server import FastMCP
+    from fastmcp.server import Context, FastMCP
     from fastmcp.server.tasks import TaskConfig
     from mcp import types as mcp_types
     from mcp.shared.exceptions import McpError
@@ -55,7 +56,7 @@ with try_import() as imports_successful:
         TextContent as McpTextContent,
         TextResourceContents,
     )
-    from pydantic import AnyUrl
+    from pydantic import AnyUrl, TypeAdapter
 
     from pydantic_ai.mcp import (
         MCPError,
@@ -1144,8 +1145,6 @@ class TestMCPToolsetIntegration:
         assert 'MCPToolset' in toolset.label
 
     async def test_tool_for_tool_def_uses_default_retries_when_unset(self):
-        from pydantic_ai.tools import ToolDefinition
-
         toolset = MCPToolset('https://example.com/mcp')
         tool = toolset.tool_for_tool_def(
             ToolDefinition(name='foo', description='', parameters_json_schema={'type': 'object'})
@@ -1507,9 +1506,7 @@ def test_construction_does_not_emit_warnings(recwarn: Any) -> None:
 
 class TestMCPToolsetBackgroundTasks:
     """SEP-1686 task-augmented execution. `MCPToolset` reads each tool's server-declared
-    `execution.taskSupport` and routes the call accordingly:
-    `'required'` and `'optional'` go through `client.call_tool(task=True)` -> `tool_task.result()`,
-    while `'forbidden'`/absent stay on the regular sync path."""
+    `execution.taskSupport` and routes the call according to the client's task preference."""
 
     @pytest.fixture
     async def task_server(self) -> FastMCP[None]:
@@ -1522,10 +1519,16 @@ class TestMCPToolsetBackgroundTasks:
             return 'task_required_completed'
 
         @server.tool(task=TaskConfig(mode='optional'))
-        async def task_optional_tool() -> str:
+        async def task_optional_tool(ctx: Context) -> str:
             """A tool that may run either as a task or synchronously."""
             await asyncio.sleep(0)
-            return 'task_optional_completed'
+            mode = 'task' if ctx.is_background_task else 'sync'
+            return f'task_optional_{mode}'
+
+        @server.tool(task=TaskConfig(mode='forbidden'))
+        async def task_forbidden_tool() -> str:
+            """A tool that forbids task-augmented execution."""
+            return 'task_forbidden_completed'
 
         @server.tool()
         async def plain_tool() -> str:
@@ -1537,21 +1540,62 @@ class TestMCPToolsetBackgroundTasks:
     async def test_get_tools_exposes_task_metadata(
         self, task_server: FastMCP[None], run_context: RunContext[None]
     ) -> None:
-        """`get_tools` exposes `task: bool` so downstream capabilities can target task-augmented tools."""
+        """`get_tools` exposes the effective `task: bool` routing choice."""
         toolset = MCPToolset(task_server)
         async with toolset:
             tools = await toolset.get_tools(run_context)
 
         assert (tools['task_required_tool'].tool_def.metadata or {}).get('task') is True
         assert (tools['task_optional_tool'].tool_def.metadata or {}).get('task') is True
+        assert (tools['task_forbidden_tool'].tool_def.metadata or {}).get('task') is False
         assert (tools['plain_tool'].tool_def.metadata or {}).get('task') is False
+
+        toolset = MCPToolset(task_server, prefer_tasks=False)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+
+        assert (tools['task_required_tool'].tool_def.metadata or {}).get('task') is True
+        assert (tools['task_optional_tool'].tool_def.metadata or {}).get('task') is False
+
+    async def test_explicit_forbidden_task_support_stays_on_sync_path(
+        self, run_context: RunContext[None], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The in-process FastMCP server omits `execution` for forbidden tools, so supply the
+        explicit protocol value to cover that distinct wire shape."""
+        toolset = MCPToolset('https://example.com/mcp')
+        monkeypatch.setattr(
+            toolset,
+            'list_tools',
+            AsyncMock(
+                return_value=[
+                    mcp_types.Tool(
+                        name='forbidden_tool',
+                        inputSchema={'type': 'object'},
+                        execution=mcp_types.ToolExecution(taskSupport='forbidden'),
+                    )
+                ]
+            ),
+        )
+        direct_call_tool = AsyncMock(return_value='completed')
+        monkeypatch.setattr(toolset, 'direct_call_tool', direct_call_tool)
+
+        tools = await toolset.get_tools(run_context)
+        metadata = tools['forbidden_tool'].tool_def.metadata
+        assert metadata is not None
+        assert metadata['task'] is False
+        result = await toolset.call_tool('forbidden_tool', {}, run_context, tools['forbidden_tool'])
+
+        assert result == 'completed'
+        direct_call_tool.assert_awaited_once_with('forbidden_tool', {}, use_task=False)
 
     async def test_required_tool_routes_through_task_path(
         self, task_server: FastMCP[None], run_context: RunContext[None]
     ) -> None:
-        """`mode='required'` succeeds - getting the real result proves `task=True` was sent (the server
-        would otherwise return `-32601: requires task-augmented execution`)."""
-        toolset = MCPToolset(task_server)
+        """Required tasks ignore the client's preference for synchronous optional tools.
+
+        Getting the real result proves `task=True` was sent: the server would otherwise return
+        `-32601: requires task-augmented execution`."""
+        toolset = MCPToolset(task_server, prefer_tasks=False)
         async with toolset:
             tools = await toolset.get_tools(run_context)
             result = await toolset.call_tool('task_required_tool', {}, run_context, tools['task_required_tool'])
@@ -1560,13 +1604,67 @@ class TestMCPToolsetBackgroundTasks:
     async def test_optional_tool_routes_through_task_path(
         self, task_server: FastMCP[None], run_context: RunContext[None]
     ) -> None:
-        """`mode='optional'` also goes through the task path by default - the SEP allows either, and the
-        task path delivers durability/cancellation/progress benefits with no functional downside."""
+        """Optional tools use task-augmented execution by default."""
         toolset = MCPToolset(task_server)
         async with toolset:
             tools = await toolset.get_tools(run_context)
             result = await toolset.call_tool('task_optional_tool', {}, run_context, tools['task_optional_tool'])
-        assert result == 'task_optional_completed'
+        assert result == 'task_optional_task'
+
+    async def test_optional_tool_uses_sync_path_when_tasks_disabled(
+        self, task_server: FastMCP[None], run_context: RunContext[None]
+    ) -> None:
+        toolset = MCPToolset(task_server, prefer_tasks=False)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool('task_optional_tool', {}, run_context, tools['task_optional_tool'])
+        assert result == 'task_optional_sync'
+
+    async def test_agent_uses_sync_path_for_optional_tool_when_tasks_disabled(self, task_server: FastMCP[None]) -> None:
+        toolset = MCPToolset(task_server, prefer_tasks=False)
+        agent = Agent(TestModel(call_tools=['task_optional_tool']), toolsets=[toolset])
+
+        result = await agent.run('Call the optional task tool')
+
+        assert result.output == '{"task_optional_tool":"task_optional_sync"}'
+
+    async def test_reconstructed_tool_definition_preserves_task_routing(
+        self,
+        task_server: FastMCP[None],
+        run_context: RunContext[None],
+    ) -> None:
+        """Serialized tool metadata preserves the effective routing choice for durable workers.
+
+        Both flag directions are asserted: the `True` direction is the one that fails loudly if
+        `tool_for_tool_def` ever drops metadata (a sync call to the required tool is rejected by
+        the server), while the `False` direction alone would be indistinguishable from that."""
+        toolset = MCPToolset(task_server, prefer_tasks=False)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            adapter = TypeAdapter(ToolDefinition)
+
+            def round_trip(name: str) -> ToolsetTool[None]:
+                tool_def = adapter.validate_json(adapter.dump_json(tools[name].tool_def))
+                return toolset.tool_for_tool_def(tool_def)
+
+            optional_result = await toolset.call_tool(
+                'task_optional_tool', {}, run_context, round_trip('task_optional_tool')
+            )
+            required_result = await toolset.call_tool(
+                'task_required_tool', {}, run_context, round_trip('task_required_tool')
+            )
+
+        assert optional_result == 'task_optional_sync'
+        assert required_result == 'task_required_completed'
+
+    async def test_forbidden_tool_stays_on_sync_path(
+        self, task_server: FastMCP[None], run_context: RunContext[None]
+    ) -> None:
+        toolset = MCPToolset(task_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool('task_forbidden_tool', {}, run_context, tools['task_forbidden_tool'])
+        assert result == 'task_forbidden_completed'
 
     async def test_plain_tool_stays_on_sync_path(
         self, task_server: FastMCP[None], run_context: RunContext[None]
@@ -1587,17 +1685,81 @@ class TestMCPToolsetBackgroundTasks:
             result = await toolset.direct_call_tool('task_required_tool', {}, use_task=True)
         assert result == 'task_required_completed'
 
-    async def test_process_tool_call_receives_use_task_partial(
-        self, task_server: FastMCP[None], run_context: RunContext[None]
+    @pytest.mark.parametrize(
+        ('prefer_tasks', 'expected'),
+        [(True, 'task_optional_task'), (False, 'task_optional_sync')],
+    )
+    async def test_process_tool_call_preserves_task_preference(
+        self,
+        task_server: FastMCP[None],
+        run_context: RunContext[None],
+        prefer_tasks: bool,
+        expected: str,
     ) -> None:
-        """`process_tool_call` gets a `CallToolFunc` that already has `use_task` baked in via `partial`,
-        so a custom wrapper doesn't need to know about the task path to preserve it."""
+        """The `CallToolFunc` delegate applies the task preference when the wrapper invokes it."""
 
         async def passthrough(ctx: RunContext[Any], call_tool: Any, name: str, args: dict[str, Any]) -> Any:
             return await call_tool(name, args)
 
-        toolset = MCPToolset(task_server, process_tool_call=passthrough)
+        toolset = MCPToolset(
+            task_server,
+            process_tool_call=passthrough,
+            prefer_tasks=prefer_tasks,
+        )
         async with toolset:
             tools = await toolset.get_tools(run_context)
-            result = await toolset.call_tool('task_required_tool', {}, run_context, tools['task_required_tool'])
-        assert result == 'task_required_completed'
+            result = await toolset.call_tool('task_optional_tool', {}, run_context, tools['task_optional_tool'])
+        assert result == expected
+
+    async def test_process_tool_call_preserves_metadata_and_task_preference(
+        self,
+        task_server: FastMCP[None],
+        run_context: RunContext[None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mocks `direct_call_tool` to pin the exact delegate kwargs: a wrapper's `metadata` must
+        arrive alongside the baked-in `use_task`. The task-preference half is covered end-to-end
+        against the real server above; this pins the internal call shape that carries both."""
+
+        async def add_metadata(ctx: RunContext[Any], call_tool: Any, name: str, args: dict[str, Any]) -> Any:
+            return await call_tool(name, args, metadata={'trace_id': '123'})
+
+        toolset = MCPToolset(
+            task_server,
+            process_tool_call=add_metadata,
+            prefer_tasks=False,
+        )
+        direct_call_tool = AsyncMock(return_value='completed')
+        monkeypatch.setattr(toolset, 'direct_call_tool', direct_call_tool)
+        tools = await toolset.get_tools(run_context)
+
+        result = await toolset.call_tool('task_optional_tool', {}, run_context, tools['task_optional_tool'])
+
+        assert result == 'completed'
+        direct_call_tool.assert_awaited_once_with(
+            'task_optional_tool',
+            {},
+            metadata={'trace_id': '123'},
+            use_task=False,
+        )
+
+    async def test_process_tool_call_can_short_circuit_without_calling_server(
+        self, run_context: RunContext[None], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A callback can return a cached result without making an MCP tool call.
+
+        Mocks `direct_call_tool` because the property under test is that no server call happens at
+        all (`assert_not_awaited`), which no real-server response could demonstrate."""
+
+        async def short_circuit(ctx: RunContext[Any], call_tool: Any, name: str, args: dict[str, Any]) -> Any:
+            return 'cached'
+
+        toolset = MCPToolset('https://example.com/mcp', process_tool_call=short_circuit)
+        direct_call_tool = AsyncMock(side_effect=AssertionError('tool call should not run'))
+        monkeypatch.setattr(toolset, 'direct_call_tool', direct_call_tool)
+        tool = toolset.tool_for_tool_def(ToolDefinition(name='durable_tool'))
+
+        result = await toolset.call_tool('durable_tool', {}, run_context, tool)
+
+        assert result == 'cached'
+        direct_call_tool.assert_not_awaited()

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -773,6 +773,33 @@ async def test_prefect_toolset_legacy_constructors() -> None:
     assert wrapped_mcp.id is None
 
 
+async def test_prefect_mcptoolset_preserves_task_routing() -> None:
+    """Effective task routing forwards through Prefect task wrappers end-to-end.
+
+    Unlike Temporal/DBOS, Prefect passes live `ToolsetTool` objects through without serializing
+    `ToolDefinition`, so this pins wrapper forwarding rather than serialization round-tripping."""
+    agent = PrefectAgent(  # pyright: ignore[reportDeprecated]
+        Agent(
+            TestModel(call_tools=['required_task_tool', 'optional_task_tool']),
+            name='mcp_task_prefect_agent',
+            toolsets=[
+                MCPToolset(
+                    StdioTransport(command='python', args=['-m', 'tests.mcp_task_server']),
+                    id='mcp_tasks',
+                    init_timeout=20,
+                    prefer_tasks=False,
+                )
+            ],
+        )
+    )
+
+    @flow(name='test_prefect_mcptoolset_preserves_task_routing')
+    async def run_agent() -> str:
+        return (await agent.run('Call both tools')).output
+
+    assert await run_agent() == '{"required_task_tool":"required_completed","optional_task_tool":"optional_sync"}'
+
+
 async def test_capability_contributed_toolset_id_from_capability():
     """A capability's `id` flows to its contributed leaf toolset, so a capability combined with a
     local MCP server is swapped for its Prefect task wrapper under a stable id. An `MCP` with no

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4096,6 +4096,49 @@ async def test_mcptoolset_in_temporal_workflow(allow_model_requests: None, clien
         assert 'pydantic' in output.lower() or 'agent' in output.lower()
 
 
+_mcp_task_agent = Agent(
+    TestModel(call_tools=['required_task_tool', 'optional_task_tool']),
+    name='mcp_task_temporal_agent',
+    toolsets=[
+        MCPToolset(
+            StdioTransport(command='python', args=['-m', 'tests.mcp_task_server']),
+            id='mcp_tasks',
+            init_timeout=20,
+            prefer_tasks=False,
+        )
+    ],
+)
+_mcp_task_temporal_agent = TemporalAgent(  # pyright: ignore[reportDeprecated]
+    _mcp_task_agent,
+    activity_config=BASE_ACTIVITY_CONFIG,
+)
+
+
+@workflow.defn
+class MCPTaskSupportWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        return (await _mcp_task_temporal_agent.run(prompt)).output
+
+
+async def test_temporal_mcptoolset_preserves_task_routing(client: Client):
+    """Effective task routing in `ToolDefinition.metadata` survives Temporal activities."""
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[MCPTaskSupportWorkflow],
+        plugins=[AgentPlugin(_mcp_task_temporal_agent)],
+    ):
+        output = await client.execute_workflow(
+            MCPTaskSupportWorkflow.run,
+            args=['Call both tools'],
+            id=MCPTaskSupportWorkflow.__name__,
+            task_queue=TASK_QUEUE,
+        )
+
+    assert output == '{"required_task_tool":"required_completed","optional_task_tool":"optional_sync"}'
+
+
 # ============================================================================
 # ctx.agent in Temporal activities
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add `MCPToolset(prefer_tasks=False)` so SEP-1686 tools advertising `taskSupport: "optional"` can use normal synchronous calls.
- Preserve task-augmented execution for `required` tools and normal calls for `forbidden` or undeclared support.
- `get_tools()` resolves the server declaration and the client preference into the existing `metadata['task']` flag, which `call_tool()` already consumes. Durable engines (Temporal/DBOS/Prefect) serialize `ToolDefinition` as-is, so the recorded routing choice replays with zero durable-execution changes, and each engine has an end-to-end test proving it.
- Default `prefer_tasks=True` keeps routing and `metadata['task']` values identical to the current release for existing users.
- Document the FastMCP 3 requirement and distinguish the newer server-directed SEP-2663 task model.

Maintainer-approved Slack follow-up to the closed #4266 and #5192. #6738 separately handles the FastMCP 4 and SEP-2663 transition.

One deliberate trade-off to flag: with `prefer_tasks=False`, `metadata['task']` reflects the effective routing choice, so metadata no longer distinguishes an opted-out `'optional'` tool from a `'forbidden'` one. The flag was already lossy (`required` and `optional` both read `True`), so nothing usable is removed; if filtering on the raw server declaration ever matters, an additive `metadata['task_support']` key can carry it without touching this design.

## Tests

- `uv run pytest tests/test_mcp.py -q`
- `uv run pytest tests/test_examples.py -q -k background_task`
- `uv run pytest tests/test_temporal.py::test_temporal_mcptoolset_preserves_task_routing tests/test_dbos.py::test_dbos_mcptoolset_preserves_task_routing tests/test_prefect.py::test_prefect_mcptoolset_preserves_task_routing -q`
- Focused Ruff and Pyright checks passed; full pre-commit gate on commit
- Adversarial review of the final diff found no substantive issues

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
