### PR TITLE
fix(prefect): treat PydanticUserError as non-retryable in retry_condition

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -6,6 +6,8 @@ from typing import Any, Literal, cast
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool
 from pydantic_ai.durable_exec._toolset import guard_run_context_enqueue
+from pydantic.errors import PydanticUserError
+
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
@@ -27,7 +29,7 @@ def with_non_retryable_errors(config: TaskConfig) -> TaskConfig:
         result = state.result(raise_on_failure=False)
         if inspect.isawaitable(result):
             result = await result
-        if isinstance(result, (UserError, UnexpectedModelBehavior)):
+        if isinstance(result, (UserError, PydanticUserError, UnexpectedModelBehavior)):
             return False
         if configured_condition is None:
             return True

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -52,6 +52,8 @@ from pydantic_ai.capabilities import (
     Toolset,
 )
 from pydantic_ai.durable_exec._toolset import DurableFunctionToolset, DurableMCPToolset
+from pydantic.errors import PydanticUserError
+
 from pydantic_ai.exceptions import (
     ApprovalRequired,
     CallDeferred,
@@ -2809,6 +2811,9 @@ async def test_prefect_with_non_retryable_errors_condition() -> None:
 
     condition = condition_of(TaskConfig())
     assert await condition(None, None, _State(UserError('bad config'))) is False
+    # Regression #6912: PydanticUserError must also be non-retryable, matching
+    # Temporal's with_non_retryable_errors which includes all three types.
+    assert await condition(None, None, _State(PydanticUserError('bad schema', code='test-error'))) is False
     assert await condition(None, None, _State(RuntimeError('boom'))) is True
 
     def deny(task: Any, task_run: Any, state: Any) -> bool:


### PR DESCRIPTION
## Summary

Part of #6912 (item 1: Prefect's non-retryable error set is missing `PydanticUserError`)

Prefect's `with_non_retryable_errors` `retry_condition` only checked for `UserError` and `UnexpectedModelBehavior`, missing `PydanticUserError`. Temporal's identically-named helper includes all three types (`temporal/_toolset.py:98`).

This meant a `PydanticUserError` raised inside a Prefect task (e.g. a schema validation failure) would be **retried** instead of failing fast, wasting retries on an error that can never succeed.

## Fix

Add `PydanticUserError` to the `isinstance` check in `retry_condition`, matching Temporal's non-retryable error set:

```python
# Before
if isinstance(result, (UserError, UnexpectedModelBehavior)):
# After
if isinstance(result, (UserError, PydanticUserError, UnexpectedModelBehavior)):
```

## Test

Added a regression assertion in `test_prefect_with_non_retryable_errors_condition`:

```python
assert await condition(None, None, _State(PydanticUserError('bad schema', code='test-error'))) is False
```

```
$ pytest tests/test_prefect.py::test_prefect_with_non_retryable_errors_condition -xvs
1 passed
```

Verified the assertion **fails** on the unfixed code (`assert True is False`) and **passes** with the fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

