### PR TITLE
Don't write the default `User-Agent` into the caller's `extra_headers` dict

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -335,7 +335,9 @@ class GroqModel(Model[AsyncGroq]):
         ):  # pragma: no branch
             response_format = {'type': 'json_object'}
 
-        extra_headers = model_settings.get('extra_headers', {})
+        # Copied before `setdefault`: `extra_headers` is nested inside the settings dict, so the
+        # shallow merge in `merge_model_settings` hands us the caller's own object.
+        extra_headers = dict(model_settings.get('extra_headers', {}))
         extra_headers.setdefault('User-Agent', get_user_agent())
 
         # qwen3 truly disables reasoning by sending `reasoning_effort='none'` (in `extra_body`); `_translate_thinking`

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1072,7 +1072,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         with _map_api_errors(self.model_name):
             try:
-                extra_headers = model_settings.get('extra_headers', {})
+                # Copied before `setdefault`: `extra_headers` is nested inside the settings dict, so the
+                # shallow merge in `merge_model_settings` hands us the caller's own object.
+                extra_headers = dict(model_settings.get('extra_headers', {}))
                 extra_headers.setdefault('User-Agent', get_user_agent())
 
                 # OpenAI SDK type stubs incorrectly use 'in-memory' but API requires 'in_memory', so we have to use `Any` to not hit type errors

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -632,6 +632,31 @@ async def test_extra_headers(allow_model_requests: None, groq_api_key: str):
     await agent.run('hello')
 
 
+async def test_extra_headers_not_mutated_in_place(allow_model_requests: None):
+    """The default `User-Agent` is added to a copy, not to the caller's `extra_headers` dict.
+
+    `extra_headers` is nested inside the settings dict, so the shallow merge in
+    `merge_model_settings` hands the model the caller's own object — a `setdefault` on it wrote
+    `pydantic-ai/<version>` back into the user's dict, where an app that reuses those headers for
+    its own requests would then ship a `User-Agent` it never set.
+
+    Only the caller-side dict is asserted here, because `MockGroq` discards the outgoing kwargs.
+    That the default still reaches the wire is asserted in the parallel OpenAI test, whose mock
+    records them; the two providers build `extra_headers` with the same two lines.
+
+    A unit test rather than a VCR one: the assertion is on a caller-side object after the request,
+    which no recorded interaction can express.
+    """
+    c = completion_message(ChatCompletionMessage(content='hello', role='assistant'))
+    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=MockGroq.create_mock(c)))
+
+    caller_headers = {'X-Tenant': 'acme'}
+    agent = Agent(m, model_settings=GroqModelSettings(extra_headers=caller_headers))
+    await agent.run('hello')
+
+    assert caller_headers == {'X-Tenant': 'acme'}
+
+
 async def test_map_text_content_input(allow_model_requests: None, groq_api_key: str):
     part = UserPromptPart(
         content=[

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -2091,6 +2091,33 @@ async def test_extra_headers(allow_model_requests: None, openai_api_key: str):
     await agent.run('hello')
 
 
+async def test_extra_headers_not_mutated_in_place(allow_model_requests: None):
+    """The default `User-Agent` is added to a copy, not to the caller's `extra_headers` dict.
+
+    `extra_headers` is nested inside the settings dict, so the shallow merge in
+    `merge_model_settings` hands the model the caller's own object — a `setdefault` on it wrote
+    `pydantic-ai/<version>` back into the user's dict, where an app that reuses those headers for
+    its own requests would then ship a `User-Agent` it never set.
+
+    A unit test rather than a VCR one: the assertion is on a caller-side object after the request,
+    which no recorded interaction can express.
+    """
+    c = completion_message(ChatCompletionMessage(content='hello', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    caller_headers = {'X-Tenant': 'acme'}
+    agent = Agent(m, model_settings=OpenAIChatModelSettings(extra_headers=caller_headers))
+    await agent.run('hello')
+
+    assert caller_headers == {'X-Tenant': 'acme'}
+    # The default still reaches the wire, it's just written to the copy.
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['extra_headers'] == {
+        'X-Tenant': 'acme',
+        'User-Agent': IsStr(regex=r'pydantic-ai\/.*'),
+    }
+
+
 async def test_openai_store_false(allow_model_requests: None):
     """Test that openai_store=False is correctly passed to the OpenAI API."""
     c = completion_message(ChatCompletionMessage(content='hello', role='assistant'))


### PR DESCRIPTION
Fixes #6866

`extra_headers` is nested inside the settings dict, and `merge_model_settings` (`settings.py:344`) is a shallow merge — `base | overrides` aliases every value, and when only one side is set the caller's dict is returned outright. So the dict `OpenAIChatModel` and `GroqModel` received was the user's own object, and `setdefault('User-Agent', get_user_agent())` wrote `pydantic-ai/<version>` back into it.

That leaks when a caller shares one headers dict between Pydantic AI and their own HTTP client, which is a natural thing to do for tracing or tenancy headers: after the first agent run, the app's outbound requests carry a `User-Agent` it never set.

The fix is one `dict(...)` at each of the two sites, copying before `setdefault`. This is the pattern two neighbouring paths already use, so it makes them consistent rather than introducing anything new:

- `openai.py:2528` (`OpenAIResponsesModel._build_request_options`)
- `anthropic.py:879` (`AnthropicModel._get_betas_and_extra_headers`) — which then `.pop('anthropic-beta')`, so copying matters even more there

I checked the rest of the surface and left it alone: `google.py:892` already `update`s a fresh dict, and every `extra_body` site copies (`cerebras.py:151`, `openrouter.py:670`, `zai.py:162`, groq's fresh `merged_extra_body`, `anthropic.py:736`'s rebind). `_drop_unsupported_params`'s `.pop()` is also safe — I shared one settings dict between a Cerebras model (which drops the penalties) and an OpenAI model and confirmed `presence_penalty`/`frequency_penalty` still reached OpenAI, because the *outer* dict does get copied. The defect was narrowly the nested `extra_headers` object.

Tests: one per affected provider. Both are unit tests rather than VCR ones because the assertion is on a caller-side object after the request, which no recorded interaction can express. The OpenAI one also asserts the default still reaches the wire, so the fix can't be "fixed" by dropping the header; the Groq one asserts only the caller side because `MockGroq` discards outgoing kwargs, and widening that shared mock felt out of scope here.

Control: with the two `dict(...)` calls reverted and the tests kept, both fail with `AssertionError: assert {'User-Agent'...nant': 'acme'} == {'X-Tenant': 'acme'}`. With the fix, `tests/models/test_openai.py` is 222 passed and `tests/models/test_groq.py` is 38 passed locally.

### Checklist

- [x] I have added tests for the changes
- [x] I have run `make lint` and `make test` (ruff format/check and pyright clean on the changed files; the 16 pyright errors pyright reports in `groq.py` are pre-existing `NotGiven` vs `Omit` noise from a local `groq` newer than the pinned `0.25.0`, identical with and without this change)
- [x] I have updated the documentation if necessary (no user-facing behaviour change: the header still reaches the wire)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

