### PR TITLE
Send `top_p=0.0` to Bedrock

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -961,7 +961,9 @@ class BedrockConverseModel(Model[BaseClient]):
             inference_config['maxTokens'] = max_tokens
         if (temperature := model_settings.get('temperature')) is not None:
             inference_config['temperature'] = temperature
-        if top_p := model_settings.get('top_p'):
+        # `topP` is checked against `None` rather than for truthiness because `0.0` is in range for
+        # Converse and asks for greedy decoding, so dropping it would silently leave sampling on.
+        if (top_p := model_settings.get('top_p')) is not None:
             inference_config['topP'] = top_p
         if stop_sequences := model_settings.get('stop_sequences'):
             inference_config['stopSequences'] = stop_sequences

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -961,8 +961,6 @@ class BedrockConverseModel(Model[BaseClient]):
             inference_config['maxTokens'] = max_tokens
         if (temperature := model_settings.get('temperature')) is not None:
             inference_config['temperature'] = temperature
-        # `topP` is checked against `None` rather than for truthiness because `0.0` is in range for
-        # Converse and asks for greedy decoding, so dropping it would silently leave sampling on.
         if (top_p := model_settings.get('top_p')) is not None:
             inference_config['topP'] = top_p
         if stop_sequences := model_settings.get('stop_sequences'):

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3263,23 +3263,11 @@ async def test_bedrock_top_k_unsupported_family_dropped(
     assert 'additionalModelRequestFields' not in kwargs
 
 
-@pytest.mark.parametrize('top_p', [0.0, 1.0])
-async def test_bedrock_top_p_boundary_values_reach_inference_config(
-    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture, top_p: float
+async def test_bedrock_top_p_zero_reaches_inference_config(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
 ) -> None:
-    """Both ends of `top_p`'s range reach `inferenceConfig.topP`.
-
-    `0.0` used to be dropped by a truthiness check, which asks for greedy decoding and so left
-    sampling on instead. It is in range, not a sentinel: AWS declares `topP` with `min: 0, max: 1`
-    exactly like `temperature`, which the line above already checks against `None` for this reason.
-    `1.0` is here as the control — it passed before the fix too, so a failure on `0.0` alone points
-    at the guard rather than at `topP` mapping in general. Mid-range is covered by
-    `test_bedrock_model_top_p`.
-
-    No-network: the assertion is on the outgoing request shape, which a cassette matcher wouldn't pin.
-    """
     model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
-    agent = Agent(model, model_settings=ModelSettings(top_p=top_p))
+    agent = Agent(model, model_settings=ModelSettings(top_p=0.0))
 
     mock_converse = mocker.patch.object(model.client, 'converse')
     mock_converse.return_value = {
@@ -3292,7 +3280,7 @@ async def test_bedrock_top_p_boundary_values_reach_inference_config(
     await agent.run('What is the capital of France?')
 
     _, kwargs = mock_converse.call_args
-    assert kwargs['inferenceConfig']['topP'] == top_p
+    assert kwargs['inferenceConfig']['topP'] == 0.0
 
 
 async def test_bedrock_model_stream_empty_text_delta(allow_model_requests: None, bedrock_provider: BedrockProvider):

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3263,6 +3263,38 @@ async def test_bedrock_top_k_unsupported_family_dropped(
     assert 'additionalModelRequestFields' not in kwargs
 
 
+@pytest.mark.parametrize('top_p', [0.0, 1.0])
+async def test_bedrock_top_p_boundary_values_reach_inference_config(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture, top_p: float
+) -> None:
+    """Both ends of `top_p`'s range reach `inferenceConfig.topP`.
+
+    `0.0` used to be dropped by a truthiness check, which asks for greedy decoding and so left
+    sampling on instead. It is in range, not a sentinel: AWS declares `topP` with `min: 0, max: 1`
+    exactly like `temperature`, which the line above already checks against `None` for this reason.
+    `1.0` is here as the control — it passed before the fix too, so a failure on `0.0` alone points
+    at the guard rather than at `topP` mapping in general. Mid-range is covered by
+    `test_bedrock_model_top_p`.
+
+    No-network: the assertion is on the outgoing request shape, which a cassette matcher wouldn't pin.
+    """
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    agent = Agent(model, model_settings=ModelSettings(top_p=top_p))
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert kwargs['inferenceConfig']['topP'] == top_p
+
+
 async def test_bedrock_model_stream_empty_text_delta(allow_model_requests: None, bedrock_provider: BedrockProvider):
     model = BedrockConverseModel(model_name='openai.gpt-oss-120b-1:0', provider=bedrock_provider)
     agent = Agent(model)


### PR DESCRIPTION
Fixes #6863

Treat `top_p=0.0` as a valid Bedrock setting instead of dropping it through a truthiness check.

The regression test asserts only the outgoing `inferenceConfig.topP` value.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).