### PR TITLE
Validate `bedrock_max_concurrency` instead of deadlocking on `0`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
@@ -197,7 +197,7 @@ class BedrockEmbeddingSettings(EmbeddingSettings, total=False):
     `amazon.nova-2-multimodal-embeddings-v1:0`
 
     When embedding multiple texts with models that only support single-text requests,
-    this controls how many requests run in parallel. Defaults to 5. Must be >= 1.
+    this controls how many requests run in parallel. Defaults to 5 and must be at least 1.
     """
 
 
@@ -613,9 +613,6 @@ class BedrockEmbeddingModel(EmbeddingModel):
     ) -> EmbeddingResult:
         """Embed inputs concurrently with controlled parallelism and combine results."""
         max_concurrency = settings.get('bedrock_max_concurrency', 5)
-        # Validated rather than passed straight to `anyio.Semaphore`, which accepts `0` and then blocks
-        # forever on the first acquire, and reports a negative value as a bare `ValueError`. Mirrors
-        # `concurrency._validate_max_running`, which rejects the same range for `ConcurrencyLimiter`.
         if max_concurrency < 1:
             raise UserError(f'bedrock_max_concurrency must be >= 1, got {max_concurrency}.')
         semaphore = anyio.Semaphore(max_concurrency)

--- a/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
@@ -197,7 +197,7 @@ class BedrockEmbeddingSettings(EmbeddingSettings, total=False):
     `amazon.nova-2-multimodal-embeddings-v1:0`
 
     When embedding multiple texts with models that only support single-text requests,
-    this controls how many requests run in parallel. Defaults to 5.
+    this controls how many requests run in parallel. Defaults to 5. Must be >= 1.
     """
 
 
@@ -613,6 +613,11 @@ class BedrockEmbeddingModel(EmbeddingModel):
     ) -> EmbeddingResult:
         """Embed inputs concurrently with controlled parallelism and combine results."""
         max_concurrency = settings.get('bedrock_max_concurrency', 5)
+        # Validated rather than passed straight to `anyio.Semaphore`, which accepts `0` and then blocks
+        # forever on the first acquire, and reports a negative value as a bare `ValueError`. Mirrors
+        # `concurrency._validate_max_running`, which rejects the same range for `ConcurrencyLimiter`.
+        if max_concurrency < 1:
+            raise UserError(f'bedrock_max_concurrency must be >= 1, got {max_concurrency}.')
         semaphore = anyio.Semaphore(max_concurrency)
 
         results: list[tuple[Sequence[float], int]] = [None] * len(inputs)  # type: ignore[list-item]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -849,6 +849,25 @@ class TestBedrock:
             )
         )
 
+    @pytest.mark.parametrize('max_concurrency', [0, -1])
+    async def test_titan_v2_rejects_non_positive_max_concurrency(
+        self, bedrock_provider: BedrockProvider, max_concurrency: int
+    ):
+        """A non-positive `bedrock_max_concurrency` raises instead of hanging or leaking a `ValueError`.
+
+        `anyio.Semaphore(0)` constructs fine and then blocks forever on the first acquire, so `0` used
+        to deadlock the embed call with no request ever sent; a negative value surfaced anyio's bare
+        `ValueError`. `ConcurrencyLimiter` rejects the same range with a `UserError`.
+
+        No cassette: the error is raised before any request, and the single-text path isn't reached
+        because only multiple inputs go through `_embed_concurrent`.
+        """
+        model = BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', provider=bedrock_provider)
+        embedder = Embedder(model, settings=BedrockEmbeddingSettings(bedrock_max_concurrency=max_concurrency))
+
+        with pytest.raises(UserError, match=f'bedrock_max_concurrency must be >= 1, got {max_concurrency}'):
+            await embedder.embed_documents(['hello', 'world'])
+
     async def test_cohere_v3_minimal(self, bedrock_provider: BedrockProvider):
         """Test Cohere V3 with default settings (1024 dimensions, truncate=NONE)."""
         model = BedrockEmbeddingModel('cohere.embed-english-v3', provider=bedrock_provider)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
+import anyio
 import httpx
 import pytest
 from pytest_mock import MockerFixture
@@ -850,23 +851,17 @@ class TestBedrock:
         )
 
     @pytest.mark.parametrize('max_concurrency', [0, -1])
-    async def test_titan_v2_rejects_non_positive_max_concurrency(
+    async def test_titan_v2_rejects_invalid_max_concurrency(
         self, bedrock_provider: BedrockProvider, max_concurrency: int
     ):
-        """A non-positive `bedrock_max_concurrency` raises instead of hanging or leaking a `ValueError`.
-
-        `anyio.Semaphore(0)` constructs fine and then blocks forever on the first acquire, so `0` used
-        to deadlock the embed call with no request ever sent; a negative value surfaced anyio's bare
-        `ValueError`. `ConcurrencyLimiter` rejects the same range with a `UserError`.
-
-        No cassette: the error is raised before any request, and the single-text path isn't reached
-        because only multiple inputs go through `_embed_concurrent`.
-        """
         model = BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', provider=bedrock_provider)
         embedder = Embedder(model, settings=BedrockEmbeddingSettings(bedrock_max_concurrency=max_concurrency))
 
-        with pytest.raises(UserError, match=f'bedrock_max_concurrency must be >= 1, got {max_concurrency}'):
-            await embedder.embed_documents(['hello', 'world'])
+        with (
+            anyio.fail_after(1),
+            pytest.raises(UserError, match=f'bedrock_max_concurrency must be >= 1, got {max_concurrency}'),
+        ):
+            await embedder.embed_query('hello')
 
     async def test_cohere_v3_minimal(self, bedrock_provider: BedrockProvider):
         """Test Cohere V3 with default settings (1024 dimensions, truncate=NONE)."""


### PR DESCRIPTION
Fixes #6877.

## Summary

`bedrock_max_concurrency=0` constructed an `anyio.Semaphore(0)` and blocked the first Bedrock embedding request forever. Negative values surfaced AnyIO's internal validation error.

The concurrent Bedrock embedding path now requires a value of at least `1` and raises Pydantic AI's `UserError`, matching the existing agent-level concurrency contract. The setting documentation states the minimum.

## Scope

Only the path used for Bedrock models that accept one text per request is changed. Batch-capable models do not construct this semaphore. Titan's single-query API still uses this path, so the regression test exercises one real query and bounds it with a one-second fail-safe to prove that zero no longer deadlocks.

## Test plan

- [x] zero and negative values raise the documented `UserError`
- [x] the regression is exercised through `Embedder.embed_query()`
- [x] 44 focused Bedrock embedding tests
- [x] changed-file Ruff formatting/lint and Pyright

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
