### PR TITLE
Raise ModelAPIError for OpenRouter responses with null choices and no error envelope

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Discriminator, ValidationError, field_validator
 from typing_extensions import TypedDict, assert_never, override
 
 from .. import usage
-from ..exceptions import ModelHTTPError, UserError
+from ..exceptions import ModelAPIError, ModelHTTPError, UserError
 from ..messages import (
     BinaryContent,
     CachePoint,
@@ -1030,15 +1030,15 @@ class OpenRouterModel(OpenAIChatModel):
                     and not isinstance(response_dict.get('provider'), dict)
                 ):
                     # A null-`choices` body with no error envelope and no nested-provider
-                    # payload is a transient provider hiccup, not a malformed request:
-                    # surface it as a retryable upstream error rather than a bare
-                    # ValidationError. A `provider` dict that failed to validate above is
-                    # excluded on purpose — that body tried to be a nested-provider
-                    # response and was malformed, which must stay fatal.
-                    raise ModelHTTPError(
-                        status_code=502,
+                    # payload is a transient provider hiccup, not a malformed request.
+                    # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so this
+                    # reaches retry/fallback machinery that a bare `ValidationError` never
+                    # did. A `provider` dict that failed to validate above is excluded on
+                    # purpose — that body tried to be a nested-provider response and was
+                    # malformed, which must stay fatal.
+                    raise ModelAPIError(
                         model_name=response_dict.get('model') or self.model_name,
-                        body='OpenRouter returned a response with null `choices` and no error envelope',
+                        message='OpenRouter returned a response with null `choices` and no error envelope',
                     ) from exc
                 raise exc
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1024,10 +1024,17 @@ class OpenRouterModel(OpenAIChatModel):
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
-                if response_dict.get('choices') is None and response_dict.get('error') is None:
-                    # A null-`choices` body with no error envelope at all is a transient
-                    # provider hiccup, not a malformed request: surface it as a retryable
-                    # upstream error rather than a bare ValidationError.
+                if (
+                    response_dict.get('choices') is None
+                    and response_dict.get('error') is None
+                    and not isinstance(response_dict.get('provider'), dict)
+                ):
+                    # A null-`choices` body with no error envelope and no nested-provider
+                    # payload is a transient provider hiccup, not a malformed request:
+                    # surface it as a retryable upstream error rather than a bare
+                    # ValidationError. A `provider` dict that failed to validate above is
+                    # excluded on purpose — that body tried to be a nested-provider
+                    # response and was malformed, which must stay fatal.
                     raise ModelHTTPError(
                         status_code=502,
                         model_name=response_dict.get('model') or self.model_name,

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1024,6 +1024,15 @@ class OpenRouterModel(OpenAIChatModel):
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
+                if response_dict.get('choices') is None and response_dict.get('error') is None:
+                    # A null-`choices` body with no error envelope at all is a transient
+                    # provider hiccup, not a malformed request: surface it as a retryable
+                    # upstream error rather than a bare ValidationError.
+                    raise ModelHTTPError(
+                        status_code=502,
+                        model_name=response_dict.get('model') or self.model_name,
+                        body='OpenRouter returned a response with null `choices` and no error envelope',
+                    ) from exc
                 raise exc
 
             validated = nested.provider

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -588,6 +588,25 @@ class _OpenRouterErrorResponse(BaseModel, extra='allow'):
     model: str | None = None
 
 
+class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
+    """OpenRouter response that carries no completion at all: `choices` is null and there is no error envelope.
+
+    A sibling of `_OpenRouterErrorResponse` — the same family of bodies OpenRouter
+    returns when a downstream provider hiccups, minus the error envelope. Modelling it
+    keeps a `ValidationError` from `_OpenRouterChatCompletion` meaning "a shape we do not
+    account for" rather than doubling as a transient signal.
+
+    `provider` is typed `str | None` on purpose: a body whose `provider` is a *dict* is a
+    malformed nested-provider response, not this shape, so it fails validation here and
+    stays fatal.
+    """
+
+    choices: None
+    error: None = None
+    provider: str | None = None
+    model: str | None = None
+
+
 class _OpenRouterNestedCompletion(_OpenRouterChatCompletion):
     """Completion nested in the `provider` field where provider name may be null (see https://github.com/pydantic/pydantic-ai/issues/3994)."""
 
@@ -1024,23 +1043,19 @@ class OpenRouterModel(OpenAIChatModel):
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
-                if (
-                    response_dict.get('choices') is None
-                    and response_dict.get('error') is None
-                    and not isinstance(response_dict.get('provider'), dict)
-                ):
-                    # A null-`choices` body with no error envelope and no nested-provider
-                    # payload is a transient provider hiccup, not a malformed request.
-                    # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so this
-                    # reaches retry/fallback machinery that a bare `ValidationError` never
-                    # did. A `provider` dict that failed to validate above is excluded on
-                    # purpose — that body tried to be a nested-provider response and was
-                    # malformed, which must stay fatal.
+                try:
+                    no_completion = _OpenRouterNoCompletionResponse.model_validate(response_dict)
+                except ValidationError:
+                    raise exc
+                else:
+                    # A body with no completion and no error envelope is a transient
+                    # provider hiccup, not a malformed request. `ModelAPIError` is
+                    # `FallbackModel`'s default `fallback_on`, so this reaches retry and
+                    # fallback machinery that a bare `ValidationError` never did.
                     raise ModelAPIError(
-                        model_name=response_dict.get('model') or self.model_name,
+                        model_name=no_completion.model or self.model_name,
                         message='OpenRouter returned a response with null `choices` and no error envelope',
                     ) from exc
-                raise exc
 
             validated = nested.provider
             if not validated.created:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1374,6 +1374,33 @@ def test_openrouter_malformed_error_fallthrough() -> None:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
 
+def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
+    """A null-`choices` body with no error envelope raises a retryable ModelHTTPError(502).
+
+    OpenRouter intermittently returns `{"choices": null, ...}` with no error field at
+    all (a provider hiccup). Re-raising the bare ValidationError makes retry layers
+    that classify on exception type treat a transient as fatal.
+    """
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+    )
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+    assert exc_info.value.status_code == 502
+    assert 'null `choices`' in str(exc_info.value)
+
+
 def test_openrouter_error_with_metadata() -> None:
     """Real-world error response with metadata field from #3994.
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -12,6 +12,7 @@ from pydantic_ai import (
     Agent,
     BinaryContent,
     DocumentUrl,
+    ModelAPIError,
     ModelHTTPError,
     ModelMessage,
     ModelRequest,
@@ -1394,10 +1395,10 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
         usage=None,
     )
 
-    with pytest.raises(ModelHTTPError) as exc_info:
+    with pytest.raises(ModelAPIError) as exc_info:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
-    assert exc_info.value.status_code == 502
+    assert not isinstance(exc_info.value, ModelHTTPError)  # not a faked HTTP status
     assert 'null `choices`' in str(exc_info.value)
 
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1401,6 +1401,30 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
     assert 'null `choices`' in str(exc_info.value)
 
 
+def test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal() -> None:
+    """A malformed nested-provider body is NOT the transient shape.
+
+    `choices=None` with no error envelope but a `provider` dict means the body
+    tried to be a nested-provider response and failed to validate. Retrying that
+    forever would mask a real contract break, so it stays fatal — only the
+    envelope-less, provider-less shape becomes a retryable 502.
+    """
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={'some_key': 'some_value'},
+        created=1234567890,
+    )
+
+    with pytest.raises(UnexpectedModelBehavior):
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+
 def test_openrouter_error_with_metadata() -> None:
     """Real-world error response with metadata field from #3994.
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1403,12 +1403,13 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
 
 
 def test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal() -> None:
-    """A malformed nested-provider body is NOT the transient shape.
+    """A malformed nested-provider body is NOT the no-completion shape.
 
-    `choices=None` with no error envelope but a `provider` dict means the body
-    tried to be a nested-provider response and failed to validate. Retrying that
-    forever would mask a real contract break, so it stays fatal — only the
-    envelope-less, provider-less shape becomes a retryable 502.
+    `choices=None` with no error envelope but a `provider` dict means the body tried
+    to be a nested-provider response and failed to validate. Retrying that forever
+    would mask a real contract break, so it stays fatal — `provider` is typed
+    `str | None` on `_OpenRouterNoCompletionResponse` precisely so this body does not
+    match it.
     """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)


### PR DESCRIPTION
Fixes #6900

OpenRouter intermittently returns a body with **null `choices` and no error envelope at all** — a transient provider hiccup carrying no completion. `_validate_completion` tries the error-envelope and nested-provider shapes (#3994), then re-raises the bare `ValidationError`, so consumers that classify on exception type treat a transient as fatal. Nothing retries it and `FallbackModel` doesn't fall back on it.

This models that shape and raises `ModelAPIError` for it.

### The shape

`_OpenRouterNoCompletionResponse`, a sibling of `_OpenRouterErrorResponse` — the same family of bodies, minus the error envelope:

```python
class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
    choices: None
    error: None = None
    provider: str | None = None
    model: str | None = None
```

Tried in the existing `except ValidationError` chain, after the error-envelope and nested-provider attempts. Deliberate details:

- **`provider: str | None`** — a body whose `provider` is a *dict* is a malformed nested-provider response, not this shape, so it fails validation here and stays fatal. Declarative, no `isinstance` check.
- **`choices: None` is required, not defaulted** — a body that merely omits `choices` doesn't silently match.
- **`_OpenRouterChatCompletion` is untouched**: `id`, `model`, `object`, `provider` all stay required and non-null, so the happy path loses no guarantees and a `ValidationError` from it still means "a shape we don't account for."

### The exception

`ModelAPIError`, not a faked HTTP status. It's `FallbackModel`'s default `fallback_on`, so the transient now reaches retry/fallback machinery that a bare `ValidationError` never did.

### Tests

Both boundaries pinned, and all existing quirky-shape tests unchanged:

- `test_openrouter_null_choices_without_error_envelope_is_retryable` — the envelope-less body raises `ModelAPIError`, and asserts it is *not* a `ModelHTTPError` so nobody re-adds a fake status.
- `test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal` — the malformed-`provider` body still raises `UnexpectedModelBehavior`.

Full `tests/models/test_openrouter.py`: 58 passed.

---

We've run the workaround for this as a monkey-patch in production — it's the last survivor of a once-574-line OpenRouter patch module, since v2 absorbed the rest. Discussed with @DouweM on a call; the approach here follows his review (`ModelAPIError` over a faked 502, and modelling the shape rather than inspecting the response dict).
