### PR TITLE
Raise `ModelAPIError` for OpenRouter responses with null choices and no error envelope

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1241,10 +1241,13 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
                     validated = _OpenRouterChatCompletionChunk.model_validate(chunk_dict)
                 except ValidationError as exc:
                     # Parity with `OpenRouterModel._validate_completion`: the same no-completion body can
-                    # arrive mid-stream, and this strict chunk model rejects it before `OpenAIStreamedResponse`
-                    # can reach its tolerant `if not chunk.choices` guard, so classify it here instead.
-                    # Classification only: `FallbackModel` catches failures while *opening* a stream, so
-                    # unlike the non-streamed path this does not reach fallback.
+                    # arrive mid-stream. `_OpenRouterChatCompletionChunk.choices` is required and non-null,
+                    # so a null-`choices` chunk has always been terminal here — unlike `OpenAIStreamedResponse`,
+                    # which skips such chunks (https://github.com/pydantic/pydantic-ai/issues/5165). This only
+                    # improves the exception, from a bare `ValidationError` to `ModelAPIError`; it does not
+                    # newly terminate any stream that used to succeed.
+                    # Classification only: `FallbackModel`'s window is `Model.request_stream`'s own
+                    # `__aenter__`, which returns before any chunk is validated, so this never falls back.
                     _raise_for_no_completion(chunk_dict, self._model_name, exc)
                     raise
                 yield validated

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Discriminator, ValidationError, field_validator
 from typing_extensions import TypedDict, assert_never, override
 
 from .. import usage
-from ..exceptions import ModelHTTPError, UserError
+from ..exceptions import ModelAPIError, ModelHTTPError, UserError
 from ..messages import (
     BinaryContent,
     CachePoint,
@@ -1030,15 +1030,15 @@ class OpenRouterModel(OpenAIChatModel):
                     and not isinstance(response_dict.get('provider'), dict)
                 ):
                     # A null-`choices` body with no error envelope and no nested-provider
-                    # payload is a transient provider hiccup, not a malformed request:
-                    # surface it as a retryable upstream error rather than a bare
-                    # ValidationError. A `provider` dict that failed to validate above is
-                    # excluded on purpose — that body tried to be a nested-provider
-                    # response and was malformed, which must stay fatal.
-                    raise ModelHTTPError(
-                        status_code=502,
+                    # payload is a transient provider hiccup, not a malformed request.
+                    # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so this
+                    # reaches retry/fallback machinery that a bare `ValidationError` never
+                    # did. A `provider` dict that failed to validate above is excluded on
+                    # purpose — that body tried to be a nested-provider response and was
+                    # malformed, which must stay fatal.
+                    raise ModelAPIError(
                         model_name=response_dict.get('model') or self.model_name,
-                        body='OpenRouter returned a response with null `choices` and no error envelope',
+                        message='OpenRouter returned a response with null `choices` and no error envelope',
                     ) from exc
                 raise exc
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -589,20 +589,17 @@ class _OpenRouterErrorResponse(BaseModel, extra='allow'):
 
 
 class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
-    """OpenRouter response that carries no completion at all: `choices` is null and there is no error envelope.
-
-    A sibling of `_OpenRouterErrorResponse` — the same family of bodies OpenRouter
-    returns when a downstream provider hiccups, minus the error envelope. Modelling it
-    keeps a `ValidationError` from `_OpenRouterChatCompletion` meaning "a shape we do not
-    account for" rather than doubling as a transient signal.
+    """OpenRouter body carrying no completion: null `choices` and no error envelope (see https://github.com/pydantic/pydantic-ai/issues/6900).
 
     `provider` is typed `str | None` on purpose: a body whose `provider` is a *dict* is a
     malformed nested-provider response, not this shape, so it fails validation here and
     stays fatal.
 
     `Literal[None]` rather than a bare `None` annotation: this module uses
-    `from __future__ import annotations`, so annotations are strings, and resolving the
-    string `'None'` raises `PydanticUserError` on the lowest supported pydantic (2.12).
+    `from __future__ import annotations`, so annotations are strings, and on Python 3.14
+    (PEP 649) resolving the string `'None'` raises `PydanticUserError` under pydantic
+    below 2.13 — the `3.14 (lowest-versions)` CI job. It resolves fine on 3.13 and on
+    pydantic 2.13+, so a local check on either will not reproduce it.
     """
 
     choices: Literal[None]
@@ -627,6 +624,26 @@ class _OpenRouterNestedProviderResponse(BaseModel, extra='allow'):
     """OpenRouter response where the real completion is nested in `provider` (see https://github.com/pydantic/pydantic-ai/issues/3994)."""
 
     provider: _OpenRouterNestedCompletion
+
+
+def _raise_for_no_completion(response_dict: dict[str, Any], model_name: str, exc: ValidationError) -> None:
+    """Raise `ModelAPIError` if the body carries no completion and no error envelope.
+
+    Returns normally for any other shape so the caller can keep trying the shapes it knows.
+    Shared by the non-streamed and streamed paths so both classify this body the same way.
+    """
+    try:
+        no_completion = _OpenRouterNoCompletionResponse.model_validate(response_dict)
+    except ValidationError:
+        return
+
+    # A body with no completion and no error envelope is a transient provider hiccup, not a
+    # malformed request, so it belongs in the `ModelAPIError` family rather than surfacing as a
+    # bare `ValidationError` (which reaches callers as `UnexpectedModelBehavior`).
+    raise ModelAPIError(
+        model_name=no_completion.model or model_name,
+        message='OpenRouter returned a response with null `choices` and no error envelope',
+    ) from exc
 
 
 def _map_openrouter_provider_details(
@@ -1044,22 +1061,14 @@ class OpenRouterModel(OpenAIChatModel):
                     body=error_response.error.message,
                 )
 
+            # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so on this non-streamed
+            # path the transient now falls back where a bare `ValidationError` never did.
+            _raise_for_no_completion(response_dict, self.model_name, exc)
+
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
-                try:
-                    no_completion = _OpenRouterNoCompletionResponse.model_validate(response_dict)
-                except ValidationError:
-                    raise exc
-                else:
-                    # A body with no completion and no error envelope is a transient
-                    # provider hiccup, not a malformed request. `ModelAPIError` is
-                    # `FallbackModel`'s default `fallback_on`, so this reaches retry and
-                    # fallback machinery that a bare `ValidationError` never did.
-                    raise ModelAPIError(
-                        model_name=no_completion.model or self.model_name,
-                        message='OpenRouter returned a response with null `choices` and no error envelope',
-                    ) from exc
+                raise exc
 
             validated = nested.provider
             if not validated.created:
@@ -1227,7 +1236,18 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
     async def _validate_response(self):
         try:
             async for chunk in self._response:
-                yield _OpenRouterChatCompletionChunk.model_validate(chunk.model_dump())
+                chunk_dict = chunk.model_dump()
+                try:
+                    validated = _OpenRouterChatCompletionChunk.model_validate(chunk_dict)
+                except ValidationError as exc:
+                    # Parity with `OpenRouterModel._validate_completion`: the same no-completion body can
+                    # arrive mid-stream, and this strict chunk model rejects it before `OpenAIStreamedResponse`
+                    # can reach its tolerant `if not chunk.choices` guard, so classify it here instead.
+                    # Classification only: `FallbackModel` catches failures while *opening* a stream, so
+                    # unlike the non-streamed path this does not reach fallback.
+                    _raise_for_no_completion(chunk_dict, self._model_name, exc)
+                    raise
+                yield validated
         except APIError as e:
             error = _OpenRouterError.model_validate(e.body)
             raise ModelHTTPError(status_code=error.code, model_name=self._model_name, body=error.message)

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1024,10 +1024,17 @@ class OpenRouterModel(OpenAIChatModel):
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
-                if response_dict.get('choices') is None and response_dict.get('error') is None:
-                    # A null-`choices` body with no error envelope at all is a transient
-                    # provider hiccup, not a malformed request: surface it as a retryable
-                    # upstream error rather than a bare ValidationError.
+                if (
+                    response_dict.get('choices') is None
+                    and response_dict.get('error') is None
+                    and not isinstance(response_dict.get('provider'), dict)
+                ):
+                    # A null-`choices` body with no error envelope and no nested-provider
+                    # payload is a transient provider hiccup, not a malformed request:
+                    # surface it as a retryable upstream error rather than a bare
+                    # ValidationError. A `provider` dict that failed to validate above is
+                    # excluded on purpose — that body tried to be a nested-provider
+                    # response and was malformed, which must stay fatal.
                     raise ModelHTTPError(
                         status_code=502,
                         model_name=response_dict.get('model') or self.model_name,

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1024,6 +1024,15 @@ class OpenRouterModel(OpenAIChatModel):
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
+                if response_dict.get('choices') is None and response_dict.get('error') is None:
+                    # A null-`choices` body with no error envelope at all is a transient
+                    # provider hiccup, not a malformed request: surface it as a retryable
+                    # upstream error rather than a bare ValidationError.
+                    raise ModelHTTPError(
+                        status_code=502,
+                        model_name=response_dict.get('model') or self.model_name,
+                        body='OpenRouter returned a response with null `choices` and no error envelope',
+                    ) from exc
                 raise exc
 
             validated = nested.provider

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -599,10 +599,14 @@ class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
     `provider` is typed `str | None` on purpose: a body whose `provider` is a *dict* is a
     malformed nested-provider response, not this shape, so it fails validation here and
     stays fatal.
+
+    `Literal[None]` rather than a bare `None` annotation: this module uses
+    `from __future__ import annotations`, so annotations are strings, and resolving the
+    string `'None'` raises `PydanticUserError` on the lowest supported pydantic (2.12).
     """
 
-    choices: None
-    error: None = None
+    choices: Literal[None]
+    error: Literal[None] = None
     provider: str | None = None
     model: str | None = None
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -588,6 +588,25 @@ class _OpenRouterErrorResponse(BaseModel, extra='allow'):
     model: str | None = None
 
 
+class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
+    """OpenRouter response that carries no completion at all: `choices` is null and there is no error envelope.
+
+    A sibling of `_OpenRouterErrorResponse` — the same family of bodies OpenRouter
+    returns when a downstream provider hiccups, minus the error envelope. Modelling it
+    keeps a `ValidationError` from `_OpenRouterChatCompletion` meaning "a shape we do not
+    account for" rather than doubling as a transient signal.
+
+    `provider` is typed `str | None` on purpose: a body whose `provider` is a *dict* is a
+    malformed nested-provider response, not this shape, so it fails validation here and
+    stays fatal.
+    """
+
+    choices: None
+    error: None = None
+    provider: str | None = None
+    model: str | None = None
+
+
 class _OpenRouterNestedCompletion(_OpenRouterChatCompletion):
     """Completion nested in the `provider` field where provider name may be null (see https://github.com/pydantic/pydantic-ai/issues/3994)."""
 
@@ -1024,23 +1043,19 @@ class OpenRouterModel(OpenAIChatModel):
             try:
                 nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
             except ValidationError:
-                if (
-                    response_dict.get('choices') is None
-                    and response_dict.get('error') is None
-                    and not isinstance(response_dict.get('provider'), dict)
-                ):
-                    # A null-`choices` body with no error envelope and no nested-provider
-                    # payload is a transient provider hiccup, not a malformed request.
-                    # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so this
-                    # reaches retry/fallback machinery that a bare `ValidationError` never
-                    # did. A `provider` dict that failed to validate above is excluded on
-                    # purpose — that body tried to be a nested-provider response and was
-                    # malformed, which must stay fatal.
+                try:
+                    no_completion = _OpenRouterNoCompletionResponse.model_validate(response_dict)
+                except ValidationError:
+                    raise exc
+                else:
+                    # A body with no completion and no error envelope is a transient
+                    # provider hiccup, not a malformed request. `ModelAPIError` is
+                    # `FallbackModel`'s default `fallback_on`, so this reaches retry and
+                    # fallback machinery that a bare `ValidationError` never did.
                     raise ModelAPIError(
-                        model_name=response_dict.get('model') or self.model_name,
+                        model_name=no_completion.model or self.model_name,
                         message='OpenRouter returned a response with null `choices` and no error envelope',
                     ) from exc
-                raise exc
 
             validated = nested.provider
             if not validated.created:

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -595,6 +595,10 @@ class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
     malformed nested-provider response, not this shape, so it fails validation here and
     stays fatal.
 
+    `choices` cannot be dropped in favour of `extra='allow'` the way `_OpenRouterErrorResponse`'s
+    was: there `error` is the discriminator, whereas here `choices` is the only field that
+    identifies the shape, so without it this model would match almost any body.
+
     `Literal[None]` rather than a bare `None` annotation: this module uses
     `from __future__ import annotations`, so annotations are strings, and on Python 3.14
     (PEP 649) resolving the string `'None'` raises `PydanticUserError` under pydantic
@@ -1061,8 +1065,8 @@ class OpenRouterModel(OpenAIChatModel):
                     body=error_response.error.message,
                 )
 
-            # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so on this non-streamed
-            # path the transient now falls back where a bare `ValidationError` never did.
+            # `ModelAPIError` is `FallbackModel`'s default `fallback_on`, so raising it here lets the
+            # transient reach fallback on this non-streamed path.
             _raise_for_no_completion(response_dict, self.model_name, exc)
 
             try:
@@ -1248,6 +1252,11 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
                     # newly terminate any stream that used to succeed.
                     # Classification only: `FallbackModel`'s window is `Model.request_stream`'s own
                     # `__aenter__`, which returns before any chunk is validated, so this never falls back.
+                    # Only the no-completion shape is mapped here: it is the only one of the three shapes
+                    # `_validate_completion` knows that has been reproduced on a stream. An error-envelope
+                    # chunk never reaches this branch — the openai SDK raises `APIError` at SSE decode for
+                    # any body carrying a truthy `error`, handled below — and the nested-provider shape
+                    # carries `message`, not `delta`, so it cannot arrive as a chunk at all.
                     _raise_for_no_completion(chunk_dict, self._model_name, exc)
                     raise
                 yield validated

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from vcr.cassette import Cassette
 
 from pydantic_ai import (
@@ -39,11 +39,12 @@ from ..conftest import IsDatetime, IsStr, message, try_import
 from .mock_openai import MockOpenAI, get_mock_chat_completion_kwargs
 
 with try_import() as imports_successful:
-    from openai.types.chat import ChatCompletion
+    from openai.types.chat import ChatCompletion, ChatCompletionChunk
     from openai.types.chat.chat_completion import Choice
     from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
     from pydantic_ai.models.anthropic import AnthropicModelSettings
+    from pydantic_ai.models.fallback import FallbackModel
     from pydantic_ai.models.openrouter import (
         OpenRouterModel,
         OpenRouterModelSettings,
@@ -52,6 +53,7 @@ with try_import() as imports_successful:
         _OpenRouterChatCompletion,  # pyright: ignore[reportPrivateUsage]
         _OpenRouterChatCompletionChunk,  # pyright: ignore[reportPrivateUsage]
     )
+    from pydantic_ai.models.test import TestModel
     from pydantic_ai.providers.openrouter import OpenRouterProvider
 
 pytestmark = [
@@ -1312,7 +1314,11 @@ def test_openrouter_nested_provider_null_name() -> None:
 
 
 def test_openrouter_provider_dict_without_choices_raises() -> None:
-    """Provider is a dict with no 'choices' key — no unwrap happens, validation fails."""
+    """Provider is a dict with no 'choices' key — no unwrap happens, validation fails.
+
+    Also pins the boundary the no-completion shape depends on: `_OpenRouterNoCompletionResponse.provider`
+    is typed `str | None`, so this body does not match it and stays fatal instead of becoming retryable.
+    """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
 
@@ -1375,12 +1381,12 @@ def test_openrouter_malformed_error_fallthrough() -> None:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
 
-def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
-    """A null-`choices` body with no error envelope raises a retryable ModelHTTPError(502).
+def test_openrouter_null_choices_without_error_envelope_raises_model_api_error() -> None:
+    """A null-`choices` body with no error envelope raises `ModelAPIError`, not a bare `ValidationError`.
 
-    OpenRouter intermittently returns `{"choices": null, ...}` with no error field at
-    all (a provider hiccup). Re-raising the bare ValidationError makes retry layers
-    that classify on exception type treat a transient as fatal.
+    OpenRouter intermittently returns `{"choices": null, ...}` with no error field at all (a provider
+    hiccup). A bare `ValidationError` surfaces as `UnexpectedModelBehavior`, which `FallbackModel`'s
+    default `fallback_on=(ModelAPIError,)` does not match, so the transient never reaches fallback.
     """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
@@ -1399,17 +1405,15 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
     assert not isinstance(exc_info.value, ModelHTTPError)  # not a faked HTTP status
-    assert 'null `choices`' in str(exc_info.value)
+    assert str(exc_info.value) == snapshot('OpenRouter returned a response with null `choices` and no error envelope')
+    assert exc_info.value.model_name == snapshot('openai/gpt-4.1-mini')
 
 
-def test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal() -> None:
-    """A malformed nested-provider body is NOT the no-completion shape.
+def test_openrouter_null_choices_named_provider_reports_body_model() -> None:
+    """The realistic body names its downstream `provider`, and its `model` wins over the configured one.
 
-    `choices=None` with no error envelope but a `provider` dict means the body tried
-    to be a nested-provider response and failed to validate. Retrying that forever
-    would mask a real contract break, so it stays fatal — `provider` is typed
-    `str | None` on `_OpenRouterNoCompletionResponse` precisely so this body does not
-    match it.
+    `provider` as a name string is the accept-side of the `str | None` discriminator that keeps a
+    `provider` *dict* fatal, so it needs its own coverage.
     """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
@@ -1417,14 +1421,92 @@ def test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal() -> N
     completion = ChatCompletion.model_construct(
         id=None,
         choices=None,
-        model=None,
+        model='google/gemini-2.5-flash',
         object=None,
-        provider={'some_key': 'some_value'},
+        provider='Google',
         created=1234567890,
+        usage=None,
     )
 
-    with pytest.raises(UnexpectedModelBehavior):
+    with pytest.raises(ModelAPIError) as exc_info:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+    assert exc_info.value.model_name == snapshot('google/gemini-2.5-flash')
+
+
+def _null_choices_chunk(provider: Any = None) -> ChatCompletionChunk:
+    """The no-completion body as a streaming chunk: null `choices`, no error envelope."""
+    return ChatCompletionChunk.model_construct(
+        id='gen-123',
+        choices=None,
+        created=1234567890,
+        model=None,
+        object=None,
+        provider=provider,
+        usage=None,
+    )
+
+
+async def test_openrouter_null_choices_streaming_raises_model_api_error(allow_model_requests: None) -> None:
+    """Streaming parity: the same no-completion body is a mapped `ModelAPIError` mid-stream too.
+
+    `_OpenRouterChatCompletionChunk.choices` is required and non-null, so this chunk is rejected in
+    `OpenRouterStreamedResponse._validate_response` before `OpenAIStreamedResponse` reaches its tolerant
+    `if not chunk.choices` guard — without the classification there it surfaces as a raw `ValidationError`,
+    which is exactly the non-retryable surface this PR removes from the non-streaming path.
+    """
+    mock_client = MockOpenAI.create_mock_stream([_null_choices_chunk()])
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
+    agent = Agent(model)
+
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello'):
+            pass
+
+    assert not isinstance(exc_info.value, ModelHTTPError)  # not a faked HTTP status
+    assert str(exc_info.value) == snapshot('OpenRouter returned a response with null `choices` and no error envelope')
+    assert exc_info.value.model_name == snapshot('openai/gpt-4.1-mini')
+
+
+async def test_openrouter_streaming_malformed_chunk_stays_fatal(allow_model_requests: None) -> None:
+    """A chunk that fails validation for some *other* reason keeps re-raising the original error.
+
+    Streaming twin of `test_openrouter_provider_dict_without_choices_raises`: a `provider` dict is not the
+    no-completion shape, so it must not be laundered into a retryable `ModelAPIError`.
+    """
+    mock_client = MockOpenAI.create_mock_stream([_null_choices_chunk(provider={'some_key': 'some_value'})])
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
+    agent = Agent(model)
+
+    with pytest.raises(ValidationError):
+        async with agent.run_stream('hello'):
+            pass
+
+
+async def test_openrouter_null_choices_triggers_fallback(allow_model_requests: None) -> None:
+    """The point of `ModelAPIError`: a no-completion body now reaches `FallbackModel`.
+
+    `fallback_on` defaults to `(ModelAPIError,)`, which a bare `ValidationError` never matched.
+
+    Non-streamed only, deliberately: `FallbackModel.request_stream` catches failures while *opening* a
+    stream, and the equivalent streamed body is only rejected once chunks are consumed, so it propagates
+    instead of falling back. That asymmetry is `FallbackModel`'s, not OpenRouter's.
+    """
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+    )
+    mock_client = MockOpenAI.create_mock(completion)
+    openrouter_model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
+    agent = Agent(FallbackModel(openrouter_model, TestModel(custom_output_text='fallback used')))
+
+    result = await agent.run('hello')
+    assert result.output == snapshot('fallback used')
 
 
 def test_openrouter_error_with_metadata() -> None:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1381,55 +1381,50 @@ def test_openrouter_malformed_error_fallthrough() -> None:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
 
-def test_openrouter_null_choices_without_error_envelope_raises_model_api_error() -> None:
+def _null_choices_completion(**kwargs: Any) -> ChatCompletion:
+    """The no-completion body: null `choices`, no error envelope."""
+    defaults: dict[str, Any] = dict(
+        id=None, choices=None, model=None, object=None, provider=None, created=1234567890, usage=None
+    )
+    return ChatCompletion.model_construct(**{**defaults, **kwargs})
+
+
+async def test_openrouter_null_choices_without_error_envelope_raises_model_api_error(
+    allow_model_requests: None,
+) -> None:
     """A null-`choices` body with no error envelope raises `ModelAPIError`, not a bare `ValidationError`.
 
     OpenRouter intermittently returns `{"choices": null, ...}` with no error field at all (a provider
     hiccup). A bare `ValidationError` surfaces as `UnexpectedModelBehavior`, which `FallbackModel`'s
     default `fallback_on=(ModelAPIError,)` does not match, so the transient never reaches fallback.
-    """
-    provider = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
 
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model=None,
-        object=None,
-        provider=None,
-        created=1234567890,
-        usage=None,
-    )
+    Mock-based rather than VCR — and so are the null-`choices` tests below: the shape is an intermittent
+    downstream-provider fault with no provoking input, so `--record-mode=rewrite` cannot capture it, and a
+    hand-written cassette would give a synthesized body the provenance of a live recording.
+    """
+    mock_client = MockOpenAI.create_mock(_null_choices_completion())
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
 
     with pytest.raises(ModelAPIError) as exc_info:
-        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+        await Agent(model).run('hello')
 
     assert not isinstance(exc_info.value, ModelHTTPError)  # not a faked HTTP status
     assert str(exc_info.value) == snapshot('OpenRouter returned a response with null `choices` and no error envelope')
     assert exc_info.value.model_name == snapshot('openai/gpt-4.1-mini')
 
 
-def test_openrouter_null_choices_named_provider_reports_body_model() -> None:
+async def test_openrouter_null_choices_named_provider_reports_body_model(allow_model_requests: None) -> None:
     """The realistic body names its downstream `provider`, and its `model` wins over the configured one.
 
     `provider` as a name string is the accept-side of the `str | None` discriminator that keeps a
     `provider` *dict* fatal, so it needs its own coverage.
     """
-    provider = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
-
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model='google/gemini-2.5-flash',
-        object=None,
-        provider='Google',
-        created=1234567890,
-        usage=None,
-    )
+    completion = _null_choices_completion(model='google/gemini-2.5-flash', provider='Google')
+    mock_client = MockOpenAI.create_mock(completion)
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
 
     with pytest.raises(ModelAPIError) as exc_info:
-        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+        await Agent(model).run('hello')
 
     assert exc_info.value.model_name == snapshot('google/gemini-2.5-flash')
 
@@ -1448,12 +1443,17 @@ def _null_choices_chunk(provider: Any = None) -> ChatCompletionChunk:
 
 
 async def test_openrouter_null_choices_streaming_raises_model_api_error(allow_model_requests: None) -> None:
-    """Streaming parity: the same no-completion body is a mapped `ModelAPIError` mid-stream too.
+    """Streaming parity: the same no-completion body is a mapped `ModelAPIError` on the stream too.
 
     `_OpenRouterChatCompletionChunk.choices` is required and non-null, so this chunk is rejected in
     `OpenRouterStreamedResponse._validate_response` before `OpenAIStreamedResponse` reaches its tolerant
-    `if not chunk.choices` guard — without the classification there it surfaces as a raw `ValidationError`,
-    which is exactly the non-retryable surface this PR removes from the non-streaming path.
+    `if not chunk.choices` guard. It already failed there; what this pins is that it now fails as
+    `ModelAPIError` rather than as the raw `ValidationError` this PR removes from the non-streamed path.
+
+    The error surfaces while entering `agent.run_stream` — the agent consumes the first event there — so
+    the block body never runs. Kept beside its non-streamed twin rather than moved to
+    `tests/test_streaming_errors.py`: this PR exists to make the two paths agree, and reading them
+    together is the point.
     """
     mock_client = MockOpenAI.create_mock_stream([_null_choices_chunk()])
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
@@ -1488,20 +1488,11 @@ async def test_openrouter_null_choices_triggers_fallback(allow_model_requests: N
 
     `fallback_on` defaults to `(ModelAPIError,)`, which a bare `ValidationError` never matched.
 
-    Non-streamed only, deliberately: `FallbackModel.request_stream` catches failures while *opening* a
-    stream, and the equivalent streamed body is only rejected once chunks are consumed, so it propagates
-    instead of falling back. That asymmetry is `FallbackModel`'s, not OpenRouter's.
+    Non-streamed only, deliberately: `FallbackModel`'s window is `Model.request_stream`'s own
+    `__aenter__`, which returns before any chunk is validated, so the streamed twin raises instead of
+    falling back. That asymmetry is `FallbackModel`'s, not OpenRouter's.
     """
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model=None,
-        object=None,
-        provider=None,
-        created=1234567890,
-        usage=None,
-    )
-    mock_client = MockOpenAI.create_mock(completion)
+    mock_client = MockOpenAI.create_mock(_null_choices_completion())
     openrouter_model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
     agent = Agent(FallbackModel(openrouter_model, TestModel(custom_output_text='fallback used')))
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1374,6 +1374,33 @@ def test_openrouter_malformed_error_fallthrough() -> None:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
 
+def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
+    """A null-`choices` body with no error envelope raises a retryable ModelHTTPError(502).
+
+    OpenRouter intermittently returns `{"choices": null, ...}` with no error field at
+    all (a provider hiccup). Re-raising the bare ValidationError makes retry layers
+    that classify on exception type treat a transient as fatal.
+    """
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+    )
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+    assert exc_info.value.status_code == 502
+    assert 'null `choices`' in str(exc_info.value)
+
+
 def test_openrouter_error_with_metadata() -> None:
     """Real-world error response with metadata field from #3994.
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -12,6 +12,7 @@ from pydantic_ai import (
     Agent,
     BinaryContent,
     DocumentUrl,
+    ModelAPIError,
     ModelHTTPError,
     ModelMessage,
     ModelRequest,
@@ -1394,10 +1395,10 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
         usage=None,
     )
 
-    with pytest.raises(ModelHTTPError) as exc_info:
+    with pytest.raises(ModelAPIError) as exc_info:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
-    assert exc_info.value.status_code == 502
+    assert not isinstance(exc_info.value, ModelHTTPError)  # not a faked HTTP status
     assert 'null `choices`' in str(exc_info.value)
 
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1401,6 +1401,30 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
     assert 'null `choices`' in str(exc_info.value)
 
 
+def test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal() -> None:
+    """A malformed nested-provider body is NOT the transient shape.
+
+    `choices=None` with no error envelope but a `provider` dict means the body
+    tried to be a nested-provider response and failed to validate. Retrying that
+    forever would mask a real contract break, so it stays fatal — only the
+    envelope-less, provider-less shape becomes a retryable 502.
+    """
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={'some_key': 'some_value'},
+        created=1234567890,
+    )
+
+    with pytest.raises(UnexpectedModelBehavior):
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+
 def test_openrouter_error_with_metadata() -> None:
     """Real-world error response with metadata field from #3994.
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1362,7 +1362,12 @@ def test_openrouter_error_with_null_fields() -> None:
 
 
 def test_openrouter_malformed_error_fallthrough() -> None:
-    """Malformed error data falls through to validation, surfacing as UnexpectedModelBehavior."""
+    """Malformed error data falls through to validation, surfacing as UnexpectedModelBehavior.
+
+    Also pins the second boundary the no-completion shape depends on: `_OpenRouterNoCompletionResponse.error`
+    is typed `Literal[None]`, so this body does not match it and stays fatal. Widening that annotation would
+    flip this test to a retryable `ModelAPIError`.
+    """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
 
@@ -1381,12 +1386,11 @@ def test_openrouter_malformed_error_fallthrough() -> None:
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
 
-def _null_choices_completion(**kwargs: Any) -> ChatCompletion:
+def _null_choices_completion(*, model: str | None = None, provider: str | None = None) -> ChatCompletion:
     """The no-completion body: null `choices`, no error envelope."""
-    defaults: dict[str, Any] = dict(
-        id=None, choices=None, model=None, object=None, provider=None, created=1234567890, usage=None
+    return ChatCompletion.model_construct(
+        id=None, choices=None, model=model, object=None, provider=provider, created=1234567890, usage=None
     )
-    return ChatCompletion.model_construct(**{**defaults, **kwargs})
 
 
 async def test_openrouter_null_choices_without_error_envelope_raises_model_api_error(
@@ -1429,7 +1433,7 @@ async def test_openrouter_null_choices_named_provider_reports_body_model(allow_m
     assert exc_info.value.model_name == snapshot('google/gemini-2.5-flash')
 
 
-def _null_choices_chunk(provider: Any = None) -> ChatCompletionChunk:
+def _null_choices_chunk(provider: dict[str, str] | None = None) -> ChatCompletionChunk:
     """The no-completion body as a streaming chunk: null `choices`, no error envelope."""
     return ChatCompletionChunk.model_construct(
         id='gen-123',
@@ -1468,17 +1472,57 @@ async def test_openrouter_null_choices_streaming_raises_model_api_error(allow_mo
     assert exc_info.value.model_name == snapshot('openai/gpt-4.1-mini')
 
 
+def _text_chunk(content: str, model: str) -> ChatCompletionChunk:
+    """A healthy content chunk, so the no-completion chunk that follows it lands mid-stream rather than first."""
+    return ChatCompletionChunk.model_validate(
+        {
+            'id': 'gen-123',
+            'choices': [{'index': 0, 'delta': {'role': 'assistant', 'content': content}, 'finish_reason': None}],
+            'created': 1234567890,
+            'model': model,
+            'object': 'chat.completion.chunk',
+            'provider': 'Google',
+        }
+    )
+
+
+async def test_openrouter_null_choices_mid_stream_reports_first_chunk_model(allow_model_requests: None) -> None:
+    """Arriving mid-stream rather than first, the same body still raises — and names the model differently.
+
+    The classification is position-independent, but the reported `model_name` is not: `OpenAIChatModel`
+    fixes `_model_name` from `first_chunk.model` when one is present, and the streamed call site passes
+    that, where the non-streamed one passes the configured name. So a stream opened by a chunk naming
+    `google/gemini-2.5-flash` reports that, not the configured `openai/gpt-4.1-mini` its first-chunk twin
+    above asserts. Pinned because the twin alone reads as if the configured name always wins.
+    """
+    mock_client = MockOpenAI.create_mock_stream(
+        [_text_chunk('hello ', model='google/gemini-2.5-flash'), _null_choices_chunk()]
+    )
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
+    agent = Agent(model)
+
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello') as result:
+            async for _ in result.stream_text(delta=True):
+                pass
+
+    assert str(exc_info.value) == snapshot('OpenRouter returned a response with null `choices` and no error envelope')
+    assert exc_info.value.model_name == snapshot('google/gemini-2.5-flash')
+
+
 async def test_openrouter_streaming_malformed_chunk_stays_fatal(allow_model_requests: None) -> None:
     """A chunk that fails validation for some *other* reason keeps re-raising the original error.
 
     Streaming twin of `test_openrouter_provider_dict_without_choices_raises`: a `provider` dict is not the
-    no-completion shape, so it must not be laundered into a retryable `ModelAPIError`.
+    no-completion shape, so it must not be laundered into a retryable `ModelAPIError`. `match` pins the
+    `provider` rejection specifically — without it the test also passes when the chunk is rejected for one
+    of the reasons the no-completion shape shares (`choices`, `model`, `object`).
     """
     mock_client = MockOpenAI.create_mock_stream([_null_choices_chunk(provider={'some_key': 'some_value'})])
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
     agent = Agent(model)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match='provider'):
         async with agent.run_stream('hello'):
             pass
 
@@ -1490,7 +1534,7 @@ async def test_openrouter_null_choices_triggers_fallback(allow_model_requests: N
 
     Non-streamed only, deliberately: `FallbackModel`'s window is `Model.request_stream`'s own
     `__aenter__`, which returns before any chunk is validated, so the streamed twin raises instead of
-    falling back. That asymmetry is `FallbackModel`'s, not OpenRouter's.
+    falling back. That asymmetry is `FallbackModel`'s, not OpenRouter's, and the test below pins it.
     """
     mock_client = MockOpenAI.create_mock(_null_choices_completion())
     openrouter_model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
@@ -1498,6 +1542,25 @@ async def test_openrouter_null_choices_triggers_fallback(allow_model_requests: N
 
     result = await agent.run('hello')
     assert result.output == snapshot('fallback used')
+
+
+async def test_openrouter_null_choices_streaming_does_not_trigger_fallback(allow_model_requests: None) -> None:
+    """The streamed half of the same composition raises instead of falling back.
+
+    `FallbackModel.request_stream` only guards `__aenter__`; once it has yielded, its own docstring says
+    mid-stream failures propagate. `OpenAIChatModel._process_streamed_response` peeks the raw SDK chunk,
+    so OpenRouter's validation runs later, during iteration — after the guard has closed. Pinned because
+    this PR's first attempt at the test above asserted the streamed path *does* fall back, and failed.
+    """
+    mock_client = MockOpenAI.create_mock_stream([_null_choices_chunk()])
+    openrouter_model = OpenRouterModel('openai/gpt-4.1-mini', provider=OpenRouterProvider(openai_client=mock_client))
+    agent = Agent(FallbackModel(openrouter_model, TestModel(custom_output_text='fallback used')))
+
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello'):
+            pass
+
+    assert str(exc_info.value) == snapshot('OpenRouter returned a response with null `choices` and no error envelope')
 
 
 def test_openrouter_error_with_metadata() -> None:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1403,12 +1403,13 @@ def test_openrouter_null_choices_without_error_envelope_is_retryable() -> None:
 
 
 def test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal() -> None:
-    """A malformed nested-provider body is NOT the transient shape.
+    """A malformed nested-provider body is NOT the no-completion shape.
 
-    `choices=None` with no error envelope but a `provider` dict means the body
-    tried to be a nested-provider response and failed to validate. Retrying that
-    forever would mask a real contract break, so it stays fatal — only the
-    envelope-less, provider-less shape becomes a retryable 502.
+    `choices=None` with no error envelope but a `provider` dict means the body tried
+    to be a nested-provider response and failed to validate. Retrying that forever
+    would mask a real contract break, so it stays fatal — `provider` is typed
+    `str | None` on `_OpenRouterNoCompletionResponse` precisely so this body does not
+    match it.
     """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)


### PR DESCRIPTION
Fixes #6900

Replaces #6885, which the linked-issue bot auto-closed when I edited its description (my fault — the rewrite dropped the issue reference, and I couldn't reopen from a fork). Same branch, same commits; @DouweM's review and the discussion of both design changes are on #6885.

OpenRouter intermittently returns a body with **null `choices` and no error envelope at all** — a transient provider hiccup carrying no completion. `_validate_completion` tries the error-envelope and nested-provider shapes (#3994), then re-raises the bare `ValidationError`, so consumers that classify on exception type treat a transient as fatal. Nothing retries it and `FallbackModel` doesn't fall back on it.

This models that shape and raises `ModelAPIError` for it.

### The shape

`_OpenRouterNoCompletionResponse`, a sibling of `_OpenRouterErrorResponse` — the same family of bodies, minus the error envelope:

```python
class _OpenRouterNoCompletionResponse(BaseModel, extra='allow'):
    choices: None
    error: None = None
    provider: str | None = None
    model: str | None = None
```

Tried in the existing `except ValidationError` chain, after the error-envelope attempt and before the nested-provider one. Position is inert — no body can match both this shape and the nested-provider shape, since `provider` is typed `str | None` here — but the description should match the code. Deliberate details:

- **`provider: str | None`** — a body whose `provider` is a *dict* is a malformed nested-provider response, not this shape, so it fails validation here and stays fatal. Declarative, no `isinstance` check.
- **`choices: None` is required, not defaulted** — a body that merely omits `choices` doesn't silently match.
- **`_OpenRouterChatCompletion` is untouched**: `id`, `model`, `object`, `provider` all stay required and non-null, so the happy path loses no guarantees and a `ValidationError` from it still means "a shape we don't account for."

### The exception

`ModelAPIError`, not a faked HTTP status. It's `FallbackModel`'s default `fallback_on`, so the transient now reaches retry/fallback machinery that a bare `ValidationError` never did.

### Tests

Both boundaries pinned, and all existing quirky-shape tests unchanged:

- `test_openrouter_null_choices_without_error_envelope_is_retryable` — the envelope-less body raises `ModelAPIError`, and asserts it is *not* a `ModelHTTPError` so nobody re-adds a fake status.
- `test_openrouter_null_choices_with_malformed_provider_dict_stays_fatal` — the malformed-`provider` body still raises `UnexpectedModelBehavior`.

Full `tests/models/test_openrouter.py`: 58 passed.

---

We've run the workaround for this as a monkey-patch in production — it's the last survivor of a once-574-line OpenRouter patch module, since v2 absorbed the rest. Discussed with @DouweM on a call; the approach here follows his review (`ModelAPIError` over a faked 502, and modelling the shape rather than inspecting the response dict).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


