### PR TITLE
Fix zero-valued `SpanQuery` maximums

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -305,7 +305,7 @@ class SpanNode:
         # Children conditions
         if (min_child_count := query.get('min_child_count')) and len(self.children) < min_child_count:
             return False
-        if (max_child_count := query.get('max_child_count')) and len(self.children) > max_child_count:
+        if (max_child_count := query.get('max_child_count')) is not None and len(self.children) > max_child_count:
             return False
         if (some_child_has := query.get('some_child_has')) and not any(
             child._matches_query(some_child_has) for child in self.children
@@ -335,7 +335,9 @@ class SpanNode:
 
         if (min_descendant_count := query.get('min_descendant_count')) and len(descendants()) < min_descendant_count:
             return False
-        if (max_descendant_count := query.get('max_descendant_count')) and len(descendants()) > max_descendant_count:
+        if (max_descendant_count := query.get('max_descendant_count')) is not None and len(
+            descendants()
+        ) > max_descendant_count:
             return False
         if (some_descendant_has := query.get('some_descendant_has')) and not any(
             descendant._matches_query(some_descendant_has) for descendant in pruned_descendants()
@@ -363,7 +365,7 @@ class SpanNode:
 
         if (min_depth := query.get('min_depth')) and len(ancestors()) < min_depth:
             return False
-        if (max_depth := query.get('max_depth')) and len(ancestors()) > max_depth:
+        if (max_depth := query.get('max_depth')) is not None and len(ancestors()) > max_depth:
             return False
         if (some_ancestor_has := query.get('some_ancestor_has')) and not any(
             ancestor._matches_query(some_ancestor_has) for ancestor in pruned_ancestors()

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -868,6 +868,22 @@ async def test_span_query_child_count():
     assert matched_names == {'parent_two_children', 'parent_three_children'}
 
 
+async def test_span_query_zero_maximums(span_tree: SpanTree):
+    """Zero-valued maximums constrain counts and depth rather than being ignored."""
+    root_node = span_tree.roots[0]
+    leaf_node = root_node.first_descendant({'name_equals': 'grandchild1'})
+    assert leaf_node is not None
+
+    assert root_node.matches({'max_depth': 0})
+    assert not leaf_node.matches({'max_depth': 0})
+
+    assert leaf_node.matches({'max_child_count': 0})
+    assert not root_node.matches({'max_child_count': 0})
+
+    assert leaf_node.matches({'max_descendant_count': 0})
+    assert not root_node.matches({'max_descendant_count': 0})
+
+
 async def test_or_cannot_be_mixed(span_tree: SpanTree):
     with pytest.raises(ValueError) as exc_info:
         span_tree.first({'name_equals': 'child1', 'or_': [SpanQuery(name_equals='child2')]})


### PR DESCRIPTION
## Summary

- treat zero-valued `max_child_count`, `max_descendant_count`, and `max_depth` as active `SpanQuery` upper bounds
- add regression coverage for all three zero-value boundaries

Fixes #6926
