### PR TITLE
Compare origins, not hostnames, when stripping sensitive redirect headers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -117,6 +117,7 @@ _CLOUD_METADATA_IPV6: frozenset[ipaddress.IPv6Address] = frozenset(
 _MAX_REDIRECTS = 10
 _DEFAULT_TIMEOUT = 30  # seconds
 _SENSITIVE_HEADERS = frozenset(('authorization', 'cookie', 'proxy-authorization'))
+_DEFAULT_PORTS = {'http': 80, 'https': 443}
 
 
 @dataclass
@@ -419,6 +420,32 @@ def resolve_redirect_url(current_url: str, location: str) -> str:
         return urlunparse((parsed_current.scheme, parsed_current.netloc, f'{base_path}/{location}', '', '', ''))
 
 
+def _origin(url: str) -> tuple[str, str | None, int | None]:
+    """Return the (scheme, host, port) origin of a URL, with the default port made explicit.
+
+    Comparing origins rather than bare hostnames matters for the sensitive-header check: a
+    same-host redirect can still change scheme or port, e.g. an `https://` page redirecting
+    to `http://` puts an `Authorization` header on the wire in plaintext.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    port = parsed.port if parsed.port is not None else _DEFAULT_PORTS.get(scheme)
+    return scheme, parsed.hostname, port
+
+
+def _is_https_upgrade(from_url: str, to_url: str) -> bool:
+    """Whether `to_url` is the plain HTTPS upgrade of `from_url`, i.e. only the scheme got safer.
+
+    Matches httpx's own carve-out: redirecting `http://host` to `https://host` moves the
+    request onto a more secure channel, so keeping the sensitive headers is not a downgrade.
+    """
+    from_scheme, from_host, from_port = _origin(from_url)
+    to_scheme, to_host, to_port = _origin(to_url)
+    return (
+        from_host == to_host and from_scheme == 'http' and from_port == 80 and to_scheme == 'https' and to_port == 443
+    )
+
+
 def _check_domain(hostname: str, *, allowed_domains: list[str] | None, blocked_domains: list[str] | None) -> None:
     """Validate a hostname against allowed/blocked domain lists.
 
@@ -475,7 +502,6 @@ async def safe_download(
     """
     current_url = url
     redirects_followed = 0
-    original_hostname = urlparse(url).hostname
     effective_headers: dict[str, str] = dict(headers) if headers else {}
 
     async with create_async_http_client(timeout=timeout) as client:
@@ -517,11 +543,16 @@ async def safe_download(
                 if not location:
                     raise ValueError('Redirect response missing Location header')
 
+                previous_url = current_url
                 current_url = resolve_redirect_url(current_url, location)
 
-                # Strip sensitive headers on cross-origin redirects (RFC 7235)
-                redirect_hostname = urlparse(current_url).hostname
-                if redirect_hostname != original_hostname:
+                # Strip sensitive headers on cross-origin redirects (RFC 7235). The comparison is
+                # by origin, not just hostname: a same-host redirect can still downgrade `https` to
+                # `http`, putting an `Authorization` header on the wire in plaintext, or change the
+                # port and hand it to a different service. An HTTPS upgrade is exempt, as in httpx,
+                # because it only makes the channel safer. Compared against the previous hop, which
+                # is the origin the headers were last entrusted to.
+                if _origin(current_url) != _origin(previous_url) and not _is_https_upgrade(previous_url, current_url):
                     effective_headers = {
                         k: v for k, v in effective_headers.items() if k.lower() not in _SENSITIVE_HEADERS
                     }

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -748,6 +748,65 @@ class TestSafeDownload:
         with pytest.raises(ValueError, match='Access to private/internal IP address'):
             await safe_download('https://example.com/file.txt')
 
+    @pytest.mark.parametrize(
+        'start_url,location,expect_kept',
+        [
+            # Same origin: the headers stay, otherwise following a redirect within one site
+            # would silently drop the caller's credentials.
+            pytest.param('https://example.com/file.txt', '/other.txt', True, id='same-origin-path'),
+            # HTTPS upgrade only makes the channel safer, so it is exempt (as in httpx).
+            pytest.param('http://example.com/file.txt', 'https://example.com/file.txt', True, id='https-upgrade'),
+            # Same host, but `https` -> `http` would put the credentials on the wire in plaintext.
+            pytest.param('https://example.com/file.txt', 'http://example.com/file.txt', False, id='https-downgrade'),
+            # Same host and scheme, different port: a different service.
+            pytest.param('https://example.com/file.txt', 'https://example.com:8443/x', False, id='different-port'),
+            # Different host, the case that was already covered.
+            pytest.param('https://example.com/file.txt', 'https://evil.com/x', False, id='different-host'),
+        ],
+    )
+    async def test_sensitive_headers_stripped_by_origin_not_hostname(
+        self,
+        mock_dns: AsyncMock,
+        mock_ssrf_client: MagicMock,
+        start_url: str,
+        location: str,
+        expect_kept: bool,
+    ) -> None:
+        """Sensitive headers survive a redirect only within the same origin.
+
+        Comparing hostnames alone kept `Authorization` across an `https` -> `http` redirect to the
+        same host, sending the credential in plaintext, and across a port change, handing it to a
+        different service. `_SENSITIVE_HEADERS` had no coverage at all, so neither leak was caught.
+        """
+        redirect_response = AsyncMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {'location': location}
+
+        final_response = AsyncMock()
+        final_response.is_redirect = False
+        final_response.raise_for_status = lambda: None
+
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [redirect_response, final_response]
+        mock_ssrf_client.return_value = mock_client
+
+        await safe_download(
+            start_url,
+            headers={'Authorization': 'Bearer secret', 'Cookie': 'session=abc', 'Accept': 'text/html'},
+        )
+
+        second_call_headers = mock_client.get.call_args_list[1][1]['headers']
+        if expect_kept:
+            assert second_call_headers['Authorization'] == 'Bearer secret'
+            assert second_call_headers['Cookie'] == 'session=abc'
+        else:
+            assert 'Authorization' not in second_call_headers
+            assert 'Cookie' not in second_call_headers
+        # Non-sensitive headers are never dropped.
+        assert second_call_headers['Accept'] == 'text/html'
+
     async def test_http_no_sni_extension(self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock) -> None:
         mock_response = AsyncMock()
         mock_response.is_redirect = False


### PR DESCRIPTION
Fixes #6879

`safe_download` follows redirects itself (`follow_redirects=False`) so it can re-validate each hop, and strips `Authorization`/`Cookie`/`Proxy-Authorization` when the redirect leaves the origin. The check compared only the hostname:

```python
redirect_hostname = urlparse(current_url).hostname
if redirect_hostname != original_hostname:
```

An origin is scheme + host + port, so two same-host redirects kept the credentials:

- `https://example.com` -> `http://example.com` sent the bearer token over **plaintext**.
- `https://example.com` -> `https://example.com:8443` handed it to a different service.

httpx's own `_redirect_headers` compares full origins via `_same_origin` and pops `Authorization` in both cases, with an explicit carve-out for the plain HTTP -> HTTPS *upgrade* (`_is_https_redirect`) because that only makes the channel safer. This mirrors that behaviour.

Two smaller points:

- The comparison is now against the **previous hop** rather than the original URL. That was already safe, since stripping is monotonic — once dropped, headers stay dropped — but the previous hop is the origin the headers were actually entrusted to, so it's what the rule means.
- `_SENSITIVE_HEADERS` had **no test coverage at all**, which is why neither leak was caught. The new parametrized test pins all five cases: same-origin path and HTTPS upgrade keep the headers; downgrade, port change, and host change drop them. It also asserts a non-sensitive header (`Accept`) is never dropped.

Verified the control: with the source change reverted and the test kept, exactly the two new cases fail (`https-downgrade`, `different-port`) and the three pre-existing behaviours pass either way. `_ssrf.py` coverage is 99.23% with the same two lines uncovered as on `main` (`build_url_with_ip`'s `except ValueError`) — the new lines are fully covered.

### Checklist

- [x] I have added tests for the changes
- [x] The new behaviour matches httpx's documented redirect semantics
- [x] `make lint` and `make typecheck` pass


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

