### PR TITLE
Filter unavailable names from Google `allowed_function_names`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -726,10 +726,7 @@ class GoogleModel(Model[Client]):
                 # Breaks caching, but Google doesn't support AUTO mode with allowed_function_names
                 tool_defs = {k: v for k, v in tool_defs.items() if k in tool_names}
             else:
-                # Use ANY mode with allowed_function_names to force one of the specified tools.
-                # Ordered by `tool_defs` rather than by iterating `tool_names`, because that is a `set`
-                # and its iteration order for strings varies between processes, which would make the
-                # outgoing request differ run to run for the same agent.
+                # Preserve tool definition order; `tool_names` is a set.
                 allowed_function_names = [name for name in tool_defs if name in tool_names]
         else:
             tool_choice_mode = resolved_tool_choice

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -726,8 +726,11 @@ class GoogleModel(Model[Client]):
                 # Breaks caching, but Google doesn't support AUTO mode with allowed_function_names
                 tool_defs = {k: v for k, v in tool_defs.items() if k in tool_names}
             else:
-                # Use ANY mode with allowed_function_names to force one of the specified tools
-                allowed_function_names = list(tool_names)
+                # Use ANY mode with allowed_function_names to force one of the specified tools.
+                # Ordered by `tool_defs` rather than by iterating `tool_names`, because that is a `set`
+                # and its iteration order for strings varies between processes, which would make the
+                # outgoing request differ run to run for the same agent.
+                allowed_function_names = [name for name in tool_defs if name in tool_names]
         else:
             tool_choice_mode = resolved_tool_choice
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -726,7 +726,7 @@ class GoogleModel(Model[Client]):
                 # Breaks caching, but Google doesn't support AUTO mode with allowed_function_names
                 tool_defs = {k: v for k, v in tool_defs.items() if k in tool_names}
             else:
-                # Preserve tool definition order; `tool_names` is a set.
+                # Ignore names that are not currently available.
                 allowed_function_names = [name for name in tool_defs if name in tool_names]
         else:
             tool_choice_mode = resolved_tool_choice

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -616,23 +616,6 @@ def test_google_auto_tuple_filters_tool_defs():
 
 
 @skip_if_no_google
-def test_google_allowed_function_names_follow_tool_defs_order():
-    m = GoogleModel('gemini-2.0-flash', provider=GoogleProvider(client=MagicMock()))
-    names = ['get_weather', 'get_time', 'get_user', 'roll_dice']
-    params = ModelRequestParameters(
-        function_tools=[make_tool(name) for name in names],
-        allow_text_output=False,
-    )
-
-    _, tool_config, _ = m._get_tool_config(params, {'tool_choice': names[:3]})  # pyright: ignore[reportPrivateUsage]
-
-    assert tool_config is not None
-    config = tool_config['function_calling_config']  # pyright: ignore[reportTypedDictNotRequiredAccess]
-    assert config is not None
-    assert config['allowed_function_names'] == names[:3]  # pyright: ignore[reportTypedDictNotRequiredAccess]
-
-
-@skip_if_no_google
 def test_google_allowed_function_names_ignore_unavailable_tools():
     m = GoogleModel('gemini-2.0-flash', provider=GoogleProvider(client=MagicMock()))
     params = ModelRequestParameters(function_tools=[make_tool('get_time')], allow_text_output=False)

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -617,37 +617,33 @@ def test_google_auto_tuple_filters_tool_defs():
 
 @skip_if_no_google
 def test_google_allowed_function_names_follow_tool_defs_order():
-    """`allowed_function_names` follows the declared tool order, and only contains available tools.
-
-    `resolve_tool_choice` returns the names as a `set`, whose iteration order for strings varies
-    between processes, so building the list by iterating it made the outgoing request differ from
-    run to run for the same agent. Ordering by `tool_defs` also drops names that aren't available,
-    which is what `_check_invalid_tools` warns it will do — iterating the set sent them to Gemini.
-    """
     m = GoogleModel('gemini-2.0-flash', provider=GoogleProvider(client=MagicMock()))
-    names = ['get_weather', 'get_time', 'get_user', 'roll_dice', 'get_location']
+    names = ['get_weather', 'get_time', 'get_user', 'roll_dice']
     params = ModelRequestParameters(
         function_tools=[make_tool(name) for name in names],
         allow_text_output=False,
     )
 
-    _, tool_config, _ = m._get_tool_config(params, {'tool_choice': names[:4]})  # pyright: ignore[reportPrivateUsage]
+    _, tool_config, _ = m._get_tool_config(params, {'tool_choice': names[:3]})  # pyright: ignore[reportPrivateUsage]
 
     assert tool_config is not None
     config = tool_config['function_calling_config']  # pyright: ignore[reportTypedDictNotRequiredAccess]
     assert config is not None
-    assert config['mode'].name == 'ANY'  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess]
-    # A list, not a set: the order itself is what's asserted.
-    assert config['allowed_function_names'] == names[:4]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert config['allowed_function_names'] == names[:3]  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
-    # A name that isn't available only warns; it must not reach the request.
+
+@skip_if_no_google
+def test_google_allowed_function_names_ignore_unavailable_tools():
+    m = GoogleModel('gemini-2.0-flash', provider=GoogleProvider(client=MagicMock()))
+    params = ModelRequestParameters(function_tools=[make_tool('get_time')], allow_text_output=False)
+
     with pytest.warns(UserWarning, match='not currently available'):
-        _, typo_config, _ = m._get_tool_config(params, {'tool_choice': ['get_time', 'nonexistent']})  # pyright: ignore[reportPrivateUsage]
+        _, tool_config, _ = m._get_tool_config(params, {'tool_choice': ['get_time', 'missing']})  # pyright: ignore[reportPrivateUsage]
 
-    assert typo_config is not None
-    typo_fcc = typo_config['function_calling_config']  # pyright: ignore[reportTypedDictNotRequiredAccess]
-    assert typo_fcc is not None
-    assert typo_fcc['allowed_function_names'] == ['get_time']  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert tool_config is not None
+    config = tool_config['function_calling_config']  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert config is not None
+    assert config['allowed_function_names'] == ['get_time']  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 NATIVE_TOOL_CONFIG_CASES = [

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -615,6 +615,41 @@ def test_google_auto_tuple_filters_tool_defs():
     assert tool_config['function_calling_config']['mode'].name == 'AUTO'  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess,reportOptionalSubscript,reportUnknownMemberType]
 
 
+@skip_if_no_google
+def test_google_allowed_function_names_follow_tool_defs_order():
+    """`allowed_function_names` follows the declared tool order, and only contains available tools.
+
+    `resolve_tool_choice` returns the names as a `set`, whose iteration order for strings varies
+    between processes, so building the list by iterating it made the outgoing request differ from
+    run to run for the same agent. Ordering by `tool_defs` also drops names that aren't available,
+    which is what `_check_invalid_tools` warns it will do — iterating the set sent them to Gemini.
+    """
+    m = GoogleModel('gemini-2.0-flash', provider=GoogleProvider(client=MagicMock()))
+    names = ['get_weather', 'get_time', 'get_user', 'roll_dice', 'get_location']
+    params = ModelRequestParameters(
+        function_tools=[make_tool(name) for name in names],
+        allow_text_output=False,
+    )
+
+    _, tool_config, _ = m._get_tool_config(params, {'tool_choice': names[:4]})  # pyright: ignore[reportPrivateUsage]
+
+    assert tool_config is not None
+    config = tool_config['function_calling_config']  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert config is not None
+    assert config['mode'].name == 'ANY'  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess]
+    # A list, not a set: the order itself is what's asserted.
+    assert config['allowed_function_names'] == names[:4]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+    # A name that isn't available only warns; it must not reach the request.
+    with pytest.warns(UserWarning, match='not currently available'):
+        _, typo_config, _ = m._get_tool_config(params, {'tool_choice': ['get_time', 'nonexistent']})  # pyright: ignore[reportPrivateUsage]
+
+    assert typo_config is not None
+    typo_fcc = typo_config['function_calling_config']  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert typo_fcc is not None
+    assert typo_fcc['allowed_function_names'] == ['get_time']  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+
 NATIVE_TOOL_CONFIG_CASES = [
     dict(
         id='native-only-pre-gemini-3-omits-config',


### PR DESCRIPTION
Fixes #6874

Filter Google `allowed_function_names` through the available tool definitions, matching the existing warning that unavailable choices will be ignored.

The focused regression test covers only that filtering contract; definition order is not treated as a provider semantic.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).