### PR TITLE
Don't reset an existing Logfire configuration in `LogfirePlugin`

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -410,7 +410,7 @@ async def main():
     )
 ```
 
-By default, the `LogfirePlugin` will instrument Temporal (including metrics) and Pydantic AI and send all data to Logfire. To customize Logfire configuration and instrumentation, you can pass a `logfire_setup` function to the `LogfirePlugin` constructor and return a custom `Logfire` instance (i.e. the result of `logfire.configure()`). To disable sending Temporal metrics to Logfire, you can pass `metrics=False` to the `LogfirePlugin` constructor.
+By default, the `LogfirePlugin` will instrument Temporal (including metrics) and Pydantic AI and send all data to Logfire. If you already called `logfire.configure()` yourself, the default setup reuses that configuration instead of resetting it. To customize Logfire configuration and instrumentation, you can pass a `logfire_setup` function to the `LogfirePlugin` constructor and return a custom `Logfire` instance (i.e. the result of `logfire.configure()`). To disable sending Temporal metrics to Logfire, you can pass `metrics=False` to the `LogfirePlugin` constructor.
 
 ## Known Issues
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
 def _default_setup_logfire() -> Logfire:
     import logfire
 
-    instance = logfire.configure()
+    instance = logfire.DEFAULT_LOGFIRE_INSTANCE
+    # If the app already called `logfire.configure()`, calling it again would reset its configuration
+    # (service name, sampling, exporters), so we reuse the existing instance instead.
+    if not getattr(instance.config, '_initialized', False):
+        instance = logfire.configure()
     instance.instrument_pydantic_ai()
     return instance
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -155,6 +155,9 @@ try:
     )
     from pydantic_ai.durable_exec.temporal._dynamic_toolset import temporalize_dynamic_toolset
     from pydantic_ai.durable_exec.temporal._function_toolset import TemporalFunctionToolset
+    from pydantic_ai.durable_exec.temporal._logfire import (
+        _default_setup_logfire,  # pyright: ignore[reportPrivateUsage]
+    )
     from pydantic_ai.durable_exec.temporal._mcp_toolset import TemporalMCPToolset
     from pydantic_ai.durable_exec.temporal._model import TemporalModel
     from pydantic_ai.durable_exec.temporal._run_context import TemporalRunContext
@@ -3265,6 +3268,40 @@ async def test_logfire_plugin(client: Client):
     plugin = LogfirePlugin(lambda: setup_logfire(metrics=False))
     new_client = await Client.connect(client.service_client.config.target_host, plugins=[plugin])
     assert new_client.service_client.config.runtime is None
+
+
+def test_default_setup_logfire_keeps_existing_configuration(capfire: CaptureLogfire):
+    # `capfire` calls `logfire.configure()`, standing in for an app that configured Logfire itself.
+    config = logfire.DEFAULT_LOGFIRE_INSTANCE.config
+    assert config.send_to_logfire is False
+    assert config.console is False
+
+    instance = _default_setup_logfire()
+
+    assert instance is logfire.DEFAULT_LOGFIRE_INSTANCE
+    assert instance.config is config
+    # The app's configuration was not reset, so no console exporter was added back.
+    assert config.send_to_logfire is False
+    assert config.console is False
+
+    # The app's span processors are still exporting.
+    logfire.info('hello')
+    assert [span['name'] for span in capfire.exporter.exported_spans_as_dict()] == ['hello']
+
+
+def test_default_setup_logfire_configures_when_not_configured(monkeypatch: pytest.MonkeyPatch):
+    configure_calls = 0
+
+    def configure() -> Logfire:
+        nonlocal configure_calls
+        configure_calls += 1
+        return logfire.DEFAULT_LOGFIRE_INSTANCE
+
+    monkeypatch.setattr(logfire.DEFAULT_LOGFIRE_INSTANCE.config, '_initialized', False)
+    monkeypatch.setattr(logfire, 'configure', configure)
+
+    assert _default_setup_logfire() is logfire.DEFAULT_LOGFIRE_INSTANCE
+    assert configure_calls == 1
 
 
 hitl_agent = Agent(


### PR DESCRIPTION
- Closes #6915

`LogfirePlugin`'s default setup (`pydantic_ai/durable_exec/temporal/_logfire.py::_default_setup_logfire`) called bare `logfire.configure()`. Because that resets `logfire.DEFAULT_LOGFIRE_INSTANCE`'s config, an app that had already called `logfire.configure(...)` itself lost its settings the moment a Temporal client connected with the plugin: service name, sampling and exporters were replaced by defaults, and the console exporter came back on (which is what produces console writes inside Temporal workflow threads).

The default setup now reuses the already-configured default instance and only calls `logfire.configure()` when Logfire has not been configured yet, so behaviour is unchanged for apps that never configure Logfire themselves. Passing a custom `setup_logfire` callable keeps working exactly as before.

Reproduced before the change with a small script: after `logfire.configure(send_to_logfire=False, console=False, service_name='host-app')`, calling `_default_setup_logfire()` left `service_name=''` and `console=ConsoleOptions(...)`; after the change the host config survives untouched.

### Tests

Two tests in `tests/test_temporal.py` (neither needs a Temporal server):

- `test_default_setup_logfire_keeps_existing_configuration` — with Logfire configured via the `capfire` fixture, asserts the default setup returns the same `DEFAULT_LOGFIRE_INSTANCE`, leaves `send_to_logfire`/`console` untouched, and that the app's span processors still export. This test fails on `main` (console options reinstated) and passes with the fix.
- `test_default_setup_logfire_configures_when_not_configured` — asserts `logfire.configure()` is still called exactly once when Logfire has not been configured.

Docs: one sentence added to `docs/durable_execution/temporal.md` noting the default setup reuses an existing configuration.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] **PR title** is fit for the release changelog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

