### PR TITLE
Fix Temporal workflow livelock when anyio scope cancellation hits an in-flight activity await

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_activity_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_activity_execution.py
@@ -1,0 +1,51 @@
+"""Cancellation-safe activity execution for workflow code that runs under anyio cancel scopes.
+
+Awaiting `workflow.execute_activity()` directly from a task inside an anyio cancel scope can
+livelock the workflow when that scope is cancelled (e.g. by `asyncio.wait_for` cancelling an
+in-flight agent run — the graph engine runs its steps as anyio task-group children):
+
+- anyio delivers scope cancellation level-triggered: it re-arms `task.cancel()` via `call_soon`
+  for as long as a task remains in the cancelled scope, deduplicating only on `task._must_cancel`
+  or a done `_fut_waiter`.
+- `task.cancel()` on a task awaiting an activity handle DELEGATES to the handle task, whose
+  `run_activity` loop swallows the `CancelledError`, emits a `request_cancel_activity` command,
+  and re-parks on a shielded result future — leaving the scoped task uncancelled with an undone
+  waiter, so anyio cancels it again on the next loop iteration, appending another cancel command.
+- The activity's resolution can only arrive in a later activation, which can never start because
+  the event loop never goes idle: the spin continues until Temporal's deadlock detector fails the
+  workflow task, which then retries identically forever.
+
+This executor keeps the cancellation delivery on OUR task instead (via `asyncio.shield`), forwards
+exactly one cancellation to Temporal's graceful machinery, and waits for the configured
+`ActivityCancellationType` resolution inside an anyio-shielded scope so re-delivery stops and the
+activation can complete. Re-raising the original `CancelledError` also keeps standard asyncio
+semantics at the caller: `asyncio.wait_for` produces `TimeoutError` instead of leaking the
+activity's `ActivityError`, and cancelling the Temporal workflow still ends it as *Cancelled*.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from typing import Any
+
+import anyio
+from temporalio import workflow
+from temporalio.workflow import ActivityConfig
+from typing_extensions import Unpack
+
+
+async def execute_activity(activity: Any, *, args: Sequence[Any], **config: Unpack[ActivityConfig]) -> Any:
+    """Drop-in replacement for `workflow.execute_activity()` — see the module docstring for why."""
+    handle = workflow.start_activity(activity, args=args, **config)
+    try:
+        return await asyncio.shield(handle)
+    except asyncio.CancelledError:
+        # The cancellation hit this task because the shield kept the activity handle alive.
+        # Delegate exactly one cancellation to Temporal, then wait for its configured
+        # cancellation behavior without anyio redelivering cancellation on every loop turn.
+        if not handle.done():
+            handle.cancel()
+            with anyio.CancelScope(shield=True):
+                await asyncio.wait([handle])
+        raise

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_activity_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_activity_execution.py
@@ -44,7 +44,9 @@ async def execute_activity(activity: Any, *, args: Sequence[Any], **config: Unpa
         # The cancellation hit this task because the shield kept the activity handle alive.
         # Delegate exactly one cancellation to Temporal, then wait for its configured
         # cancellation behavior without anyio redelivering cancellation on every loop turn.
-        if not handle.done():
+        # The already-done arm is a real race (cancel landing in the same tick the activity
+        # resolves) that cannot be timed deterministically through the workflow API.
+        if not handle.done():  # pragma: no branch
             handle.cancel()
             with anyio.CancelScope(shield=True):
                 await asyncio.wait([handle])

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -45,6 +45,7 @@ from pydantic_ai.tools import (
 )
 
 from .._runtime_toolsets import reject_unsupported_runtime_toolsets
+from ._activity_execution import execute_activity
 from ._model import TemporalModel, TemporalProviderFactory
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import temporalize_toolset, toolset_temporal_activities
@@ -274,7 +275,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         serialized_run_context = self.run_context_type.serialize_run_context(ctx)
         async for event in stream:
             activity_config: ActivityConfig = {'summary': f'handle event: {event.event_kind}', **self.activity_config}
-            await workflow.execute_activity(
+            await execute_activity(
                 activity=self.event_stream_handler_activity,
                 args=[
                     _EventStreamHandlerParams(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -45,6 +45,7 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import AbstractToolset, WrapperToolset
 
+from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
     TemporalWrapperToolset,
@@ -433,7 +434,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             'summary': f'handle event: {event.event_kind}',
             **self._event_stream_handler_activity_config,
         }
-        await workflow.execute_activity(
+        await execute_activity(
             activity=self.event_stream_handler_activity,
             args=[
                 _EventStreamHandlerParams(event=event, serialized_run_context=serialized_run_context),
@@ -511,16 +512,14 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
 
         async def request_segment(request: ModelRequestContext) -> ModelResponse:
             config: ActivityConfig = {'summary': f'request model: {model_name}', **self._model_activity_config}
-            return await workflow.execute_activity(
-                activity=self.request_activity, args=[params(request), deps], **config
-            )
+            return await execute_activity(activity=self.request_activity, args=[params(request), deps], **config)
 
         async def request_stream_segment(request: ModelRequestContext) -> StreamedActivityResult:
             config: ActivityConfig = {
                 'summary': f'request model: {model_name} (stream)',
                 **self._model_activity_config,
             }
-            result = await workflow.execute_activity(
+            result = await execute_activity(
                 activity=self.request_stream_activity, args=[params(request), deps], **config
             )
             if isinstance(result, ModelResponse):
@@ -537,7 +536,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                 'summary': f'cancel suspended response: {model_name}',
                 **self._model_activity_config,
             }
-            await workflow.execute_activity(
+            await execute_activity(
                 activity=self.cancel_suspended_response_activity,
                 args=[
                     _CancelParams(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
@@ -21,6 +21,7 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
+from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
     CallToolParams,
@@ -68,7 +69,7 @@ def temporalize_dynamic_toolset(
 
     async def get_tools_operation(ctx: RunContext[AgentDepsT]) -> DynamicToolsResult:
         config: ActivityConfig = {'summary': f'get tools: {toolset.id}', **activity_config}
-        return await workflow.execute_activity(
+        return await execute_activity(
             activity=registered_get_tools,
             args=[
                 GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)),
@@ -92,7 +93,7 @@ def temporalize_dynamic_toolset(
                 **config,
             },
         )
-        result = await workflow.execute_activity(
+        result = await execute_activity(
             activity=registered_call_tool,
             args=[
                 CallToolParams(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
@@ -17,6 +17,7 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets.function import FunctionToolsetTool
 
+from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import CallToolParams, call_tool_in_activity, resolve_tool_activity_config
 
@@ -76,7 +77,7 @@ def temporalize_function_toolset(
                 **config,
             },
         )
-        result = await workflow.execute_activity(
+        result = await execute_activity(
             activity=registered_activity,
             args=[
                 CallToolParams(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
@@ -19,6 +19,7 @@ from pydantic_ai.mcp import MCPToolset
 from pydantic_ai.messages import InstructionPart
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
+from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import CallToolParams, GetToolsParams, resolve_tool_activity_config
 
@@ -85,7 +86,7 @@ def temporalize_mcp_toolset(
 
     async def get_tools_operation(ctx: RunContext[AgentDepsT]) -> dict[str, ToolDefinition]:
         config: ActivityConfig = {'summary': f'get tools: {toolset.id}', **activity_config}
-        return await workflow.execute_activity(
+        return await execute_activity(
             activity=get_tools_activity_def,
             args=[GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)), ctx.deps],
             **config,
@@ -95,7 +96,7 @@ def temporalize_mcp_toolset(
         ctx: RunContext[AgentDepsT],
     ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
         config: ActivityConfig = {'summary': f'get instructions: {toolset.id}', **activity_config}
-        return await workflow.execute_activity(
+        return await execute_activity(
             activity=get_instructions_activity_def,
             args=[GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)), ctx.deps],
             **config,
@@ -112,7 +113,7 @@ def temporalize_mcp_toolset(
             'ActivityConfig',
             {'summary': f'call tool: {toolset.id}:{name}', **activity_config, **config},
         )
-        result = await workflow.execute_activity(
+        result = await execute_activity(
             activity=call_tool_activity_def,
             args=[
                 CallToolParams(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -29,6 +29,7 @@ from pydantic_ai.providers import Provider
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, RunContext
 
+from ._activity_execution import execute_activity
 from ._durability import _RequestParams  # pyright: ignore[reportPrivateUsage]
 from ._run_context import TemporalRunContext, deserialize_run_context
 
@@ -173,7 +174,7 @@ class TemporalModel(WrapperModel):
 
         model_name = model_id or self.model_id
         activity_config: ActivityConfig = {'summary': f'request model: {model_name}', **self.activity_config}
-        return await workflow.execute_activity(
+        return await execute_activity(
             activity=self.request_activity,
             args=[
                 _RequestParams(
@@ -218,7 +219,7 @@ class TemporalModel(WrapperModel):
         serialized_run_context = self.run_context_type.serialize_run_context(run_context)
         model_name = model_id or self.model_id
         activity_config: ActivityConfig = {'summary': f'request model: {model_name} (stream)', **self.activity_config}
-        response = await workflow.execute_activity(
+        response = await execute_activity(
             activity=self.request_stream_activity,
             args=[
                 _RequestParams(
@@ -244,7 +245,7 @@ class TemporalModel(WrapperModel):
             'summary': f'cancel suspended response: {model_name}',
             **self.activity_config,
         }
-        await workflow.execute_activity(
+        await execute_activity(
             activity=self.cancel_suspended_response_activity,
             args=[_CancelParams(response=response, model_id=model_id)],
             **activity_config,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
+import anyio
 import pytest
 from pydantic import BaseModel, TypeAdapter
 
@@ -142,6 +143,9 @@ try:
         PydanticAIWorkflow,
         TemporalAgent,  # pyright: ignore[reportDeprecated]
         TemporalDurability,
+    )
+    from pydantic_ai.durable_exec.temporal._activity_execution import (
+        execute_activity as execute_temporal_activity,
     )
     from pydantic_ai.durable_exec.temporal._durability import (
         _CancelParams,  # pyright: ignore[reportPrivateUsage]
@@ -431,6 +435,117 @@ class CancellationBackstopWorkflow:
     @workflow.run
     async def run(self, prompt: str) -> str:
         return (await _cancellation_agent.run(prompt)).output
+
+
+@activity.defn
+async def _slow_cancellable_activity() -> str:
+    await asyncio.sleep(1)
+    return 'completed slowly'
+
+
+@workflow.defn
+class AnyioScopeActivityCancellationWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        async def run_activity() -> None:
+            await execute_temporal_activity(
+                _slow_cancellable_activity,
+                args=[],
+                start_to_close_timeout=timedelta(seconds=5),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+                cancellation_type=ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+            )
+
+        async def run_in_task_group() -> None:
+            async with anyio.create_task_group() as task_group:
+                task_group.start_soon(run_activity)
+
+        try:
+            await asyncio.wait_for(run_in_task_group(), timeout=0.1)
+        except asyncio.TimeoutError:
+            return 'timed out cleanly'
+        return 'completed'
+
+
+async def test_anyio_scope_cancel_of_activity_await_does_not_wedge(client: Client) -> None:
+    """Exercise the precise anyio/Temporal interaction that cannot be timed reliably through the agent API.
+
+    Agent-level activity awaits use the same executor, and the test below covers the public path.
+    """
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[AnyioScopeActivityCancellationWorkflow],
+        activities=[_slow_cancellable_activity],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        handle = await client.start_workflow(
+            AnyioScopeActivityCancellationWorkflow.run,
+            id=f'{AnyioScopeActivityCancellationWorkflow.__name__}-{uuid.uuid4()}',
+            task_queue=TASK_QUEUE,
+        )
+        assert await handle.result() == 'timed out cleanly'
+        history = await handle.fetch_history()
+
+    assert not [event for event in history.events if 'WORKFLOW_TASK_FAILED' in str(event.event_type)]
+
+
+async def _wait_for_timeout_stream_model(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+    while True:
+        activity.heartbeat()
+        await asyncio.sleep(0.01)
+        yield ''
+
+
+async def _consume_wait_for_timeout_events(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+    async for _ in stream:
+        pass
+
+
+_wait_for_timeout_agent = Agent(
+    FunctionModel(stream_function=_wait_for_timeout_stream_model),
+    name='wait_for_timeout_agent',
+    deps_type=type(None),
+    capabilities=[
+        TemporalDurability(
+            event_stream_handler=_consume_wait_for_timeout_events,
+            model_activity_config=ActivityConfig(
+                start_to_close_timeout=timedelta(seconds=10),
+                heartbeat_timeout=timedelta(seconds=1),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+                cancellation_type=ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+            ),
+        )
+    ],
+)
+
+
+@workflow.defn
+class WaitForAgentTimeoutWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        try:
+            await asyncio.wait_for(_wait_for_timeout_agent.run('go slowly'), timeout=0.5)
+        except asyncio.TimeoutError:
+            return 'timed out cleanly'
+        return 'completed'
+
+
+async def test_wait_for_agent_timeout_in_workflow_does_not_livelock(client: Client) -> None:
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[WaitForAgentTimeoutWorkflow],
+        plugins=[AgentPlugin(_wait_for_timeout_agent)],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        result = await client.execute_workflow(
+            WaitForAgentTimeoutWorkflow.run,
+            id=f'{WaitForAgentTimeoutWorkflow.__name__}-{uuid.uuid4()}',
+            task_queue=TASK_QUEUE,
+        )
+
+    assert result == 'timed out cleanly'
 
 
 @pytest.mark.skipif(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -464,7 +464,7 @@ class AnyioScopeActivityCancellationWorkflow:
             await asyncio.wait_for(run_in_task_group(), timeout=0.1)
         except asyncio.TimeoutError:
             return 'timed out cleanly'
-        return 'completed'
+        return 'completed'  # pragma: no cover
 
 
 async def test_anyio_scope_cancel_of_activity_await_does_not_wedge(client: Client) -> None:
@@ -498,7 +498,7 @@ class WaitForNonStreamingAgentTimeoutWorkflow:
             result = await asyncio.wait_for(_wait_for_nonstreaming_agent.run('say hi'), timeout=0.5)
         except asyncio.TimeoutError:
             return 'clean-timeout'
-        return f'unexpected-success:{result.output}'
+        return f'unexpected-success:{result.output}'  # pragma: no cover
 
 
 async def _slow_nonstreaming_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -572,7 +572,7 @@ class WaitForAgentTimeoutWorkflow:
             await asyncio.wait_for(_wait_for_timeout_agent.run('go slowly'), timeout=0.5)
         except asyncio.TimeoutError:
             return 'timed out cleanly'
-        return 'completed'
+        return 'completed'  # pragma: no cover
 
 
 async def test_wait_for_agent_timeout_in_workflow_does_not_livelock(client: Client) -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -490,6 +490,50 @@ async def test_anyio_scope_cancel_of_activity_await_does_not_wedge(client: Clien
     assert not [event for event in history.events if 'WORKFLOW_TASK_FAILED' in str(event.event_type)]
 
 
+@workflow.defn
+class WaitForNonStreamingAgentTimeoutWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        try:
+            result = await asyncio.wait_for(_wait_for_nonstreaming_agent.run('say hi'), timeout=0.5)
+        except asyncio.TimeoutError:
+            return 'clean-timeout'
+        return f'unexpected-success:{result.output}'
+
+
+async def _slow_nonstreaming_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    await asyncio.sleep(10)
+    return ModelResponse(parts=[TextPart('done')])  # pragma: no cover
+
+
+_wait_for_nonstreaming_agent = Agent(
+    FunctionModel(_slow_nonstreaming_model, model_name='slow-model'),
+    name='wait_for_nonstreaming_agent',
+    deps_type=type(None),
+    capabilities=[TemporalDurability()],
+)
+
+
+async def test_wait_for_nonstreaming_agent_timeout_does_not_livelock(client: Client) -> None:
+    """The exact MRE shape from #6883 (trigger A): a non-streaming model request as an activity,
+    the workflow body bounding `agent.run()` with `asyncio.wait_for`. Must end in a clean
+    `TimeoutError`, not a deadlock-detector livelock."""
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[WaitForNonStreamingAgentTimeoutWorkflow],
+        plugins=[AgentPlugin(_wait_for_nonstreaming_agent)],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        result = await client.execute_workflow(
+            WaitForNonStreamingAgentTimeoutWorkflow.run,
+            id=f'{WaitForNonStreamingAgentTimeoutWorkflow.__name__}-{uuid.uuid4()}',
+            task_queue=TASK_QUEUE,
+        )
+
+    assert result == 'clean-timeout'
+
+
 async def _wait_for_timeout_stream_model(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
     while True:
         activity.heartbeat()


### PR DESCRIPTION
Fixes the application-issued trigger (A) of #6883 — independently validated by the reporter on his unmodified repro. The issue stays open until his staging run delivers a verdict on the cache-eviction trigger (B), whose zero-delivery spin our analysis places downstream of the same absorption this PR removes.

## Summary

A user reported (Critical) a deterministic livelock: inside a workflow body, `asyncio.wait_for(agent.run(...), timeout=...)` cancelling an in-flight run wedges the workflow task at ~17k spins/sec until Temporal's deadlock detector fails it — and the retried activation fails identically, forever.

**Mechanism (all three parts verified empirically):**
- anyio delivers scope cancellation **level-triggered**: `CancelScope._deliver_cancellation` re-arms itself via `call_soon` for as long as a task remains in a cancelled scope, deduplicating only on `task._must_cancel` or a done `_fut_waiter`.
- temporalio's `run_activity` is a `while True` that swallows `CancelledError`, emits `request_cancel_activity`, and re-parks on a shielded result future. `task.cancel()` on a task awaiting an activity handle **delegates** to the handle task, so the scoped task stays parked, uncancelled, with an undone waiter.
- anyio re-cancels every event-loop iteration (appending another cancel command each time); the activity's resolution can only arrive in a **later activation**, which can never start because the loop never goes idle: `[TMPRL1101] Potential deadlock detected`.

Pydantic AI puts user code in this position: the graph engine runs steps as anyio task-group children, and every Temporal activity await (model request, tools, MCP, event dispatch) happens beneath them.

## The fix

A cancellation-safe activity executor (`durable_exec/temporal/_activity_execution.py`) now wraps **all 15** `workflow.execute_activity` call sites: it shields the activity handle so the cancellation is delivered to *our* task, delegates exactly one cancel to temporalio's graceful machinery (honoring the configured `ActivityCancellationType`), waits for the resolution inside an `anyio.CancelScope(shield=True)` so re-delivery stops and the activation can complete, then re-raises the original `CancelledError`.

Re-raising `CancelledError` (instead of letting the activity's `ActivityError` leak) also fixes a second bug found while reproducing: `asyncio.wait_for(agent.run(...), t)` in a workflow used to **fail the workflow** with `ActivityError: Activity cancelled` instead of raising `TimeoutError` — the `except asyncio.TimeoutError` in workflow code never matched. Both are pinned by tests:

- `test_anyio_scope_cancel_of_activity_await_does_not_wedge` — the primitive wedge shape through our executor (unit-style by necessity: the exact timing can't be forced through the agent API; before the fix this exact workflow shape produced `[TMPRL1101]` task failures, verified live).
- `test_wait_for_agent_timeout_in_workflow_does_not_livelock` — public-API: `wait_for` over a run with a slow streaming activity returns `'timed out cleanly'`.

External cancellation semantics are unchanged: cancelling the Temporal workflow still delivers `CancelledError` and ends the workflow as *Cancelled* (`test_temporal_cancellation_backstop_survives_absorbed_activity_cancel` still passes).

Note: the full local `test_temporal.py` run flakes on the shared dev server dying mid-suite; the same batch fails identically on unmodified `main`, so that instability is pre-existing and unrelated (focused runs pass consistently).

## #6883's two triggers

- **Trigger A (application-issued, e.g. `asyncio.wait_for`)**: fixed and pinned — including the issue's exact MRE shape (`test_wait_for_nonstreaming_agent_timeout_does_not_livelock`) alongside the streaming and primitive variants.
- **Trigger B (SDK cache-eviction cancel)**: the zero-delivery spin (`_must_cancel` set on every task while anyio re-arms) is downstream of tasks *absorbing* cancellation instead of unwinding. With this fix, an eviction's direct `task.cancel()` is not blocked by the executor's shield (`anyio.CancelScope(shield=True)` only stops **anyio's** delivery; a direct cancel reaches the shielded `asyncio.wait` and propagates), so activity-awaiting tasks unwind promptly and eviction can complete. That analysis wants validation against the reporter's production shape — @ZacharyHampton, if you can run your eviction profile against this branch, that would be the definitive check.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



