### PR TITLE
Add Hugging Face logprobs settings and response details

### DIFF
--- a/docs/models/huggingface.md
+++ b/docs/models/huggingface.md
@@ -97,6 +97,24 @@ agent = Agent(model)
 ...
 ```
 
+## Logprobs
+
+You can return logprobs from the model by setting `huggingface_logprobs` and `huggingface_top_logprobs` in the [`HuggingFaceModelSettings`][pydantic_ai.models.huggingface.HuggingFaceModelSettings]. They are returned under `provider_details['logprobs']`, for both streamed and non-streamed requests.
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.models.huggingface import HuggingFaceModel, HuggingFaceModelSettings
+
+model = HuggingFaceModel('Qwen/Qwen3-235B-A22B')
+settings = HuggingFaceModelSettings(huggingface_logprobs=True, huggingface_top_logprobs=2)
+agent = Agent(model, model_settings=settings)
+
+result = agent.run_sync('Your prompt here')
+logprobs = result.response.provider_details.get('logprobs')
+```
+
+Not every inference provider supports these parameters; one that doesn't will ignore them and return no logprobs.
+
 ## Streaming cancellation
 
 !!! warning "Cancellation limitations"

--- a/docs/models/huggingface.md
+++ b/docs/models/huggingface.md
@@ -113,7 +113,7 @@ result = agent.run_sync('Your prompt here')
 logprobs = result.response.provider_details.get('logprobs')
 ```
 
-Not every inference provider supports these parameters; one that doesn't will ignore them and return no logprobs.
+Support depends on the selected inference provider and model. `huggingface_top_logprobs` must be between 0 and 5 and requires `huggingface_logprobs=True`; see the [Hugging Face chat completion parameters](https://huggingface.co/docs/inference-providers/tasks/chat-completion#request).
 
 ## Streaming cancellation
 

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -141,7 +141,10 @@ class HuggingFaceModelSettings(ModelSettings, total=False):
     """
 
     huggingface_top_logprobs: int
-    """Include log probabilities of the top n tokens in the response."""
+    """Include log probabilities for the top 0 to 5 tokens at each position.
+
+    Requires `huggingface_logprobs=True`.
+    """
 
 
 @dataclass(init=False)

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -63,8 +63,10 @@ try:
         ChatCompletionInputToolChoiceClass,
         ChatCompletionInputURL,
         ChatCompletionOutput,
+        ChatCompletionOutputLogprobs,
         ChatCompletionOutputMessage,
         ChatCompletionStreamOutput,
+        ChatCompletionStreamOutputLogprobs,
         TextGenerationOutputFinishReason,
     )
     from huggingface_hub.errors import HfHubHTTPError
@@ -131,7 +133,15 @@ class HuggingFaceModelSettings(ModelSettings, total=False):
     """Settings used for a Hugging Face model request."""
 
     # ALL FIELDS MUST BE `huggingface_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
-    # This class is a placeholder for any future huggingface-specific settings
+
+    huggingface_logprobs: bool
+    """Include log probabilities in the response.
+
+    These will be included in `ModelResponse.provider_details['logprobs']`.
+    """
+
+    huggingface_top_logprobs: int
+    """Include log probabilities of the top n tokens in the response."""
 
 
 @dataclass(init=False)
@@ -273,8 +283,8 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                 presence_penalty=model_settings.get('presence_penalty', None),
                 frequency_penalty=model_settings.get('frequency_penalty', None),
                 logit_bias=model_settings.get('logit_bias', None),  # pyright: ignore[reportArgumentType]
-                logprobs=model_settings.get('logprobs', None),
-                top_logprobs=model_settings.get('top_logprobs', None),
+                logprobs=model_settings.get('huggingface_logprobs', None),
+                top_logprobs=model_settings.get('huggingface_top_logprobs', None),
                 extra_body=model_settings.get('extra_body'),  # pyright: ignore[reportArgumentType]
             )
 
@@ -298,6 +308,8 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
         provider_details: dict[str, Any] = {'finish_reason': raw_finish_reason}
         if response.created:  # pragma: no branch
             provider_details['timestamp'] = datetime.fromtimestamp(response.created, tz=timezone.utc)
+        if choice.logprobs and choice.logprobs.content:
+            provider_details['logprobs'] = _map_logprobs(choice.logprobs)
         finish_reason = _FINISH_REASON_MAP.get(cast(HuggingFaceFinishReason, raw_finish_reason), None)
 
         return ModelResponse(
@@ -550,6 +562,10 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                 raise
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        # Each chunk carries the logprobs for its own tokens only, so they're accumulated across the
+        # stream: the final `provider_details` covers the whole response, matching what the
+        # non-streamed path returns for the same request.
+        logprobs: list[dict[str, Any]] = []
         with _map_api_errors(self._model_name):
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
@@ -567,6 +583,10 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                 if raw_finish_reason := choice.finish_reason:
                     self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}
                     self.finish_reason = _FINISH_REASON_MAP.get(cast(HuggingFaceFinishReason, raw_finish_reason), None)
+
+                if choice.logprobs and choice.logprobs.content:
+                    logprobs.extend(_map_logprobs(choice.logprobs))
+                    self.provider_details = {**(self.provider_details or {}), 'logprobs': logprobs}
 
                 # Handle the text part of the response
                 content = choice.delta.content
@@ -608,6 +628,25 @@ class HuggingFaceStreamedResponse(StreamedResponse):
     def timestamp(self) -> datetime:
         """Get the timestamp of the response."""
         return self._timestamp
+
+
+def _map_logprobs(
+    logprobs: ChatCompletionOutputLogprobs | ChatCompletionStreamOutputLogprobs,
+) -> list[dict[str, Any]]:
+    """Convert Hugging Face logprobs to a serializable format.
+
+    Shaped like the OpenAI and xAI mappings so `provider_details['logprobs']` is consistent across
+    providers. Hugging Face doesn't return the `bytes` field those two do, so it's omitted rather
+    than emitted as `None`.
+    """
+    return [
+        {
+            'token': lp.token,
+            'logprob': lp.logprob,
+            'top_logprobs': [{'token': tlp.token, 'logprob': tlp.logprob} for tlp in lp.top_logprobs],
+        }
+        for lp in logprobs.content
+    ]
 
 
 def _map_usage(response: ChatCompletionOutput | ChatCompletionStreamOutput) -> usage.RequestUsage:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -522,17 +522,6 @@ def text_chunk(text: str, finish_reason: FinishReason | None = None) -> ChatComp
 
 
 async def test_huggingface_logprobs(allow_model_requests: None):
-    """`huggingface_logprobs`/`huggingface_top_logprobs` reach the API and come back in `provider_details`.
-
-    The two request parameters were read from the unprefixed `logprobs`/`top_logprobs` keys, which
-    `HuggingFaceModelSettings` never declared, so they were unreachable: the settings class rejects
-    them statically, and a user who set them anyway had them silently dropped. The response side was
-    missing too — `choice.logprobs` was never mapped, so even a hand-forced request returned nothing.
-
-    A mock-client test rather than a VCR one, matching the rest of this file: the request half asserts
-    an outgoing payload, which the cassette matchers (method + URI) aren't sensitive to, so a recording
-    made against the broken code plays back identically.
-    """
     c = completion_message(
         ChatCompletionOutputMessage(content='hello', role='assistant'),
         logprobs={
@@ -553,27 +542,18 @@ async def test_huggingface_logprobs(allow_model_requests: None):
 
     kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     assert (kwargs['logprobs'], kwargs['top_logprobs']) == (True, 2)
-    assert result.response.provider_details == snapshot(
-        {
-            'finish_reason': 'stop',
-            'timestamp': IsDatetime(),
-            'logprobs': [
-                {
-                    'token': 'hello',
-                    'logprob': -0.25,
-                    'top_logprobs': [{'token': 'hello', 'logprob': -0.25}, {'token': 'hi', 'logprob': -2.5}],
-                }
-            ],
-        }
+    assert result.response.provider_details['logprobs'] == snapshot(
+        [
+            {
+                'token': 'hello',
+                'logprob': -0.25,
+                'top_logprobs': [{'token': 'hello', 'logprob': -0.25}, {'token': 'hi', 'logprob': -2.5}],
+            }
+        ]
     )
 
 
 async def test_huggingface_logprobs_not_requested(allow_model_requests: None):
-    """Without the settings, both parameters are left unset and no `logprobs` key is added.
-
-    The negative half of the case above: the settings are optional, and a response that carries no
-    logprobs must not grow an empty key in `provider_details`.
-    """
     c = completion_message(ChatCompletionOutputMessage(content='hello', role='assistant'))
     mock_client = MockHuggingFace.create_mock(c)
     m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
@@ -583,7 +563,7 @@ async def test_huggingface_logprobs_not_requested(allow_model_requests: None):
 
     kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     assert (kwargs['logprobs'], kwargs['top_logprobs']) == (None, None)
-    assert result.response.provider_details == snapshot({'finish_reason': 'stop', 'timestamp': IsDatetime()})
+    assert 'logprobs' not in result.response.provider_details
 
 
 def logprobs_chunk(text: str, logprob: float, finish_reason: FinishReason | None = None) -> ChatCompletionStreamOutput:
@@ -612,31 +592,21 @@ def logprobs_chunk(text: str, logprob: float, finish_reason: FinishReason | None
 
 
 async def test_huggingface_logprobs_streaming(allow_model_requests: None):
-    """Streamed logprobs accumulate across chunks so the final `provider_details` covers every token.
-
-    Each chunk carries only its own token's logprobs, so overwriting per chunk would leave just the
-    last one — the streamed response would silently disagree with the non-streamed one for the same
-    request.
-    """
     stream = [logprobs_chunk('hello ', -0.25), logprobs_chunk('world', -1.5, finish_reason='stop')]
     mock_client = MockHuggingFace.create_stream_mock(stream)
     m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
     agent = Agent(m, model_settings=HuggingFaceModelSettings(huggingface_logprobs=True, huggingface_top_logprobs=1))
 
     async with agent.run_stream('') as result:
-        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['hello ', 'hello world'])
+        await result.get_output()
 
     kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     assert (kwargs['logprobs'], kwargs['top_logprobs']) == (True, 1)
-    assert result.response.provider_details == snapshot(
-        {
-            'timestamp': IsDatetime(),
-            'logprobs': [
-                {'token': 'hello ', 'logprob': -0.25, 'top_logprobs': [{'token': 'hello ', 'logprob': -0.25}]},
-                {'token': 'world', 'logprob': -1.5, 'top_logprobs': [{'token': 'world', 'logprob': -1.5}]},
-            ],
-            'finish_reason': 'stop',
-        }
+    assert result.response.provider_details['logprobs'] == snapshot(
+        [
+            {'token': 'hello ', 'logprob': -0.25, 'top_logprobs': [{'token': 'hello ', 'logprob': -0.25}]},
+            {'token': 'world', 'logprob': -1.5, 'top_logprobs': [{'token': 'world', 'logprob': -1.5}]},
+        ]
     )
 
 

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -53,6 +53,7 @@ with try_import() as imports_successful:
         ChatCompletionOutput,
         ChatCompletionOutputComplete,
         ChatCompletionOutputFunctionDefinition,
+        ChatCompletionOutputLogprobs,
         ChatCompletionOutputMessage,
         ChatCompletionOutputToolCall,
         ChatCompletionOutputUsage,
@@ -65,7 +66,7 @@ with try_import() as imports_successful:
     )
     from huggingface_hub.errors import HfHubHTTPError
 
-    from pydantic_ai.models.huggingface import HuggingFaceModel, HuggingFaceStreamedResponse
+    from pydantic_ai.models.huggingface import HuggingFaceModel, HuggingFaceModelSettings, HuggingFaceStreamedResponse
     from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
     MockChatCompletion = ChatCompletionOutput | Exception
@@ -137,9 +138,17 @@ def get_mock_chat_completion_kwargs(hf_client: AsyncInferenceClient) -> list[dic
 
 
 def completion_message(
-    message: ChatCompletionInputMessage | ChatCompletionOutputMessage, *, usage: ChatCompletionOutputUsage | None = None
+    message: ChatCompletionInputMessage | ChatCompletionOutputMessage,
+    *,
+    usage: ChatCompletionOutputUsage | None = None,
+    logprobs: dict[str, Any] | None = None,
 ) -> ChatCompletionOutput:
-    choices = [ChatCompletionOutputComplete(finish_reason='stop', index=0, message=message)]  # pyright: ignore[reportArgumentType]
+    parsed_logprobs = (
+        ChatCompletionOutputLogprobs.parse_obj_as_instance(logprobs)  # pyright: ignore[reportUnknownMemberType]
+        if logprobs is not None
+        else None
+    )
+    choices = [ChatCompletionOutputComplete(finish_reason='stop', index=0, message=message, logprobs=parsed_logprobs)]  # pyright: ignore[reportArgumentType]
     return ChatCompletionOutput.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
         {
             'id': '123',
@@ -510,6 +519,125 @@ def chunk(
 
 def text_chunk(text: str, finish_reason: FinishReason | None = None) -> ChatCompletionStreamOutput:
     return chunk([ChatCompletionStreamOutputDelta(content=text, role='assistant')], finish_reason=finish_reason)
+
+
+async def test_huggingface_logprobs(allow_model_requests: None):
+    """`huggingface_logprobs`/`huggingface_top_logprobs` reach the API and come back in `provider_details`.
+
+    The two request parameters were read from the unprefixed `logprobs`/`top_logprobs` keys, which
+    `HuggingFaceModelSettings` never declared, so they were unreachable: the settings class rejects
+    them statically, and a user who set them anyway had them silently dropped. The response side was
+    missing too — `choice.logprobs` was never mapped, so even a hand-forced request returned nothing.
+
+    A mock-client test rather than a VCR one, matching the rest of this file: the request half asserts
+    an outgoing payload, which the cassette matchers (method + URI) aren't sensitive to, so a recording
+    made against the broken code plays back identically.
+    """
+    c = completion_message(
+        ChatCompletionOutputMessage(content='hello', role='assistant'),
+        logprobs={
+            'content': [
+                {
+                    'token': 'hello',
+                    'logprob': -0.25,
+                    'top_logprobs': [{'token': 'hello', 'logprob': -0.25}, {'token': 'hi', 'logprob': -2.5}],
+                }
+            ]
+        },
+    )
+    mock_client = MockHuggingFace.create_mock(c)
+    m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
+    agent = Agent(m, model_settings=HuggingFaceModelSettings(huggingface_logprobs=True, huggingface_top_logprobs=2))
+
+    result = await agent.run('hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert (kwargs['logprobs'], kwargs['top_logprobs']) == (True, 2)
+    assert result.response.provider_details == snapshot(
+        {
+            'finish_reason': 'stop',
+            'timestamp': IsDatetime(),
+            'logprobs': [
+                {
+                    'token': 'hello',
+                    'logprob': -0.25,
+                    'top_logprobs': [{'token': 'hello', 'logprob': -0.25}, {'token': 'hi', 'logprob': -2.5}],
+                }
+            ],
+        }
+    )
+
+
+async def test_huggingface_logprobs_not_requested(allow_model_requests: None):
+    """Without the settings, both parameters are left unset and no `logprobs` key is added.
+
+    The negative half of the case above: the settings are optional, and a response that carries no
+    logprobs must not grow an empty key in `provider_details`.
+    """
+    c = completion_message(ChatCompletionOutputMessage(content='hello', role='assistant'))
+    mock_client = MockHuggingFace.create_mock(c)
+    m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
+    agent = Agent(m)
+
+    result = await agent.run('hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert (kwargs['logprobs'], kwargs['top_logprobs']) == (None, None)
+    assert result.response.provider_details == snapshot({'finish_reason': 'stop', 'timestamp': IsDatetime()})
+
+
+def logprobs_chunk(text: str, logprob: float, finish_reason: FinishReason | None = None) -> ChatCompletionStreamOutput:
+    """A streamed chunk carrying the logprobs for its own token, as the API returns them."""
+    return ChatCompletionStreamOutput.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
+        {
+            'id': 'x',
+            'choices': [
+                {
+                    'index': 0,
+                    'delta': ChatCompletionStreamOutputDelta(content=text, role='assistant'),
+                    'finish_reason': finish_reason,
+                    'logprobs': {
+                        'content': [
+                            {'token': text, 'logprob': logprob, 'top_logprobs': [{'token': text, 'logprob': logprob}]}
+                        ]
+                    },
+                }
+            ],
+            'created': 1704067200,  # 2024-01-01
+            'model': 'hf-model',
+            'object': 'chat.completion.chunk',
+            'usage': ChatCompletionStreamOutputUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+        }
+    )
+
+
+async def test_huggingface_logprobs_streaming(allow_model_requests: None):
+    """Streamed logprobs accumulate across chunks so the final `provider_details` covers every token.
+
+    Each chunk carries only its own token's logprobs, so overwriting per chunk would leave just the
+    last one — the streamed response would silently disagree with the non-streamed one for the same
+    request.
+    """
+    stream = [logprobs_chunk('hello ', -0.25), logprobs_chunk('world', -1.5, finish_reason='stop')]
+    mock_client = MockHuggingFace.create_stream_mock(stream)
+    m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
+    agent = Agent(m, model_settings=HuggingFaceModelSettings(huggingface_logprobs=True, huggingface_top_logprobs=1))
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['hello ', 'hello world'])
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert (kwargs['logprobs'], kwargs['top_logprobs']) == (True, 1)
+    assert result.response.provider_details == snapshot(
+        {
+            'timestamp': IsDatetime(),
+            'logprobs': [
+                {'token': 'hello ', 'logprob': -0.25, 'top_logprobs': [{'token': 'hello ', 'logprob': -0.25}]},
+                {'token': 'world', 'logprob': -1.5, 'top_logprobs': [{'token': 'world', 'logprob': -1.5}]},
+            ],
+            'finish_reason': 'stop',
+        }
+    )
 
 
 async def test_stream_text(allow_model_requests: None):

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -542,7 +542,9 @@ async def test_huggingface_logprobs(allow_model_requests: None):
 
     kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     assert (kwargs['logprobs'], kwargs['top_logprobs']) == (True, 2)
-    assert result.response.provider_details['logprobs'] == snapshot(
+    provider_details = result.response.provider_details
+    assert provider_details is not None
+    assert provider_details['logprobs'] == snapshot(
         [
             {
                 'token': 'hello',
@@ -563,7 +565,9 @@ async def test_huggingface_logprobs_not_requested(allow_model_requests: None):
 
     kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     assert (kwargs['logprobs'], kwargs['top_logprobs']) == (None, None)
-    assert 'logprobs' not in result.response.provider_details
+    provider_details = result.response.provider_details
+    assert provider_details is not None
+    assert 'logprobs' not in provider_details
 
 
 def logprobs_chunk(text: str, logprob: float, finish_reason: FinishReason | None = None) -> ChatCompletionStreamOutput:
@@ -602,7 +606,9 @@ async def test_huggingface_logprobs_streaming(allow_model_requests: None):
 
     kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     assert (kwargs['logprobs'], kwargs['top_logprobs']) == (True, 1)
-    assert result.response.provider_details['logprobs'] == snapshot(
+    provider_details = result.response.provider_details
+    assert provider_details is not None
+    assert provider_details['logprobs'] == snapshot(
         [
             {'token': 'hello ', 'logprob': -0.25, 'top_logprobs': [{'token': 'hello ', 'logprob': -0.25}]},
             {'token': 'world', 'logprob': -1.5, 'top_logprobs': [{'token': 'world', 'logprob': -1.5}]},


### PR DESCRIPTION
Fixes #6854

Add `huggingface_logprobs` and `huggingface_top_logprobs`, forward them to the SDK, and expose returned token data in `ModelResponse.provider_details["logprobs"]`.

Focused unit tests cover request mapping and streamed and non-streamed response mapping. A live recording still requires a Hugging Face token and a provider/model combination that supports logprobs.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).