### PR TITLE
Install the `EnqueueGuard` on the DBOS/Prefect model-request and `cancel_suspended_response` units

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import copy
 from abc import abstractmethod
-from collections.abc import AsyncIterable, AsyncIterator, Generator, Mapping
-from contextlib import contextmanager
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Generator, Mapping
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, ClassVar
 
 from typing_extensions import Self
@@ -294,6 +294,23 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         guarded = self._durable_run_context(ctx)
         with set_current_run_context(guarded):
             yield guarded
+
+    @asynccontextmanager
+    async def _durable_model_scope(
+        self, model_id: str | None, run_context: RunContext[AgentDepsT]
+    ) -> AsyncGenerator[tuple[Model, RunContext[AgentDepsT]]]:
+        """Enter a model durable unit: guard the run context, then rebuild the request's model.
+
+        Every model unit (request, streaming request, suspended-response cancellation) needs
+        both halves, and the guard is not optional for any of them: the unit's recorded result is
+        replayed on recovery or a cache hit without re-running its body, so a `ctx.enqueue()` from
+        the model — or from a `resolve_model_id` capability rebuilding it — would be dropped.
+        Pairing the two here means a unit can't get its model without the guard, instead of each
+        engine remembering to install it per unit (Temporal has its own chokepoint in
+        `deserialize_run_context`, so it doesn't use this).
+        """
+        with self._durable_run_context_scope(run_context) as ctx:
+            yield await self._resolve_model_for_request(model_id, ctx), ctx
 
     @abstractmethod
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -8,7 +8,6 @@ from typing import Any, ClassVar, cast
 from dbos import DBOS
 
 from pydantic_ai import messages as _messages
-from pydantic_ai._run_context import set_current_run_context
 from pydantic_ai.agent import EventStreamHandler, ParallelExecutionMode
 from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.capabilities.abstract import WrapModelRequestHandler, WrapRunHandler
@@ -149,8 +148,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             model_request_parameters: ModelRequestParameters,
             run_context: RunContext[Any],
         ) -> ModelResponse:
-            model = await self._resolve_model_for_request(model_id, run_context)
-            with set_current_run_context(run_context):
+            async with self._durable_model_scope(model_id, run_context) as (model, _):
                 return await model.request(messages, model_settings, model_request_parameters)
 
         self._request_step = request_step
@@ -163,8 +161,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             model_request_parameters: ModelRequestParameters,
             run_context: RunContext[Any],
         ) -> StreamedActivityResult:
-            model = await self._resolve_model_for_request(model_id, run_context)
-            with self._durable_run_context_scope(run_context) as ctx:
+            async with self._durable_model_scope(model_id, run_context) as (model, ctx):
                 async with model.request_stream(
                     messages, model_settings, model_request_parameters, ctx
                 ) as streamed_response:
@@ -181,8 +178,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         async def cancel_suspended_response_step(
             model_id: str | None, response: ModelResponse, run_context: RunContext[Any]
         ) -> None:
-            model = await self._resolve_model_for_request(model_id, run_context)
-            with set_current_run_context(run_context):
+            async with self._durable_model_scope(model_id, run_context) as (model, _):
                 await model.cancel_suspended_response(response)
 
         self._cancel_suspended_response_step = cancel_suspended_response_step

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
@@ -28,7 +28,8 @@ def dbosify_dynamic_toolset(
 
     @DBOS.step(name=f'{name}.get_tools', **(step_config or {}))
     async def get_tools_step(ctx: RunContext[AgentDepsT]) -> DynamicToolsResult:
-        return await get_dynamic_tools(wrapped, ctx)
+        # The context is guarded because the user's toolset factory receives it and could enqueue.
+        return await get_dynamic_tools(wrapped, guard_enqueue_in_workflow(ctx))
 
     @DBOS.step(name=f'{name}.call_tool', **(step_config or {}))
     async def call_tool_step(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> CallToolResult:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
@@ -26,12 +26,13 @@ def dbosify_mcp_toolset(
 
     @DBOS.step(name=f'{name}.get_tools', **(step_config or {}))
     async def get_tools_step(ctx: RunContext[AgentDepsT]) -> dict[str, ToolDefinition]:
-        return {tool_name: tool.tool_def for tool_name, tool in (await wrapped.get_tools(ctx)).items()}
+        step_ctx = guard_enqueue_in_workflow(ctx)
+        return {tool_name: tool.tool_def for tool_name, tool in (await wrapped.get_tools(step_ctx)).items()}
 
     @DBOS.step(name=f'{name}.get_instructions', **(step_config or {}))
     async def get_instructions_step(ctx: RunContext[AgentDepsT]):
         async with wrapped:
-            return await wrapped.get_instructions(ctx)
+            return await wrapped.get_instructions(guard_enqueue_in_workflow(ctx))
 
     @DBOS.step(name=f'{name}.call_tool', **(step_config or {}))
     async def call_tool_step(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -8,7 +8,6 @@ from prefect import task
 from prefect.context import FlowRunContext
 
 from pydantic_ai import messages as _messages
-from pydantic_ai._run_context import set_current_run_context
 from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.capabilities.abstract import WrapModelRequestHandler
@@ -133,8 +132,7 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
             model_request_parameters: ModelRequestParameters,
             run_context: RunContext[Any],
         ) -> ModelResponse:
-            model = await self._resolve_model_for_request(model_id, run_context)
-            with set_current_run_context(run_context):
+            async with self._durable_model_scope(model_id, run_context) as (model, _):
                 response = await model.request(messages, model_settings, model_request_parameters)
             _stamp_response_provenance(response, messages)
             return response
@@ -149,8 +147,7 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
             model_request_parameters: ModelRequestParameters,
             run_context: RunContext[Any],
         ) -> StreamedActivityResult:
-            model = await self._resolve_model_for_request(model_id, run_context)
-            with self._durable_run_context_scope(run_context) as ctx:
+            async with self._durable_model_scope(model_id, run_context) as (model, ctx):
                 async with model.request_stream(
                     messages, model_settings, model_request_parameters, ctx
                 ) as streamed_response:
@@ -169,8 +166,7 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
         async def cancel_suspended_response_task(
             model_id: str | None, response: ModelResponse, run_context: RunContext[Any]
         ) -> None:
-            model = await self._resolve_model_for_request(model_id, run_context)
-            with set_current_run_context(run_context):
+            async with self._durable_model_scope(model_id, run_context) as (model, _):
                 await model.cancel_suspended_response(response)
 
         self._cancel_suspended_response_task = cancel_suspended_response_task

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -52,7 +52,12 @@ from pydantic_ai.exceptions import (
     UsageLimitExceeded,
     UserError,
 )
-from pydantic_ai.models import ModelRequestContext, ModelResolutionContext, create_async_http_client
+from pydantic_ai.models import (
+    ModelRequestContext,
+    ModelRequestParameters,
+    ModelResolutionContext,
+    create_async_http_client,
+)
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
@@ -2449,6 +2454,184 @@ async def test_dbos_dynamic_tool_rejects_enqueue_in_workflow(dbos: DBOS) -> None
         await run_workflow()
 
     await agent.run('run')
+
+
+async def test_dbos_dynamic_get_tools_rejects_enqueue_in_workflow(dbos: DBOS) -> None:
+    """The dynamic-toolset discovery step guards enqueue: the user's factory receives the context."""
+    enqueue_errors: list[str] = []
+
+    def factory(ctx: RunContext[object]) -> FunctionToolset[object]:
+        try:
+            ctx.enqueue('later')
+        except UserError as e:
+            enqueue_errors.append(str(e))
+        return FunctionToolset([])
+
+    agent = Agent(
+        TestModel(),
+        deps_type=object,
+        name='dbos_dynamic_get_tools_enqueue',
+        toolsets=[DynamicToolset(factory, id='enqueue_factory')],
+        capabilities=[DBOSDurability()],
+    )
+
+    @DBOS.workflow()
+    async def run_workflow() -> None:
+        await agent.run('run')
+
+    await run_workflow()
+    assert enqueue_errors == snapshot(
+        [
+            "`ctx.enqueue()` is not supported inside a durable step: the durable runtime replays the step's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from workflow-level code instead."
+        ]
+    )
+
+
+async def test_dbos_mcp_get_tools_and_instructions_reject_enqueue_in_workflow(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The MCP discovery steps guard enqueue too, like the MCP call step."""
+    enqueue_errors: list[str] = []
+    mcp_toolset = MCPToolset(
+        StdioTransport(command='python', args=['-m', 'tests.mcp_server']),
+        id='enqueue_mcp_discovery',
+        include_instructions=True,
+    )
+
+    async def enqueue_get_tools(ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
+        with pytest.raises(UserError) as exc_info:
+            ctx.enqueue('later')
+        enqueue_errors.append(str(exc_info.value))
+        return {}
+
+    async def enqueue_get_instructions(ctx: RunContext[None]) -> str:
+        with pytest.raises(UserError) as exc_info:
+            ctx.enqueue('later')
+        enqueue_errors.append(str(exc_info.value))
+        return ''
+
+    monkeypatch.setattr(mcp_toolset, 'get_tools', enqueue_get_tools)
+    monkeypatch.setattr(mcp_toolset, 'get_instructions', enqueue_get_instructions)
+    durable = dbosify_mcp_toolset(mcp_toolset, step_name_prefix='enqueue_mcp_discovery_agent', step_config={})
+    # A live queue, so the raise below can only come from the step's guard.
+    run_context = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=[])
+
+    @DBOS.workflow()
+    async def run_workflow() -> None:
+        await durable.get_tools(run_context)
+        await durable.get_instructions(run_context)
+
+    await run_workflow()
+    assert enqueue_errors == snapshot(
+        [
+            "`ctx.enqueue()` is not supported inside a durable step: the durable runtime replays the step's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from workflow-level code instead.",
+            "`ctx.enqueue()` is not supported inside a durable step: the durable runtime replays the step's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from workflow-level code instead.",
+        ]
+    )
+    assert run_context.pending_messages == []
+
+
+async def test_dbos_model_request_step_rejects_enqueue(dbos: DBOS) -> None:
+    """The non-streaming model-request step guards enqueue like its streaming sibling.
+
+    `Model.request` takes no run context, so code inside the step (a custom model, a `models=`
+    wrapper, a `resolve_model_id` capability rebuilding it) reaches the run through
+    `get_current_run_context()`. Recovery replays the recorded step output without re-running
+    it, so an enqueue there would be dropped.
+    """
+    enqueue_errors: list[str] = []
+    enqueued: list[str | None] = []
+
+    class AmbientEnqueueModel(TestModel):
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            ambient = get_current_run_context()
+            assert ambient is not None
+            # Only on the first request of a run: a successful enqueue triggers another request,
+            # and enqueueing from each of those would never terminate.
+            if not (enqueue_errors or enqueued):
+                try:
+                    enqueued.append(ambient.enqueue('later'))
+                except UserError as e:
+                    enqueue_errors.append(str(e))
+            return await super().request(messages, model_settings, model_request_parameters)
+
+    agent = Agent(AmbientEnqueueModel(), name='dbos_model_request_enqueue', capabilities=[DBOSDurability()])
+
+    @DBOS.workflow()
+    async def run_workflow() -> None:
+        await agent.run('go')
+
+    await run_workflow()
+    assert enqueued == []
+    assert enqueue_errors == snapshot(
+        [
+            "`ctx.enqueue()` is not supported inside a durable step: the durable runtime replays the step's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from workflow-level code instead."
+        ]
+    )
+
+    # Outside a workflow the step degrades to a plain call and enqueueing keeps working.
+    enqueue_errors.clear()
+    result = await agent.run('go')
+    assert enqueue_errors == []
+    assert len(enqueued) == 1
+    assert result.output == snapshot('success (no tool calls)')
+
+
+async def test_dbos_cancel_suspended_response_step_rejects_enqueue(dbos: DBOS) -> None:
+    """The suspended-response cancellation step guards enqueue too.
+
+    The teardown is a provider call inside its own step, so the same replay argument applies.
+    """
+    enqueue_errors: list[str] = []
+
+    class AmbientEnqueueContinuationModel(ScriptedContinuationModel):
+        async def cancel_suspended_response(self, response: ModelResponse) -> None:
+            ambient = get_current_run_context()
+            assert ambient is not None
+            try:
+                ambient.enqueue('later')
+            except UserError as e:
+                enqueue_errors.append(str(e))
+            await super().cancel_suspended_response(response)
+
+    model = AmbientEnqueueContinuationModel(
+        responses=[
+            scripted_response(
+                texts=['still going '],
+                state='suspended',
+                provider_response_id='cont1',
+                input_tokens=10,
+                output_tokens=5,
+            ),
+            scripted_response(
+                texts=['keeps going '],
+                state='suspended',
+                provider_response_id='cont2',
+                input_tokens=100,
+                output_tokens=50,
+            ),
+        ]
+    )
+    agent = Agent(model, name='dbos_cancel_enqueue', capabilities=[DBOSDurability()])
+
+    @DBOS.workflow()
+    async def run_workflow() -> None:
+        await agent.run('go', usage_limits=UsageLimits(total_tokens_limit=20))
+
+    with pytest.raises(UsageLimitExceeded, match='total_tokens_limit'):
+        await run_workflow()
+
+    assert [cancelled.provider_response_id for cancelled in model.cancelled] == ['cont2']
+    assert enqueue_errors == snapshot(
+        [
+            "`ctx.enqueue()` is not supported inside a durable step: the durable runtime replays the step's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from workflow-level code instead."
+        ]
+    )
 
 
 async def test_dbos_durability_parallel_mode_applies_inside_run(dbos: DBOS) -> None:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2763,6 +2763,109 @@ async def test_prefect_mcp_task_wrapped_call_rejects_enqueue(monkeypatch: pytest
     assert len(outside_context.pending_messages or []) == 1
 
 
+async def test_prefect_model_request_task_rejects_enqueue() -> None:
+    """The non-streaming model-request task guards enqueue like its streaming sibling.
+
+    `Model.request` takes no run context, so code inside the task (a custom model, a
+    `models=` wrapper, a `resolve_model_id` capability rebuilding it) reaches the run
+    through `get_current_run_context()`. The task's cached result is replayed without
+    re-running it, so an enqueue there would be dropped.
+    """
+    enqueue_errors: list[str] = []
+    enqueued: list[str | None] = []
+
+    class AmbientEnqueueModel(TestModel):
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            ambient = get_current_run_context()
+            assert ambient is not None
+            # Only on the first request of a run: a successful enqueue triggers another request,
+            # and enqueueing from each of those would never terminate.
+            if not (enqueue_errors or enqueued):
+                try:
+                    enqueued.append(ambient.enqueue('later'))
+                except UserError as e:
+                    enqueue_errors.append(str(e))
+            return await super().request(messages, model_settings, model_request_parameters)
+
+    agent = Agent(AmbientEnqueueModel(), name='prefect_model_request_enqueue', capabilities=[PrefectDurability()])
+
+    @flow
+    async def run_agent() -> None:
+        await agent.run('go')
+
+    await run_agent()
+    assert enqueued == []
+    assert enqueue_errors == snapshot(
+        [
+            "`ctx.enqueue()` is not supported inside a durable task: the durable runtime replays the task's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from flow-level code instead."
+        ]
+    )
+
+    # Outside a flow the model runs inline and enqueueing keeps working.
+    enqueue_errors.clear()
+    result = await agent.run('go')
+    assert enqueue_errors == []
+    assert len(enqueued) == 1
+    assert result.output == snapshot('success (no tool calls)')
+
+
+async def test_prefect_cancel_suspended_response_task_rejects_enqueue() -> None:
+    """The suspended-response cancellation task guards enqueue too.
+
+    The teardown is a provider call inside its own task, so the same replay argument applies.
+    """
+    enqueue_errors: list[str] = []
+
+    class AmbientEnqueueContinuationModel(ScriptedContinuationModel):
+        async def cancel_suspended_response(self, response: ModelResponse) -> None:
+            ambient = get_current_run_context()
+            assert ambient is not None
+            try:
+                ambient.enqueue('later')
+            except UserError as e:
+                enqueue_errors.append(str(e))
+            await super().cancel_suspended_response(response)
+
+    model = AmbientEnqueueContinuationModel(
+        responses=[
+            scripted_response(
+                texts=['still going '],
+                state='suspended',
+                provider_response_id='cont1',
+                input_tokens=10,
+                output_tokens=5,
+            ),
+            scripted_response(
+                texts=['keeps going '],
+                state='suspended',
+                provider_response_id='cont2',
+                input_tokens=100,
+                output_tokens=50,
+            ),
+        ]
+    )
+    agent = Agent(model, name='prefect_cancel_enqueue', capabilities=[PrefectDurability()])
+
+    @flow
+    async def run_agent() -> None:
+        await agent.run('go', usage_limits=UsageLimits(total_tokens_limit=20))
+
+    with pytest.raises(UsageLimitExceeded, match='total_tokens_limit'):
+        await run_agent()
+
+    assert [cancelled.provider_response_id for cancelled in model.cancelled] == ['cont2']
+    assert enqueue_errors == snapshot(
+        [
+            "`ctx.enqueue()` is not supported inside a durable task: the durable runtime replays the task's recorded result without re-running your code, so the enqueued messages would be dropped. Enqueue messages from flow-level code instead."
+        ]
+    )
+
+
 async def test_prefect_tool_model_retry_is_not_retried_by_task_engine() -> None:
     calls = 0
 


### PR DESCRIPTION
- Closes #6909

DBOS's `request_step`/`cancel_suspended_response_step` and Prefect's `request_task`/`cancel_suspended_response_task` set the run context as ambient with a bare `set_current_run_context`, unlike their streaming siblings three lines below, which use `_durable_run_context_scope`. Code running inside those units could therefore `enqueue()` a message that a DBOS recovery or a Prefect cache hit silently drops — the exact failure #6666/#6671 added the guard to prevent.

### What I verified, and one correction to the issue

The issue frames the affected user code as a capability's `before_model_request` / `after_model_request` hook. **That framing is wrong, and I checked it before fixing anything.** Those hooks are called from graph code (`_agent_graph.py:1564` and `:1621`), and the durability capability is `innermost`, so a probe against real Prefect 3.7.7 shows both running with `TaskRunContext.get() is None` — flow-level, where enqueueing is legitimate and still works after this change.

What actually runs *inside* the unit is `model.request(...)` and `_resolve_model_for_request(...)`. `Model.request` takes no run context, so a custom model, a `models=` wrapper, or a `resolve_model_id` capability rebuilding the model reaches the run through `get_current_run_context()` — and on `main` that returns the **unguarded** context, because DBOS and Prefect pass the live in-process context. Same probe, before the fix:

```
('before_model_request', in_task=False, 'enqueued OK')     # flow-level, correct
('model.request ambient', in_task=True,  'enqueued OK')    # <- the bug
('after_model_request',  in_task=False, 'enqueued OK')     # flow-level, correct
```

and after:

```
('model.request ambient', in_task=True, "UserError: `ctx.enqueue()` is not supported inside a durable task: …")
```

The four new tests were each confirmed to fail against unpatched `main` and pass with the change.

### The fix is structural rather than two more hand-listed sites

The issue's own point is that DBOS/Prefect have no chokepoint and instead hand-list guard call sites, so coverage silently regresses when a unit is added. Rather than adding two more entries to those lists, the model-unit family now goes through one shared base helper:

```python
@asynccontextmanager
async def _durable_model_scope(self, model_id, run_context) -> AsyncGenerator[tuple[Model, RunContext[AgentDepsT]]]:
    with self._durable_run_context_scope(run_context) as ctx:
        yield await self._resolve_model_for_request(model_id, ctx), ctx
```

All six model units (request / streaming request / cancellation × DBOS, Prefect) use it, so a unit **can't get its model without the guard**. Temporal keeps its own chokepoint in `deserialize_run_context` and is untouched. As a side effect the guard now also covers `_resolve_model_for_request`, which previously ran before the context was set at all.

The DBOS discovery steps (`_dynamic_toolset.py` `get_tools`, `_mcp_toolset.py` `get_tools`/`get_instructions`) are the remaining `UNGUARDED` cells in the issue's table; they're one-line argument guards matching the `call_tool` convention already in those same files, so they're closed here too rather than left as a known hole under a closed issue. The dynamic-toolset one is the reachable one: the user's toolset factory receives that context.

Nothing else in the table changed, and no engine's durable schedule (step/task names or ordering) changed.

### Tests

`tests/test_prefect.py`
- `test_prefect_model_request_task_rejects_enqueue`
- `test_prefect_cancel_suspended_response_task_rejects_enqueue`

`tests/test_dbos.py`
- `test_dbos_model_request_step_rejects_enqueue`
- `test_dbos_cancel_suspended_response_step_rejects_enqueue`
- `test_dbos_dynamic_get_tools_rejects_enqueue_in_workflow`
- `test_dbos_mcp_get_tools_and_instructions_reject_enqueue_in_workflow`

Full `tests/test_dbos.py` + `tests/test_prefect.py` pass (225 tests).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

