### PR TITLE
Add shim package for pydantic_ai to forward imports to pydantic_ai_slim,

### DIFF
--- a/pydantic_ai/__init__.py
+++ b/pydantic_ai/__init__.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import pkgutil
+
+# Pre‑load the instrumentation submodule that the slim package expects under the legacy name
+try:
+    _instrumentation = importlib.import_module('pydantic_ai_slim.pydantic_ai._instrumentation')
+    sys.modules['pydantic_ai._instrumentation'] = _instrumentation
+except ImportError:
+    pass
+
+# Import the actual implementation package
+_real_pkg = importlib.import_module('pydantic_ai_slim.pydantic_ai')
+
+# Expose all attributes of the real package at the top level of the shim
+globals().update(_real_pkg.__dict__)
+
+# Ensure that submodules of the real package are importable via the old package name
+if hasattr(_real_pkg, '__path__'):
+    for finder, name, ispkg in pkgutil.iter_modules(_real_pkg.__path__, _real_pkg.__name__ + '.'):
+        submod = importlib.import_module(name)
+        alias_name = name.replace('pydantic_ai_slim.', 'pydantic_ai.')
+        sys.modules[alias_name] = submod
+        if alias_name == 'pydantic_ai.__init__':
+            sys.modules['pydantic_ai'] = submod
+
+# Finally, register the shim itself as the package
+

--- a/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai/_instrumentation.py
@@ -1,0 +1,1 @@
+from pydantic_ai_slim.pydantic_ai._instrumentation import *

--- a/pydantic_ai/_spec.py
+++ b/pydantic_ai/_spec.py
@@ -1,0 +1,9 @@
+import importlib
+
+# Forward imports from the slim package implementation
+_real = importlib.import_module('pydantic_ai_slim.pydantic_ai._spec')
+# Export everything
+globals().update(_real.__dict__)
+# Preserve __all__ if defined
+if hasattr(_real, '__all__'):
+    __all__ = list(_real.__all__)


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

