### PR TITLE
Raise a `UserError` when an OpenRouter model omits its provider prefix

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -154,13 +154,11 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
 
         profile = None
 
-        # OpenRouter identifies every model as `provider/model`, so a name without a slash is a
-        # mistake rather than a model this gateway could route. Say so instead of letting the unpack
-        # below raise a bare `ValueError` that names neither the setting nor the model.
+        # OpenRouter identifies models as `provider/model`.
         if '/' not in model_name:
             raise UserError(
                 f'OpenRouter model names must be prefixed with the upstream provider, e.g. '
-                f'{f"openai/{model_name}"!r}, not {model_name!r}. '
+                f'{("openai/" + model_name)!r}, not {model_name!r}. '
                 'See https://openrouter.ai/models for the available model names.'
             )
 

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -160,7 +160,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         if '/' not in model_name:
             raise UserError(
                 f'OpenRouter model names must be prefixed with the upstream provider, e.g. '
-                f'`openai/{model_name}`, not `{model_name}`. '
+                f'{f"openai/{model_name}"!r}, not {model_name!r}. '
                 'See https://openrouter.ai/models for the available model names.'
             )
 

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -154,6 +154,16 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
 
         profile = None
 
+        # OpenRouter identifies every model as `provider/model`, so a name without a slash is a
+        # mistake rather than a model this gateway could route. Say so instead of letting the unpack
+        # below raise a bare `ValueError` that names neither the setting nor the model.
+        if '/' not in model_name:
+            raise UserError(
+                f'OpenRouter model names must be prefixed with the upstream provider, e.g. '
+                f'`openai/{model_name}`, not `{model_name}`. '
+                'See https://openrouter.ai/models for the available model names.'
+            )
+
         # OpenRouter exposes latest-model aliases as `~provider/model`; strip the
         # alias marker before using the provider prefix for profile selection.
         provider, model_name = model_name.removeprefix('~').split('/', 1)

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -279,21 +279,8 @@ def test_openrouter_model_profile_forced_tool_choice_with_thinking(model_name: s
 
 
 def test_openrouter_model_profile_requires_provider_prefix() -> None:
-    """A model name without the `provider/` prefix raises an actionable `UserError`.
-
-    OpenRouter identifies every model as `provider/model`, so omitting the prefix — the natural
-    mistake when moving an `OpenAIChatModel('gpt-4o')` call over — used to reach an unguarded
-    `split('/', 1)` unpack and surface as a bare `ValueError: not enough values to unpack`, naming
-    neither the model nor the gateway. Every sibling gateway provider guards this; only OpenRouter
-    didn't. Raising rather than falling back to a bare OpenAI profile, because unlike those siblings
-    OpenRouter cannot route an unprefixed name at all — a fallback would only defer the failure to a
-    404 from the API.
-
-    A unit test rather than a VCR one: the request never leaves the process, so there's nothing to
-    record.
-    """
     provider = OpenRouterProvider(api_key='api-key')
-    with pytest.raises(UserError, match=re.escape('e.g. `openai/gpt-4o`, not `gpt-4o`')):
+    with pytest.raises(UserError, match=re.escape("e.g. 'openai/gpt-4o', not 'gpt-4o'")):
         provider.model_profile('gpt-4o')
 
 

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -278,6 +278,25 @@ def test_openrouter_model_profile_forced_tool_choice_with_thinking(model_name: s
     assert profile.get('openrouter_supports_forced_tool_choice_with_thinking') is expected
 
 
+def test_openrouter_model_profile_requires_provider_prefix() -> None:
+    """A model name without the `provider/` prefix raises an actionable `UserError`.
+
+    OpenRouter identifies every model as `provider/model`, so omitting the prefix — the natural
+    mistake when moving an `OpenAIChatModel('gpt-4o')` call over — used to reach an unguarded
+    `split('/', 1)` unpack and surface as a bare `ValueError: not enough values to unpack`, naming
+    neither the model nor the gateway. Every sibling gateway provider guards this; only OpenRouter
+    didn't. Raising rather than falling back to a bare OpenAI profile, because unlike those siblings
+    OpenRouter cannot route an unprefixed name at all — a fallback would only defer the failure to a
+    404 from the API.
+
+    A unit test rather than a VCR one: the request never leaves the process, so there's nothing to
+    record.
+    """
+    provider = OpenRouterProvider(api_key='api-key')
+    with pytest.raises(UserError, match=re.escape('e.g. `openai/gpt-4o`, not `gpt-4o`')):
+        provider.model_profile('gpt-4o')
+
+
 def test_openrouter_google_json_schema_transformer():
     """Test _OpenRouterGoogleJsonSchemaTransformer covers all transformation cases."""
     schema = {


### PR DESCRIPTION
Fixes #6859

Raise an actionable `UserError` when an OpenRouter model name has no `/` provider separator, instead of exposing an internal unpacking error.

The regression test covers the missing-prefix case.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).