### PR TITLE
fix(embeddings): extract usage from Gemini API response body when available

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -324,14 +324,35 @@ def _map_usage(
 ) -> RequestUsage:
     """Map Google embedding response to RequestUsage.
 
-    Note: The Gemini API doesn't return token usage information.
-    Google Cloud (formerly known as Vertex AI) returns token_count in embedding statistics.
+    Google Cloud (formerly known as Vertex AI) returns token_count in each
+    embedding's statistics. The Gemini API returns usageMetadata in the HTTP
+    response body, but the google-genai SDK currently discards it when
+    constructing EmbedContentResponse (only headers are kept in
+    sdk_http_response). When the SDK surfaces the body, this function
+    automatically picks up promptTokenCount from usageMetadata.
     """
     total_tokens = 0
+
+    # Vertex AI path: token_count in per-embedding statistics.
     if response.embeddings:  # pragma: no branch
         for emb in response.embeddings:
             if emb.statistics and emb.statistics.token_count:
-                # Requires Vertex AI.
                 total_tokens += int(emb.statistics.token_count)  # pragma: lax no cover
+
+    # Gemini API fallback: parse usageMetadata from the raw response body.
+    # The google-genai SDK sets sdk_http_response.body when it preserves the
+    # full HTTP payload (currently it only sets headers, so body is None).
+    # This path activates automatically once the SDK surfaces the body.
+    if total_tokens == 0 and response.sdk_http_response and response.sdk_http_response.body:
+        try:
+            import json as _json
+
+            body = _json.loads(response.sdk_http_response.body)
+            usage_metadata = body.get('usageMetadata', {})
+            prompt_token_count = usage_metadata.get('promptTokenCount', 0)
+            if prompt_token_count:
+                total_tokens = int(prompt_token_count)
+        except (ValueError, TypeError, AttributeError):  # pragma: no cover
+            pass
 
     return RequestUsage(input_tokens=total_tokens)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
+import anyio
 import httpx
 import pytest
 from pytest_mock import MockerFixture
@@ -75,7 +76,6 @@ with try_import() as google_imports_successful:
         GoogleEmbeddingSettings,
         LatestGoogleGLAEmbeddingModelNames,
         LatestGoogleVertexEmbeddingModelNames,
-        _map_usage,
     )
     from pydantic_ai.providers.google import GoogleProvider
     from pydantic_ai.providers.google_cloud import GoogleCloudProvider
@@ -849,6 +849,19 @@ class TestBedrock:
                 usage=RequestUsage(input_tokens=4),
             )
         )
+
+    @pytest.mark.parametrize('max_concurrency', [0, -1])
+    async def test_titan_v2_rejects_invalid_max_concurrency(
+        self, bedrock_provider: BedrockProvider, max_concurrency: int
+    ):
+        model = BedrockEmbeddingModel('amazon.titan-embed-text-v2:0', provider=bedrock_provider)
+        embedder = Embedder(model, settings=BedrockEmbeddingSettings(bedrock_max_concurrency=max_concurrency))
+
+        with (
+            anyio.fail_after(1),
+            pytest.raises(UserError, match=f'bedrock_max_concurrency must be >= 1, got {max_concurrency}'),
+        ):
+            await embedder.embed_query('hello')
 
     async def test_cohere_v3_minimal(self, bedrock_provider: BedrockProvider):
         """Test Cohere V3 with default settings (1024 dimensions, truncate=NONE)."""
@@ -1880,55 +1893,6 @@ class TestGoogle:
         )
 
 
-@pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
-class TestGoogleUsageMapping:
-    """`_map_usage` maps Google embedding responses to RequestUsage.
-
-    The Gemini API (Google AI Studio) surfaces token usage in `usageMetadata`
-    on the raw HTTP response body. The google-genai SDK only exposes this once
-    it preserves the body on `sdk_http_response`, so the fallback path must
-    resolve `promptTokenCount` when per-embedding statistics are absent. These
-    tests lock in the Gemini-API fallback and the no-usage baselines.
-    """
-
-    def test_gemini_api_usage_metadata_fallback(self):
-        from types import SimpleNamespace
-
-        response = SimpleNamespace(
-            embeddings=[],
-            sdk_http_response=SimpleNamespace(
-                body='{"usageMetadata": {"promptTokenCount": 7}}'
-            ),
-        )
-        usage = _map_usage(
-            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
-        )
-        assert usage.input_tokens == 7
-
-    def test_gemini_api_usage_metadata_missing(self):
-        from types import SimpleNamespace
-
-        # Body present but no usageMetadata -> usage stays at zero.
-        response = SimpleNamespace(
-            embeddings=[],
-            sdk_http_response=SimpleNamespace(body='{}'),
-        )
-        usage = _map_usage(
-            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
-        )
-        assert usage.input_tokens == 0
-
-    def test_no_sdk_http_response(self):
-        from types import SimpleNamespace
-
-        # Vertex-style response with no body: no usage is inferred.
-        response = SimpleNamespace(embeddings=[], sdk_http_response=None)
-        usage = _map_usage(
-            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
-        )
-        assert usage.input_tokens == 0
-
-
 @pytest.mark.skipif(not sentence_transformers_imports_successful(), reason='SentenceTransformers not installed')
 class TestSentenceTransformers:
     def _load_stsb_bert_tiny_model(self):
@@ -2295,3 +2259,51 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
             }
         ]
     )
+
+@pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
+class TestGoogleUsageMapping:
+    """`_map_usage` maps Google embedding responses to RequestUsage.
+
+    The Gemini API (Google AI Studio) surfaces token usage in `usageMetadata`
+    on the raw HTTP response body. The google-genai SDK only exposes this once
+    it preserves the body on `sdk_http_response`, so the fallback path must
+    resolve `promptTokenCount` when per-embedding statistics are absent. These
+    tests lock in the Gemini-API fallback and the no-usage baselines.
+    """
+
+    def test_gemini_api_usage_metadata_fallback(self):
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(
+            embeddings=[],
+            sdk_http_response=SimpleNamespace(
+                body='{"usageMetadata": {"promptTokenCount": 7}}'
+            ),
+        )
+        usage = _map_usage(
+            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
+        )
+        assert usage.input_tokens == 7
+
+    def test_gemini_api_usage_metadata_missing(self):
+        from types import SimpleNamespace
+
+        # Body present but no usageMetadata -> usage stays at zero.
+        response = SimpleNamespace(
+            embeddings=[],
+            sdk_http_response=SimpleNamespace(body='{}'),
+        )
+        usage = _map_usage(
+            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
+        )
+        assert usage.input_tokens == 0
+
+    def test_no_sdk_http_response(self):
+        from types import SimpleNamespace
+
+        # Vertex-style response with no body: no usage is inferred.
+        response = SimpleNamespace(embeddings=[], sdk_http_response=None)
+        usage = _map_usage(
+            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
+        )
+        assert usage.input_tokens == 0

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -75,6 +75,7 @@ with try_import() as google_imports_successful:
         GoogleEmbeddingSettings,
         LatestGoogleGLAEmbeddingModelNames,
         LatestGoogleVertexEmbeddingModelNames,
+        _map_usage,
     )
     from pydantic_ai.providers.google import GoogleProvider
     from pydantic_ai.providers.google_cloud import GoogleCloudProvider
@@ -1877,6 +1878,55 @@ class TestGoogle:
                 },
             }
         )
+
+
+@pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
+class TestGoogleUsageMapping:
+    """`_map_usage` maps Google embedding responses to RequestUsage.
+
+    The Gemini API (Google AI Studio) surfaces token usage in `usageMetadata`
+    on the raw HTTP response body. The google-genai SDK only exposes this once
+    it preserves the body on `sdk_http_response`, so the fallback path must
+    resolve `promptTokenCount` when per-embedding statistics are absent. These
+    tests lock in the Gemini-API fallback and the no-usage baselines.
+    """
+
+    def test_gemini_api_usage_metadata_fallback(self):
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(
+            embeddings=[],
+            sdk_http_response=SimpleNamespace(
+                body='{"usageMetadata": {"promptTokenCount": 7}}'
+            ),
+        )
+        usage = _map_usage(
+            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
+        )
+        assert usage.input_tokens == 7
+
+    def test_gemini_api_usage_metadata_missing(self):
+        from types import SimpleNamespace
+
+        # Body present but no usageMetadata -> usage stays at zero.
+        response = SimpleNamespace(
+            embeddings=[],
+            sdk_http_response=SimpleNamespace(body='{}'),
+        )
+        usage = _map_usage(
+            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
+        )
+        assert usage.input_tokens == 0
+
+    def test_no_sdk_http_response(self):
+        from types import SimpleNamespace
+
+        # Vertex-style response with no body: no usage is inferred.
+        response = SimpleNamespace(embeddings=[], sdk_http_response=None)
+        usage = _map_usage(
+            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
+        )
+        assert usage.input_tokens == 0
 
 
 @pytest.mark.skipif(not sentence_transformers_imports_successful(), reason='SentenceTransformers not installed')

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -76,6 +76,7 @@ with try_import() as google_imports_successful:
         GoogleEmbeddingSettings,
         LatestGoogleGLAEmbeddingModelNames,
         LatestGoogleVertexEmbeddingModelNames,
+        _map_usage,
     )
     from pydantic_ai.providers.google import GoogleProvider
     from pydantic_ai.providers.google_cloud import GoogleCloudProvider

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -76,7 +76,7 @@ with try_import() as google_imports_successful:
         GoogleEmbeddingSettings,
         LatestGoogleGLAEmbeddingModelNames,
         LatestGoogleVertexEmbeddingModelNames,
-        _map_usage,
+        _map_usage,  # type: ignore[reportPrivateUsage]
     )
     from pydantic_ai.providers.google import GoogleProvider
     from pydantic_ai.providers.google_cloud import GoogleCloudProvider
@@ -2261,6 +2261,7 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
         ]
     )
 
+
 @pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
 class TestGoogleUsageMapping:
     """`_map_usage` maps Google embedding responses to RequestUsage.
@@ -2277,13 +2278,9 @@ class TestGoogleUsageMapping:
 
         response = SimpleNamespace(
             embeddings=[],
-            sdk_http_response=SimpleNamespace(
-                body='{"usageMetadata": {"promptTokenCount": 7}}'
-            ),
+            sdk_http_response=SimpleNamespace(body='{"usageMetadata": {"promptTokenCount": 7}}'),
         )
-        usage = _map_usage(
-            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
-        )
+        usage = _map_usage(response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001')  # type: ignore[reportArgumentType]
         assert usage.input_tokens == 7
 
     def test_gemini_api_usage_metadata_missing(self):
@@ -2294,9 +2291,7 @@ class TestGoogleUsageMapping:
             embeddings=[],
             sdk_http_response=SimpleNamespace(body='{}'),
         )
-        usage = _map_usage(
-            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
-        )
+        usage = _map_usage(response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001')  # type: ignore[reportArgumentType]
         assert usage.input_tokens == 0
 
     def test_no_sdk_http_response(self):
@@ -2304,7 +2299,5 @@ class TestGoogleUsageMapping:
 
         # Vertex-style response with no body: no usage is inferred.
         response = SimpleNamespace(embeddings=[], sdk_http_response=None)
-        usage = _map_usage(
-            response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001'
-        )
+        usage = _map_usage(response, 'google', 'https://generativelanguage.googleapis.com', 'gemini-embedding-001')  # type: ignore[reportArgumentType]
         assert usage.input_tokens == 0

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -38,7 +38,7 @@ from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UserError
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.usage import RequestUsage
 
-from .conftest import IsDatetime, IsFloat, IsInt, IsList, IsStr, try_import
+from .conftest import IsDatetime, IsFloat, IsInt, IsList, IsStr, TestEnv, try_import
 
 pytestmark = [
     pytest.mark.anyio,
@@ -1645,9 +1645,16 @@ class TestGoogle:
         assert model.system == 'google'
         assert urlparse(model.base_url).hostname == 'generativelanguage.googleapis.com'
 
-    async def test_infer_model_google_cloud(self):
-        with patch.dict(os.environ, {'GOOGLE_API_KEY': 'mock-api-key'}):
-            model = infer_embedding_model('google-cloud:gemini-embedding-001')
+    async def test_infer_model_google_cloud(self, env: TestEnv):
+        for name in {
+            'GOOGLE_APPLICATION_CREDENTIALS',
+            'GOOGLE_CLOUD_PROJECT',
+            'GOOGLE_CLOUD_LOCATION',
+            'GEMINI_API_KEY',
+        }:
+            env.remove(name)
+        env.set('GOOGLE_API_KEY', 'mock-api-key')
+        model = infer_embedding_model('google-cloud:gemini-embedding-001')
         assert isinstance(model, GoogleEmbeddingModel)
         assert model.model_name == 'gemini-embedding-001'
         assert model.system == 'google-cloud'
@@ -2152,6 +2159,46 @@ async def test_instrument_all():
     assert get_model() is model
 
 
+class ExplicitPortEmbeddingModel(TestEmbeddingModel):
+    @property
+    def base_url(self) -> str:
+        return 'https://example.com:8000/v1'
+
+
+class MalformedPortEmbeddingModel(TestEmbeddingModel):
+    @property
+    def base_url(self) -> str:
+        return 'https://example.com:notaport/v1'
+
+
+@pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
+@pytest.mark.parametrize(
+    'model_type,expected_server_attributes',
+    [
+        pytest.param(
+            ExplicitPortEmbeddingModel,
+            snapshot({'server.address': 'example.com', 'server.port': 8000}),
+            id='explicit-port',
+        ),
+        pytest.param(MalformedPortEmbeddingModel, snapshot({}), id='malformed-port'),
+    ],
+)
+async def test_instrumented_embedding_model_server_attributes(
+    model_type: type[TestEmbeddingModel], expected_server_attributes: dict[str, str | int], capfire: CaptureLogfire
+):
+    """A `base_url` whose port isn't an integer omits the server attributes instead of failing the request.
+
+    `urlparse` accepts the URL and only raises when `hostname`/`port` are read, so this is a unit test:
+    no real provider produces a `base_url` that survives client construction and fails at attribute-building.
+    """
+    model = InstrumentedEmbeddingModel(model_type(), InstrumentationSettings())
+
+    await model.embed('Hello, world!', input_type='query')
+
+    [span] = capfire.exporter.exported_spans_as_dict()
+    assert {k: v for k, v in span['attributes'].items() if k.startswith('server.')} == expected_server_attributes
+
+
 def test_override():
     model = TestEmbeddingModel()
     embedder = Embedder(model)
@@ -2260,7 +2307,6 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
             }
         ]
     )
-
 
 @pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
 class TestGoogleUsageMapping:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2308,6 +2308,7 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
         ]
     )
 
+
 @pytest.mark.skipif(not google_imports_successful(), reason='google not installed')
 class TestGoogleUsageMapping:
     """`_map_usage` maps Google embedding responses to RequestUsage.


### PR DESCRIPTION
## Problem

EmbeddingResult.usage is always RequestUsage(input_tokens=0) for Gemini API embeddings, so result.cost() is always 0. Vertex AI is unaffected because it reports token_count in each embedding statistics.

The Gemini API does return token usage in the HTTP response body (usageMetadata.promptTokenCount), but the google-genai SDK discards it when constructing EmbedContentResponse - only headers are kept in sdk_http_response.

Closes #6781

## Solution

Add a forward-compatible fallback in _map_usage that parses sdk_http_response.body for usageMetadata.promptTokenCount when the Vertex path yields 0 and body is not None.

Currently the SDK sets body = None, so this path is inert. When the SDK surfaces the response body (HttpResponse already has a body field), this fix activates automatically.

## Changes

- Updated _map_usage to parse usageMetadata.promptTokenCount from sdk_http_response.body as fallback
- Updated docstring to document Gemini API vs Vertex AI behavior

## Notes

- Intentionally a no-op until upstream SDK surfaces the body
- HttpResponse.body field already exists in SDK types (Optional[str])
- Happy to add a unit test with mocked sdk_http_response.body if desired

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

