### PR TITLE
Support requesting approval or deferring a call from a tool's `args_validator`

### DIFF
--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -94,6 +94,8 @@ If a tool function always requires approval, you can pass the `requires_approval
 
 If whether a tool function requires approval depends on the tool call arguments or the agent [run context][pydantic_ai.tools.RunContext] (e.g. [dependencies](dependencies.md) or message history), you can raise the [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] exception from the tool function. The [`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] property will be `True` if the tool call has already been approved.
 
+You can also raise it from the tool's [`args_validator`](tools-advanced.md#args-validator), which runs before the tool function and lets you reject invalid arguments before asking a human to approve them.
+
 To require approval for calls to tools provided by a [toolset](toolsets.md) (like an [MCP server](mcp/client.md)), see the [`ApprovalRequiredToolset` documentation](toolsets.md#requiring-tool-approval).
 
 !!! warning "Approval is not an authorization boundary against an untrusted client"
@@ -316,6 +318,8 @@ When the result of a tool call cannot be generated inside the same agent run in 
 Examples of external tools are client-side tools implemented by a web or app frontend, and slow tasks that are passed off to a background worker or external service instead of keeping the agent process running.
 
 If whether a tool call should be executed externally depends on the tool call arguments, the agent [run context][pydantic_ai.tools.RunContext] (e.g. [dependencies](dependencies.md) or message history), or how long the task is expected to take, you can define a tool function and conditionally raise the [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] exception. Before raising the exception, the tool function would typically schedule some background task and pass along the [`RunContext.tool_call_id`][pydantic_ai.tools.RunContext.tool_call_id] so that the result can be matched to the deferred tool call later.
+
+As with approval, the tool's [`args_validator`](tools-advanced.md#args-validator) can raise `CallDeferred` too, so only calls with valid arguments are handed off.
 
 If a tool is always executed externally and its definition is provided to your code along with a JSON schema for its arguments, you can use an [`ExternalToolset`](toolsets.md#external-toolset). If the external tools are known up front and you don't have the arguments JSON schema handy, you can also define a tool function with the appropriate signature that does nothing but raise the [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] exception.
 

--- a/docs/tools-advanced.md
+++ b/docs/tools-advanced.md
@@ -582,6 +582,8 @@ The `args_validator` parameter lets you define custom validation that runs after
 
 The validator receives [`RunContext`][pydantic_ai.tools.RunContext] as its first argument, followed by the same parameters as the tool function. Return `None` on success, raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to ask the model to correct the arguments and try again, or raise [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] to report a terminal failure the model should adapt to instead of retrying.
 
+A validator can also raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] to [defer the call](deferred-tools.md), just like the tool function itself can. The validator is the better place to make that decision: bad arguments are rejected before a human is asked to approve them.
+
 ```python {title="args_validator_approval.py"}
 from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
 
@@ -612,6 +614,54 @@ print(result.output.approvals[0].args)
 _(This example is complete, it can be run "as is")_
 
 When schema validation fails, or an `args_validator` raises `ModelRetry`, the error message is sent back to the LLM as a retry prompt (with instructions to try again) and respects the tool's `retries` setting. When an `args_validator` raises `ToolFailed`, the model instead receives a failed tool result it should adapt to rather than retry, and the retry budget is left untouched. For [deferred tools](deferred-tools.md), validation runs at deferral time — only tool calls with valid arguments are deferred.
+
+A validator that raises `ApprovalRequired` or `CallDeferred` doesn't consume the retry budget either — the arguments were valid, so the deferral is treated as a deliberate decision rather than a failure. The tool function is not executed, and the call joins the run's other [deferred tool calls](deferred-tools.md): it's resolved inline by a [`HandleDeferredToolCalls`][pydantic_ai.capabilities.HandleDeferredToolCalls] handler if you have one, or surfaced in the run's `DeferredToolRequests` output. Once the call is approved, the validator runs again with [`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] set to `True` and the tool executes:
+
+```python {title="args_validator_conditional_approval.py"}
+from pydantic_ai import (
+    Agent,
+    ApprovalRequired,
+    DeferredToolRequests,
+    ModelMessage,
+    ModelResponse,
+    ModelRetry,
+    RunContext,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+agent = Agent(deps_type=int, output_type=[str, DeferredToolRequests])
+
+
+def validate_transfer(ctx: RunContext[int], amount: int) -> None:
+    if amount > ctx.deps:
+        raise ModelRetry(f'Amount must not exceed {ctx.deps}')  # (1)!
+    if amount > 100 and not ctx.tool_call_approved:
+        raise ApprovalRequired()  # (2)!
+
+
+@agent.tool(args_validator=validate_transfer)
+def transfer_funds(ctx: RunContext[int], amount: int) -> str:
+    return f'Transferred {amount}'
+
+
+def call_transfer(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    if len(messages) == 1:
+        return ModelResponse(parts=[ToolCallPart('transfer_funds', {'amount': 500})])
+    return ModelResponse(parts=[TextPart('done')])
+
+
+result = agent.run_sync('transfer 500', deps=1000, model=FunctionModel(call_transfer))
+assert isinstance(result.output, DeferredToolRequests)
+print(result.output.approvals[0].args)
+#> {'amount': 500}
+```
+
+1. The model can fix an impossible amount itself, without a human ever seeing the call.
+2. Only calls that made it past validation are put in front of a human.
+
+_(This example is complete, it can be run "as is")_
 
 The `args_validator` parameter is available on [`@agent.tool`][pydantic_ai.agent.Agent.tool], [`@agent.tool_plain`][pydantic_ai.agent.Agent.tool_plain], [`Tool`][pydantic_ai.tools.Tool], [`Tool.from_schema`][pydantic_ai.tools.Tool.from_schema], and [`FunctionToolset`][pydantic_ai.toolsets.function.FunctionToolset]. Validators can be sync or async functions.
 

--- a/docs/tools-advanced.md
+++ b/docs/tools-advanced.md
@@ -580,9 +580,7 @@ When a timeout occurs, the tool is treated as a retryable failure and the model 
 
 The `args_validator` parameter lets you define custom validation that runs after Pydantic schema validation but before the tool executes. This is useful for business logic validation, cross-field validation, or validating arguments before requesting [human approval](deferred-tools.md) for deferred tools.
 
-The validator receives [`RunContext`][pydantic_ai.tools.RunContext] as its first argument, followed by the same parameters as the tool function. Return `None` on success, raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to ask the model to correct the arguments and try again, or raise [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] to report a terminal failure the model should adapt to instead of retrying.
-
-A validator can also raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] to [defer the call](deferred-tools.md), just like the tool function itself can. The validator is the better place to make that decision: bad arguments are rejected before a human is asked to approve them.
+The validator receives [`RunContext`][pydantic_ai.tools.RunContext] as its first argument, followed by the same parameters as the tool function. Return `None` on success, raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to ask the model to correct the arguments and try again, raise [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] to report a terminal failure the model should adapt to instead of retrying, or raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] / [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] to [defer the call](deferred-tools.md) (see below).
 
 ```python {title="args_validator_approval.py"}
 from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
@@ -615,7 +613,9 @@ _(This example is complete, it can be run "as is")_
 
 When schema validation fails, or an `args_validator` raises `ModelRetry`, the error message is sent back to the LLM as a retry prompt (with instructions to try again) and respects the tool's `retries` setting. When an `args_validator` raises `ToolFailed`, the model instead receives a failed tool result it should adapt to rather than retry, and the retry budget is left untouched. For [deferred tools](deferred-tools.md), validation runs at deferral time — only tool calls with valid arguments are deferred.
 
-A validator that raises `ApprovalRequired` or `CallDeferred` doesn't consume the retry budget either — the arguments were valid, so the deferral is treated as a deliberate decision rather than a failure. The tool function is not executed, and the call joins the run's other [deferred tool calls](deferred-tools.md): it's resolved inline by a [`HandleDeferredToolCalls`][pydantic_ai.capabilities.HandleDeferredToolCalls] handler if you have one, or surfaced in the run's `DeferredToolRequests` output. Once the call is approved, the validator runs again with [`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] set to `True` and the tool executes:
+A validator can defer the call itself, just like the tool function can — and it's the better place to make that decision, since bad arguments are rejected before a human is asked to approve them. A validator that raises `ApprovalRequired` or `CallDeferred` doesn't consume the retry budget either: the arguments were valid, so the deferral is a deliberate decision rather than a failure. The tool function is not executed, and the call joins the run's other [deferred tool calls](deferred-tools.md): it's resolved inline by a [`HandleDeferredToolCalls`][pydantic_ai.capabilities.HandleDeferredToolCalls] handler if you have one, or surfaced in the run's `DeferredToolRequests` output. Once the call is [approved](deferred-tools.md#human-in-the-loop-tool-approval), the validator runs again — this time with [`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] set to `True` — and the tool executes.
+
+Here, an impossible amount is rejected outright while a large one is put in front of a human:
 
 ```python {title="args_validator_conditional_approval.py"}
 from pydantic_ai import (

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
@@ -37,7 +37,7 @@ print(result.output)
 Two key rules:
 
 - `DeferredToolRequests` must be in the output type
-- for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True`
+- for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True` — from the tool function, or from its `args_validator=` so invalid arguments are rejected before a human is asked (see below)
 
 Deferred batches also surface in the event stream: `DeferredToolRequestsEvent` carries the `DeferredToolRequests` once per batch, before any `HandleDeferredToolCalls` handler runs; `DeferredToolResultsEvent` carries the `DeferredToolResults` when a handler resolves requests inline (not when results are provided to a new run via `deferred_tool_results`).
 
@@ -97,20 +97,30 @@ The failure is recorded in message history as a `ToolReturnPart` with `outcome='
 
 Use `args_validator=` when arguments are structurally valid but still need business-rule validation before execution or approval. A validator returns `None` on success, raises `ModelRetry` to ask the model to correct the arguments and try again, or raises `ToolFailed` to report a terminal failure the model should adapt to instead of retrying.
 
+It can also raise `ApprovalRequired` or `CallDeferred` to defer the call, exactly as the tool function can — and this is the better place for a conditional-approval decision, since bad arguments are rejected before a human is asked to approve them. The tool isn't executed, the deferral doesn't consume the retry budget, and once the call is approved the validator runs again with `ctx.tool_call_approved` set to `True`.
+
 ```python
-from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
+from pydantic_ai import (
+    Agent,
+    ApprovalRequired,
+    DeferredToolRequests,
+    ModelRetry,
+    RunContext,
+)
 
 agent = Agent('openai:gpt-5.2', name='validation_agent', deps_type=int, output_type=[str, DeferredToolRequests])
 
 
-def validate_sum_limit(ctx: RunContext[int], x: int, y: int) -> None:
-    if x + y > ctx.deps:
-        raise ModelRetry(f'Sum of x and y must not exceed {ctx.deps}')
+def validate_transfer(ctx: RunContext[int], amount: int) -> None:
+    if amount > ctx.deps:
+        raise ModelRetry(f'Amount must not exceed {ctx.deps}')
+    if amount > 100 and not ctx.tool_call_approved:
+        raise ApprovalRequired()
 
 
-@agent.tool(requires_approval=True, args_validator=validate_sum_limit)
-def add_numbers(ctx: RunContext[int], x: int, y: int) -> int:
-    return x + y
+@agent.tool(args_validator=validate_transfer)
+def transfer_funds(ctx: RunContext[int], amount: int) -> str:
+    return f'Transferred {amount}'
 ```
 
 ## Use Advanced Tool Features

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -746,7 +746,11 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         **Raise** the original `error` (or a different exception) to propagate it.
         **Return** validated args to suppress the error and continue as if validation passed.
 
-        Not called for [`SkipToolValidation`][pydantic_ai.exceptions.SkipToolValidation].
+        Not called for [`SkipToolValidation`][pydantic_ai.exceptions.SkipToolValidation], or for the
+        deferrals a tool's `args_validator` can raise
+        ([`CallDeferred`][pydantic_ai.exceptions.CallDeferred],
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired]) — those are control flow, not
+        errors, and the call is deferred instead of executed.
         """
         raise error
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -75,6 +75,29 @@ class ValidatedToolCall(Generic[AgentDepsT]):
     """
     validation_error: ToolRetryError | ToolFailedError | None = None
     """The model-visible tool result if validation failed, None otherwise."""
+    deferral: CallDeferred | ApprovalRequired | None = None
+    """The deferral raised by the tool's `args_validator`, if any.
+
+    A validator that raises [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+    [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] made a deliberate control-flow choice
+    about arguments that were already valid, so `args_valid` is `True` and `validated_args` holds
+    the schema-validated arguments. `execute_tool_call` re-raises this instead of running the tool,
+    so the deferral is handled exactly like one raised by the tool function itself.
+    """
+
+
+class _ValidationDeferral(Exception):
+    """Internal signal that a tool's `args_validator` requested approval or deferred the call.
+
+    Carries the schema-validated arguments alongside the user's deferral so `validate_tool_call`
+    can report the call as valid and re-raise the deferral at the execution boundary. Never
+    escapes `ToolManager`.
+    """
+
+    def __init__(self, deferral: CallDeferred | ApprovalRequired, validated_args: dict[str, Any]):
+        self.deferral = deferral
+        self.validated_args = validated_args
+        super().__init__()
 
 
 @dataclass
@@ -253,6 +276,7 @@ class ToolManager(Generic[AgentDepsT]):
         Raises:
             ValidationError: If argument validation fails.
             ModelRetry: If argument validation fails with a retry request.
+            _ValidationDeferral: If the custom validator requested approval or deferred the call.
         """
         raw_args = args_override if args_override is not None else call.args
         pyd_allow_partial = 'trailing-strings' if allow_partial else 'off'
@@ -267,9 +291,15 @@ class ToolManager(Generic[AgentDepsT]):
             )
 
         if tool.args_validator_func is not None:
-            result = tool.args_validator_func(ctx, **args_dict)
-            if inspect.isawaitable(result):
-                await result
+            try:
+                result = tool.args_validator_func(ctx, **args_dict)
+                if inspect.isawaitable(result):
+                    await result
+            except (CallDeferred, ApprovalRequired) as e:
+                # Control flow, not a validation error: the arguments are valid and the validator
+                # deliberately chose to request approval or defer. Carry the validated arguments
+                # out with the deferral so `validate_tool_call` can report the call as valid.
+                raise _ValidationDeferral(e, args_dict) from e
 
         return args_dict
 
@@ -459,6 +489,13 @@ class ToolManager(Generic[AgentDepsT]):
         2. Handle validation failures differently from execution failures
         3. Decide whether to execute or defer based on validation result
 
+        A tool's `args_validator` can raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired]
+        or [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] to defer the call once the arguments
+        are known to be valid. That's control flow rather than a validation failure: the returned
+        `ValidatedToolCall` has `args_valid=True` and carries the exception on
+        [`deferral`][pydantic_ai.tool_manager.ValidatedToolCall.deferral], which `execute_tool_call`
+        raises in place of running the tool, so callers handle deferrals in one place.
+
         Args:
             call: The tool call part to validate.
             approved: Whether the tool call has been approved.
@@ -488,6 +525,14 @@ class ToolManager(Generic[AgentDepsT]):
             assert tool is not None
             # Hook asked us to skip validation entirely; accept the args it provided.
             return self._make_validation_success(call, tool, ctx, e.validated_args)
+        except _ValidationDeferral as e:
+            assert tool is not None
+            # The `args_validator` requested approval or deferred the call. The arguments passed
+            # validation, so this is not a failure: the call is reported valid (no retry budget
+            # consumed, no `on_tool_validate_error`) and the deferral is carried on the result for
+            # `execute_tool_call` to raise, which routes it into the same deferred-call handling as
+            # a deferral raised by the tool function.
+            return replace(self._make_validation_success(call, tool, ctx, e.validated_args), deferral=e.deferral)
         except (ValidationError, ModelRetry) as e:
             if not wrap_validation_errors:
                 raise
@@ -533,6 +578,10 @@ class ToolManager(Generic[AgentDepsT]):
             ToolFailedError: If validation failed with `ToolFailed`, or the tool raised
                 `ToolFailed`. Only when `wrap_validation_errors=True`.
             ModelRetry / ValidationError / ToolFailed: When `wrap_validation_errors=False`.
+            CallDeferred / ApprovalRequired: If the tool's `args_validator` deferred the call
+                (see [`ValidatedToolCall.deferral`][pydantic_ai.tool_manager.ValidatedToolCall.deferral])
+                or the tool function raised one of these itself. The tool is not executed in the
+                former case.
             RuntimeError: If trying to execute an external tool.
         """
         if self.ctx is None:
@@ -758,12 +807,22 @@ class ToolManager(Generic[AgentDepsT]):
         validation carries a pre-wrapped `ToolRetryError`; raw-mode callers get raw
         errors at the `validate_tool_call(wrap_validation_errors=False)` boundary.
 
+        A `ValidatedToolCall` carrying a `deferral` (its `args_validator` requested approval or
+        deferred the call) re-raises that exception here without executing the tool.
+
         Raises ToolRetryError if validation previously failed with a retry prompt or the
         tool raises ModelRetry (when `wrap_validation_errors=True`). Raises ToolFailedError
         if validation previously failed with ToolFailed or the tool raises ToolFailed.
         When False, ModelRetry / ToolFailed from the tool body or hooks propagates raw.
         Raises UnexpectedModelBehavior if max retries exceeded.
         """
+        if validated.deferral is not None:
+            # The `args_validator` requested approval or deferred the call, so the tool must not run.
+            # Raising here (instead of at validation time) means a validate-stage deferral takes the
+            # same path as one raised by the tool function: callers collect it into the run's
+            # `DeferredToolRequests` or resolve it inline via a `HandleDeferredToolCalls` handler.
+            raise validated.deferral
+
         # Asserts narrow types for pyright; invariants guaranteed by ValidatedToolCall construction
         if not validated.args_valid:
             assert validated.validation_error is not None
@@ -837,7 +896,8 @@ class ToolManager(Generic[AgentDepsT]):
 
         This is a convenience method that combines validate_tool_call() and execute_tool_call().
 
-        If the tool raises [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+        If the tool or its `args_validator` raises
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
         [`CallDeferred`][pydantic_ai.exceptions.CallDeferred], the capability handler
         (if any) is invoked to resolve it inline; otherwise the exception propagates.
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -11006,6 +11006,29 @@ class TestToolValidateErrorHooks:
         result = await agent.run('greet someone')
         assert 'hello correct' in result.output
 
+    async def test_args_validator_deferral_is_not_a_validate_error(self):
+        """A deferral raised by an `args_validator` passes through the validate hooks as control flow.
+
+        Like an execute-stage deferral, it's not an error: `on_tool_validate_error` doesn't fire, the
+        hooks that run after successful validation don't either, and the tool is never executed.
+        """
+        cap = LoggingCapability()
+
+        def my_validator(ctx: RunContext[Any], x: int) -> None:
+            raise ApprovalRequired()
+
+        agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], capabilities=[cap])
+
+        @agent.tool_plain(args_validator=my_validator)
+        def my_tool(x: int) -> int:  # pragma: no cover
+            return x
+
+        result = await agent.run('call the tool')
+        assert isinstance(result.output, DeferredToolRequests)
+        assert [entry for entry in cap.log if 'tool_validate' in entry or 'tool_execute' in entry] == snapshot(
+            ['before_tool_validate:my_tool', 'wrap_tool_validate:my_tool:before']
+        )
+
 
 # --- Tool execute error hook tests ---
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -52,6 +52,7 @@ from pydantic_ai import (
     TextPartDelta,
     ThinkingPart,
     ToolCallPart,
+    ToolCallPartDelta,
     ToolReturnPart,
     UnexpectedModelBehavior,
     UserError,
@@ -5873,6 +5874,98 @@ async def test_args_validator_event_args_valid_field():
             PartDeltaEvent(index=0, delta=TextPartDelta(content_delta='mbers":0}')),
             PartEndEvent(index=0, part=TextPart(content='{"add_numbers":0}')),
             AgentRunResultEvent(result=AgentRunResult(output='{"add_numbers":0}')),
+        ]
+    )
+
+
+async def test_args_validator_deferral_not_triggered_by_partial_args():
+    """A deferring `args_validator` is consulted once, on the complete arguments.
+
+    Tool call arguments arrive in fragments while streaming, and a validator that saw those would
+    be able to request approval for a half-built call. Function tool arguments are only ever
+    validated once the model response is complete, so the validator sees the full arguments
+    (`ctx.partial_output` is `False`) and exactly one deferral reaches the deferred batch.
+    """
+    validator_calls: list[tuple[int, int, bool]] = []
+
+    async def stream_args(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[DeltaToolCalls]:
+        yield {0: DeltaToolCall(name='add_numbers')}
+        yield {0: DeltaToolCall(json_args='{"x": 1,')}
+        yield {0: DeltaToolCall(json_args=' "y": 2}')}
+
+    def my_validator(ctx: RunContext, x: int, y: int) -> None:
+        validator_calls.append((x, y, ctx.partial_output))
+        raise ApprovalRequired()
+
+    agent = Agent(
+        FunctionModel(stream_function=stream_args),
+        output_type=[str, DeferredToolRequests],
+    )
+
+    @agent.tool(args_validator=my_validator)
+    def add_numbers(ctx: RunContext, x: int, y: int) -> int:  # pragma: no cover
+        return x + y
+
+    events: list[Any] = []
+    async with agent.run_stream_events('add 1 and 2') as event_stream:
+        async for event in event_stream:
+            events.append(event)
+
+    assert validator_calls == snapshot([(1, 2, False)])
+    assert events == snapshot(
+        [
+            PartStartEvent(
+                index=0,
+                part=ToolCallPart(tool_name='add_numbers', tool_call_id=IsStr()),
+            ),
+            PartDeltaEvent(
+                index=0,
+                delta=ToolCallPartDelta(args_delta='{"x": 1,', tool_call_id=IsStr()),
+            ),
+            PartDeltaEvent(
+                index=0,
+                delta=ToolCallPartDelta(args_delta=' "y": 2}', tool_call_id=IsStr()),
+            ),
+            PartEndEvent(
+                index=0,
+                part=ToolCallPart(
+                    tool_name='add_numbers',
+                    args='{"x": 1, "y": 2}',
+                    tool_call_id=IsStr(),
+                ),
+            ),
+            FunctionToolCallEvent(
+                part=ToolCallPart(
+                    tool_name='add_numbers',
+                    args='{"x": 1, "y": 2}',
+                    tool_call_id=IsStr(),
+                ),
+                args_valid=True,
+            ),
+            DeferredToolRequestsEvent(
+                requests=DeferredToolRequests(
+                    approvals=[
+                        ToolCallPart(
+                            tool_name='add_numbers',
+                            args='{"x": 1, "y": 2}',
+                            tool_call_id=IsStr(),
+                        )
+                    ]
+                )
+            ),
+            AgentRunResultEvent(
+                result=AgentRunResult(
+                    output=DeferredToolRequests(
+                        approvals=[
+                            ToolCallPart(
+                                tool_name='add_numbers',
+                                args='{"x": 1, "y": 2}',
+                                tool_call_id=IsStr(),
+                            )
+                        ]
+                    )
+                )
+            ),
         ]
     )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4279,20 +4279,15 @@ def test_args_validator_defers_call():
         deferred_tool_results=DeferredToolResults(calls={tool_call_id: 'done externally'}),
     )
     assert executed == []
-    assert result.all_messages()[-2] == snapshot(
-        ModelRequest(
-            parts=[
-                ToolReturnPart(
-                    tool_name='my_tool',
-                    content='done externally',
-                    tool_call_id='pyd_ai_tool_call_id__my_tool',
-                    timestamp=IsDatetime(),
-                )
-            ],
-            timestamp=IsDatetime(),
-            run_id=IsStr(),
-            conversation_id=IsStr(),
-        )
+    assert result.all_messages()[-2].parts == snapshot(
+        [
+            ToolReturnPart(
+                tool_name='my_tool',
+                content='done externally',
+                tool_call_id='pyd_ai_tool_call_id__my_tool',
+                timestamp=IsDatetime(),
+            )
+        ]
     )
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -31,7 +31,7 @@ from pydantic_ai import (
     UserError,
     UserPromptPart,
 )
-from pydantic_ai.capabilities import PrepareTools
+from pydantic_ai.capabilities import HandleDeferredToolCalls, PrepareTools
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolFailed, UnexpectedModelBehavior
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
@@ -4159,6 +4159,175 @@ def test_args_validator_not_double_called_for_approved_tools():
     # Validator should have been called exactly once with approved=True
     assert len(validator_calls) == 1
     assert validator_calls[0] == (0, True)  # retry=0, approved=True
+
+
+def test_args_validator_requests_approval():
+    """An `args_validator` can raise `ApprovalRequired` to request approval for valid arguments.
+
+    The tool is not executed, the call is deferred with the validator's metadata, and approving it
+    on a follow-up run runs the tool with `ctx.tool_call_approved` set. `retries=0` pins that the
+    deferral doesn't consume the retry budget: if it were treated as a validation failure, the run
+    would fail with `UnexpectedModelBehavior` instead of deferring.
+    """
+    validator_calls: list[bool] = []
+    executed: list[int] = []
+
+    def my_validator(ctx: RunContext, x: int) -> None:
+        validator_calls.append(ctx.tool_call_approved)
+        if not ctx.tool_call_approved:
+            raise ApprovalRequired(metadata={'reason': 'sensitive'})
+
+    agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
+
+    @agent.tool(args_validator=my_validator, retries=0)
+    def my_tool(ctx: RunContext, x: int) -> int:
+        executed.append(x)
+        return x * 42
+
+    result = agent.run_sync('Hello')
+    assert result.output == snapshot(
+        DeferredToolRequests(
+            approvals=[ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')],
+            metadata={'pyd_ai_tool_call_id__my_tool': {'reason': 'sensitive'}},
+        )
+    )
+    assert executed == []
+    assert validator_calls == [False]
+
+    assert isinstance(result.output, DeferredToolRequests)
+    tool_call_id = result.output.approvals[0].tool_call_id
+    result = agent.run_sync(
+        message_history=result.all_messages(),
+        deferred_tool_results=DeferredToolResults(approvals={tool_call_id: ToolApproved()}),
+    )
+    assert executed == [0]
+    assert validator_calls == [False, True]
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')],
+                usage=RequestUsage(input_tokens=51, output_tokens=4),
+                model_name='test',
+                timestamp=IsDatetime(),
+                provider_name='test',
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='my_tool',
+                        content=0,
+                        tool_call_id='pyd_ai_tool_call_id__my_tool',
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='{"my_tool":0}')],
+                usage=RequestUsage(input_tokens=52, output_tokens=7),
+                model_name='test',
+                timestamp=IsDatetime(),
+                provider_name='test',
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+        ]
+    )
+
+
+def test_args_validator_defers_call():
+    """An `args_validator` can raise `CallDeferred` so the call is executed externally.
+
+    As with approval, the tool isn't executed and the retry budget isn't touched (`retries=0`);
+    the external result supplied on the follow-up run is recorded verbatim.
+    """
+    executed: list[int] = []
+
+    def my_validator(ctx: RunContext, x: int) -> None:
+        raise CallDeferred(metadata={'job_id': 'abc'})
+
+    agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
+
+    @agent.tool(args_validator=my_validator, retries=0)
+    def my_tool(ctx: RunContext, x: int) -> int:  # pragma: no cover
+        executed.append(x)
+        return x * 42
+
+    result = agent.run_sync('Hello')
+    assert result.output == snapshot(
+        DeferredToolRequests(
+            calls=[ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')],
+            metadata={'pyd_ai_tool_call_id__my_tool': {'job_id': 'abc'}},
+        )
+    )
+    assert executed == []
+
+    assert isinstance(result.output, DeferredToolRequests)
+    tool_call_id = result.output.calls[0].tool_call_id
+    result = agent.run_sync(
+        message_history=result.all_messages(),
+        deferred_tool_results=DeferredToolResults(calls={tool_call_id: 'done externally'}),
+    )
+    assert executed == []
+    assert result.all_messages()[-2] == snapshot(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    content='done externally',
+                    tool_call_id='pyd_ai_tool_call_id__my_tool',
+                    timestamp=IsDatetime(),
+                )
+            ],
+            timestamp=IsDatetime(),
+            run_id=IsStr(),
+            conversation_id=IsStr(),
+        )
+    )
+
+
+def test_args_validator_approval_resolved_inline_by_capability():
+    """A validator's `ApprovalRequired` is resolvable inline by a `HandleDeferredToolCalls` handler."""
+    requests: list[DeferredToolRequests] = []
+    executed: list[int] = []
+
+    def handle_deferred(ctx: RunContext, reqs: DeferredToolRequests) -> DeferredToolResults:
+        requests.append(reqs)
+        return reqs.build_results(approve_all=True)
+
+    def my_validator(ctx: RunContext, x: int) -> None:
+        if not ctx.tool_call_approved:
+            raise ApprovalRequired()
+
+    agent = Agent(TestModel(), capabilities=[HandleDeferredToolCalls(handler=handle_deferred)])
+
+    @agent.tool(args_validator=my_validator)
+    def my_tool(ctx: RunContext, x: int) -> int:
+        executed.append(x)
+        return x * 42
+
+    result = agent.run_sync('Hello')
+    assert result.output == snapshot('{"my_tool":0}')
+    assert executed == [0]
+    assert requests == snapshot(
+        [
+            DeferredToolRequests(
+                approvals=[
+                    ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')
+                ]
+            )
+        ]
+    )
 
 
 def test_args_validator_single_base_model_arg():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4291,6 +4291,48 @@ def test_args_validator_defers_call():
     )
 
 
+def test_args_validator_deferral_metadata_not_merged_for_already_deferred_kinds():
+    """Pins current behavior: a tool that's already deferred by kind ignores the deferral's metadata.
+
+    A `requires_approval=True` (or external) tool is collected as deferred by its kind without being
+    executed, so neither its `args_validator` nor its function body can contribute
+    `ApprovalRequired(metadata=...)` to `DeferredToolRequests.metadata` — the validator case behaves
+    exactly like the pre-existing tool-body case, both asserted here. Only tools deferred *by* the
+    deferral itself (a plain function tool) carry metadata through.
+    """
+    executed: list[str] = []
+
+    def my_validator(ctx: RunContext, x: int) -> None:
+        raise ApprovalRequired(metadata={'from': 'validator'})
+
+    agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
+
+    @agent.tool(requires_approval=True, args_validator=my_validator)
+    def validator_defers(ctx: RunContext, x: int) -> int:  # pragma: no cover
+        executed.append('validator_defers')
+        return x
+
+    @agent.tool(requires_approval=True)
+    def body_defers(ctx: RunContext, x: int) -> int:  # pragma: no cover
+        executed.append('body_defers')
+        raise ApprovalRequired(metadata={'from': 'body'})
+
+    result = agent.run_sync('Hello')
+    assert result.output == snapshot(
+        DeferredToolRequests(
+            approvals=[
+                ToolCallPart(
+                    tool_name='validator_defers', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__validator_defers'
+                ),
+                ToolCallPart(tool_name='body_defers', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__body_defers'),
+            ]
+        )
+    )
+    assert isinstance(result.output, DeferredToolRequests)
+    assert result.output.metadata == {}  # neither the validator's nor the body's metadata
+    assert executed == []
+
+
 def test_args_validator_approval_resolved_inline_by_capability():
     """A validator's `ApprovalRequired` is resolvable inline by a `HandleDeferredToolCalls` handler."""
     requests: list[DeferredToolRequests] = []


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

Fixes a bug with no existing issue: an `args_validator` that raises `ApprovalRequired` or `CallDeferred` aborts the whole run instead of deferring the call.

### The bug

```python
from pydantic_ai import Agent, ApprovalRequired, DeferredToolRequests, RunContext
from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
from pydantic_ai.models.function import AgentInfo, FunctionModel
from pydantic_ai.toolsets import FunctionToolset


def validate_delete(ctx: RunContext[None], path: str) -> None:
    if path.startswith('/etc') and not ctx.tool_call_approved:
        raise ApprovalRequired()


toolset = FunctionToolset[None]()


@toolset.tool(args_validator=validate_delete)
def delete_file(ctx: RunContext[None], path: str) -> str:
    return f'deleted {path}'


def call_tool(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
    if len(messages) == 1:
        return ModelResponse(parts=[ToolCallPart('delete_file', {'path': '/etc/passwd'})])
    return ModelResponse(parts=[TextPart('done')])


agent = Agent(FunctionModel(call_tool), toolsets=[toolset], output_type=[str, DeferredToolRequests])
print(agent.run_sync('delete /etc/passwd').output)
```

Before this PR the run dies with a bare exception:

```
  File "pydantic_ai/_tool_execution.py", line 458, in _validate_function_calls
    validated = await self.tool_manager.validate_tool_call(call)
  File "pydantic_ai/tool_manager.py", line 485, in validate_tool_call
    validated_args = await self._run_validate_hooks(call, tool, ctx, allow_partial=False)
  File "pydantic_ai/tool_manager.py", line 270, in _validate_tool_args
    result = tool.args_validator_func(ctx, **args_dict)
  File "repro.py", line 11, in validate_delete
    raise ApprovalRequired()
pydantic_ai.exceptions.ApprovalRequired
```

After it, `DeferredToolRequests(approvals=[ToolCallPart(tool_name='delete_file', ...)])`.

`tool_manager.py` treats `(SkipToolExecution, CallDeferred, ApprovalRequired, ToolRetryError, ToolFailedError)` as "Control flow, not errors" around tool **execution**, but nothing gave the same treatment to the **validation** stage. `ModelRetry` and `ToolFailed` from a validator work correctly today; the deferral-shaped exceptions didn't.

Our own docs invite exactly this pattern:

- `docs/tools-advanced.md`: "`args_validator` … is useful for … validating arguments before requesting [human approval](deferred-tools.md) for deferred tools"
- the agent skill reference `references/TOOLS-ADVANCED.md`: "for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True`"

A user following either sentence from a validator got the traceback above.

### Why support it rather than reject it

`args_validator` exists because of #3893 ("Tool args are not validated when tool is marked as `approval_required`"), whose complaint was: "with deferred tools or tools that require approval, we end up requesting approval first to potentially run into invalid input. It would be better to have all validation occur up-front before any logic is run." #4016 delivered that: "For deferred tools, validation now runs at deferral time — only tool calls with valid arguments are deferred."

So the feature exists precisely to make approval decisions happen after arguments are known good, which makes the validator arguably the *better* place to decide conditional approval. To be straight about what's being widened: #4016's design notes said "Validators should raise `ModelRetry` on failure. Other exceptions propagate as tool errors." Deferral-shaped exceptions were never considered there, so this extends a deliberately narrow decision rather than reversing a considered one.

### How it works

The deferral is routed into the machinery that already exists for execution-stage deferrals, rather than a second collection path:

- `_validate_tool_args` catches `CallDeferred`/`ApprovalRequired` from `args_validator_func` and re-raises it wrapped in a private `_ValidationDeferral` that also carries the schema-validated args (so they aren't lost as the exception passes the hook boundary). It never escapes `ToolManager`.
- `validate_tool_call` unwraps it into `ValidatedToolCall(args_valid=True, validated_args=..., deferral=exc)` — a new field.
- `execute_tool_call` re-raises `validated.deferral` instead of running the tool.

That last step is the whole trick: from there on the exception is indistinguishable from one raised by the tool function, so `_tool_execution.py` needed **no changes at all**. The existing `except (CallDeferred, ApprovalRequired)` handlers in `_call_tools`/`run_one` collect it into `deferred_calls['unapproved']`/`['external']` with its metadata, `_resolve_deferred_calls` announces the batch (`DeferredToolRequestsEvent`), a `HandleDeferredToolCalls` handler can resolve it inline, and otherwise it surfaces in the run's `DeferredToolRequests` output. `ToolManager.handle_call` (used for sandboxed/code-mode dispatch) resolves it via `_resolve_single_deferred` for free.

### Design decisions

1. **`args_valid` is `True`.** Schema validation passed and the validator made a deliberate control-flow choice, so this is not a validation failure: `FunctionToolCallEvent.args_valid` is `True` and `validated_args` carries the schema-validated dict. This matches what a `requires_approval=True` tool already reports when it's collected as deferred.
2. **The retry budget is untouched**, and `failed_tools` isn't marked — a deferral isn't a failure. Pinned by giving the tool `retries=0` in the tests: if the deferral were treated as a validation failure, `_check_max_retries` would raise `UnexpectedModelBehavior` immediately instead of deferring.
3. **`on_tool_validate_error` does not fire.** `_run_validate_hooks` only catches `(ValidationError, ModelRetry)`, so the deferral already propagated past it; the `wrap_tool_validate` handler chain in `CombinedCapability` passes it through untouched too. Both are now pinned by a test, and `AbstractCapability.on_tool_validate_error`'s docstring says so explicitly (mirroring what `on_tool_execute_error` already documents). `after_tool_validate` doesn't run either, mirroring `after_tool_execute` on the execution side.
4. **Partial/streaming validation needs no change, and the premise that it did turned out not to hold.** `_validate_tool_args` threads an `allow_partial` flag, but for function tools its only caller (`validate_tool_call`) hardcodes `allow_partial=False`; output tools take a different path (`validate_output_tool_call` → `processor.hook_validate`) and never have an `args_validator_func` at all (`OutputToolset.get_tools` sets only the schema `args_validator`). So a custom validator can never see partially-built args today and can't emit a deferral from one. A streaming regression test pins it: with tool-call args arriving in three fragments, the validator is consulted exactly once, with `ctx.partial_output` `False`, and exactly one deferral reaches the batch. I deliberately did **not** change the partial-validation code paths.
5. **`SkipToolExecution` is deliberately *not* honoured from a validator.** It's documented as a hook signal for `before_tool_execute`/`wrap_tool_execute` ("skip execution, use this result"), no doc invites it from a validator, and nothing was reported. Honouring it would also require deciding validate-stage semantics for `usage.tool_calls` accounting and `succeeded_tools` that no user has asked for. It stays an ordinary exception that aborts the run, as before. If demand appears it's an additive follow-up, not a behavior change.

### Known limitation: deferral metadata on tools that are already deferred by kind

For a tool that's *already* deferred by kind (`requires_approval=True`, or an `ExternalToolset` tool), `_collect_deferred_calls` collects the call by kind without executing it. Its `args_validator`'s `ApprovalRequired(metadata=...)` therefore changes nothing about the outcome and **its `metadata` does not reach `DeferredToolRequests.metadata`**. Someone will eventually pass metadata there and wonder, so to be explicit:

- this is pre-existing behavior, not something this PR introduces: a tool *body* raising `ApprovalRequired(metadata=...)` on a `requires_approval=True` tool has always had its metadata dropped for the same reason (the body never runs before approval);
- it's pinned by `test_args_validator_deferral_metadata_not_merged_for_already_deferred_kinds`, which asserts the validator case and the tool-body case behave identically, so changing it later is a deliberate decision rather than an accident;
- metadata *does* flow for the case this PR is about — a plain function tool deferred *by* the validator's exception (asserted in `test_args_validator_requests_approval`);
- wiring validator metadata into the kind-based collection path is orthogonal to this fix and out of scope.

### Backward compatibility

Nothing changes for validators that don't raise these two exceptions: the only new behavior is on a path that previously crashed the run. `ValidatedToolCall` gains one optional field with a default.

### Durable execution and cross-engine parity

No files under `durable_exec/` are touched, and this change is inherently parity-clean across Temporal, DBOS, and Prefect. Evidence, by static analysis (the engines aren't installed in this environment, so I could not run their suites):

- **Validation is engine-agnostic.** `args_validator_func` is invoked in exactly one place, `ToolManager._validate_tool_args` (`tool_manager.py`), reached only via `validate_tool_call`, whose only callers are the graph's `_tool_execution.py:458`, `:480` and `:801`. That's workflow (Temporal), flow (Prefect), or inline workflow code (DBOS) on every engine. `grep -rn "validate_tool_call\|ToolManager\|args_validator_func" pydantic_ai_slim/pydantic_ai/durable_exec/` returns nothing, so no engine intercepts, replaces, or relocates the validation step.
- **The engines diverge only below `call_tool`, which a deferring validator never reaches** (`execute_tool_call` raises before `_run_execute_hooks`): Temporal runs it in an activity (`temporal/_function_toolset.py:37-49`), Prefect in a task (`prefect/_function_toolset.py:33`), and DBOS runs function tools inline with no wrapper at all (`dbos/_agent.py:321`). Each shares `wrap_tool_call_result`/`unwrap_tool_call_result` (`durable_exec/_toolset.py:163`, `:179`) for *execution*-stage `ApprovalRequired`/`CallDeferred`.
- **The workflow-side tool object keeps the real validator** for static function toolsets: `DurableFunctionToolset` overrides only `call_tool` (`durable_exec/_toolset.py:333-363`) and inherits the wrapper's pass-through `get_tools`, so `args_validator_func` is present and runs where it always did.
- **The one asymmetry vs. the non-durable path is dynamic toolsets, and it is identical on all three engines** because it lives in shared code: `DurableDynamicToolset.get_tools` hands the workflow a placeholder `ToolsetTool` with `args_validator=TOOL_SCHEMA_VALIDATOR` and no `args_validator_func` (`durable_exec/_toolset.py:411-423`), and `call_dynamic_tool` re-validates only the *schema* inside the durable unit before calling the tool (`durable_exec/_toolset.py:100-101`, Temporal's variant at `temporal/_toolset.py:148-149`). So a custom `args_validator` on a dynamic toolset's tool is skipped under durable execution today — for `ModelRetry` exactly as much as for a deferral. Pre-existing, engine-uniform, and out of scope here.

Note for the in-flight PR that moves argument validation into its own durable unit: the deferral will then have to cross that boundary, and it should be round-tripped as a value the way `wrap_tool_call_result`/`unwrap_tool_call_result` already do for execution-stage deferrals (feeding into the `_validate_tool_args` handling here rather than duplicating it), or a user's approval request will surface as an activity failure.

### Tests

- `tests/test_tools.py::test_args_validator_requests_approval` — validator's `ApprovalRequired` defers the call into `approvals` with its metadata, the tool doesn't run, the retry budget is untouched (`retries=0`), and approving it on a follow-up run re-runs the validator with `ctx.tool_call_approved=True` and executes the tool.
- `tests/test_tools.py::test_args_validator_defers_call` — `CallDeferred` lands in `calls`; the external result supplied on the follow-up run is recorded without executing the tool.
- `tests/test_tools.py::test_args_validator_deferral_metadata_not_merged_for_already_deferred_kinds` — pins the known limitation above: on a `requires_approval=True` tool, neither the validator's nor the tool body's `ApprovalRequired(metadata=...)` reaches `DeferredToolRequests.metadata`.
- `tests/test_tools.py::test_args_validator_approval_resolved_inline_by_capability` — a `HandleDeferredToolCalls` handler resolves the validator's approval request inline, in the same run.
- `tests/test_streaming.py::test_args_validator_deferral_not_triggered_by_partial_args` — fragmented streamed args; one validator call on the complete args, `args_valid=True` on the `FunctionToolCallEvent`, one `DeferredToolRequestsEvent`, no result event.
- `tests/test_capabilities.py::TestToolValidateErrorHooks::test_args_validator_deferral_is_not_a_validate_error` — no `on_tool_validate_error`, no `after_tool_validate`, no execute hooks.
- Existing `ModelRetry` / `ToolFailed` / max-retries validator tests are unchanged and still pass.

Verified: `uv run pytest` (full suite, 6298 passed) and `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/tool_manager.py` (clean). Docs examples in this environment are skipped ("extras not installed"), so the new `args_validator_conditional_approval.py` example was verified by extracting and running it (prints `{'amount': 500}`, matching the `#>` line) and by `ruff check`/`ruff format` at the docs example settings; the skill example is covered by `tests/test_skill_examples.py`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
