### PR TITLE
Allow `ApprovalRequired`/`CallDeferred` from post-validation tool hooks, `UserError` from pre-validation ones

### DIFF
--- a/docs/capabilities/custom.md
+++ b/docs/capabilities/custom.md
@@ -578,7 +578,9 @@ All tool hooks receive a `tool_def` parameter with the [`ToolDefinition`][pydant
 
 To skip validation and provide pre-validated args, raise [`SkipToolValidation(args)`][pydantic_ai.exceptions.SkipToolValidation] from `before_tool_validate` or `wrap_tool_validate`.
 
-`after_tool_validate` is a gate on validated arguments, so it also runs when a tool's [`args_validator`](../tools-advanced.md#args-validator) [deferred](../deferred-tools.md) the call: rejecting there (with `ModelRetry` or [`ToolFailed`][pydantic_ai.exceptions.ToolFailed]) wins over the deferral, and the args it returns are the ones the deferred call carries.
+A tool call can only be [deferred](../deferred-tools.md) once its arguments have been validated, since whoever resolves the deferral is shown those arguments. [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] and [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] can therefore be raised from `after_tool_validate`, and from `wrap_tool_validate` once its `handler()` has returned; raising one from `before_tool_validate`, from `wrap_tool_validate` before it calls `handler()`, or from `on_tool_validate_error` (which only runs because validation failed) raises a [`UserError`][pydantic_ai.exceptions.UserError] naming the hook. A permitted deferral behaves exactly like one from a tool's [`args_validator`](../tools-advanced.md#args-validator): the tool isn't executed, the retry budget is untouched, and the call joins the run's [`DeferredToolRequests`][pydantic_ai.tools.DeferredToolRequests].
+
+`after_tool_validate` stays a reliable gate on validated arguments: it runs even when the `args_validator` or `wrap_tool_validate` already deferred the call, so rejecting there (with `ModelRetry` or [`ToolFailed`][pydantic_ai.exceptions.ToolFailed]) wins over that deferral, deferring there replaces it, and the args it returns are the ones the deferred call carries.
 
 **Execution hooks** — `args` is always the validated `dict[str, Any]`:
 
@@ -590,6 +592,8 @@ To skip validation and provide pre-validated args, raise [`SkipToolValidation(ar
 | [`on_tool_execute_error`][pydantic_ai.capabilities.AbstractCapability.on_tool_execute_error] | `(ctx: `[`RunContext`][pydantic_ai.tools.RunContext]`, *, call: `[`ToolCallPart`][pydantic_ai.messages.ToolCallPart]`, tool_def: `[`ToolDefinition`][pydantic_ai.tools.ToolDefinition]`, args: `[`ValidatedToolArgs`][pydantic_ai.capabilities.ValidatedToolArgs]`, error: Exception) -> Any` | Handle execution errors (see [error hooks](#error-hooks)) |
 
 To skip execution and provide a replacement result, raise [`SkipToolExecution(result)`][pydantic_ai.exceptions.SkipToolExecution] from `before_tool_execute` or `wrap_tool_execute`.
+
+Any execution hook can defer the call, but raise `ApprovalRequired`/`CallDeferred` from `before_tool_execute` (or from `wrap_tool_execute` before it calls `handler()`) so the tool function doesn't run: a deferral from `after_tool_execute`, or from `wrap_tool_execute` after `handler()` returned, is accepted but the tool has already executed, so its side effects happened and its result is discarded.
 
 Tool validation and execution hooks can raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to request a retry, or [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] to report a failed tool result without retrying. See [triggering retries and tool failures](../hooks.md#triggering-retries-with-modelretry) for the full pattern.
 

--- a/docs/capabilities/custom.md
+++ b/docs/capabilities/custom.md
@@ -578,6 +578,8 @@ All tool hooks receive a `tool_def` parameter with the [`ToolDefinition`][pydant
 
 To skip validation and provide pre-validated args, raise [`SkipToolValidation(args)`][pydantic_ai.exceptions.SkipToolValidation] from `before_tool_validate` or `wrap_tool_validate`.
 
+`after_tool_validate` is a gate on validated arguments, so it also runs when a tool's [`args_validator`](../tools-advanced.md#args-validator) [deferred](../deferred-tools.md) the call: rejecting there (with `ModelRetry` or [`ToolFailed`][pydantic_ai.exceptions.ToolFailed]) wins over the deferral, and the args it returns are the ones the deferred call carries.
+
 **Execution hooks** — `args` is always the validated `dict[str, Any]`:
 
 | Hook | Signature | Purpose |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -164,6 +164,8 @@ Validation hooks fire when the model's JSON arguments are parsed and validated. 
 
 To skip validation, raise [`SkipToolValidation(args)`][pydantic_ai.exceptions.SkipToolValidation] from `before_tool_validate` or `tool_validate` (wrap).
 
+A tool call can only be [deferred](deferred-tools.md) once its arguments have been validated, since whoever resolves the deferral is shown those arguments. So [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] and [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] can be raised from `after_tool_validate` (and from `tool_validate` after its `handler()` has returned), but raising them from `before_tool_validate`, from `tool_validate` before it calls `handler()`, or from `tool_validate_error` is a [`UserError`][pydantic_ai.exceptions.UserError]. To decide per tool rather than per capability, use the tool's [`args_validator`](tools-advanced.md#args-validator).
+
 ### Tool execution hooks
 
 | `hooks.on.` | Constructor kwarg | `AbstractCapability` method |
@@ -176,6 +178,8 @@ To skip validation, raise [`SkipToolValidation(args)`][pydantic_ai.exceptions.Sk
 Execution hooks fire when the tool function runs. `args` is always the validated `dict[str, Any]`.
 
 To skip execution, raise [`SkipToolExecution(result)`][pydantic_ai.exceptions.SkipToolExecution] from `before_tool_execute` or `tool_execute` (wrap).
+
+Every execution hook can [defer](deferred-tools.md) the call — the arguments are validated by this point — but raise `ApprovalRequired`/`CallDeferred` from `before_tool_execute` (or from `tool_execute` before it calls `handler()`). A deferral from `after_tool_execute`, or from `tool_execute` after `handler()` has returned, is accepted but happens too late to be useful: the tool function already ran, so its side effects happened and its result is discarded.
 
 ### Output validation hooks
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -102,6 +102,8 @@ From tool-validation and tool-execution hooks you can raise `ModelRetry` (the mo
 
 At wrap boundaries, `ModelRetry` is control flow and bypasses `on_model_request_error`, `on_tool_execute_error`, and `on_output_process_error`. `ToolFailed` bypasses only `on_tool_execute_error`; from model-request or output-process hooks it is an ordinary exception passed to the corresponding error hook.
 
+For deferrals (`ApprovalRequired`, `CallDeferred`), the rule is that a tool call can only be deferred once its arguments have been validated, since whoever resolves it is shown those arguments. So they are allowed from `after_tool_validate`, from `wrap_tool_validate` after `handler()` returns, and from every tool-execution hook — prefer `before_tool_execute`, since deferring after the tool body ran means its side effects happened and its result is discarded. Raising one from `before_tool_validate`, from `wrap_tool_validate` before `handler()`, or from `on_tool_validate_error` is a `UserError`. For a per-tool decision, use the tool's `args_validator` instead of a hook.
+
 Use hooks when the user wants observability, auditing, or light interception without adding a new abstraction.
 
 ## Build a Custom Capability

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -712,6 +712,12 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
         Raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to reject the validated args
         and ask the model to redo the tool call.
+
+        This also runs when the tool's `args_validator` deferred the call with
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred], so the hook stays a reliable gate on
+        validated arguments: rejecting here wins over the deferral, and the args returned here are
+        the ones the deferred call carries.
         """
         return args
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -835,7 +835,9 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         """Wraps tool execution. handler() runs the tool.
 
         Defer before calling `handler()`: a deferral raised after it has returned is accepted, but
-        the tool function already ran and its result is discarded.
+        the tool function already ran and its result is discarded. Defer from
+        [`before_tool_execute`][pydantic_ai.capabilities.AbstractCapability.before_tool_execute]
+        instead.
         """
         return await handler(args)
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -697,6 +697,13 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
         Raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to skip validation and
         ask the model to redo the tool call.
+
+        A tool call can only be deferred once its arguments have been validated, so raising
+        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] or
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] here is a `UserError`. Defer
+        from [`after_tool_validate`][pydantic_ai.capabilities.AbstractCapability.after_tool_validate],
+        a tool's `args_validator`, or
+        [`before_tool_execute`][pydantic_ai.capabilities.AbstractCapability.before_tool_execute].
         """
         return args
 
@@ -713,11 +720,16 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         Raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to reject the validated args
         and ask the model to redo the tool call.
 
-        This also runs when the tool's `args_validator` deferred the call with
-        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
-        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred], so the hook stays a reliable gate on
-        validated arguments: rejecting here wins over the deferral, and the args returned here are
-        the ones the deferred call carries.
+        The arguments are valid by this point, so raising
+        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] or
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] here defers the call — the tool
+        isn't executed, and the deferral joins the run's
+        [`DeferredToolRequests`][pydantic_ai.tools.DeferredToolRequests] with the validated arguments.
+
+        This hook also runs when the tool's `args_validator` (or `wrap_tool_validate`) already
+        deferred the call, so it stays a reliable gate on validated arguments: rejecting here wins
+        over that deferral, deferring here replaces it, and the args returned here are the ones the
+        deferred call carries.
         """
         return args
 
@@ -730,7 +742,13 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         args: RawToolArgs,
         handler: WrapToolValidateHandler,
     ) -> ValidatedToolArgs:
-        """Wraps tool argument validation. handler() runs the validation."""
+        """Wraps tool argument validation. handler() runs the validation.
+
+        Deferring with [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] or
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] is allowed *after* `handler()`
+        has returned, when the arguments are known to be valid; raising one before that is a
+        `UserError`.
+        """
         return await handler(args)
 
     async def on_tool_validate_error(
@@ -752,11 +770,13 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         **Raise** the original `error` (or a different exception) to propagate it.
         **Return** validated args to suppress the error and continue as if validation passed.
 
-        Not called for [`SkipToolValidation`][pydantic_ai.exceptions.SkipToolValidation], or for the
-        deferrals a tool's `args_validator` can raise
-        ([`CallDeferred`][pydantic_ai.exceptions.CallDeferred],
-        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired]) — those are control flow, not
+        Not called for [`SkipToolValidation`][pydantic_ai.exceptions.SkipToolValidation], or when a
+        tool's `args_validator` raises [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] or
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] — those are control flow, not
         errors, and the call is deferred instead of executed.
+
+        Raising a deferral *from this hook* is a `UserError`: it only runs because validation failed,
+        so there are no valid arguments to show whoever would resolve the deferral.
         """
         raise error
 
@@ -774,6 +794,11 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
         Raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to skip execution and
         ask the model to redo the tool call.
+
+        This is the hook to defer from: raising
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] here defers the call *before* the tool
+        function runs, so nothing happens until it's resolved.
         """
         return args
 
@@ -790,6 +815,11 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
         Raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to reject the tool result
         and ask the model to redo the tool call.
+
+        Deferring from here is accepted but rarely what you want: the tool function has already run,
+        so its side effects happened and `result` is discarded. Defer from
+        [`before_tool_execute`][pydantic_ai.capabilities.AbstractCapability.before_tool_execute]
+        instead.
         """
         return result
 
@@ -802,7 +832,11 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         args: ValidatedToolArgs,
         handler: WrapToolExecuteHandler,
     ) -> Any:
-        """Wraps tool execution. handler() runs the tool."""
+        """Wraps tool execution. handler() runs the tool.
+
+        Defer before calling `handler()`: a deferral raised after it has returned is accepted, but
+        the tool function already ran and its result is discarded.
+        """
         return await handler(args)
 
     async def on_tool_execute_error(

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -27,6 +27,7 @@ from .exceptions import (
     ToolFailedError,
     ToolRetryError,
     UnexpectedModelBehavior,
+    UserError,
 )
 from .messages import ToolCallPart, ToolReturn
 from .tools import DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDefinition, ToolDenied
@@ -76,28 +77,44 @@ class ValidatedToolCall(Generic[AgentDepsT]):
     validation_error: ToolRetryError | ToolFailedError | None = None
     """The model-visible tool result if validation failed, None otherwise."""
     deferral: CallDeferred | ApprovalRequired | None = None
-    """The deferral raised by the tool's `args_validator`, if any.
+    """The deferral raised during validation, if any.
 
-    A validator that raises [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
-    [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] made a deliberate control-flow choice
+    Set when the tool's `args_validator` — or a validation hook that runs once the arguments are
+    valid — raises [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+    [`CallDeferred`][pydantic_ai.exceptions.CallDeferred]. That's a deliberate control-flow choice
     about arguments that were already valid, so `args_valid` is `True` and `validated_args` holds
-    the schema-validated arguments. `execute_tool_call` re-raises this instead of running the tool,
-    so the deferral is handled exactly like one raised by the tool function itself.
+    the validated arguments. `execute_tool_call` re-raises this instead of running the tool, so the
+    deferral is handled exactly like one raised by the tool function itself.
     """
 
 
 class _ValidationDeferral(Exception):
-    """Internal signal that a tool's `args_validator` requested approval or deferred the call.
+    """Internal signal that validation requested approval for or deferred the tool call.
 
-    Carries the schema-validated arguments alongside the user's deferral so `validate_tool_call`
-    can report the call as valid and re-raise the deferral at the execution boundary. Never
-    escapes `ToolManager`.
+    Raised for a deferral from the tool's `args_validator` or from a validation hook that already
+    has validated arguments. Carries those arguments alongside the user's deferral so
+    `validate_tool_call` can report the call as valid and re-raise the deferral at the execution
+    boundary. Never escapes `ToolManager`.
     """
 
     def __init__(self, deferral: CallDeferred | ApprovalRequired, validated_args: dict[str, Any]):
         self.deferral = deferral
         self.validated_args = validated_args
         super().__init__()
+
+
+def _validate_hook_deferral_error(hook_name: str, error: CallDeferred | ApprovalRequired) -> UserError:
+    """Build the error for a tool validation hook that deferred before the arguments were validated.
+
+    A tool call may only be deferred once its arguments are known to be valid — whoever resolves the
+    deferral is shown those arguments. Hooks that run before validation (or after it failed) have
+    none, so they get this error instead; the message names the positions that do.
+    """
+    return UserError(
+        f'`{hook_name}` raised `{type(error).__name__}`, but a tool call can only be deferred once its arguments '
+        "have been validated. Raise it from `after_tool_validate`, from the tool's `args_validator`, or from "
+        '`before_tool_execute` instead.'
+    )
 
 
 @dataclass
@@ -313,10 +330,15 @@ class ToolManager(Generic[AgentDepsT]):
     ) -> dict[str, Any]:
         """Run validation with before/wrap/after tool_validate hooks."""
         cap = self.root_capability
+        handler_validated_args: dict[str, Any] | None = None
 
         async def do_validate(args: str | dict[str, Any]) -> dict[str, Any]:
+            nonlocal handler_validated_args
             # Update call.args with the (possibly modified) args before validation
             validated = await self._validate_tool_args(call, tool, ctx, allow_partial=allow_partial, args_override=args)
+            # Recorded so that a `wrap_tool_validate` hook deferring *after* it called the handler
+            # can be told apart from one deferring before: only the former has validated arguments.
+            handler_validated_args = validated
             return validated
 
         # Output tools are internal — they don't fire user-facing tool hooks, matching how
@@ -324,9 +346,12 @@ class ToolManager(Generic[AgentDepsT]):
         if cap is not None and tool.tool_def.kind != 'output':
             tool_def = tool.tool_def
 
-            # before_tool_validate
+            # before_tool_validate runs before the arguments have been validated, so it can't defer.
             raw_args: str | dict[str, Any] = call.args if call.args is not None else {}
-            raw_args = await cap.before_tool_validate(ctx, call=call, tool_def=tool_def, args=raw_args)
+            try:
+                raw_args = await cap.before_tool_validate(ctx, call=call, tool_def=tool_def, args=raw_args)
+            except (CallDeferred, ApprovalRequired) as e:
+                raise _validate_hook_deferral_error('before_tool_validate', e) from e
 
             # wrap_tool_validate wraps the validation; on_tool_validate_error on failure
             deferral: _ValidationDeferral | None = None
@@ -341,17 +366,34 @@ class ToolManager(Generic[AgentDepsT]):
                 # external execution.
                 deferral = e
                 validated_args = e.validated_args
+            except (CallDeferred, ApprovalRequired) as e:
+                # Whether this hook may defer depends on where it raised: after its `handler(args)`
+                # returned, the arguments are validated and the deferral is honored like an
+                # `args_validator`'s; before that, there's nothing valid to defer.
+                if handler_validated_args is None:
+                    raise _validate_hook_deferral_error('wrap_tool_validate', e) from e
+                deferral = _ValidationDeferral(e, handler_validated_args)
+                validated_args = handler_validated_args
             except (ValidationError, ModelRetry) as e:
-                validated_args = await cap.on_tool_validate_error(
-                    ctx, call=call, tool_def=tool_def, args=raw_args, error=e
-                )
+                try:
+                    validated_args = await cap.on_tool_validate_error(
+                        ctx, call=call, tool_def=tool_def, args=raw_args, error=e
+                    )
+                except (CallDeferred, ApprovalRequired) as hook_deferral:
+                    # Only reached because validation failed, so there are no validated arguments.
+                    raise _validate_hook_deferral_error('on_tool_validate_error', hook_deferral) from hook_deferral
 
-            # after_tool_validate
-            validated_args = await cap.after_tool_validate(ctx, call=call, tool_def=tool_def, args=validated_args)
+            # after_tool_validate gates validated arguments, so it runs even when the call has
+            # already been deferred, and may still reject or defer it itself.
+            try:
+                validated_args = await cap.after_tool_validate(ctx, call=call, tool_def=tool_def, args=validated_args)
+            except (CallDeferred, ApprovalRequired) as e:
+                # This hook ran last and is the policy layer, so its deferral replaces a held one.
+                raise _ValidationDeferral(e, validated_args) from e
 
             if deferral is not None:
-                # The hook accepted the call, so the deferral stands. It carries the hook's args:
-                # they're what a call that wasn't deferred would have proceeded with.
+                # The hook accepted the call, so the held deferral stands. It carries the hook's
+                # args: they're what a call that wasn't deferred would have proceeded with.
                 raise _ValidationDeferral(deferral.deferral, validated_args) from deferral
         else:
             validated_args = await do_validate(call.args if call.args is not None else {})
@@ -502,9 +544,14 @@ class ToolManager(Generic[AgentDepsT]):
         2. Handle validation failures differently from execution failures
         3. Decide whether to execute or defer based on validation result
 
-        A tool's `args_validator` can raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired]
-        or [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] to defer the call once the arguments
-        are known to be valid. That's control flow rather than a validation failure: the returned
+        A tool call can be deferred during validation by raising
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] — but only once its arguments are known
+        to be valid, which the caller is shown. That means the tool's `args_validator`,
+        `after_tool_validate`, or `wrap_tool_validate` after its handler has returned; the same
+        exception raised before validation has run raises a `UserError` naming the alternatives.
+
+        A permitted deferral is control flow rather than a validation failure: the returned
         `ValidatedToolCall` has `args_valid=True` and carries the exception on
         [`deferral`][pydantic_ai.tool_manager.ValidatedToolCall.deferral], which `execute_tool_call`
         raises in place of running the tool, so callers handle deferrals in one place.

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -329,10 +329,18 @@ class ToolManager(Generic[AgentDepsT]):
             raw_args = await cap.before_tool_validate(ctx, call=call, tool_def=tool_def, args=raw_args)
 
             # wrap_tool_validate wraps the validation; on_tool_validate_error on failure
+            deferral: _ValidationDeferral | None = None
             try:
                 validated_args = await cap.wrap_tool_validate(
                     ctx, call=call, tool_def=tool_def, args=raw_args, handler=do_validate
                 )
+            except _ValidationDeferral as e:
+                # The `args_validator` deferred the call. Hold the deferral rather than letting it
+                # escape: `after_tool_validate` is a policy gate on validated arguments and has to
+                # run — and keep the ability to reject — before a call is queued for approval or
+                # external execution.
+                deferral = e
+                validated_args = e.validated_args
             except (ValidationError, ModelRetry) as e:
                 validated_args = await cap.on_tool_validate_error(
                     ctx, call=call, tool_def=tool_def, args=raw_args, error=e
@@ -340,6 +348,11 @@ class ToolManager(Generic[AgentDepsT]):
 
             # after_tool_validate
             validated_args = await cap.after_tool_validate(ctx, call=call, tool_def=tool_def, args=validated_args)
+
+            if deferral is not None:
+                # The hook accepted the call, so the deferral stands. It carries the hook's args:
+                # they're what a call that wasn't deferred would have proceeded with.
+                raise _ValidationDeferral(deferral.deferral, validated_args) from deferral
         else:
             validated_args = await do_validate(call.args if call.args is not None else {})
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -11106,6 +11106,223 @@ class TestAfterToolValidateOnDeferral:
         assert cap.seen == snapshot([{'x': 0}])
 
 
+# --- Deferrals raised from tool hooks ---
+
+
+@dataclass
+class DeferringHookCap(AbstractCapability[Any]):
+    """Raises a deferral from the single hook position named by `where`."""
+
+    where: str
+    exc_type: type[ApprovalRequired] | type[CallDeferred] = ApprovalRequired
+
+    def _maybe(self, position: str) -> None:
+        if self.where == position:
+            raise self.exc_type(metadata={'from': position})
+
+    async def before_tool_validate(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any
+    ) -> Any:
+        self._maybe('before_tool_validate')
+        return args
+
+    async def wrap_tool_validate(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, handler: Any
+    ) -> Any:
+        self._maybe('wrap_tool_validate_before')
+        result = await handler(args)
+        self._maybe('wrap_tool_validate_after')
+        return result
+
+    async def after_tool_validate(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any
+    ) -> Any:
+        self._maybe('after_tool_validate')
+        return args
+
+    async def on_tool_validate_error(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Any
+    ) -> Any:
+        self._maybe('on_tool_validate_error')
+        raise error  # pragma: no cover
+
+    async def before_tool_execute(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any
+    ) -> Any:
+        self._maybe('before_tool_execute')
+        return args
+
+    async def wrap_tool_execute(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, handler: Any
+    ) -> Any:
+        self._maybe('wrap_tool_execute_before')
+        result = await handler(args)
+        self._maybe('wrap_tool_execute_after')
+        return result
+
+    async def after_tool_execute(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, result: Any
+    ) -> Any:
+        self._maybe('after_tool_execute')
+        return result
+
+
+class TestToolHookDeferrals:
+    """A tool call may only be deferred once its arguments are known to be valid.
+
+    That admits the tool's `args_validator` (covered by `tests/test_tools.py`), the validation hooks
+    that run after validation, and every execution hook; the validation hooks that run before it get
+    a `UserError` instead of the bare exception aborting the run.
+    """
+
+    @pytest.mark.parametrize('exc_type', [ApprovalRequired, CallDeferred])
+    @pytest.mark.parametrize('where', ['after_tool_validate', 'wrap_tool_validate_after'])
+    async def test_validate_hook_defers_once_args_are_valid(
+        self, where: str, exc_type: type[ApprovalRequired] | type[CallDeferred]
+    ):
+        """Hooks holding validated args defer the call, exactly like an `args_validator` does."""
+        executed: list[int] = []
+
+        agent = Agent(
+            TestModel(),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where=where, exc_type=exc_type)],
+        )
+
+        # `retries=0` pins that deferring doesn't consume the retry budget: charging it would raise
+        # `UnexpectedModelBehavior` here rather than deferring.
+        @agent.tool(retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            executed.append(x)
+            return x
+
+        events: list[Any] = []
+        async with agent.run_stream_events('call the tool') as stream:
+            async for event in stream:
+                events.append(event)
+
+        result = events[-1]
+        assert isinstance(result, AgentRunResultEvent)
+        requests = result.result.output
+        assert isinstance(requests, DeferredToolRequests)
+        deferred = requests.approvals if exc_type is ApprovalRequired else requests.calls
+        assert [call.tool_name for call in deferred] == ['my_tool']
+        assert requests.metadata == {deferred[0].tool_call_id: {'from': where}}
+        assert [e.args_valid for e in events if isinstance(e, FunctionToolCallEvent)] == [True]
+        assert executed == []
+
+    @pytest.mark.parametrize('exc_type', [ApprovalRequired, CallDeferred])
+    @pytest.mark.parametrize('where', ['before_tool_validate', 'wrap_tool_validate_before'])
+    async def test_validate_hook_cannot_defer_before_args_are_valid(
+        self, where: str, exc_type: type[ApprovalRequired] | type[CallDeferred]
+    ):
+        """Deferring before validation has run is a usage error, not a bare exception aborting the run."""
+        agent = Agent(
+            TestModel(),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where=where, exc_type=exc_type)],
+        )
+
+        @agent.tool
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            return x
+
+        # The full wording is pinned once by `test_on_tool_validate_error_cannot_defer`; here we pin
+        # that each rejected position is named, so a user can find the hook that raised.
+        hook_name = 'wrap_tool_validate' if where.startswith('wrap') else where
+        with pytest.raises(UserError, match=re.escape(f'`{hook_name}` raised `{exc_type.__name__}`')):
+            await agent.run('call the tool')
+
+    async def test_on_tool_validate_error_cannot_defer(self):
+        """The error hook only runs when validation failed, so it has no valid arguments to defer."""
+
+        def bad_args_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            return ModelResponse(parts=[ToolCallPart(tool_name='greet', args='{"wrong": 1}', tool_call_id='call-1')])
+
+        agent = Agent(
+            FunctionModel(bad_args_model),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where='on_tool_validate_error')],
+        )
+
+        @agent.tool_plain
+        def greet(name: str) -> str:  # pragma: no cover
+            return f'hello {name}'
+
+        with pytest.raises(UserError) as exc_info:
+            await agent.run('greet someone')
+        assert str(exc_info.value) == snapshot(
+            "`on_tool_validate_error` raised `ApprovalRequired`, but a tool call can only be deferred once its arguments have been validated. Raise it from `after_tool_validate`, from the tool's `args_validator`, or from `before_tool_execute` instead."
+        )
+
+    async def test_hook_deferral_replaces_an_args_validator_deferral(self):
+        """When both defer, the hook wins: it runs later and is the policy layer.
+
+        The `args_validator` asks for approval; `after_tool_validate` — which runs even for an
+        already-deferred call — defers for external execution instead, and that's what the run
+        surfaces, with the hook's metadata.
+        """
+        agent = Agent(
+            TestModel(),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where='after_tool_validate', exc_type=CallDeferred)],
+        )
+
+        def my_validator(ctx: RunContext[Any], x: int) -> None:
+            raise ApprovalRequired(metadata={'from': 'args_validator'})
+
+        @agent.tool(args_validator=my_validator, retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            return x
+
+        result = await agent.run('call the tool')
+        assert result.output == snapshot(
+            DeferredToolRequests(
+                calls=[ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')],
+                metadata={'pyd_ai_tool_call_id__my_tool': {'from': 'after_tool_validate'}},
+            )
+        )
+
+    @pytest.mark.parametrize('exc_type', [ApprovalRequired, CallDeferred])
+    @pytest.mark.parametrize(
+        'where',
+        ['before_tool_execute', 'wrap_tool_execute_before', 'wrap_tool_execute_after', 'after_tool_execute'],
+    )
+    async def test_execute_hook_defers(self, where: str, exc_type: type[ApprovalRequired] | type[CallDeferred]):
+        """Every execution hook can defer: by then the arguments are validated.
+
+        The two positions that run after the tool body defer a call whose side effects already
+        happened and whose result is discarded — documented, not fixed here.
+        """
+        executed: list[int] = []
+
+        agent = Agent(
+            TestModel(),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where=where, exc_type=exc_type)],
+        )
+
+        @agent.tool(retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:
+            executed.append(x)
+            return x
+
+        events: list[Any] = []
+        async with agent.run_stream_events('call the tool') as stream:
+            async for event in stream:
+                events.append(event)
+
+        result = events[-1]
+        assert isinstance(result, AgentRunResultEvent)
+        requests = result.result.output
+        assert isinstance(requests, DeferredToolRequests)
+        deferred = requests.approvals if exc_type is ApprovalRequired else requests.calls
+        assert [call.tool_name for call in deferred] == ['my_tool']
+        assert requests.metadata == {deferred[0].tool_call_id: {'from': where}}
+        assert [e.args_valid for e in events if isinstance(e, FunctionToolCallEvent)] == [True]
+        assert executed == ([0] if where.endswith('_after') or where == 'after_tool_execute' else [])
+
+
 # --- Tool execute error hook tests ---
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -11111,7 +11111,7 @@ class TestAfterToolValidateOnDeferral:
 
 @dataclass
 class DeferringHookCap(AbstractCapability[Any]):
-    """Raises a deferral from the single hook position named by `where`."""
+    """Raises a deferral from the single hook position named by `where` (none, if `where` is empty)."""
 
     where: str
     exc_type: type[ApprovalRequired] | type[CallDeferred] = ApprovalRequired
@@ -11139,12 +11139,6 @@ class DeferringHookCap(AbstractCapability[Any]):
     ) -> Any:
         self._maybe('after_tool_validate')
         return args
-
-    async def on_tool_validate_error(
-        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Any
-    ) -> Any:
-        self._maybe('on_tool_validate_error')
-        raise error  # pragma: no cover
 
     async def before_tool_execute(
         self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any
@@ -11196,7 +11190,7 @@ class TestToolHookDeferrals:
             executed.append(x)
             return x
 
-        events: list[Any] = []
+        events: list[AgentStreamEvent | AgentRunResultEvent[Any]] = []
         async with agent.run_stream_events('call the tool') as stream:
             async for event in stream:
                 events.append(event)
@@ -11239,10 +11233,17 @@ class TestToolHookDeferrals:
         def bad_args_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             return ModelResponse(parts=[ToolCallPart(tool_name='greet', args='{"wrong": 1}', tool_call_id='call-1')])
 
+        @dataclass
+        class DeferringValidateErrorCap(AbstractCapability[Any]):
+            async def on_tool_validate_error(
+                self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Any
+            ) -> Any:
+                raise ApprovalRequired()
+
         agent = Agent(
             FunctionModel(bad_args_model),
             output_type=[str, DeferredToolRequests],
-            capabilities=[DeferringHookCap(where='on_tool_validate_error')],
+            capabilities=[DeferringValidateErrorCap()],
         )
 
         @agent.tool_plain
@@ -11307,7 +11308,7 @@ class TestToolHookDeferrals:
             executed.append(x)
             return x
 
-        events: list[Any] = []
+        events: list[AgentStreamEvent | AgentRunResultEvent[Any]] = []
         async with agent.run_stream_events('call the tool') as stream:
             async for event in stream:
                 events.append(event)
@@ -11321,6 +11322,28 @@ class TestToolHookDeferrals:
         assert requests.metadata == {deferred[0].tool_call_id: {'from': where}}
         assert [e.args_valid for e in events if isinstance(e, FunctionToolCallEvent)] == [True]
         assert executed == ([0] if where.endswith('_after') or where == 'after_tool_execute' else [])
+
+    async def test_hooks_that_defer_nowhere_leave_the_call_alone(self):
+        """Control case: the same capability without a deferral runs the tool and returns its result.
+
+        Pins that it's the deferral, not the hooks themselves, that changes any of the above.
+        """
+        executed: list[int] = []
+
+        agent = Agent(
+            TestModel(),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where='')],
+        )
+
+        @agent.tool(retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:
+            executed.append(x)
+            return x
+
+        result = await agent.run('call the tool')
+        assert result.output == snapshot('{"my_tool":0}')
+        assert executed == [0]
 
 
 # --- Tool execute error hook tests ---

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -11160,6 +11160,12 @@ class DeferringHookCap(AbstractCapability[Any]):
         self._maybe('after_tool_execute')
         return result
 
+    async def on_tool_execute_error(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Exception
+    ) -> Any:
+        self._maybe('on_tool_execute_error')
+        raise error
+
 
 class TestToolHookDeferrals:
     """A tool call may only be deferred once its arguments are known to be valid.
@@ -11322,6 +11328,26 @@ class TestToolHookDeferrals:
         assert requests.metadata == {deferred[0].tool_call_id: {'from': where}}
         assert [e.args_valid for e in events if isinstance(e, FunctionToolCallEvent)] == [True]
         assert executed == ([0] if where.endswith('_after') or where == 'after_tool_execute' else [])
+
+    @pytest.mark.parametrize('exc_type', [ApprovalRequired, CallDeferred])
+    async def test_execute_error_hook_defers(self, exc_type: type[ApprovalRequired] | type[CallDeferred]):
+        """The execution error hook can replace a tool failure with a deferral."""
+        agent = Agent(
+            TestModel(),
+            output_type=[str, DeferredToolRequests],
+            capabilities=[DeferringHookCap(where='on_tool_execute_error', exc_type=exc_type)],
+        )
+
+        @agent.tool(retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:
+            raise RuntimeError('tool failed')
+
+        result = await agent.run('call the tool')
+        requests = result.output
+        assert isinstance(requests, DeferredToolRequests)
+        deferred = requests.approvals if exc_type is ApprovalRequired else requests.calls
+        assert [call.tool_name for call in deferred] == ['my_tool']
+        assert requests.metadata == {deferred[0].tool_call_id: {'from': 'on_tool_execute_error'}}
 
     async def test_hooks_that_defer_nowhere_leave_the_call_alone(self):
         """Control case: the same capability without a deferral runs the tool and returns its result.

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -11164,7 +11164,6 @@ class DeferringHookCap(AbstractCapability[Any]):
         self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Exception
     ) -> Any:
         self._maybe('on_tool_execute_error')
-        raise error
 
 
 class TestToolHookDeferrals:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -82,6 +82,7 @@ from pydantic_ai.messages import (
     BinaryImage,
     EnqueuedMessagesEvent,
     FilePart,
+    FunctionToolCallEvent,
     ImageUrl,
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
@@ -10945,8 +10946,9 @@ class TestToolValidateErrorHooks:
     async def test_args_validator_deferral_is_not_a_validate_error(self):
         """A deferral raised by an `args_validator` passes through the validate hooks as control flow.
 
-        Like an execute-stage deferral, it's not an error: `on_tool_validate_error` doesn't fire, the
-        hooks that run after successful validation don't either, and the tool is never executed.
+        Like an execute-stage deferral, it's not an error, so `on_tool_validate_error` doesn't fire
+        and the tool is never executed. `after_tool_validate` still runs: it guards validated
+        arguments, and a deferred call is queued with exactly those.
         """
         cap = LoggingCapability()
 
@@ -10962,8 +10964,146 @@ class TestToolValidateErrorHooks:
         result = await agent.run('call the tool')
         assert isinstance(result.output, DeferredToolRequests)
         assert [entry for entry in cap.log if 'tool_validate' in entry or 'tool_execute' in entry] == snapshot(
-            ['before_tool_validate:my_tool', 'wrap_tool_validate:my_tool:before']
+            ['before_tool_validate:my_tool', 'wrap_tool_validate:my_tool:before', 'after_tool_validate:my_tool']
         )
+
+
+# --- `after_tool_validate` as a policy gate on deferred calls ---
+
+
+@dataclass
+class ArgsGateCap(AbstractCapability[Any]):
+    """An `after_tool_validate` policy gate: records the args it sees, and can reject or rewrite them."""
+
+    reject_first: bool = False
+    rewrite: dict[str, Any] | None = None
+    seen: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
+
+    async def after_tool_validate(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.seen.append(dict(args))
+        if self.reject_first and len(self.seen) == 1:
+            raise ModelRetry('policy says no')
+        return self.rewrite if self.rewrite is not None else args
+
+
+class TestAfterToolValidateOnDeferral:
+    """`after_tool_validate` guards validated arguments, so a deferral must not bypass it.
+
+    Before this was fixed, an `args_validator` deferral escaped `wrap_tool_validate` and skipped the
+    hook entirely, so a deployment using it as an authorization gate had a privileged call queued for
+    approval without ever passing the gate.
+    """
+
+    async def test_runs_when_args_validator_defers(self):
+        """The gate sees the validated args, and the call is still deferred once it passes."""
+        cap = ArgsGateCap()
+        agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], capabilities=[cap])
+
+        def my_validator(ctx: RunContext[Any], x: int) -> None:
+            raise ApprovalRequired(metadata={'from': 'args_validator'})
+
+        # `retries=0` pins that the deferral still doesn't consume the retry budget.
+        @agent.tool(args_validator=my_validator, retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            return x
+
+        events: list[AgentStreamEvent | AgentRunResultEvent[Any]] = []
+        async with agent.run_stream_events('call the tool') as stream:
+            async for event in stream:
+                events.append(event)
+
+        result = events[-1]
+        assert isinstance(result, AgentRunResultEvent)
+        assert result.result.output == snapshot(
+            DeferredToolRequests(
+                approvals=[
+                    ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')
+                ],
+                metadata={'pyd_ai_tool_call_id__my_tool': {'from': 'args_validator'}},
+            )
+        )
+        assert cap.seen == snapshot([{'x': 0}])
+        assert [e.args_valid for e in events if isinstance(e, FunctionToolCallEvent)] == [True]
+
+    async def test_rejection_wins_over_the_deferral(self):
+        """A gate that rejects is honored: the model gets the retry, not a queued approval request."""
+        cap = ArgsGateCap(reject_first=True)
+        agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], capabilities=[cap])
+
+        def my_validator(ctx: RunContext[Any], x: int) -> None:
+            raise ApprovalRequired()
+
+        @agent.tool(args_validator=my_validator, retries=1)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            return x
+
+        result = await agent.run('call the tool')
+        retries = [
+            part.content
+            for msg in result.all_messages()
+            if isinstance(msg, ModelRequest)
+            for part in msg.parts
+            if isinstance(part, RetryPromptPart)
+        ]
+        assert retries == snapshot(['policy says no'])
+        # The second attempt passes the gate, so that one defers.
+        assert isinstance(result.output, DeferredToolRequests)
+        assert cap.seen == snapshot([{'x': 0}, {'x': 0}])
+
+    async def test_still_runs_after_a_recovered_validation_failure(self):
+        """Regression pin: the failure path already ran the gate, via `on_tool_validate_error`."""
+
+        @dataclass
+        class RecoverCap(AbstractCapability[Any]):
+            async def on_tool_validate_error(
+                self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Any
+            ) -> dict[str, Any]:
+                return {'name': 'recovered'}
+
+        def bad_args_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            for msg in messages:
+                for part in msg.parts:
+                    if isinstance(part, ToolReturnPart):
+                        return make_text_response(f'got: {part.content}')
+            return ModelResponse(parts=[ToolCallPart(tool_name='greet', args='{"wrong": 1}', tool_call_id='call-1')])
+
+        gate = ArgsGateCap()
+        agent = Agent(FunctionModel(bad_args_model), capabilities=[RecoverCap(), gate])
+
+        @agent.tool_plain
+        def greet(name: str) -> str:
+            return f'hello {name}'
+
+        result = await agent.run('greet someone')
+        assert result.output == snapshot('got: hello recovered')
+        assert gate.seen == snapshot([{'name': 'recovered'}])
+
+    async def test_deferral_carries_the_hooks_args(self):
+        """A deferred call carries `after_tool_validate`'s output — what a non-deferred call would use.
+
+        `ValidatedToolCall.validated_args` has no public observable on the deferral path (the request
+        holds the model's original `ToolCallPart`, and resuming re-validates from it), so the
+        contract is pinned directly on the tool manager.
+        """
+        toolset = FunctionToolset[None]()
+
+        def my_validator(ctx: RunContext[None], x: int) -> None:
+            raise ApprovalRequired()
+
+        @toolset.tool(args_validator=my_validator)
+        def my_tool(ctx: RunContext[None], x: int) -> int:  # pragma: no cover
+            return x
+
+        cap = ArgsGateCap(rewrite={'x': 99})
+        manager = await ToolManager[None](toolset=toolset, root_capability=cap).for_run_step(_build_run_context())
+
+        validated = await manager.validate_tool_call(ToolCallPart('my_tool', {'x': 0}, tool_call_id='call-1'))
+        assert validated.args_valid is True
+        assert isinstance(validated.deferral, ApprovalRequired)
+        assert validated.validated_args == snapshot({'x': 99})
+        assert cap.seen == snapshot([{'x': 0}])
 
 
 # --- Tool execute error hook tests ---

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -11160,11 +11160,6 @@ class DeferringHookCap(AbstractCapability[Any]):
         self._maybe('after_tool_execute')
         return result
 
-    async def on_tool_execute_error(
-        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Exception
-    ) -> Any:
-        self._maybe('on_tool_execute_error')
-
 
 class TestToolHookDeferrals:
     """A tool call may only be deferred once its arguments are known to be valid.
@@ -11331,10 +11326,18 @@ class TestToolHookDeferrals:
     @pytest.mark.parametrize('exc_type', [ApprovalRequired, CallDeferred])
     async def test_execute_error_hook_defers(self, exc_type: type[ApprovalRequired] | type[CallDeferred]):
         """The execution error hook can replace a tool failure with a deferral."""
+
+        @dataclass
+        class DeferringExecuteErrorCap(AbstractCapability[Any]):
+            async def on_tool_execute_error(
+                self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Exception
+            ) -> Any:
+                raise exc_type(metadata={'from': 'on_tool_execute_error'})
+
         agent = Agent(
             TestModel(),
             output_type=[str, DeferredToolRequests],
-            capabilities=[DeferringHookCap(where='on_tool_execute_error', exc_type=exc_type)],
+            capabilities=[DeferringExecuteErrorCap()],
         )
 
         @agent.tool(retries=0)


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

Follow-up to #6897, which made a tool's `args_validator` able to raise `ApprovalRequired`/`CallDeferred`. The same exceptions raised from a **capability's tool-validation hooks** still aborted the run with a bare exception. No existing issue; the defect is reproduced below.

### What happened before this PR

Probing every hook position with a capability that raises the deferral from exactly one of them, against `main`:

```
before_tool_validate       ApprovalRequired -> CRASH pydantic_ai.exceptions.ApprovalRequired
wrap_tool_validate:before  ApprovalRequired -> CRASH pydantic_ai.exceptions.ApprovalRequired
wrap_tool_validate:after   ApprovalRequired -> CRASH pydantic_ai.exceptions.ApprovalRequired
after_tool_validate        ApprovalRequired -> CRASH pydantic_ai.exceptions.ApprovalRequired
before_tool_execute        ApprovalRequired -> DEFERRED (approvals)  executed=[]
wrap_tool_execute:before   ApprovalRequired -> DEFERRED (approvals)  executed=[]
wrap_tool_execute:after    ApprovalRequired -> DEFERRED (approvals)  executed=[0]
after_tool_execute         ApprovalRequired -> DEFERRED (approvals)  executed=[0]
```

`CallDeferred` behaves identically, routing to `calls`. #6897's `_ValidationDeferral` wrap sits inside `do_validate`, so it only catches the `args_validator`'s own deferral — a hook raising *around* the handler produced the bare exception, exactly the pre-#6897 failure mode. Execution hooks were already fine (they sit inside the existing `except (SkipToolExecution, CallDeferred, ApprovalRequired, ...)` at the execute stage); this PR only pins that with tests.

### The rule

**A tool call can only be deferred once its arguments have been validated** — whoever resolves the deferral is shown those arguments, so offering them arguments that were never validated would be wrong.

That admits:

- a tool's `args_validator` (#6897, unchanged here)
- `after_tool_validate`
- `wrap_tool_validate` **after** its `handler()` has returned
- every tool-execution hook

and rejects, with a `UserError` naming the hook that raised:

- `before_tool_validate`
- `wrap_tool_validate` **before** it calls `handler()`
- `on_tool_validate_error` — it only runs because validation failed, so there are no valid arguments

```
`before_tool_validate` raised `ApprovalRequired`, but a tool call can only be deferred once its
arguments have been validated. Raise it from `after_tool_validate`, from the tool's
`args_validator`, or from `before_tool_execute` instead.
```

A permitted deferral goes through the same `_ValidationDeferral` machinery as the `args_validator` case: `args_valid=True`, `validated_args` holding the real validated dict, retry budget untouched, `on_tool_validate_error` not fired, and the call collected into `deferred_calls['unapproved']`/`['external']` with its metadata. **No changes to `_tool_execution.py`, and `ValidatedToolCall.args_valid` is not widened** — that invariant stays honest precisely because every allowed position has validated arguments in hand.

### 🚩 One judgement call to confirm or overrule

When listing what to skip, @DouweM said "and I suppose also wrap tool validate" — but the principle stated immediately after is about whether validation has run, and a `wrap_tool_validate` hook that raises *after* `handler()` returned is in exactly the same epistemic state as `after_tool_validate`. **I've supported that position rather than rejecting it.** The alternative reading is to reject the whole `wrap_tool_validate` hook regardless of position: simpler to document ("only `after_tool_validate` may defer"), at the cost of rejecting a case that is genuinely post-validation. Happy to flip it — it's a two-line change to the guard and one test.

Telling the two `wrap_tool_validate` positions apart fell out cleanly: `do_validate` already produced the validated args, so recording them in a `nonlocal` and checking whether that local is populated when the exception surfaces is the whole distinction. No contortion.

### Deferral precedence

The existing policy gate holds an `args_validator` deferral while `after_tool_validate` runs. This PR extends that behavior to supported hook deferrals while preserving a single `after_tool_validate` call site:

- a deferral from the `args_validator` **or** from `wrap_tool_validate`-after-handler is held, not raised immediately;
- `after_tool_validate` then runs, and can still **reject** (its `ModelRetry`/`ToolFailed` wins over the held deferral) or **defer itself**;
- **a deferral raised by `after_tool_validate` replaces a held one** — it runs last and is the policy layer, so its decision wins. Pinned by `test_hook_deferral_replaces_an_args_validator_deferral`: an `args_validator` asking for approval plus an `after_tool_validate` raising `CallDeferred` surfaces as an *external* call carrying the hook's metadata.

### Execute-stage footgun, now documented

`after_tool_execute` and `wrap_tool_execute`-after-handler *do* defer successfully, but the tool body has already run: its side effects happened and its result is discarded (`executed=[0]` in the probe above). A user reaching for conditional approval will naturally try `after_tool_execute` and get exactly the wrong behaviour, so the docs and the hook docstrings now steer to `before_tool_execute`. Not changed in code — deferring after execution is a coherent thing to allow, it's just rarely what you want.

### Tests

In `tests/test_capabilities.py::TestToolHookDeferrals`, parametrized over `ApprovalRequired`/`CallDeferred`:

- `test_validate_hook_defers_once_args_are_valid` — `after_tool_validate` and `wrap_tool_validate`-after defer the call with the deferral's metadata, `args_valid=True` on the `FunctionToolCallEvent`, tool not executed, retry budget untouched (`retries=0` would otherwise raise `UnexpectedModelBehavior`).
- `test_validate_hook_cannot_defer_before_args_are_valid` — `before_tool_validate` and `wrap_tool_validate`-before raise `UserError` naming the hook and the exception.
- `test_on_tool_validate_error_cannot_defer` — same, reached through a genuine validation failure; pins the full message wording.
- `test_execute_hook_defers` — all four execution positions still defer with metadata preserved and `args_valid=True`, and the assertion encodes which positions ran the tool body first.
- `test_hook_deferral_replaces_an_args_validator_deferral` — the precedence rule above.
- `test_hooks_that_defer_nowhere_leave_the_call_alone` — control case: the same capability without a deferral runs the tool normally.

### Docs

`docs/hooks.md` (validation and execution hook sections), `docs/capabilities/custom.md` (same two sections), the `AbstractCapability` docstrings for `before_tool_validate`, `after_tool_validate`, `wrap_tool_validate`, `on_tool_validate_error`, `before_tool_execute`, `after_tool_execute` and `wrap_tool_execute`, and the `CAPABILITIES-AND-HOOKS.md` skill reference. The `on_tool_validate_error` docstring in particular was narrowed: after #6897 it implied validate-stage deferrals were supported generally, which under this rule is wrong.

Verified: full `uv run pytest` (6452 passed), `pyright` clean on both changed source files.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

