### PR TITLE
Restore typed values in a dynamic tool's Temporal `ActivityConfig` after the activity round trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from pydantic import ConfigDict, with_config
+from pydantic import ConfigDict, TypeAdapter, ValidationError, with_config
 from pydantic.errors import PydanticUserError
 from temporalio import workflow
 from temporalio.common import RetryPolicy
@@ -100,6 +100,18 @@ def with_non_retryable_errors(retry_policy: RetryPolicy | None) -> RetryPolicy:
     return retry_policy
 
 
+@with_config(ConfigDict(extra='forbid'))
+class _ValidatedActivityConfig(ActivityConfig):
+    """`ActivityConfig` with validation settings attached, for `_activity_config_adapter`.
+
+    `extra='forbid'` so a misspelled key is reported rather than dropped: without it, validation
+    would silently swallow the typo that `workflow.execute_activity(**config)` currently rejects.
+    """
+
+
+_activity_config_adapter: TypeAdapter[ActivityConfig] = TypeAdapter(_ValidatedActivityConfig)
+
+
 def resolve_tool_activity_config(
     tool: ToolsetTool[Any] | None,
     tool_name: str,
@@ -110,6 +122,13 @@ def resolve_tool_activity_config(
     Reads `tool.tool_def.metadata['temporal']` first, then falls back to the explicit
     `tool_activity_config` dict keyed by tool name. Returns an `ActivityConfig` dict
     (possibly empty), or `False` to skip activity wrapping.
+
+    The config is validated back into Temporal's own types: a `DynamicToolset`'s tools are
+    discovered inside the get-tools activity, so their `ToolDefinition.metadata` returns to the
+    workflow as JSON, where `timedelta(minutes=5)` has become `'PT5M'`, a `RetryPolicy` a plain
+    dict, and an `ActivityCancellationType` an int. Handing those to
+    `workflow.execute_activity` fails the workflow *task*, which Temporal retries forever;
+    a `UserError` for what validation can't restore fails the workflow instead.
     """
     config = cast(
         'ActivityConfig | Literal[False]',
@@ -123,7 +142,10 @@ def resolve_tool_activity_config(
     )
     if config is False:
         return False
-    config = copy.copy(config)
+    try:
+        config = _activity_config_adapter.validate_python(config)
+    except ValidationError as e:
+        raise UserError(f'Tool {tool_name!r} has an invalid Temporal `ActivityConfig`: {e}') from e
     if 'retry_policy' in config:
         config['retry_policy'] = with_non_retryable_errors(config.get('retry_policy'))
     return config

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -6912,6 +6912,67 @@ def test_resolve_tool_activity_config_reads_metadata():
         resolve_tool_activity_config(tool, 'fn_tool', {})
 
 
+def test_resolve_tool_activity_config_restores_round_tripped_types():
+    """A config that came back from an activity as JSON is validated into Temporal's own types.
+
+    A `DynamicToolset`'s tools are discovered inside the get-tools activity, so their
+    `ToolDefinition.metadata` returns to the workflow as JSON: `timedelta(minutes=5)` as `'PT5M'`,
+    a `RetryPolicy` as a dict, an `ActivityCancellationType` as an int. `workflow.execute_activity`
+    rejects those, failing the workflow *task*, which Temporal retries forever.
+    """
+    fn_toolset = FunctionToolset[None](id='round_trip_toolset')
+    tool = ToolsetTool[None](
+        toolset=fn_toolset,
+        tool_def=ToolDefinition(
+            name='slow',
+            metadata={
+                'temporal': {
+                    'start_to_close_timeout': 'PT5M',
+                    'heartbeat_timeout': 'PT30S',
+                    'cancellation_type': 0,
+                    'retry_policy': {'initial_interval': 'PT1S', 'maximum_attempts': 2},
+                }
+            },
+        ),
+        max_retries=0,
+        args_validator=None,  # pyright: ignore[reportArgumentType]
+    )
+
+    resolved = resolve_tool_activity_config(tool, 'slow', {})
+    assert resolved is not False
+    assert resolved.get('start_to_close_timeout') == timedelta(minutes=5)
+    assert resolved.get('heartbeat_timeout') == timedelta(seconds=30)
+    assert resolved.get('cancellation_type') == ActivityCancellationType.TRY_CANCEL
+    retry_policy = resolved.get('retry_policy')
+    assert retry_policy is not None
+    assert retry_policy.initial_interval == timedelta(seconds=1)
+    assert retry_policy.maximum_attempts == 2
+    assert retry_policy.non_retryable_error_types == ['UserError', 'PydanticUserError', 'UnexpectedModelBehavior']
+
+
+def test_resolve_tool_activity_config_rejects_unusable_config():
+    """What validation can't restore fails the workflow with a `UserError` instead of livelocking it.
+
+    `UserError` is in `workflow_failure_exception_types`, so it terminates the workflow; anything
+    else `workflow.execute_activity` chokes on is a workflow-task failure Temporal retries forever.
+    """
+    fn_toolset = FunctionToolset[None](id='unusable_config_toolset')
+    tool = ToolsetTool[None](
+        toolset=fn_toolset,
+        tool_def=ToolDefinition(name='slow', metadata={'temporal': {'start_to_close_timeout': 'five minutes'}}),
+        max_retries=0,
+        args_validator=None,  # pyright: ignore[reportArgumentType]
+    )
+    with pytest.raises(UserError, match=r"Tool 'slow' has an invalid Temporal `ActivityConfig`"):
+        resolve_tool_activity_config(tool, 'slow', {})
+
+    # A misspelled key is reported rather than dropped: `execute_activity` would reject it too,
+    # but as a workflow-task failure.
+    tool.tool_def.metadata = {'temporal': {'start_to_close_timout': timedelta(minutes=5)}}
+    with pytest.raises(UserError, match=r'Extra inputs are not permitted'):
+        resolve_tool_activity_config(tool, 'slow', {})
+
+
 @pytest.mark.parametrize(
     'content',
     [
@@ -8093,6 +8154,57 @@ async def test_durability_dynamic_toolset_in_workflow(client: Client):
             task_queue=TASK_QUEUE,
         )
         assert output == snapshot('{"get_dynamic_weather":"Weather in a for Alice: sunny."}')
+
+
+def _dynamic_activity_config_toolset(ctx: RunContext[Any]) -> FunctionToolset[Any]:
+    toolset = FunctionToolset[Any](id='dynamic_activity_config_inner')
+
+    @toolset.tool_plain(metadata={'temporal': ActivityConfig(start_to_close_timeout=timedelta(seconds=30))})
+    def timed_tool() -> str:
+        assert activity.in_activity()
+        return 'timed result'
+
+    return toolset
+
+
+# Passed at construction time so the durability capability actually wraps it (see #6902).
+_dynamic_activity_config_agent = Agent(
+    TestModel(),
+    name='dynamic_activity_config_agent',
+    toolsets=[DynamicToolset(_dynamic_activity_config_toolset, id='dynamic_activity_config')],
+    capabilities=[TemporalDurability(activity_config=BASE_ACTIVITY_CONFIG)],
+)
+
+
+@workflow.defn
+class DynamicToolActivityConfigWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return (await _dynamic_activity_config_agent.run('Call the tool')).output
+
+
+async def test_durability_dynamic_tool_timedelta_activity_config_survives_round_trip(client: Client):
+    """A `timedelta` in a dynamic tool's `ActivityConfig` metadata reaches `execute_activity` intact.
+
+    The tool is discovered inside the get-tools activity, so its metadata comes back to the
+    workflow as JSON and the `timedelta` arrives as the string `'PT5M'`. Handing that to
+    `workflow.execute_activity` raises inside protobuf's `Duration.FromTimedelta`, which is a
+    workflow-*task* failure that Temporal retries forever — hence the short `execution_timeout`,
+    so a regression fails the test instead of hanging it.
+    """
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[DynamicToolActivityConfigWorkflow],
+        plugins=[AgentPlugin(_dynamic_activity_config_agent)],
+    ):
+        output = await client.execute_workflow(
+            DynamicToolActivityConfigWorkflow.run,
+            id='test_dynamic_tool_activity_config',
+            task_queue=TASK_QUEUE,
+            execution_timeout=timedelta(seconds=30),
+        )
+    assert output == snapshot('{"timed_tool":"timed result"}')
 
 
 @dataclass


### PR DESCRIPTION
- Closes #6896

A `DynamicToolset`'s tools are discovered inside the get-tools activity, so their `ToolDefinition.metadata` returns to the workflow as JSON. Everything typed in the tool's `ActivityConfig` degrades on the way back — `timedelta(minutes=5)` becomes `'PT5M'`, a `RetryPolicy` becomes a plain dict, an `ActivityCancellationType` becomes an int — and the workflow then hands that to `workflow.execute_activity`. That's a workflow-*task* failure, which Temporal retries forever, so the workflow never reaches a terminal state.

### Reproduced, not just read

New end-to-end test `test_durability_dynamic_tool_timedelta_activity_config_survives_round_trip` runs a real workflow against a real dev server, with the dynamic toolset passed at construction time so it really is wrapped (`@agent.toolset` registers too late — that's #6902). Against unpatched `main` it produces exactly the reported failure and then hangs until the workflow's `execution_timeout`:

```
AttributeError: Fail to convert to Duration. Expected a timedelta like object got str: 'str' object has no attribute 'seconds'
  .../temporalio/worker/_workflow_instance.py:3054 in _apply_schedule_command
    v.start_to_close_timeout.FromTimedelta(self._input.start_to_close_timeout)
```

The test carries a short `execution_timeout` on purpose, so a regression fails the test rather than hanging it.

I also found a second, earlier failure mode on the same round trip that the issue didn't mention: a round-tripped `retry_policy` reaches `with_non_retryable_errors` as a dict and raises `AttributeError: 'dict' object has no attribute 'non_retryable_error_types'` before `execute_activity` is even reached. Same class, same fix.

### The fix (option 2, and it restores everything)

`resolve_tool_activity_config` now validates the resolved config through a `TypeAdapter(ActivityConfig)` before handing it on. The issue guessed this "won't restore all of them" because `ActivityConfig` holds non-Pydantic types; measured against temporalio's actual `ActivityConfig`, it restores **every** field:

| field | wire value | validated back to |
|---|---|---|
| `start_to_close_timeout` etc. | `'PT5M'` | `timedelta` |
| `retry_policy` | dict | `RetryPolicy` |
| `cancellation_type` | `0` | `ActivityCancellationType` |
| `versioning_intent` | `1` | `VersioningIntent` |
| `priority` | dict | `Priority` |

A fully-populated native config validates to an equal config, so statically-configured tools are unaffected.

Option 1 (a typed field on `DynamicToolInfo`) was rejected: `DynamicToolInfo` is the engine-agnostic dataclass in `durable_exec/_toolset.py`, and giving it a Temporal `ActivityConfig` field would leak one engine's types into the shared wire format.

**Option 3 is folded in rather than done separately.** Per @DouweM's comment, failing loudly beats livelocking. Anything validation *can't* restore now raises a `UserError`, which is in `workflow_failure_exception_types` and so fails the workflow instead of retrying the workflow task forever. That includes a misspelled key: `extra='forbid'` is set deliberately, because without it validation would silently drop the typo that `workflow.execute_activity(**config)` currently rejects (loudly, but as a livelock) — so this direction is strictly better than both the old and the permissive behaviour.

Validation lives in `resolve_tool_activity_config`, the single place that reads per-tool Temporal config, so the MCP get-tools activity — which round-trips `ToolDefinition`s the same way — is covered by the same code path rather than a second special case.

### Tests

- `test_durability_dynamic_tool_timedelta_activity_config_survives_round_trip` (end-to-end workflow; fails on `main` with the reported `AttributeError`)
- `test_resolve_tool_activity_config_restores_round_tripped_types`
- `test_resolve_tool_activity_config_rejects_unusable_config`

Full `tests/test_temporal.py` passes (207 passed, 2 skipped).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

