### PR TITLE
fix(evals): honor zero-valued `SpanQuery` maximums

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -305,7 +305,7 @@ class SpanNode:
         # Children conditions
         if (min_child_count := query.get('min_child_count')) and len(self.children) < min_child_count:
             return False
-        if (max_child_count := query.get('max_child_count')) and len(self.children) > max_child_count:
+        if (max_child_count := query.get('max_child_count')) is not None and len(self.children) > max_child_count:
             return False
         if (some_child_has := query.get('some_child_has')) and not any(
             child._matches_query(some_child_has) for child in self.children
@@ -335,7 +335,9 @@ class SpanNode:
 
         if (min_descendant_count := query.get('min_descendant_count')) and len(descendants()) < min_descendant_count:
             return False
-        if (max_descendant_count := query.get('max_descendant_count')) and len(descendants()) > max_descendant_count:
+        if (max_descendant_count := query.get('max_descendant_count')) is not None and len(
+            descendants()
+        ) > max_descendant_count:
             return False
         if (some_descendant_has := query.get('some_descendant_has')) and not any(
             descendant._matches_query(some_descendant_has) for descendant in pruned_descendants()
@@ -363,7 +365,7 @@ class SpanNode:
 
         if (min_depth := query.get('min_depth')) and len(ancestors()) < min_depth:
             return False
-        if (max_depth := query.get('max_depth')) and len(ancestors()) > max_depth:
+        if (max_depth := query.get('max_depth')) is not None and len(ancestors()) > max_depth:
             return False
         if (some_ancestor_has := query.get('some_ancestor_has')) and not any(
             ancestor._matches_query(some_ancestor_has) for ancestor in pruned_ancestors()

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -210,6 +210,11 @@ async def test_span_node_find_descendants(span_tree: SpanTree):
     assert child1_node is not None
     assert child1_node.matches({'min_descendant_count': 2, 'max_descendant_count': 2})
 
+    grandchild1_node = root_node.first_descendant(lambda node: node.name == 'grandchild1')
+    assert grandchild1_node is not None
+    assert grandchild1_node.matches({'max_descendant_count': 0})
+    assert not root_node.matches({'max_descendant_count': 0})
+
 
 async def test_span_node_matches(span_tree: SpanTree):
     """Test the matches method of SpanNode."""
@@ -377,6 +382,11 @@ async def test_span_tree_ancestors_methods():
     assert leaf_node.matches({'min_depth': 4, 'max_depth': 4})
     assert not leaf_node.matches({'min_depth': 3, 'max_depth': 3})
     assert not leaf_node.matches({'min_depth': 5, 'max_depth': 5})
+
+    root_node = tree.first(lambda node: node.name == 'root')
+    assert root_node is not None
+    assert root_node.matches({'max_depth': 0})
+    assert not leaf_node.matches({'max_depth': 0})
 
     assert [node.name for node in leaf_node.ancestors] == ['level3', 'level2', 'level1', 'root']
     assert leaf_node.matches({'some_ancestor_has': {'name_equals': 'level1'}})
@@ -856,6 +866,13 @@ async def test_span_query_child_count():
     assert parent_three.matches({'min_child_count': 3})
     assert parent_three.matches({'min_child_count': 2, 'max_child_count': 3})
     assert not parent_three.matches({'max_child_count': 2})
+
+    parent_no_children = tree.first(lambda node: node.name == 'parent_no_children')
+    parent_one_child = tree.first(lambda node: node.name == 'parent_one_child')
+    assert parent_no_children is not None
+    assert parent_one_child is not None
+    assert parent_no_children.matches({'max_child_count': 0})
+    assert not parent_one_child.matches({'max_child_count': 0})
 
     # Test with logical operators
     logical_query: SpanQuery = {


### PR DESCRIPTION
- Closes #6926

### Summary

- treat explicit zero values for `max_child_count`, `max_descendant_count`, and `max_depth` as real upper bounds
- preserve the existing behavior when those optional conditions are omitted
- cover both matching zero-count/depth nodes and rejecting non-zero nodes

### Verification

- `uv run pytest tests/evals/test_otel.py` (27 passed)
- `uv run ruff format --check pydantic_evals/pydantic_evals/otel/span_tree.py tests/evals/test_otel.py`
- `uv run ruff check pydantic_evals/pydantic_evals/otel/span_tree.py tests/evals/test_otel.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_evals/pydantic_evals/otel/span_tree.py tests/evals/test_otel.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] **PR title** is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

