### PR TITLE
Fix Prefect tool-call cache keys: replay tool results on flow retry and stop colliding on `RunContext` fields a tool can read

### DIFF
--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -291,7 +291,7 @@ This prevents requests from being retried multiple times at different layers.
 
 Prefect 3.0 provides built-in caching and transactional semantics. Tasks with identical inputs will not re-execute if their results are already cached, making workflows naturally idempotent and resilient to failures.
 
-* **Task inputs**: A model request's messages, settings and parameters; a tool call's name, arguments and definition; and the run state the task's work can depend on: dependencies, [`metadata`][pydantic_ai.tools.RunContext.metadata], [`validation_context`][pydantic_ai.tools.RunContext.validation_context], the prompt, and the message history.
+* **Task inputs**: A model request's messages, settings and parameters; a tool call's name, arguments, definition and [`tool_call_id`][pydantic_ai.tools.RunContext.tool_call_id] (so two parallel calls to the same tool with the same arguments each execute); and the run state the task's work can depend on: dependencies, [`metadata`][pydantic_ai.tools.RunContext.metadata], [`validation_context`][pydantic_ai.tools.RunContext.validation_context], the prompt, and the message history.
 
 Per-run identifiers like [`run_id`][pydantic_ai.tools.RunContext.run_id] and [`conversation_id`][pydantic_ai.tools.RunContext.conversation_id], and message timestamps, are deliberately left out, so an otherwise identical run replays recorded results instead of re-executing them.
 

--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -291,9 +291,11 @@ This prevents requests from being retried multiple times at different layers.
 
 Prefect 3.0 provides built-in caching and transactional semantics. Tasks with identical inputs will not re-execute if their results are already cached, making workflows naturally idempotent and resilient to failures.
 
-* **Task inputs**: Messages, settings, parameters, tool arguments, and serializable dependencies
+* **Task inputs**: A model request's messages, settings and parameters; a tool call's name, arguments and definition; and the run state the task's work can depend on: dependencies, [`metadata`][pydantic_ai.tools.RunContext.metadata], [`validation_context`][pydantic_ai.tools.RunContext.validation_context], the prompt, and the message history.
 
-**Note**: For user dependencies to be included in cache keys, they must be serializable (e.g., Pydantic models or basic Python types). Non-serializable dependencies are automatically excluded from cache computation.
+Per-run identifiers like [`run_id`][pydantic_ai.tools.RunContext.run_id] and [`conversation_id`][pydantic_ai.tools.RunContext.conversation_id], and message timestamps, are deliberately left out, so an otherwise identical run replays recorded results instead of re-executing them.
+
+**Note**: For user dependencies, `metadata` and `validation_context` to be included in cache keys, they must be serializable (e.g., Pydantic models or basic Python types). Non-serializable values are automatically excluded from cache computation.
 
 ## Observability with Prefect and Logfire
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -164,7 +164,7 @@ def _strip_cache_excluded_fields(
 def _replace_toolset_tools(
     inputs: dict[str, Any],
 ) -> Any:
-    """Replace `ToolsetTool` objects with their JSON-native `ToolDefinition`.
+    """Replace `ToolsetTool` objects with their JSON-native toolset ID and `ToolDefinition`.
 
     A `ToolsetTool` carries live objects — the toolset that produced it, the function to call, and
     an `args_validator` Prefect's JSON serializer can't handle — which pushes `hash_objects` onto
@@ -173,11 +173,19 @@ def _replace_toolset_tools(
     between the first attempt, where the tool name and the tool definition's name are the same
     string object, and a flow retry, where the model response was replayed from its own cache and
     deserialized into fresh objects. That made tool results never replay, re-running non-idempotent
-    tools on every retry. The `ToolDefinition` is the tool's value identity and hashes over the
-    JSON path, so the key is value-addressed and stable across attempts.
+    tools on every retry.
+
+    The toolset's ID and the `ToolDefinition` together are the tool's value identity, and both hash
+    over the JSON path, so the key is value-addressed and stable across attempts. The ID is what
+    distinguishes two toolsets that expose an identically defined tool: every toolset's tool task is
+    the same function, so `TASK_SOURCE` doesn't tell them apart, and a tool's name is only unique
+    within its own toolset.
     """
     return {
-        key: _cacheable_value(value.tool_def) if _is_toolset_tool(value) else value for key, value in inputs.items()
+        key: {'toolset': value.toolset.id, 'tool_def': _cacheable_value(value.tool_def)}
+        if _is_toolset_tool(value)
+        else value
+        for key, value in inputs.items()
     }
 
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -33,15 +33,15 @@ def _is_run_context(obj: Any) -> TypeGuard[RunContext[object]]:
     return isinstance(obj, RunContext)
 
 
-def _cacheable_deps(deps: Any) -> Any:
-    """Project `deps` for cache-key hashing, excluding non-serializable values.
+def _cacheable_value(value: Any) -> Any:
+    """Project an arbitrary user-provided value for cache-key hashing, excluding non-serializable parts.
 
-    Dependencies routinely hold live resources (HTTP clients, DB connections, locks) that
-    Prefect can't hash; those values are replaced with a stable sentinel rather than failing
-    the task, while serializable siblings still fork the key. Plain non-dataclass and
-    non-`BaseModel` objects are treated as indivisible values.
+    Dependencies, run metadata and validation contexts routinely hold live resources (HTTP clients,
+    DB connections, locks) that Prefect can't hash; those values are replaced with a stable sentinel
+    rather than failing the task, while serializable siblings still fork the key. Plain non-dataclass
+    and non-`BaseModel` objects are treated as indivisible values.
     """
-    projected = _strip_cache_excluded_fields(deps)
+    projected = _strip_cache_excluded_fields(value)
 
     def exclude_non_serializable(value: Any) -> Any:
         if hash_objects(value, raise_on_failure=False) is not None:
@@ -62,16 +62,43 @@ def _cacheable_deps(deps: Any) -> Any:
 def _replace_run_context(
     inputs: dict[str, Any],
 ) -> Any:
-    """Replace RunContext objects with a dict containing only hashable fields."""
+    """Replace RunContext objects with a dict containing only hashable fields.
+
+    This projection is hand-authored rather than derived from `fields(RunContext)`: most of what a
+    `RunContext` holds is live run machinery that can't be hashed. Every field a task's work can
+    depend on has to be listed here, because a tool task's only other inputs are the tool's name,
+    its arguments and its `ToolDefinition` — there is no `messages`, `prompt` or `model_settings`
+    input to carry them the way the model-request task's inputs do.
+    `test_cache_key_run_context_projection_is_exhaustive` fails when a new field is neither
+    projected here nor consciously categorized as cache-irrelevant.
+    """
     for key, value in inputs.items():
         if _is_run_context(value):
             inputs[key] = {
-                'deps': _cacheable_deps(value.deps),
+                'deps': _cacheable_value(value.deps),
                 'agent': value.agent.name if value.agent is not None else None,
                 'model': value.model.model_id,
                 'retries': value.retries,
+                # Keyed verbatim, unlike the framework-generated tool call IDs inside `messages`:
+                # those are normalized so an identical history hashes the same across runs, but the
+                # ID of the call being made is what separates two parallel calls to the same tool
+                # with the same arguments, which must each execute rather than replay each other.
                 'tool_call_id': value.tool_call_id,
                 'tool_name': value.tool_name,
+                # The run inputs a tool body can read. `metadata` and `validation_context` hold
+                # arbitrary user values, so they get the same sentinel treatment as `deps`.
+                'prompt': value.prompt,
+                'metadata': _cacheable_value(value.metadata),
+                'validation_context': _cacheable_value(value.validation_context),
+                # Populated before every model request and still set while tools run, so two runs
+                # that differ only in their settings must not share a tool result. Model-request
+                # tasks additionally take it as a separate input.
+                'model_settings': value.model_settings,
+                # Tool keys are deliberately history-sensitive: a tool reading `ctx.messages` must
+                # not replay a result produced against a different history. A flow retry replays a
+                # value-identical history (per-run fields are stripped below), so this costs
+                # cross-run reuse of tool results, not retry idempotency.
+                'messages': value.messages,
                 'tool_call_approved': value.tool_call_approved,
                 'tool_call_metadata': value.tool_call_metadata,
                 'retry': value.retry,
@@ -134,15 +161,24 @@ def _strip_cache_excluded_fields(
     return obj
 
 
-def _replace_toolsets(
+def _replace_toolset_tools(
     inputs: dict[str, Any],
 ) -> Any:
-    """Replace Toolset objects with a dict containing only hashable fields."""
-    inputs = inputs.copy()
-    for key, value in inputs.items():
-        if _is_toolset_tool(value):
-            inputs[key] = {field.name: getattr(value, field.name) for field in fields(value) if field.name != 'toolset'}
-    return inputs
+    """Replace `ToolsetTool` objects with their JSON-native `ToolDefinition`.
+
+    A `ToolsetTool` carries live objects — the toolset that produced it, the function to call, and
+    an `args_validator` Prefect's JSON serializer can't handle — which pushes `hash_objects` onto
+    its `cloudpickle` fallback. There the digest depends on which objects the payload *shares*
+    (pickle emits memo references for repeats) rather than on their values, so the key changes
+    between the first attempt, where the tool name and the tool definition's name are the same
+    string object, and a flow retry, where the model response was replayed from its own cache and
+    deserialized into fresh objects. That made tool results never replay, re-running non-idempotent
+    tools on every retry. The `ToolDefinition` is the tool's value identity and hashes over the
+    JSON path, so the key is value-addressed and stable across attempts.
+    """
+    return {
+        key: _cacheable_value(value.tool_def) if _is_toolset_tool(value) else value for key, value in inputs.items()
+    }
 
 
 class PrefectAgentInputs(CachePolicy):
@@ -163,8 +199,8 @@ class PrefectAgentInputs(CachePolicy):
         if not inputs:
             return None
 
-        inputs_without_toolsets = _replace_toolsets(inputs)
-        inputs_with_hashable_context = _replace_run_context(inputs_without_toolsets)
+        inputs_without_toolset_tools = _replace_toolset_tools(inputs)
+        inputs_with_hashable_context = _replace_run_context(inputs_without_toolset_tools)
         filtered_inputs = _strip_cache_excluded_fields(inputs_with_hashable_context)
 
         return INPUTS.compute_key(task_ctx, filtered_inputs, flow_parameters, **kwargs)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -96,8 +96,8 @@ def _replace_run_context(
                 'model_settings': value.model_settings,
                 # Tool keys are deliberately history-sensitive: a tool reading `ctx.messages` must
                 # not replay a result produced against a different history. A flow retry replays a
-                # value-identical history (per-run fields are stripped below), so this costs
-                # cross-run reuse of tool results, not retry idempotency.
+                # value-identical history (`_strip_cache_excluded_fields` drops the per-run fields),
+                # so this costs cross-run reuse of tool results, not retry idempotency.
                 'messages': value.messages,
                 'tool_call_approved': value.tool_call_approved,
                 'tool_call_metadata': value.tool_call_metadata,

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1576,6 +1576,111 @@ def test_cache_policy_normalizes_only_framework_tool_call_ids():
     assert key_for('model-first') != key_for('model-second')
 
 
+async def test_cache_policy_hashes_tools_by_value_not_object_identity():
+    """A tool task's key must depend on the tool's value, not on which objects the payload shares.
+
+    `hash_objects` falls back to `cloudpickle` for anything its JSON serializer can't handle — a
+    `ToolsetTool` carries an `args_validator` and a live toolset — and on that path the digest
+    depends on object *sharing*, because pickle emits memo references for repeats. A first attempt
+    passes the same string object as both `tool_name` and the tool definition's name, while a retry
+    that replays the recorded `ModelResponse` passes a freshly deserialized one, so an
+    identity-sensitive key never replays a tool result.
+    """
+    cache_policy = PrefectAgentInputs()
+    mock_task_ctx = MagicMock()
+
+    toolset = FunctionToolset[None](id='value_addressed_toolset')
+
+    @toolset.tool
+    async def side_effect(ctx: RunContext[None]) -> str:
+        return 'ok'  # pragma: no cover
+
+    @toolset.tool
+    async def other_effect(ctx: RunContext[None]) -> str:
+        return 'ok'  # pragma: no cover
+
+    ctx = RunContext[None](deps=None, model=TestModel(), usage=RunUsage())
+    tools = await toolset.get_tools(ctx)
+
+    def key_for(tool_name: str, tool: ToolsetTool[None]) -> str | None:
+        return cache_policy.compute_key(
+            task_ctx=mock_task_ctx,
+            inputs={'tool_name': tool_name, 'tool_args': {}, 'ctx': ctx, 'tool': tool},
+            flow_parameters={},
+        )
+
+    shared_name = tools['side_effect'].tool_def.name
+    # An equal name that is a different object, as a deserialized `ToolCallPart.tool_name` is.
+    deserialized_name = ''.join(['side', '_', 'effect'])
+    assert deserialized_name == shared_name
+    assert deserialized_name is not shared_name
+
+    assert key_for(shared_name, tools['side_effect']) == key_for(deserialized_name, tools['side_effect'])
+    # The tool definition still forks the key: a different tool is a different cache entry.
+    assert key_for(shared_name, tools['side_effect']) != key_for(shared_name, tools['other_effect'])
+
+
+def test_cache_policy_keys_the_run_context_tool_call_id_verbatim():
+    """The ID of the call being made is keyed verbatim; the ones inside `messages` are normalized.
+
+    `_strip_cache_excluded_fields` replaces framework-generated tool call IDs so an otherwise
+    identical history hashes the same across runs, but it never reaches the `RunContext` itself —
+    `_replace_run_context` has already projected it to a plain dict. That's deliberate: the current
+    call's ID is what separates two parallel calls to the same tool with identical arguments, which
+    must each execute rather than replay one another.
+    """
+    cache_policy = PrefectAgentInputs()
+    mock_task_ctx = MagicMock()
+
+    def key_for_current_call(tool_call_id: str) -> str | None:
+        ctx = RunContext[None](
+            deps=None, model=TestModel(), usage=RunUsage(), tool_name='tool', tool_call_id=tool_call_id
+        )
+        return cache_policy.compute_key(task_ctx=mock_task_ctx, inputs={'ctx': ctx}, flow_parameters={})
+
+    assert key_for_current_call('pyd_ai_first') != key_for_current_call('pyd_ai_second')
+
+    def key_for_history(tool_call_id: str) -> str | None:
+        ctx = RunContext[None](
+            deps=None,
+            model=TestModel(),
+            usage=RunUsage(),
+            messages=[ModelResponse(parts=[ToolCallPart('tool', tool_call_id=tool_call_id)])],
+        )
+        return cache_policy.compute_key(task_ctx=mock_task_ctx, inputs={'ctx': ctx}, flow_parameters={})
+
+    assert key_for_history('pyd_ai_first') == key_for_history('pyd_ai_second')
+    assert key_for_history('model-first') != key_for_history('model-second')
+
+
+def test_cache_policy_excludes_non_serializable_metadata_and_validation_context():
+    """`metadata` and `validation_context` hold arbitrary user values, like `deps`.
+
+    They fork the key when they differ, and unhashable values fall back to the same stable
+    sentinel instead of failing the task.
+    """
+    cache_policy = PrefectAgentInputs()
+    mock_task_ctx = MagicMock()
+
+    def key_for(metadata: dict[str, Any] | None = None, validation_context: Any = None) -> str | None:
+        ctx = RunContext[None](
+            deps=None,
+            model=TestModel(),
+            usage=RunUsage(),
+            metadata=metadata,
+            validation_context=validation_context,
+        )
+        return cache_policy.compute_key(task_ctx=mock_task_ctx, inputs={'ctx': ctx}, flow_parameters={})
+
+    assert key_for(metadata={'tenant': 'acme'}) != key_for(metadata={'tenant': 'globex'})
+    assert key_for(validation_context={'lang': 'en'}) != key_for(validation_context={'lang': 'fr'})
+
+    unhashable_key = key_for(metadata={'tenant': 'acme', 'lock': threading.Lock()})
+    assert unhashable_key is not None
+    assert unhashable_key == key_for(metadata={'tenant': 'acme', 'lock': threading.Lock()})
+    assert unhashable_key != key_for(metadata={'tenant': 'globex', 'lock': threading.Lock()})
+
+
 def test_cache_policy_excludes_non_serializable_deps():
     """Non-serializable dependency values are excluded without dropping serializable siblings.
 
@@ -1678,28 +1783,28 @@ def test_cache_key_run_context_projection_is_exhaustive():
     one replays the other's result. This test fails when a `RunContext` field is added until
     it's either included in the projection or listed in `cache_irrelevant` with a reason — the
     same drift that left `loaded_capability_ids`/`discovered_tool_names` out of the key.
+
+    Each reason has to hold for the *tool* task, whose only other inputs are the tool's name, its
+    arguments, and its `ToolDefinition`. "Hashed as a separate task input" is a model-request-task
+    reason and never a tool-task one: nothing carries the prompt, the history or the run metadata
+    into a tool task's key except this projection.
     """
     # Fields that legitimately don't belong in the cache key, each with its reason.
     cache_irrelevant = {
-        'usage',  # accumulates per run; not an input that should fork the cache
+        'usage',  # accumulates during the run rather than being an input to it
         'tracer',  # tracing plumbing, not run state
         'tool_manager',  # live ToolManager, not hashable run state
         'capabilities',  # live capability objects, not hashable run state
         'root_capability',  # live capability tree (static config); run-varying loaded state is projected via loaded_capability_ids/discovered_tool_names
         'pending_messages',  # live run queue, not hashable run state
-        'messages',  # hashed as the separate `messages` task input
-        'prompt',  # hashed as the separate prompt task input
-        'validation_context',  # arbitrary user object, not run state
-        'trace_include_content',  # tracing config, not run state
-        'instrumentation_version',  # tracing config, not run state
-        'partial_output',  # output-validator flag, not a tool-execution input
-        'run_id',  # per-run id; deliberately excluded so keys are stable across runs
+        'trace_include_content',  # tracing config, fixed for the agent rather than varying per run
+        'instrumentation_version',  # tracing config, fixed for the agent rather than varying per run
+        'partial_output',  # only set for output validators, which run in flow code, never inside a task
+        'run_id',  # per-run id; deliberately excluded so an identical run replays instead of re-executing
         'conversation_id',  # per-conversation id; same rationale as run_id
-        'metadata',  # free-form run metadata, not a tool-execution input
-        'model_settings',  # hashed via the model request inputs, not RunContext
-        'capability_loaded',  # transient per-hook flag; `None` during tool execution
+        'capability_loaded',  # transient flag describing the capability being dispatched, not a run input
         '_mcp_tool_defs_cache',  # live per-run memo of MCP tool defs, reconstructed from messages
-        '_event_stream_buffer',  # live per-run event buffer drained in workflow code, not a tool-execution input
+        '_event_stream_buffer',  # live per-run event buffer drained in flow code, not a task input
     }
     ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
     projected = set(_replace_run_context({'ctx': ctx})['ctx'])
@@ -1791,6 +1896,97 @@ async def test_durability_repeated_run_hits_cache_preserves_provenance():
         producing_conversation_id,
     ]
     assert result2.all_messages()[0].run_id != response2.run_id
+
+
+async def test_flow_retry_replays_tool_result() -> None:
+    """A flow retry replays a tool task's recorded result instead of re-running the tool body.
+
+    A tool task's hashed inputs have to be value-addressed. When the preceding model-request task
+    replays its recorded `ModelResponse`, the deserialized `tool_name` is a different string object
+    than the one the live call produced, so any input that pushes `hash_objects` onto its
+    `cloudpickle` fallback (before: the live `ToolsetTool` and its `args_validator`) makes the key
+    depend on pickle memo layout rather than on values, and the tool's side effects are duplicated.
+    """
+    tool_runs: list[str] = []
+    model_runs = 0
+
+    def model_fn(messages: list[ModelMessage], _agent_info: AgentInfo) -> ModelResponse:
+        nonlocal model_runs
+        model_runs += 1
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[TextPart('done')])
+        return ModelResponse(parts=[ToolCallPart('record_side_effect')])
+
+    toolset = FunctionToolset[object](id='retry_replay_toolset')
+
+    @toolset.tool
+    async def record_side_effect(ctx: RunContext[object]) -> str:
+        """Stands in for a charge, an email, or any other non-idempotent effect."""
+        tool_runs.append(ctx.tool_name or '')
+        return 'ok'
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        name='retry_replay_agent',
+        toolsets=[toolset],
+        capabilities=[PrefectDurability[object]()],
+    )
+
+    attempts = 0
+
+    @flow(retries=1)
+    async def flaky() -> str:
+        nonlocal attempts
+        attempts += 1
+        result = await agent.run('go')
+        # Fail after the agent run, so the retry has both tasks' results to replay.
+        if attempts == 1:
+            raise RuntimeError('boom')
+        return result.output
+
+    assert await flaky() == 'done'
+    assert attempts == 2
+    assert tool_runs == ['record_side_effect']
+    assert model_runs == 2
+
+
+async def test_runs_in_one_flow_differing_in_metadata_do_not_share_results() -> None:
+    """Two runs in one flow that differ only in `metadata` must not share cached results.
+
+    `metadata` is a run input a tool can read, so it has to fork both the model-request and the
+    tool-call cache key. Before, neither task's key carried it and the second run silently
+    replayed the first run's response and tool result.
+    """
+    tool_metadata: list[Any] = []
+
+    async def echo_metadata(ctx: RunContext[object]) -> str:
+        tool_metadata.append(ctx.metadata)
+        assert ctx.metadata is not None
+        return f'tenant={ctx.metadata["tenant"]}'
+
+    def model_fn(messages: list[ModelMessage], _agent_info: AgentInfo) -> ModelResponse:
+        for message in messages:
+            for part in message.parts:
+                if isinstance(part, ToolReturnPart):
+                    return ModelResponse(parts=[TextPart(str(part.content))])
+        # No `tool_call_id`, so the framework generates one, as Gemini/Cohere/Mistral responses do.
+        return ModelResponse(parts=[ToolCallPart('echo_metadata')])
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        name='metadata_cache_probe',
+        tools=[echo_metadata],
+        capabilities=[PrefectDurability[object]()],
+    )
+
+    @flow
+    async def two_runs() -> tuple[str, str]:
+        first = await agent.run('same question', metadata={'tenant': 'a'})
+        second = await agent.run('same question', metadata={'tenant': 'b'})
+        return first.output, second.output
+
+    assert await two_runs() == ('tenant=a', 'tenant=b')
+    assert tool_metadata == [{'tenant': 'a'}, {'tenant': 'b'}]
 
 
 # Test custom model settings

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1620,6 +1620,40 @@ async def test_cache_policy_hashes_tools_by_value_not_object_identity():
     assert key_for(shared_name, tools['side_effect']) != key_for(shared_name, tools['other_effect'])
 
 
+async def test_cache_policy_forks_identically_defined_tools_from_different_toolsets():
+    """Two toolsets exposing an identically defined tool must not share a cache entry.
+
+    Tool names are only unique within a toolset, and every toolset's tool task is the same
+    function, so `TASK_SOURCE` doesn't tell two toolsets apart either. The toolset's `id` is what
+    separates them.
+    """
+    cache_policy = PrefectAgentInputs()
+    mock_task_ctx = MagicMock()
+
+    def toolset_with_search(toolset_id: str, result: str) -> FunctionToolset[None]:
+        toolset = FunctionToolset[None](id=toolset_id)
+
+        async def search(ctx: RunContext[None], query: str) -> str:
+            return result  # pragma: no cover
+
+        toolset.add_function(search)
+        return toolset
+
+    ctx = RunContext[None](deps=None, model=TestModel(), usage=RunUsage())
+    alpha = (await toolset_with_search('alpha', 'from alpha').get_tools(ctx))['search']
+    beta = (await toolset_with_search('beta', 'from beta').get_tools(ctx))['search']
+    assert alpha.tool_def == beta.tool_def
+
+    def key_for(tool: ToolsetTool[None]) -> str | None:
+        return cache_policy.compute_key(
+            task_ctx=mock_task_ctx,
+            inputs={'tool_name': 'search', 'tool_args': {'query': 'x'}, 'ctx': ctx, 'tool': tool},
+            flow_parameters={},
+        )
+
+    assert key_for(alpha) != key_for(beta)
+
+
 def test_cache_policy_keys_the_run_context_tool_call_id_verbatim():
     """The ID of the call being made is keyed verbatim; the ones inside `messages` are normalized.
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1802,7 +1802,7 @@ def test_cache_key_run_context_projection_is_exhaustive():
         'partial_output',  # only set for output validators, which run in flow code, never inside a task
         'run_id',  # per-run id; deliberately excluded so an identical run replays instead of re-executing
         'conversation_id',  # per-conversation id; same rationale as run_id
-        'capability_loaded',  # transient flag describing the capability being dispatched, not a run input
+        'capability_loaded',  # derived from loaded_capability_ids plus the static capability set, which are projected
         '_mcp_tool_defs_cache',  # live per-run memo of MCP tool defs, reconstructed from messages
         '_event_stream_buffer',  # live per-run event buffer drained in flow code, not a task input
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

- Closes #6907
- Closes #6903

Two linked defects in the Prefect cache key. #6907 masks #6903, so they're fixed together.

### #6907 — tool results never replayed on flow retry

A tool task hashed the live `ToolsetTool`. Its `args_validator` isn't JSON-serializable, so `hash_objects` fell back to `cloudpickle`, where the digest depends on which objects the payload *shares* rather than on their values. The model-request task's own (correct) cache hit deserializes the `ModelResponse`, so `tool_name` is no longer the same string object as the tool definition's name, the composite key changes, and the tool body re-executes — contradicting the "naturally idempotent" promise at `docs/durable_execution/prefect.md`.

`_replace_toolset_tools` (was `_replace_toolsets`) now projects a `ToolsetTool` to its JSON-native `ToolDefinition`, so the key is value-addressed and stable across attempts.

**Deviation from the fix sketched in the issue, flagging it explicitly:** the issue suggests sending `tool_def` as the *task parameter*, like Temporal's `CallToolParams`. I kept the live `tool` parameter and changed what the policy hashes instead. Prefect tasks run in-process and don't serialize their arguments — the cache key is their only consumer — so the parameter change would buy nothing but would force re-deriving the live tool inside the task via `get_tools`, re-running every tool's `prepare` on every call (the Temporal wart #6890 is about). The cache policy is the layer that already owned this projection. Happy to switch if you'd rather have the signatures match Temporal's.

### #6903 — runs colliding on omitted `RunContext` fields

The projection dropped `metadata`, `validation_context`, `prompt`, `messages` and `model_settings`. All five are run inputs a tool body can read, and for a tool task nothing else carries them: its only other inputs are the tool's name, arguments and definition. They're now projected; `metadata` and `validation_context` hold arbitrary user values, so they get the same non-serializable-sentinel treatment `deps` already had (`_cacheable_deps` → `_cacheable_value`).

`run_id`/`conversation_id` stay excluded as required — `test_repeated_run_hits_cache` still passes.

Notes on the two judgement calls the issue asked for:

- **`messages`: included.** Tool keys become history-sensitive, which is correct — a tool reading `ctx.messages` must not replay a result produced against a different history. The hit-rate cost is close to zero in practice: a tool cache hit already presupposes that the model request that produced the tool call hit too, and that request is keyed on the same history. The retry-replay promise is unaffected, because a flow retry replays a value-identical history (per-run IDs and timestamps are stripped) — `test_flow_retry_replays_tool_result` covers exactly that.
- **`model_settings`: included.** The issue reasons it's safe because it's `None` during tool execution. It isn't: `_agent_graph` sets `run_context.model_settings` before each request and never clears it, so a tool reading `ctx.model_settings` sees the settings of the preceding request (verified against a plain agent run). Two runs differing only in `model_settings=` therefore collide on the tool key. Model-request tasks additionally take it as a separate input, so nothing changes for them.

`tool_call_id` is now documented as keyed **verbatim** — the dead-code finding resolved in favour of not normalizing. `_strip_cache_excluded_fields` normalizes framework-generated IDs inside `messages` so an identical history hashes the same across runs, but the ID of the *call being made* is what separates two parallel calls to the same tool with identical arguments, which must each execute rather than replay one another. (Now that `messages` is in the projection, the normalization does reach the history it carries.)

### Upgrade note

**This changes the cache key, so existing cache entries are invalidated.** A flow run that is in flight when you deploy this will re-execute its model requests and tool calls on its next retry instead of replaying the recorded results — the same hazard already documented for the `PrefectAgent` → `PrefectDurability` migration. Let in-flight flow runs finish before deploying if re-execution matters to you.

### Tests

Flow-level regression tests, both of which fail on `main`:

- `test_flow_retry_replays_tool_result` — a flow retry replays the tool result; the tool body runs once (#6907).
- `test_runs_in_one_flow_differing_in_metadata_do_not_share_results` — two runs in one flow differing only in `metadata` each get their own answer (#6903). Verified that it still fails with only the #6907 fix applied, i.e. it guards the collision rather than passing incidentally.

Plus unit coverage for the mechanisms: `test_cache_policy_hashes_tools_by_value_not_object_identity`, `test_cache_policy_keys_the_run_context_tool_call_id_verbatim`, `test_cache_policy_excludes_non_serializable_metadata_and_validation_context`, and the corrected per-field rationales in `test_cache_key_run_context_projection_is_exhaustive`.

`uv run pytest tests/test_prefect.py`: 110 passed, 100% coverage of the Prefect module and the test file.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
