### PR TITLE
Fix Prefect tool-call cache misses on flow retry (#6907)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -90,6 +90,11 @@ def _replace_run_context(
                 # entry. `_strip_cache_excluded_fields` recurses into the `UsageLimits` dataclass to
                 # hash it by value; `None` (bare/synthetic context) hashes distinctly.
                 'usage_limits': value.usage_limits,
+                # Tools can read `metadata` / `validation_context` (#6903). Sanitize like `deps`:
+                # arbitrary user values may be non-hashable; replace those with a stable sentinel
+                # rather than failing the task or silently disabling the cache.
+                'metadata': _cacheable_deps(value.metadata),
+                'validation_context': _cacheable_deps(value.validation_context),
             }
 
     return inputs
@@ -137,11 +142,20 @@ def _strip_cache_excluded_fields(
 def _replace_toolsets(
     inputs: dict[str, Any],
 ) -> Any:
-    """Replace Toolset objects with a dict containing only hashable fields."""
+    """Replace live `ToolsetTool` values with JSON-native fields for cache hashing.
+
+    Prefect function/MCP tool tasks no longer pass `ToolsetTool` as a task argument (#6907), but
+    this projection remains as a defensive path for custom task configs. Crucially it must not
+    include `args_validator`: that type is not JSON-serializable and forces cloudpickle, whose
+    memo layout is identity-sensitive and breaks cache hits across flow retries.
+    """
     inputs = inputs.copy()
     for key, value in inputs.items():
         if _is_toolset_tool(value):
-            inputs[key] = {field.name: getattr(value, field.name) for field in fields(value) if field.name != 'toolset'}
+            inputs[key] = {
+                'tool_def': value.tool_def,
+                'max_retries': value.max_retries,
+            }
     return inputs
 
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -144,10 +144,10 @@ def _replace_toolsets(
 ) -> Any:
     """Replace live `ToolsetTool` values with JSON-native fields for cache hashing.
 
-    Prefect function/MCP tool tasks no longer pass `ToolsetTool` as a task argument (#6907), but
-    this projection remains as a defensive path for custom task configs. Crucially it must not
-    include `args_validator`: that type is not JSON-serializable and forces cloudpickle, whose
-    memo layout is identity-sensitive and breaks cache hits across flow retries.
+    Crucially this must not include `args_validator`: that type is not JSON-serializable and forces
+    cloudpickle, whose memo layout is identity-sensitive and breaks cache hits across flow retries
+    (#6907). Include `toolset_id` so two FunctionToolset instances that expose the same tool name /
+    schema in one flow do not share a cached result under the default policy.
     """
     inputs = inputs.copy()
     for key, value in inputs.items():
@@ -155,6 +155,7 @@ def _replace_toolsets(
             inputs[key] = {
                 'tool_def': value.tool_def,
                 'max_retries': value.max_retries,
+                'toolset_id': value.toolset.id,
             }
     return inputs
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -15,6 +15,7 @@ from pydantic_ai.durable_exec._toolset import (
     unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
 
 from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
@@ -22,14 +23,26 @@ from ._types import TaskConfig, default_task_config
 
 
 def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
+    # Do not pass the live `ToolsetTool` into the Prefect task. Its `args_validator` is not
+    # JSON-serializable, so Prefect's input hash falls back to cloudpickle, which is sensitive to
+    # object identity / memo sharing. On a flow retry the model-request task often cache-hits and
+    # deserializes a fresh `tool_name` string while `tool_def.name` is a different object with the
+    # same value — identical logical inputs, different pickle bytes, cache miss, duplicated side
+    # effects (#6907). Resolve the tool inside the task instead (Temporal / dynamic Prefect parity).
     @task
     async def call_tool_task(
         tool_name: str,
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
-        tool: ToolsetTool[AgentDepsT],
     ) -> Any:
         task_ctx = guard_task_enqueue(ctx)
+        try:
+            tool = (await wrapped.get_tools(task_ctx))[tool_name]
+        except KeyError as exc:  # pragma: no cover
+            raise UserError(
+                f'Tool {tool_name!r} not found in toolset {wrapped.id!r}. '
+                'Removing or renaming tools during an agent run is not supported with Prefect.'
+            ) from exc
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(
@@ -41,7 +54,7 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
     ) -> Any:
         merged_config = with_non_retryable_errors(cast('TaskConfig', base_config | dict(config)))
         result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
-            name, tool_args, ctx, tool
+            name, tool_args, ctx
         )
         # A persisted cache entry written before this task wrapped control-flow exceptions (still
         # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -16,10 +16,57 @@ from pydantic_ai.durable_exec._toolset import (
     wrap_tool_call_result,
 )
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
+from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
+
+
+def _registered_tool_name(wrapped: FunctionToolset[AgentDepsT], tool: FunctionToolsetTool[AgentDepsT]) -> str:
+    """Map a prepared `FunctionToolsetTool` back to its registry key in `wrapped.tools`.
+
+    `prepare` may rename the tool, so the call name is not always the registry key. Prefer matching
+    the bound `FunctionSchema` on `call_func` (accessing `.call` creates a new bound method each
+    time, so identity on `call_func` itself is unreliable) rather than re-running `get_tools` /
+    `prepare_tool_def`.
+    """
+    schema = getattr(tool.call_func, '__self__', None)
+    if schema is not None:
+        for name, registered in wrapped.tools.items():
+            if registered.function_schema is schema:
+                return name
+    return tool.tool_def.name
+
+
+def _function_tool_from_prepared(
+    wrapped: FunctionToolset[AgentDepsT],
+    *,
+    registered_name: str,
+    tool_def: ToolDefinition,
+    max_retries: int,
+) -> FunctionToolsetTool[AgentDepsT]:
+    """Rebuild a `FunctionToolsetTool` from the already-prepared definition + registered callable.
+
+    Uses the prepared `tool_def` as-is so `prepare_tool_def` is not invoked again inside the task.
+    """
+    try:
+        registered = wrapped.tools[registered_name]
+    except KeyError as exc:  # pragma: no cover
+        raise UserError(
+            f'Tool {registered_name!r} not found in toolset {wrapped.id!r}. '
+            'Removing or renaming tools during an agent run is not supported with Prefect.'
+        ) from exc
+    return FunctionToolsetTool(
+        toolset=wrapped,
+        tool_def=tool_def,
+        max_retries=max_retries,
+        args_validator=registered.function_schema.validator,
+        args_validator_func=registered.args_validator,
+        call_func=registered.function_schema.call,
+        is_async=registered.function_schema.is_async,
+        timeout=tool_def.timeout,
+    )
 
 
 def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
@@ -28,21 +75,28 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
     # object identity / memo sharing. On a flow retry the model-request task often cache-hits and
     # deserializes a fresh `tool_name` string while `tool_def.name` is a different object with the
     # same value — identical logical inputs, different pickle bytes, cache miss, duplicated side
-    # effects (#6907). Resolve the tool inside the task instead (Temporal / dynamic Prefect parity).
+    # effects (#6907).
+    #
+    # Pass the already-prepared JSON-native `tool_def` (plus registry key / max_retries) and rebuild
+    # the callable wrapper inside the task. Do not call `get_tools` here: that would re-run every
+    # tool's `prepare_tool_def` (side effects / non-determinism) for a call that was already prepared
+    # when the model request was built.
     @task
     async def call_tool_task(
         tool_name: str,
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
+        tool_def: ToolDefinition,
+        max_retries: int,
+        registered_name: str,
     ) -> Any:
         task_ctx = guard_task_enqueue(ctx)
-        try:
-            tool = (await wrapped.get_tools(task_ctx))[tool_name]
-        except KeyError as exc:  # pragma: no cover
-            raise UserError(
-                f'Tool {tool_name!r} not found in toolset {wrapped.id!r}. '
-                'Removing or renaming tools during an agent run is not supported with Prefect.'
-            ) from exc
+        tool = _function_tool_from_prepared(
+            wrapped,
+            registered_name=registered_name,
+            tool_def=tool_def,
+            max_retries=max_retries,
+        )
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(
@@ -52,9 +106,15 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> Any:
+        assert isinstance(tool, FunctionToolsetTool)
         merged_config = with_non_retryable_errors(cast('TaskConfig', base_config | dict(config)))
         result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
-            name, tool_args, ctx
+            name,
+            tool_args,
+            ctx,
+            tool.tool_def,
+            tool.max_retries,
+            _registered_tool_name(wrapped, tool),
         )
         # A persisted cache entry written before this task wrapped control-flow exceptions (still
         # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -15,88 +15,31 @@ from pydantic_ai.durable_exec._toolset import (
     unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
-from pydantic_ai.exceptions import UserError
-from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
-from pydantic_ai.toolsets.function import FunctionToolsetTool
+from pydantic_ai.tools import AgentDepsT, RunContext
 
 from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
-def _registered_tool_name(wrapped: FunctionToolset[AgentDepsT], tool: FunctionToolsetTool[AgentDepsT]) -> str:
-    """Map a prepared `FunctionToolsetTool` back to its registry key in `wrapped.tools`.
-
-    `prepare` may rename the tool, so the call name is not always the registry key. Prefer matching
-    the bound `FunctionSchema` on `call_func` (accessing `.call` creates a new bound method each
-    time, so identity on `call_func` itself is unreliable) rather than re-running `get_tools` /
-    `prepare_tool_def`.
-    """
-    schema = getattr(tool.call_func, '__self__', None)
-    if schema is not None:
-        for name, registered in wrapped.tools.items():
-            if registered.function_schema is schema:
-                return name
-    return tool.tool_def.name
-
-
-def _function_tool_from_prepared(
-    wrapped: FunctionToolset[AgentDepsT],
-    *,
-    registered_name: str,
-    tool_def: ToolDefinition,
-    max_retries: int,
-) -> FunctionToolsetTool[AgentDepsT]:
-    """Rebuild a `FunctionToolsetTool` from the already-prepared definition + registered callable.
-
-    Uses the prepared `tool_def` as-is so `prepare_tool_def` is not invoked again inside the task.
-    """
-    try:
-        registered = wrapped.tools[registered_name]
-    except KeyError as exc:  # pragma: no cover
-        raise UserError(
-            f'Tool {registered_name!r} not found in toolset {wrapped.id!r}. '
-            'Removing or renaming tools during an agent run is not supported with Prefect.'
-        ) from exc
-    return FunctionToolsetTool(
-        toolset=wrapped,
-        tool_def=tool_def,
-        max_retries=max_retries,
-        args_validator=registered.function_schema.validator,
-        args_validator_func=registered.args_validator,
-        call_func=registered.function_schema.call,
-        is_async=registered.function_schema.is_async,
-        timeout=tool_def.timeout,
-    )
-
-
 def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
-    # Do not pass the live `ToolsetTool` into the Prefect task. Its `args_validator` is not
-    # JSON-serializable, so Prefect's input hash falls back to cloudpickle, which is sensitive to
-    # object identity / memo sharing. On a flow retry the model-request task often cache-hits and
-    # deserializes a fresh `tool_name` string while `tool_def.name` is a different object with the
-    # same value — identical logical inputs, different pickle bytes, cache miss, duplicated side
-    # effects (#6907).
+    # Pass the already-prepared live `ToolsetTool` so subclass `get_tools()` customizations
+    # (`call_func` wrappers, validators, timeouts) and prepare renames are preserved, and so
+    # `prepare_tool_def` is not re-run inside the task.
     #
-    # Pass the already-prepared JSON-native `tool_def` (plus registry key / max_retries) and rebuild
-    # the callable wrapper inside the task. Do not call `get_tools` here: that would re-run every
-    # tool's `prepare_tool_def` (side effects / non-determinism) for a call that was already prepared
-    # when the model request was built.
+    # Hashing must not see `args_validator`: that type is not JSON-serializable, so Prefect falls
+    # back to cloudpickle and becomes identity/memo-sensitive — flow retries then miss the tool
+    # cache and re-execute side effects (#6907). `PrefectAgentInputs._replace_toolsets` projects
+    # the live tool to JSON-native `{tool_def, max_retries, toolset_id}` before hashing. The
+    # `toolset_id` discriminator keeps two same-named tools from different FunctionToolset
+    # instances from sharing a cache entry under the default policy (same RUN_ID + TASK_SOURCE).
     @task
     async def call_tool_task(
         tool_name: str,
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
-        tool_def: ToolDefinition,
-        max_retries: int,
-        registered_name: str,
+        tool: ToolsetTool[AgentDepsT],
     ) -> Any:
         task_ctx = guard_task_enqueue(ctx)
-        tool = _function_tool_from_prepared(
-            wrapped,
-            registered_name=registered_name,
-            tool_def=tool_def,
-            max_retries=max_retries,
-        )
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(
@@ -106,15 +49,9 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> Any:
-        assert isinstance(tool, FunctionToolsetTool)
         merged_config = with_non_retryable_errors(cast('TaskConfig', base_config | dict(config)))
         result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
-            name,
-            tool_args,
-            ctx,
-            tool.tool_def,
-            tool.max_retries,
-            _registered_tool_name(wrapped, tool),
+            name, tool_args, ctx, tool
         )
         # A persisted cache entry written before this task wrapped control-flow exceptions (still
         # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -15,7 +15,7 @@ from pydantic_ai.durable_exec._toolset import (
     unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
-from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
 from ._toolset import guard_task_enqueue, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
@@ -25,15 +25,20 @@ if TYPE_CHECKING:
 
 
 def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
+    # Pass the JSON-native `ToolDefinition`, not the live `ToolsetTool`. The latter's
+    # `args_validator` forces Prefect's input hash onto cloudpickle, which is identity-sensitive
+    # and breaks tool-result replay on flow retry (#6907). Temporal already rebuilds via
+    # `tool_for_tool_def` for the same reason.
     @task
     async def call_tool_task(
         tool_name: str,
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
-        tool: ToolsetTool[AgentDepsT],
+        tool_def: ToolDefinition,
     ) -> Any:
         # The context is guarded because a `process_tool_call=` hook receives it and could enqueue.
         task_ctx = guard_task_enqueue(ctx)
+        tool = wrapped.tool_for_tool_def(tool_def)
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(
@@ -45,7 +50,7 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
     ) -> ToolResult:
         task_config = with_non_retryable_errors(base_config)
         result = await call_tool_task.with_options(name=f'Call MCP Tool: {name}', **task_config)(
-            name, tool_args, ctx, tool
+            name, tool_args, ctx, tool.tool_def
         )
         # A persisted cache entry written before this task wrapped control-flow exceptions (still
         # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -25,17 +25,22 @@ if TYPE_CHECKING:
 
 
 def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
-    # Pass the JSON-native `ToolDefinition`, not the live `ToolsetTool`. The latter's
+    # Pass the JSON-native `ToolDefinition` (not the live `ToolsetTool`). The latter's
     # `args_validator` forces Prefect's input hash onto cloudpickle, which is identity-sensitive
     # and breaks tool-result replay on flow retry (#6907). Temporal already rebuilds via
-    # `tool_for_tool_def` for the same reason.
+    # `tool_for_tool_def` for the same reason. Include `toolset_id` so two MCP toolsets that
+    # expose the same tool name in one flow do not share a cached result.
     @task
     async def call_tool_task(
         tool_name: str,
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
         tool_def: ToolDefinition,
+        toolset_id: str | None,
     ) -> Any:
+        # `toolset_id` is intentionally part of the hashed task inputs so two MCP toolsets that
+        # expose the same tool name in one flow do not share a cached result.
+        _ = toolset_id
         # The context is guarded because a `process_tool_call=` hook receives it and could enqueue.
         task_ctx = guard_task_enqueue(ctx)
         tool = wrapped.tool_for_tool_def(tool_def)
@@ -50,7 +55,7 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
     ) -> ToolResult:
         task_config = with_non_retryable_errors(base_config)
         result = await call_tool_task.with_options(name=f'Call MCP Tool: {name}', **task_config)(
-            name, tool_args, ctx, tool.tool_def
+            name, tool_args, ctx, tool.tool_def, wrapped.id
         )
         # A persisted cache entry written before this task wrapped control-flow exceptions (still
         # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.

--- a/tests/prefect_tool_cache_helpers.py
+++ b/tests/prefect_tool_cache_helpers.py
@@ -1,0 +1,42 @@
+"""Importable helpers for Prefect tool-cache regression tests.
+
+Tools used in Prefect cache-key tests must live in a normal module (not the test
+module / `__main__`). cloudpickle serializes `__main__` callables by value,
+including referenced globals, so a counter mutation would fork the task's own
+source hash and accidentally mask cache-miss bugs (#6903 footnote, #6907).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from pydantic_ai import FunctionToolset, RunContext
+
+SIDE_EFFECT_COUNTER = Path(tempfile.gettempdir()) / 'pydantic_ai_prefect_tool_side_effect_runs.txt'
+side_effect_toolset = FunctionToolset[None](id='prefect-cache-side-effect')
+
+_echo_invocations: list[tuple[object, object]] = []
+echo_context_toolset = FunctionToolset[None](id='prefect-cache-echo-context')
+
+
+@side_effect_toolset.tool
+async def side_effect(ctx: RunContext[None]) -> str:
+    n = int(SIDE_EFFECT_COUNTER.read_text() or '0') if SIDE_EFFECT_COUNTER.exists() else 0
+    SIDE_EFFECT_COUNTER.write_text(str(n + 1))
+    return 'ok'
+
+
+@echo_context_toolset.tool
+async def echo_context(ctx: RunContext[None]) -> str:
+    """Answer depends only on RunContext fields the cache key must include."""
+    _echo_invocations.append((ctx.prompt, ctx.metadata))
+    return f'prompt={ctx.prompt!r} metadata={ctx.metadata!r}'
+
+
+def reset_echo_invocations() -> None:
+    _echo_invocations.clear()
+
+
+def echo_invocations() -> list[tuple[object, object]]:
+    return list(_echo_invocations)

--- a/tests/prefect_tool_cache_helpers.py
+++ b/tests/prefect_tool_cache_helpers.py
@@ -11,13 +11,16 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from pydantic_ai import FunctionToolset, RunContext
+from pydantic_ai import FunctionToolset, RunContext, ToolDefinition
 
 SIDE_EFFECT_COUNTER = Path(tempfile.gettempdir()) / 'pydantic_ai_prefect_tool_side_effect_runs.txt'
 side_effect_toolset = FunctionToolset[None](id='prefect-cache-side-effect')
 
 _echo_invocations: list[tuple[object, object]] = []
 echo_context_toolset = FunctionToolset[None](id='prefect-cache-echo-context')
+
+prepare_calls: list[str] = []
+prepare_toolset = FunctionToolset[None](id='prefect-cache-prepare')
 
 
 @side_effect_toolset.tool
@@ -34,9 +37,46 @@ async def echo_context(ctx: RunContext[None]) -> str:
     return f'prompt={ctx.prompt!r} metadata={ctx.metadata!r}'
 
 
+async def _counting_prepare(ctx: RunContext[None], tool_def: ToolDefinition) -> ToolDefinition | None:
+    prepare_calls.append(tool_def.name)
+    return tool_def
+
+
+async def _rename_prepare(ctx: RunContext[None], tool_def: ToolDefinition) -> ToolDefinition | None:
+    prepare_calls.append(tool_def.name)
+    return ToolDefinition(
+        name='exposed_name',
+        description=tool_def.description,
+        parameters_json_schema=tool_def.parameters_json_schema,
+        timeout=tool_def.timeout,
+    )
+
+
+@prepare_toolset.tool(prepare=_counting_prepare)
+async def alpha(ctx: RunContext[None]) -> str:
+    return 'alpha-ok'
+
+
+@prepare_toolset.tool(prepare=_counting_prepare)
+async def beta(ctx: RunContext[None]) -> str:
+    return 'beta-ok'
+
+
+renamed_toolset = FunctionToolset[None](id='prefect-cache-renamed')
+
+
+@renamed_toolset.tool(prepare=_rename_prepare)
+async def raw_name(ctx: RunContext[None]) -> str:
+    return 'renamed-ok'
+
+
 def reset_echo_invocations() -> None:
     _echo_invocations.clear()
 
 
 def echo_invocations() -> list[tuple[object, object]]:
     return list(_echo_invocations)
+
+
+def reset_prepare_calls() -> None:
+    prepare_calls.clear()

--- a/tests/prefect_tool_cache_helpers.py
+++ b/tests/prefect_tool_cache_helpers.py
@@ -10,39 +10,45 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from pydantic_ai import FunctionToolset, RunContext, ToolDefinition
 
 SIDE_EFFECT_COUNTER = Path(tempfile.gettempdir()) / 'pydantic_ai_prefect_tool_side_effect_runs.txt'
-side_effect_toolset = FunctionToolset[None](id='prefect-cache-side-effect')
+side_effect_toolset: FunctionToolset[Any] = FunctionToolset(id='prefect-cache-side-effect')
 
 _echo_invocations: list[tuple[object, object]] = []
-echo_context_toolset = FunctionToolset[None](id='prefect-cache-echo-context')
+echo_context_toolset: FunctionToolset[Any] = FunctionToolset(id='prefect-cache-echo-context')
 
 prepare_calls: list[str] = []
-prepare_toolset = FunctionToolset[None](id='prefect-cache-prepare')
+prepare_toolset: FunctionToolset[Any] = FunctionToolset(id='prefect-cache-prepare')
+
+dual_a_calls = 0
+dual_b_calls = 0
+dual_toolset_a: FunctionToolset[Any] = FunctionToolset(id='prefect-cache-dual-a')
+dual_toolset_b: FunctionToolset[Any] = FunctionToolset(id='prefect-cache-dual-b')
 
 
 @side_effect_toolset.tool
-async def side_effect(ctx: RunContext[None]) -> str:
+async def side_effect(ctx: RunContext[Any]) -> str:
     n = int(SIDE_EFFECT_COUNTER.read_text() or '0') if SIDE_EFFECT_COUNTER.exists() else 0
     SIDE_EFFECT_COUNTER.write_text(str(n + 1))
     return 'ok'
 
 
 @echo_context_toolset.tool
-async def echo_context(ctx: RunContext[None]) -> str:
+async def echo_context(ctx: RunContext[Any]) -> str:
     """Answer depends only on RunContext fields the cache key must include."""
     _echo_invocations.append((ctx.prompt, ctx.metadata))
     return f'prompt={ctx.prompt!r} metadata={ctx.metadata!r}'
 
 
-async def _counting_prepare(ctx: RunContext[None], tool_def: ToolDefinition) -> ToolDefinition | None:
+async def _counting_prepare(ctx: RunContext[Any], tool_def: ToolDefinition) -> ToolDefinition | None:
     prepare_calls.append(tool_def.name)
     return tool_def
 
 
-async def _rename_prepare(ctx: RunContext[None], tool_def: ToolDefinition) -> ToolDefinition | None:
+async def _rename_prepare(ctx: RunContext[Any], tool_def: ToolDefinition) -> ToolDefinition | None:
     prepare_calls.append(tool_def.name)
     return ToolDefinition(
         name='exposed_name',
@@ -53,21 +59,35 @@ async def _rename_prepare(ctx: RunContext[None], tool_def: ToolDefinition) -> To
 
 
 @prepare_toolset.tool(prepare=_counting_prepare)
-async def alpha(ctx: RunContext[None]) -> str:
+async def alpha(ctx: RunContext[Any]) -> str:
     return 'alpha-ok'
 
 
 @prepare_toolset.tool(prepare=_counting_prepare)
-async def beta(ctx: RunContext[None]) -> str:
+async def beta(ctx: RunContext[Any]) -> str:
     return 'beta-ok'
 
 
-renamed_toolset = FunctionToolset[None](id='prefect-cache-renamed')
+renamed_toolset: FunctionToolset[Any] = FunctionToolset(id='prefect-cache-renamed')
 
 
 @renamed_toolset.tool(prepare=_rename_prepare)
-async def raw_name(ctx: RunContext[None]) -> str:
+async def raw_name(ctx: RunContext[Any]) -> str:
     return 'renamed-ok'
+
+
+@dual_toolset_a.tool(name='shared')
+async def shared_from_a(ctx: RunContext[Any]) -> str:
+    global dual_a_calls
+    dual_a_calls += 1
+    return 'from-a'
+
+
+@dual_toolset_b.tool(name='shared')
+async def shared_from_b(ctx: RunContext[Any]) -> str:
+    global dual_b_calls
+    dual_b_calls += 1
+    return 'from-b'
 
 
 def reset_echo_invocations() -> None:
@@ -80,3 +100,9 @@ def echo_invocations() -> list[tuple[object, object]]:
 
 def reset_prepare_calls() -> None:
     prepare_calls.clear()
+
+
+def reset_dual_calls() -> None:
+    global dual_a_calls, dual_b_calls
+    dual_a_calls = 0
+    dual_b_calls = 0

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1848,7 +1848,9 @@ async def test_tool_call_does_not_reprepare_tool_defs():
 
     def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         if len(messages) == 1:
-            return ModelResponse(parts=[ToolCallPart('alpha', {})])
+            # Execute both registered tools so prepare-helper bodies stay covered and we
+            # still prove prepare is discovery-only (not re-run inside each tool task).
+            return ModelResponse(parts=[ToolCallPart('alpha', {}), ToolCallPart('beta', {})])
         return ModelResponse(parts=[TextPart('done')])
 
     agent = Agent(
@@ -1864,7 +1866,7 @@ async def test_tool_call_does_not_reprepare_tool_defs():
         return result.output
 
     assert await run_agent() == 'done'
-    # Two model steps × two tools discovered each step; no extra prepares from the tool task.
+    # Two model steps × two tools discovered each step; no extra prepares from the tool tasks.
     assert helpers.prepare_calls == ['alpha', 'beta', 'alpha', 'beta']
 
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1823,6 +1823,66 @@ async def test_metadata_forks_tool_cache_within_flow():
     ]
 
 
+async def test_tool_call_does_not_reprepare_tool_defs():
+    """Prefect tool tasks must not re-run `prepare_tool_def` via `get_tools` (#6941 review).
+
+    Discovery calls `get_tools` once per model step (both tools). Re-resolving inside the tool
+    task would invoke prepare for every registered tool again on each call.
+    """
+    from . import prefect_tool_cache_helpers as helpers
+
+    helpers.reset_prepare_calls()
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('alpha', {})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        name=f'prepare_once_{uuid.uuid4().hex[:8]}',
+        toolsets=[helpers.prepare_toolset],
+        capabilities=[PrefectDurability()],
+    )
+
+    @flow(name=f'prepare_once_flow_{uuid.uuid4().hex[:8]}')
+    async def run_agent() -> str:
+        result = await agent.run('go')
+        return result.output
+
+    assert await run_agent() == 'done'
+    # Two model steps × two tools discovered each step; no extra prepares from the tool task.
+    assert helpers.prepare_calls == ['alpha', 'beta', 'alpha', 'beta']
+
+
+async def test_prepared_rename_still_executes_without_reprepare():
+    """A prepare rename must execute using the already-prepared definition, not a second prepare."""
+    from . import prefect_tool_cache_helpers as helpers
+
+    helpers.reset_prepare_calls()
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('exposed_name', {})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        name=f'prepare_rename_{uuid.uuid4().hex[:8]}',
+        toolsets=[helpers.renamed_toolset],
+        capabilities=[PrefectDurability()],
+    )
+
+    @flow(name=f'prepare_rename_flow_{uuid.uuid4().hex[:8]}')
+    async def run_agent() -> str:
+        result = await agent.run('go')
+        return result.output
+
+    assert await run_agent() == 'done'
+    # Discovery only (two model steps); tool execution must not call prepare again.
+    assert helpers.prepare_calls == ['raw_name', 'raw_name']
+
+
 async def test_repeated_run_hits_cache():
     """Same prompt across two separate flow runs must only call the model once.
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -88,6 +88,7 @@ try:
     from pydantic_ai.durable_exec.prefect._cache_policies import (
         PrefectAgentInputs,
         _replace_run_context,  # pyright: ignore[reportPrivateUsage]
+        _replace_toolsets,  # pyright: ignore[reportPrivateUsage]
         _strip_cache_excluded_fields,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.durable_exec.prefect._mcp_toolset import prefectify_mcp_toolset
@@ -1687,15 +1688,16 @@ def test_cache_key_run_context_projection_is_exhaustive():
         'capabilities',  # live capability objects, not hashable run state
         'root_capability',  # live capability tree (static config); run-varying loaded state is projected via loaded_capability_ids/discovered_tool_names
         'pending_messages',  # live run queue, not hashable run state
-        'messages',  # hashed as the separate `messages` task input
-        'prompt',  # hashed as the separate prompt task input
-        'validation_context',  # arbitrary user object, not run state
+        # `messages` / `prompt` are hashed as separate model-request task inputs. Tool-call tasks
+        # only receive `(tool_name, tool_args, ctx[, tool_def])`, so for those tasks these fields
+        # are simply absent from the key rather than carried via a separate input (#6903).
+        'messages',
+        'prompt',
         'trace_include_content',  # tracing config, not run state
         'instrumentation_version',  # tracing config, not run state
         'partial_output',  # output-validator flag, not a tool-execution input
         'run_id',  # per-run id; deliberately excluded so keys are stable across runs
         'conversation_id',  # per-conversation id; same rationale as run_id
-        'metadata',  # free-form run metadata, not a tool-execution input
         'model_settings',  # hashed via the model request inputs, not RunContext
         'capability_loaded',  # transient per-hook flag; `None` during tool execution
         '_mcp_tool_defs_cache',  # live per-run memo of MCP tool defs, reconstructed from messages
@@ -1713,6 +1715,112 @@ def test_cache_key_run_context_projection_is_exhaustive():
         f'Uncategorized `RunContext` fields: {uncategorized}. Add each to the `_replace_run_context` '
         'projection (if it should fork the cache key) or to `cache_irrelevant` (with a reason).'
     )
+
+
+def test_cache_policy_toolset_tool_projection_is_json_stable():
+    """Projected ToolsetTool inputs must not depend on cloudpickle object identity (#6907).
+
+    Including `args_validator` forces Prefect onto cloudpickle, where equal values with different
+    object-sharing layouts produce different hashes. Projecting only JSON-native fields keeps the
+    key value-addressed even when a live `ToolsetTool` still appears in custom task inputs.
+    """
+    from prefect.utilities.hashing import hash_objects
+
+    shared_name = 'side_effect'
+    distinct_name = ''.join(['side', '_', 'effect'])
+    assert shared_name == distinct_name
+    assert shared_name is not distinct_name
+
+    toolset = FunctionToolset[None](id='projection-probe')
+    tool_a = ToolsetTool(
+        toolset=toolset,
+        tool_def=ToolDefinition(name=shared_name, parameters_json_schema={'type': 'object', 'properties': {}}),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+    tool_b = ToolsetTool(
+        toolset=toolset,
+        tool_def=ToolDefinition(name=shared_name, parameters_json_schema={'type': 'object', 'properties': {}}),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+
+    # Simulate attempt-1 vs retry: same logical values, different string identity for `tool_name`.
+    projected_a = _strip_cache_excluded_fields(_replace_toolsets({'tool_name': shared_name, 'tool': tool_a}))
+    projected_b = _strip_cache_excluded_fields(_replace_toolsets({'tool_name': distinct_name, 'tool': tool_b}))
+    assert hash_objects(projected_a) == hash_objects(projected_b)
+
+
+async def test_tool_result_replays_on_flow_retry():
+    """Flow retry must load the cached tool result instead of re-executing side effects (#6907)."""
+    from . import prefect_tool_cache_helpers as helpers
+
+    helpers.SIDE_EFFECT_COUNTER.write_text('0')
+    attempts = 0
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('side_effect', {})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        name=f'tool_replay_{uuid.uuid4().hex[:8]}',
+        toolsets=[helpers.side_effect_toolset],
+        capabilities=[PrefectDurability()],
+    )
+
+    @flow(name=f'tool_replay_flow_{uuid.uuid4().hex[:8]}', retries=1)
+    async def flaky() -> str:
+        nonlocal attempts
+        attempts += 1
+        result = await agent.run('go')
+        if attempts == 1:
+            raise RuntimeError('boom')
+        return result.output
+
+    assert await flaky() == 'done'
+    assert attempts == 2
+    assert int(helpers.SIDE_EFFECT_COUNTER.read_text()) == 1
+
+
+async def test_metadata_forks_tool_cache_within_flow():
+    """Two runs in one flow that differ only in `metadata` must not share tool results (#6903).
+
+    Stabilizing the tool-task key (#6907) unmasks this collision unless `metadata` is projected
+    into the RunContext cache key.
+    """
+    from . import prefect_tool_cache_helpers as helpers
+
+    helpers.reset_echo_invocations()
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        for message in messages:
+            for part in message.parts:
+                if isinstance(part, ToolReturnPart):
+                    return ModelResponse(parts=[TextPart(str(part.content))])
+        return ModelResponse(parts=[ToolCallPart('echo_context', {})])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        name=f'metadata_fork_{uuid.uuid4().hex[:8]}',
+        toolsets=[helpers.echo_context_toolset],
+        capabilities=[PrefectDurability()],
+    )
+
+    @flow(name=f'metadata_fork_flow_{uuid.uuid4().hex[:8]}')
+    async def two_runs() -> tuple[str, str]:
+        first = await agent.run('same question', metadata={'tenant': 'a'})
+        second = await agent.run('same question', metadata={'tenant': 'b'})
+        return first.output, second.output
+
+    first_out, second_out = await two_runs()
+    assert first_out == "prompt='same question' metadata={'tenant': 'a'}"
+    assert second_out == "prompt='same question' metadata={'tenant': 'b'}"
+    assert helpers.echo_invocations() == [
+        ('same question', {'tenant': 'a'}),
+        ('same question', {'tenant': 'b'}),
+    ]
 
 
 async def test_repeated_run_hits_cache():

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1720,9 +1720,9 @@ def test_cache_key_run_context_projection_is_exhaustive():
 def test_cache_policy_toolset_tool_projection_is_json_stable():
     """Projected ToolsetTool inputs must not depend on cloudpickle object identity (#6907).
 
-    Including `args_validator` forces Prefect onto cloudpickle, where equal values with different
+    Including rgs_validator forces Prefect onto cloudpickle, where equal values with different
     object-sharing layouts produce different hashes. Projecting only JSON-native fields keeps the
-    key value-addressed even when a live `ToolsetTool` still appears in custom task inputs.
+    key value-addressed even when a live ToolsetTool still appears in task inputs.
     """
     from prefect.utilities.hashing import hash_objects
 
@@ -1731,7 +1731,7 @@ def test_cache_policy_toolset_tool_projection_is_json_stable():
     assert shared_name == distinct_name
     assert shared_name is not distinct_name
 
-    toolset = FunctionToolset[None](id='projection-probe')
+    toolset = FunctionToolset(id='projection-probe')
     tool_a = ToolsetTool(
         toolset=toolset,
         tool_def=ToolDefinition(name=shared_name, parameters_json_schema={'type': 'object', 'properties': {}}),
@@ -1745,10 +1745,23 @@ def test_cache_policy_toolset_tool_projection_is_json_stable():
         args_validator=TOOL_SCHEMA_VALIDATOR,
     )
 
-    # Simulate attempt-1 vs retry: same logical values, different string identity for `tool_name`.
+    # Simulate attempt-1 vs retry: same logical values, different string identity for 	ool_name.
     projected_a = _strip_cache_excluded_fields(_replace_toolsets({'tool_name': shared_name, 'tool': tool_a}))
     projected_b = _strip_cache_excluded_fields(_replace_toolsets({'tool_name': distinct_name, 'tool': tool_b}))
     assert hash_objects(projected_a) == hash_objects(projected_b)
+    assert projected_a['tool']['max_retries'] == 1
+    assert projected_a['tool']['toolset_id'] == 'projection-probe'
+    assert 'args_validator' not in projected_a['tool']
+
+    other = FunctionToolset(id='other-probe')
+    tool_other = ToolsetTool(
+        toolset=other,
+        tool_def=ToolDefinition(name=shared_name, parameters_json_schema={'type': 'object', 'properties': {}}),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+    projected_other = _strip_cache_excluded_fields(_replace_toolsets({'tool_name': shared_name, 'tool': tool_other}))
+    assert hash_objects(projected_a) != hash_objects(projected_other)
 
 
 async def test_tool_result_replays_on_flow_retry():
@@ -1785,9 +1798,9 @@ async def test_tool_result_replays_on_flow_retry():
 
 
 async def test_metadata_forks_tool_cache_within_flow():
-    """Two runs in one flow that differ only in `metadata` must not share tool results (#6903).
+    """Two runs in one flow that differ only in metadata must not share tool results (#6903).
 
-    Stabilizing the tool-task key (#6907) unmasks this collision unless `metadata` is projected
+    Stabilizing the tool-task key (#6907) unmasks this collision unless metadata is projected
     into the RunContext cache key.
     """
     from . import prefect_tool_cache_helpers as helpers
@@ -1824,9 +1837,9 @@ async def test_metadata_forks_tool_cache_within_flow():
 
 
 async def test_tool_call_does_not_reprepare_tool_defs():
-    """Prefect tool tasks must not re-run `prepare_tool_def` via `get_tools` (#6941 review).
+    """Prefect tool tasks must not re-run prepare_tool_def via get_tools (#6941 review).
 
-    Discovery calls `get_tools` once per model step (both tools). Re-resolving inside the tool
+    Discovery calls get_tools once per model step (both tools). Re-resolving inside the tool
     task would invoke prepare for every registered tool again on each call.
     """
     from . import prefect_tool_cache_helpers as helpers
@@ -1881,6 +1894,45 @@ async def test_prepared_rename_still_executes_without_reprepare():
     assert await run_agent() == 'done'
     # Discovery only (two model steps); tool execution must not call prepare again.
     assert helpers.prepare_calls == ['raw_name', 'raw_name']
+
+
+async def test_distinct_toolsets_same_tool_name_do_not_share_cache():
+    """Two FunctionToolsets with the same tool name in one flow must not share results (#6941 review)."""
+    from . import prefect_tool_cache_helpers as helpers
+
+    helpers.reset_dual_calls()
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        for message in messages:
+            for part in message.parts:
+                if isinstance(part, ToolReturnPart):
+                    return ModelResponse(parts=[TextPart(str(part.content))])
+        return ModelResponse(parts=[ToolCallPart('shared', {})])
+
+    agent_a = Agent(
+        FunctionModel(model_fn),
+        name=f'dual_a_{uuid.uuid4().hex[:8]}',
+        toolsets=[helpers.dual_toolset_a],
+        capabilities=[PrefectDurability()],
+    )
+    agent_b = Agent(
+        FunctionModel(model_fn),
+        name=f'dual_b_{uuid.uuid4().hex[:8]}',
+        toolsets=[helpers.dual_toolset_b],
+        capabilities=[PrefectDurability()],
+    )
+
+    @flow(name=f'dual_toolset_flow_{uuid.uuid4().hex[:8]}')
+    async def two_agents() -> tuple[str, str]:
+        first = await agent_a.run('go')
+        second = await agent_b.run('go')
+        return first.output, second.output
+
+    first_out, second_out = await two_agents()
+    assert first_out == 'from-a'
+    assert second_out == 'from-b'
+    assert helpers.dual_a_calls == 1
+    assert helpers.dual_b_calls == 1
 
 
 async def test_repeated_run_hits_cache():


### PR DESCRIPTION
## Summary
- Stop passing live `ToolsetTool` into Prefect function/MCP tool tasks so cache keys stay on the JSON hashing path instead of identity-sensitive cloudpickle (Temporal/dynamic parity). Function tools resolve via `get_tools`; MCP tools pass `tool_def` and rebuild with `tool_for_tool_def`.
- Defensively project any remaining `ToolsetTool` cache inputs to `tool_def` + `max_retries` only (no `args_validator`).
- Include `metadata` and `validation_context` in the RunContext cache projection (sanitized like `deps`). Stabilizing the tool key otherwise unmasks same-flow collisions when two `agent.run()` calls differ only in those fields (#6903).

## Test plan
- [x] `test_tool_result_replays_on_flow_retry` — flow retry loads cached tool result; side effect runs once
- [x] `test_metadata_forks_tool_cache_within_flow` — different `metadata` in one flow does not share tool results
- [x] `test_cache_policy_toolset_tool_projection_is_json_stable` — projected tool inputs ignore string object identity
- [x] `test_cache_key_run_context_projection_is_exhaustive` updated for the new projected fields
- [x] Independent issue repro: tool body executions go from 2 → 1 after the fix

Fixes #6907
Fixes #6903

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

