### PR TITLE
Preserve caller-owned OpenAI model settings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -482,6 +482,9 @@ def _drop_sampling_params_for_reasoning(
 ) -> None:
     """Drop sampling params when reasoning is enabled on models that support it.
 
+    Mutates `model_settings`, so callers must hand it a dict they own: `merge_model_settings` returns
+    the caller's own dict by identity when only one side is set.
+
     Reasoning models don't support sampling parameters while reasoning is active. For models that
     can turn reasoning off (`openai_supports_reasoning_effort_none`), sampling params are allowed
     when reasoning is off. Whether reasoning is on when no effort is set depends on the model's
@@ -518,6 +521,9 @@ def _drop_sampling_params_for_reasoning(
 
 def _drop_unsupported_params(profile: OpenAIModelProfile, model_settings: OpenAIChatModelSettings) -> None:
     """Drop unsupported parameters based on model profile.
+
+    Mutates `model_settings`, so callers must hand it a dict they own: `merge_model_settings` returns
+    the caller's own dict by identity when only one side is set.
 
     Used currently only by Cerebras
     """
@@ -1066,6 +1072,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         ):  # pragma: no branch
             response_format = {'type': 'json_object'}
 
+        # Copied because both helpers `pop` in place and `merge_model_settings` hands us the caller's
+        # own dict when only one of the model's and the run's settings is set.
+        model_settings = OpenAIChatModelSettings(**model_settings)
         _drop_sampling_params_for_reasoning(profile, model_settings, model_request_parameters)
 
         _drop_unsupported_params(profile, model_settings)
@@ -2563,6 +2572,9 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             model_request_parameters,
             profile,
         )
+        # Copied because both helpers `pop` in place and `merge_model_settings` hands us the caller's
+        # own dict when only one of the model's and the run's settings is set.
+        model_settings = OpenAIResponsesModelSettings(**model_settings)
         _drop_sampling_params_for_reasoning(profile, model_settings, model_request_parameters)
         _drop_unsupported_params(profile, model_settings)
         extra_headers, timeout = self._build_request_options(model_settings)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -482,8 +482,7 @@ def _drop_sampling_params_for_reasoning(
 ) -> None:
     """Drop sampling params when reasoning is enabled on models that support it.
 
-    Mutates `model_settings`, so callers must hand it a dict they own: `merge_model_settings` returns
-    the caller's own dict by identity when only one side is set.
+    Mutates `model_settings`.
 
     Reasoning models don't support sampling parameters while reasoning is active. For models that
     can turn reasoning off (`openai_supports_reasoning_effort_none`), sampling params are allowed
@@ -522,8 +521,7 @@ def _drop_sampling_params_for_reasoning(
 def _drop_unsupported_params(profile: OpenAIModelProfile, model_settings: OpenAIChatModelSettings) -> None:
     """Drop unsupported parameters based on model profile.
 
-    Mutates `model_settings`, so callers must hand it a dict they own: `merge_model_settings` returns
-    the caller's own dict by identity when only one side is set.
+    Mutates `model_settings`.
 
     Used currently only by Cerebras
     """
@@ -1072,8 +1070,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         ):  # pragma: no branch
             response_format = {'type': 'json_object'}
 
-        # Copied because both helpers `pop` in place and `merge_model_settings` hands us the caller's
-        # own dict when only one of the model's and the run's settings is set.
+        # Both helpers mutate the settings they receive.
         model_settings = OpenAIChatModelSettings(**model_settings)
         _drop_sampling_params_for_reasoning(profile, model_settings, model_request_parameters)
 
@@ -2572,8 +2569,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             model_request_parameters,
             profile,
         )
-        # Copied because both helpers `pop` in place and `merge_model_settings` hands us the caller's
-        # own dict when only one of the model's and the run's settings is set.
+        # Both helpers mutate the settings they receive.
         model_settings = OpenAIResponsesModelSettings(**model_settings)
         _drop_sampling_params_for_reasoning(profile, model_settings, model_request_parameters)
         _drop_unsupported_params(profile, model_settings)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4948,6 +4948,38 @@ async def test_openai_gpt_5_2_temperature_warns_when_reasoning_enabled(allow_mod
     assert 'temperature' not in get_mock_chat_completion_kwargs(mock_client)[0]
 
 
+async def test_sampling_params_dropped_for_reasoning_without_mutating_caller(allow_model_requests: None):
+    """Dropping the sampling params for a reasoning model doesn't empty the caller's settings dict.
+
+    `merge_model_settings` returns the caller's own dict by identity when only one of the model's and
+    the run's settings is set, so `_drop_sampling_params_for_reasoning`'s `pop` loop used to strip the
+    user's dict. Reusing it then silently lost the settings — with a reasoning and a non-reasoning
+    model sharing one dict, the second model's `temperature` was dropped too, which is exactly the
+    case `_drop_sampling_params_for_reasoning` is careful *not* to apply to.
+
+    A unit test rather than a VCR one: the assertions are on a caller-side object and on the request
+    a second model receives, neither of which a recorded interaction can express.
+    """
+    shared_settings = OpenAIChatModelSettings(temperature=0.5, top_p=0.9)
+
+    reasoning_client = MockOpenAI.create_mock(completion_message(ChatCompletionMessage(content='hi', role='assistant')))
+    reasoning_model = OpenAIChatModel('o3-mini', provider=OpenAIProvider(openai_client=reasoning_client))
+    with pytest.warns(UserWarning, match='Sampling parameters'):
+        await Agent(reasoning_model, model_settings=shared_settings).run('hello')
+
+    assert shared_settings == {'temperature': 0.5, 'top_p': 0.9}
+    # Still dropped from the request itself, which is the point of the helper.
+    assert 'temperature' not in get_mock_chat_completion_kwargs(reasoning_client)[0]
+
+    # The settings the reasoning model rejected still reach a model that accepts them.
+    chat_client = MockOpenAI.create_mock(completion_message(ChatCompletionMessage(content='hi', role='assistant')))
+    chat_model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=chat_client))
+    await Agent(chat_model, model_settings=shared_settings).run('hello')
+
+    chat_kwargs = get_mock_chat_completion_kwargs(chat_client)[0]
+    assert (chat_kwargs['temperature'], chat_kwargs['top_p']) == (0.5, 0.9)
+
+
 async def test_openai_model_cerebras_provider(allow_model_requests: None, cerebras_api_key: str):
     m = OpenAIChatModel('llama3.3-70b', provider=CerebrasProvider(api_key=cerebras_api_key))
     agent = Agent(m)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4948,18 +4948,7 @@ async def test_openai_gpt_5_2_temperature_warns_when_reasoning_enabled(allow_mod
     assert 'temperature' not in get_mock_chat_completion_kwargs(mock_client)[0]
 
 
-async def test_sampling_params_dropped_for_reasoning_without_mutating_caller(allow_model_requests: None):
-    """Dropping the sampling params for a reasoning model doesn't empty the caller's settings dict.
-
-    `merge_model_settings` returns the caller's own dict by identity when only one of the model's and
-    the run's settings is set, so `_drop_sampling_params_for_reasoning`'s `pop` loop used to strip the
-    user's dict. Reusing it then silently lost the settings — with a reasoning and a non-reasoning
-    model sharing one dict, the second model's `temperature` was dropped too, which is exactly the
-    case `_drop_sampling_params_for_reasoning` is careful *not* to apply to.
-
-    A unit test rather than a VCR one: the assertions are on a caller-side object and on the request
-    a second model receives, neither of which a recorded interaction can express.
-    """
+async def test_reasoning_model_does_not_mutate_caller_settings(allow_model_requests: None):
     shared_settings = OpenAIChatModelSettings(temperature=0.5, top_p=0.9)
 
     reasoning_client = MockOpenAI.create_mock(completion_message(ChatCompletionMessage(content='hi', role='assistant')))
@@ -4968,16 +4957,6 @@ async def test_sampling_params_dropped_for_reasoning_without_mutating_caller(all
         await Agent(reasoning_model, model_settings=shared_settings).run('hello')
 
     assert shared_settings == {'temperature': 0.5, 'top_p': 0.9}
-    # Still dropped from the request itself, which is the point of the helper.
-    assert 'temperature' not in get_mock_chat_completion_kwargs(reasoning_client)[0]
-
-    # The settings the reasoning model rejected still reach a model that accepts them.
-    chat_client = MockOpenAI.create_mock(completion_message(ChatCompletionMessage(content='hi', role='assistant')))
-    chat_model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=chat_client))
-    await Agent(chat_model, model_settings=shared_settings).run('hello')
-
-    chat_kwargs = get_mock_chat_completion_kwargs(chat_client)[0]
-    assert (chat_kwargs['temperature'], chat_kwargs['top_p']) == (0.5, 0.9)
 
 
 async def test_openai_model_cerebras_provider(allow_model_requests: None, cerebras_api_key: str):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -2761,16 +2761,6 @@ async def test_reasoning_model_with_temperature(allow_model_requests: None, open
 
 
 async def test_reasoning_model_with_temperature_does_not_mutate_caller_settings(allow_model_requests: None):
-    """Dropping the sampling params for a reasoning model doesn't empty the caller's settings dict.
-
-    The Responses path drops them with the same two helpers as the Chat Completions path, and
-    `merge_model_settings` hands both the caller's own dict by identity when only one of the model's
-    and the run's settings is set — so the `pop` loop used to strip the user's dict. See
-    `test_sampling_params_dropped_for_reasoning_without_mutating_caller` in `test_openai.py`.
-
-    A unit test rather than a VCR one: the assertion is on a caller-side object after the request,
-    which no recorded interaction can express.
-    """
     c = response_message(
         [
             ResponseOutputMessage(
@@ -2790,8 +2780,6 @@ async def test_reasoning_model_with_temperature_does_not_mutate_caller_settings(
         await Agent(model, model_settings=settings).run('What is the capital of Mexico?')
 
     assert settings == {'temperature': 0.5, 'top_p': 0.9}
-    # Still dropped from the request itself, which is the point of the helper.
-    assert 'temperature' not in get_mock_responses_kwargs(mock_client)[0]
 
 
 async def test_gpt5_pro(allow_model_requests: None, openai_api_key: str):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -2760,6 +2760,40 @@ async def test_reasoning_model_with_temperature(allow_model_requests: None, open
     )
 
 
+async def test_reasoning_model_with_temperature_does_not_mutate_caller_settings(allow_model_requests: None):
+    """Dropping the sampling params for a reasoning model doesn't empty the caller's settings dict.
+
+    The Responses path drops them with the same two helpers as the Chat Completions path, and
+    `merge_model_settings` hands both the caller's own dict by identity when only one of the model's
+    and the run's settings is set — so the `pop` loop used to strip the user's dict. See
+    `test_sampling_params_dropped_for_reasoning_without_mutating_caller` in `test_openai.py`.
+
+    A unit test rather than a VCR one: the assertion is on a caller-side object after the request,
+    which no recorded interaction can express.
+    """
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('o3-mini', provider=OpenAIProvider(openai_client=mock_client))
+
+    settings = OpenAIResponsesModelSettings(temperature=0.5, top_p=0.9)
+    with pytest.warns(UserWarning, match='Sampling parameters'):
+        await Agent(model, model_settings=settings).run('What is the capital of Mexico?')
+
+    assert settings == {'temperature': 0.5, 'top_p': 0.9}
+    # Still dropped from the request itself, which is the point of the helper.
+    assert 'temperature' not in get_mock_responses_kwargs(mock_client)[0]
+
+
 async def test_gpt5_pro(allow_model_requests: None, openai_api_key: str):
     m = OpenAIResponsesModel('gpt-5-pro', provider=OpenAIProvider(api_key=openai_api_key))
     agent = Agent(m)


### PR DESCRIPTION
Fixes #6869

Copy prepared settings before removing unsupported sampling parameters in the OpenAI Chat Completions and Responses paths. Caller-owned dictionaries remain unchanged.

One focused regression test covers each API path.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).