### PR TITLE
fix(azure): send `max_tokens` for Mistral models, not `max_completion_tokens`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -62,6 +62,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
         }
 
         base: ModelProfile | None = None
+        is_mistral = False
         for prefix, profile_func in prefix_to_profile.items():
             if model_name.startswith(prefix):
                 if prefix.endswith('-'):
@@ -71,13 +72,22 @@ class AzureProvider(Provider[AsyncOpenAI]):
                     OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
                     profile_func(model_name),
                 )
+                is_mistral = prefix.startswith('mistral')
                 break
         if base is None:
             # OpenAI models are unprefixed.
             base = openai_model_profile(model_name)
 
         # Azure Chat Completions API doesn't support document input.
-        return merge_profile(base, OpenAIModelProfile(openai_chat_supports_document_input=False))
+        base = merge_profile(base, OpenAIModelProfile(openai_chat_supports_document_input=False))
+
+        # Azure AI Foundry's Mistral gateway only accepts the legacy `max_tokens`
+        # field and rejects `max_completion_tokens` with a 422 error.
+        # See https://github.com/pydantic/pydantic-ai/issues/6593
+        if is_mistral:
+            base = merge_profile(base, OpenAIModelProfile(openai_chat_supports_max_completion_tokens=False))
+
+        return base
 
     @overload
     def __init__(self, *, openai_client: AsyncAzureOpenAI) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -57,6 +57,8 @@ class AzureProvider(Provider[AsyncOpenAI]):
             'deepseek': deepseek_model_profile,
             'mistralai-': mistral_model_profile,
             'mistral': mistral_model_profile,
+            'ministral': mistral_model_profile,
+            'magistral': mistral_model_profile,
             'cohere-': cohere_model_profile,
             'grok': grok_model_profile,
         }
@@ -72,7 +74,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
                     OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
                     profile_func(model_name),
                 )
-                is_mistral = prefix.startswith('mistral')
+                is_mistral = profile_func is mistral_model_profile
                 break
         if base is None:
             # OpenAI models are unprefixed.
@@ -81,8 +83,9 @@ class AzureProvider(Provider[AsyncOpenAI]):
         # Azure Chat Completions API doesn't support document input.
         base = merge_profile(base, OpenAIModelProfile(openai_chat_supports_document_input=False))
 
-        # Azure AI Foundry's Mistral gateway only accepts the legacy `max_tokens`
-        # field and rejects `max_completion_tokens` with a 422 error.
+        # Reported in #6593 (not verified against the live API here): Azure AI Foundry's
+        # Mistral gateway rejects `max_completion_tokens` with a 422 and accepts the legacy
+        # `max_tokens` field, so route the `max_tokens` setting to the legacy field.
         # See https://github.com/pydantic/pydantic-ai/issues/6593
         if is_mistral:
             base = merge_profile(base, OpenAIModelProfile(openai_chat_supports_max_completion_tokens=False))

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -1112,6 +1112,7 @@ def test_azure_mistral_prefix():
         {
             'json_schema_transformer': OpenAIJsonSchemaTransformer,
             'openai_chat_supports_document_input': False,
+            'openai_chat_supports_max_completion_tokens': False,
         }
     )
 
@@ -1125,6 +1126,7 @@ def test_azure_mistral_small_latest():
         {
             'json_schema_transformer': OpenAIJsonSchemaTransformer,
             'openai_chat_supports_document_input': False,
+            'openai_chat_supports_max_completion_tokens': False,
         }
     )
 

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -1131,6 +1131,36 @@ def test_azure_mistral_small_latest():
     )
 
 
+def test_azure_ministral_3b():
+    """Azure — a Mistral-family model whose name has no `mistral` prefix must still resolve to the Mistral profile."""
+    from pydantic_ai.providers.azure import AzureProvider
+
+    profile = AzureProvider.model_profile('ministral-3b')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_supports_document_input': False,
+            'openai_chat_supports_max_completion_tokens': False,
+        }
+    )
+
+
+def test_azure_magistral_small_latest():
+    """Azure — a Mistral-family model whose name has no `mistral` prefix must still resolve to the Mistral profile (magistral additionally sets thinking flags)."""
+    from pydantic_ai.providers.azure import AzureProvider
+
+    profile = AzureProvider.model_profile('magistral-small-latest')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_supports_document_input': False,
+            'openai_chat_supports_max_completion_tokens': False,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+        }
+    )
+
+
 def test_azure_cohere_prefix():
     from pydantic_ai.providers.azure import AzureProvider
 

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -353,8 +353,6 @@ def test_openrouter_openai_gpt_5_6_reasoning_mode(model_name: str):
 @pytest.mark.parametrize('model_name', ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
 def test_azure_gpt_5_6_reasoning_mode(model_name: str):
     """Not a VCR test: this validates local provider-profile capability resolution."""
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile(model_name)
     assert profile is not None
     assert profile.get('openai_responses_supports_reasoning_mode') is True
@@ -1080,8 +1078,6 @@ def test_openrouter_unknown_provider_falls_back_to_overlay_only():
 
 def test_azure_openai_gpt_5():
     """Azure OpenAI — bare model name."""
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('gpt-5.4')
     assert _normalize(profile) == snapshot(
         {
@@ -1105,8 +1101,6 @@ def test_azure_openai_gpt_5():
 
 
 def test_azure_mistral_prefix():
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('mistral-large-latest')
     assert _normalize(profile) == snapshot(
         {
@@ -1119,8 +1113,6 @@ def test_azure_mistral_prefix():
 
 def test_azure_mistral_small_latest():
     """Azure reuses the shared Mistral profile, so `thinking` is ignored: adjustable reasoning is native-provider-only."""
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('mistral-small-latest')
     assert _normalize(profile) == snapshot(
         {
@@ -1133,8 +1125,6 @@ def test_azure_mistral_small_latest():
 
 def test_azure_ministral_3b():
     """Azure — a Mistral-family model whose name has no `mistral` prefix must still resolve to the Mistral profile."""
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('ministral-3b')
     assert _normalize(profile) == snapshot(
         {
@@ -1147,8 +1137,6 @@ def test_azure_ministral_3b():
 
 def test_azure_magistral_small_latest():
     """Azure — a Mistral-family model whose name has no `mistral` prefix must still resolve to the Mistral profile (magistral additionally sets thinking flags)."""
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('magistral-small-latest')
     assert _normalize(profile) == snapshot(
         {
@@ -1162,8 +1150,6 @@ def test_azure_magistral_small_latest():
 
 
 def test_azure_cohere_prefix():
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('cohere-command-r-plus')
     assert _normalize(profile) == snapshot(
         {
@@ -1174,8 +1160,6 @@ def test_azure_cohere_prefix():
 
 
 def test_azure_grok_prefix():
-    from pydantic_ai.providers.azure import AzureProvider
-
     profile = AzureProvider.model_profile('grok-4')
     assert _normalize(profile) == snapshot(
         {

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -12,7 +12,7 @@ from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
 
 from .._inline_snapshot import snapshot
 from ..conftest import try_import
@@ -274,14 +274,6 @@ async def test_azure_mistral_sends_max_tokens_not_max_completion_tokens(allow_mo
 
     See https://github.com/pydantic/pydantic-ai/issues/6593
     """
-    from unittest.mock import MagicMock
-
-    from openai.types.chat.chat_completion import ChatCompletion
-    from openai.types.chat.chat_completion_message import ChatCompletionMessage
-    from openai.types.completion_usage import CompletionUsage
-
-    from pydantic_ai.settings import ModelSettings
-
     provider = AzureProvider(
         azure_endpoint='https://project-id.openai.azure.com/',
         api_version='2023-03-15-preview',

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -12,7 +12,7 @@ from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 
 from .._inline_snapshot import snapshot
 from ..conftest import try_import
@@ -234,3 +234,61 @@ def test_azure_provider_foundry_serverless_with_openai_model():
         ),
     )
     assert type(model.client) is AsyncOpenAI
+
+
+def test_azure_mistral_model_profile_disables_max_completion_tokens():
+    """Azure AI Foundry's Mistral gateway rejects `max_completion_tokens` with a 422 error.
+
+    The profile must set `openai_chat_supports_max_completion_tokens=False` so the
+    `max_tokens` setting is sent as the legacy `max_tokens` field instead.
+    See https://github.com/pydantic/pydantic-ai/issues/6593
+    """
+    provider = AzureProvider(
+        azure_endpoint='https://project-id.openai.azure.com/',
+        api_version='2023-03-15-preview',
+        api_key='1234567890',
+    )
+
+    # Mistral-prefixed models must disable max_completion_tokens.
+    mistral_profile = provider.model_profile('mistral-medium-2505')
+    assert mistral_profile is not None
+    assert mistral_profile.get('openai_chat_supports_max_completion_tokens') is False
+
+    mistralai_profile = provider.model_profile('mistralai-Mixtral-8x22B-Instruct-v0-1')
+    assert mistralai_profile is not None
+    assert mistralai_profile.get('openai_chat_supports_max_completion_tokens') is False
+
+    # Non-Mistral models must NOT be affected.
+    openai_profile = provider.model_profile('gpt-4o')
+    assert openai_profile is not None
+    # Default is True (or absent, which falls through to True in the model code).
+    assert openai_profile.get('openai_chat_supports_max_completion_tokens', True) is True
+
+    deepseek_profile = provider.model_profile('DeepSeek-R1')
+    assert deepseek_profile is not None
+    assert deepseek_profile.get('openai_chat_supports_max_completion_tokens', True) is True
+
+
+async def test_azure_mistral_sends_max_tokens_not_max_completion_tokens(allow_model_requests: None):
+    """Regression test: Azure + Mistral must send `max_tokens`, not `max_completion_tokens`.
+
+    See https://github.com/pydantic/pydantic-ai/issues/6593
+    """
+    from unittest.mock import MagicMock
+
+    from openai.types.chat.chat_completion import ChatCompletion
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+    from openai.types.completion_usage import CompletionUsage
+
+    from pydantic_ai.settings import ModelSettings
+
+    provider = AzureProvider(
+        azure_endpoint='https://project-id.openai.azure.com/',
+        api_version='2023-03-15-preview',
+        api_key='1234567890',
+    )
+    model = OpenAIChatModel('mistral-medium-2505', provider=provider)
+
+    # Verify the profile has the correct flag set.
+    profile = model.profile
+    assert profile.get('openai_chat_supports_max_completion_tokens') is False

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -13,15 +13,19 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
+from pydantic_ai.settings import ModelSettings
 
 from .._inline_snapshot import snapshot
 from ..conftest import try_import
+from ..models.mock_openai import MockOpenAI, completion_message, get_mock_chat_completion_kwargs
 
 with try_import() as imports_successful:
     from openai import AsyncAzureOpenAI, AsyncOpenAI
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
     from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.azure import AzureProvider
+    from pydantic_ai.providers.openai import OpenAIProvider
 
 
 pytestmark = [
@@ -237,11 +241,11 @@ def test_azure_provider_foundry_serverless_with_openai_model():
 
 
 def test_azure_mistral_model_profile_disables_max_completion_tokens():
-    """Azure AI Foundry's Mistral gateway rejects `max_completion_tokens` with a 422 error.
+    """Reported for Azure AI Foundry's Mistral gateway (see #6593): it rejects
+    `max_completion_tokens` with a 422 and accepts the legacy `max_tokens` field.
 
     The profile must set `openai_chat_supports_max_completion_tokens=False` so the
     `max_tokens` setting is sent as the legacy `max_tokens` field instead.
-    See https://github.com/pydantic/pydantic-ai/issues/6593
     """
     provider = AzureProvider(
         azure_endpoint='https://project-id.openai.azure.com/',
@@ -249,7 +253,7 @@ def test_azure_mistral_model_profile_disables_max_completion_tokens():
         api_key='1234567890',
     )
 
-    # Mistral-prefixed models must disable max_completion_tokens.
+    # Mistral-family models must disable max_completion_tokens.
     mistral_profile = provider.model_profile('mistral-medium-2505')
     assert mistral_profile is not None
     assert mistral_profile.get('openai_chat_supports_max_completion_tokens') is False
@@ -257,6 +261,14 @@ def test_azure_mistral_model_profile_disables_max_completion_tokens():
     mistralai_profile = provider.model_profile('mistralai-Mixtral-8x22B-Instruct-v0-1')
     assert mistralai_profile is not None
     assert mistralai_profile.get('openai_chat_supports_max_completion_tokens') is False
+
+    ministral_profile = provider.model_profile('ministral-3b')
+    assert ministral_profile is not None
+    assert ministral_profile.get('openai_chat_supports_max_completion_tokens') is False
+
+    magistral_profile = provider.model_profile('magistral-small-latest')
+    assert magistral_profile is not None
+    assert magistral_profile.get('openai_chat_supports_max_completion_tokens') is False
 
     # Non-Mistral models must NOT be affected.
     openai_profile = provider.model_profile('gpt-4o')
@@ -270,9 +282,8 @@ def test_azure_mistral_model_profile_disables_max_completion_tokens():
 
 
 async def test_azure_mistral_sends_max_tokens_not_max_completion_tokens(allow_model_requests: None):
-    """Regression test: Azure + Mistral must send `max_tokens`, not `max_completion_tokens`.
-
-    See https://github.com/pydantic/pydantic-ai/issues/6593
+    """Reported for Azure AI Foundry's Mistral gateway (see #6593): the model must send
+    `max_tokens`, not `max_completion_tokens`.
     """
     provider = AzureProvider(
         azure_endpoint='https://project-id.openai.azure.com/',
@@ -284,3 +295,27 @@ async def test_azure_mistral_sends_max_tokens_not_max_completion_tokens(allow_mo
     # Verify the profile has the correct flag set.
     profile = model.profile
     assert profile.get('openai_chat_supports_max_completion_tokens') is False
+
+
+@pytest.mark.parametrize('model_name', ['Ministral-3B', 'magistral-small-latest'])
+async def test_azure_mistral_family_sends_max_tokens(allow_model_requests: None, model_name: str):
+    """Wire-level regression: a Mistral-family model with no `mistral` prefix (Ministral,
+    Magistral) must still route the `max_tokens` setting to the legacy `max_tokens` field
+    and omit `max_completion_tokens`. Uses a mock client because VCR matchers ignore the
+    request body. Reported for Azure AI Foundry's Mistral gateway (see #6593).
+    """
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+
+    # Resolve the profile exactly as the Azure provider would, then confirm the flag.
+    profile = AzureProvider.model_profile(model_name)
+    assert profile is not None
+    assert profile.get('openai_chat_supports_max_completion_tokens') is False
+
+    model = OpenAIChatModel(model_name, provider=OpenAIProvider(openai_client=mock_client), profile=profile)
+    agent = Agent(model, model_settings=ModelSettings(max_tokens=100))
+    await agent.run('Hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert kwargs['max_tokens'] == 100
+    assert 'max_completion_tokens' not in kwargs


### PR DESCRIPTION
## AI Disclosure

This PR was written with AI assistance (Claude) and reviewed and edited by a human.

## Root Cause

`AzureProvider.model_profile()` routes Mistral-prefixed models (`mistral-*`, `mistralai-*`) through `mistral_model_profile()`, but the resulting profile does not set `openai_chat_supports_max_completion_tokens`. The default is `True`, so `OpenAIChatModel` sends `max_completion_tokens` in the request body. Azure AI Foundry's Mistral gateway strictly validates the payload and rejects `max_completion_tokens` with a 422 `Extra inputs are not permitted` error.

## Fix

In `AzureProvider.model_profile()`, after identifying a Mistral model, merge `openai_chat_supports_max_completion_tokens=False` into the profile. This causes `OpenAIChatModel.prepare_request()` to send the legacy `max_tokens` field instead, which Azure's Mistral gateway accepts.

The mechanism already exists and is used by other providers (e.g. OpenRouter sets the same flag for the same reason).

## Changes

- **`pydantic_ai_slim/pydantic_ai/providers/azure.py`**: Track whether the matched prefix is Mistral and merge `openai_chat_supports_max_completion_tokens=False` into the profile.
- **`tests/providers/test_azure.py`**: Two regression tests:
  - `test_azure_mistral_model_profile_disables_max_completion_tokens`: verifies Mistral profiles get the flag and non-Mistral profiles are unaffected.
  - `test_azure_mistral_sends_max_tokens_not_max_completion_tokens`: verifies the resolved model profile has the correct flag.

Fixes #6593

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

