### PR TITLE
Raise a `UserError` when a history processor or `fallback_on` handler has unresolvable type annotations

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -793,7 +793,7 @@ agent = Agent('openai:gpt-5.2', capabilities=[ProcessHistory(context_aware_proce
 
 This allows for more sophisticated message processing based on the current state of the agent run.
 
-Whether the processor wants a `RunContext` is detected by resolving its type hints at runtime, so every annotated type in the processor signature must be imported at runtime rather than only under `if TYPE_CHECKING:`. If any annotation can't be resolved, a `UserError` is raised instead of the processor being silently called without the context.
+Whether the processor wants a [`RunContext`][pydantic_ai.tools.RunContext] is detected by resolving its type hints at runtime, so every annotated type in the processor signature must be imported at runtime rather than only under `if TYPE_CHECKING:`. If any annotation can't be resolved, a [`UserError`][pydantic_ai.exceptions.UserError] is raised instead of the processor being silently called without the context.
 
 #### Summarize Old Messages
 

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -793,6 +793,8 @@ agent = Agent('openai:gpt-5.2', capabilities=[ProcessHistory(context_aware_proce
 
 This allows for more sophisticated message processing based on the current state of the agent run.
 
+Whether the processor wants a `RunContext` is detected by resolving the first parameter's type hint at runtime, so `RunContext` needs to be imported at runtime rather than only under `if TYPE_CHECKING:`. If it can't be resolved, a `UserError` is raised instead of the processor being silently called without the context.
+
 #### Summarize Old Messages
 
 Use an LLM to summarize older messages to preserve context while reducing tokens. This is one of several ways to keep a conversation within the context window — see [Compaction](capabilities/compaction.md) for the full picture, including provider-native compaction and ready-made strategies from [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/compaction/).

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -793,7 +793,7 @@ agent = Agent('openai:gpt-5.2', capabilities=[ProcessHistory(context_aware_proce
 
 This allows for more sophisticated message processing based on the current state of the agent run.
 
-Whether the processor wants a `RunContext` is detected by resolving the first parameter's type hint at runtime, so `RunContext` needs to be imported at runtime rather than only under `if TYPE_CHECKING:`. If it can't be resolved, a `UserError` is raised instead of the processor being silently called without the context.
+Whether the processor wants a `RunContext` is detected by resolving its type hints at runtime, so every annotated type in the processor signature must be imported at runtime rather than only under `if TYPE_CHECKING:`. If any annotation can't be resolved, a `UserError` is raised instead of the processor being silently called without the context.
 
 #### Summarize Old Messages
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -410,7 +410,7 @@ The `fallback_on` parameter accepts:
 
 Handler type is auto-detected by inspecting type hints on the first parameter. If the first parameter is hinted as [`ModelResponse`][pydantic_ai.messages.ModelResponse], it's a response handler. Otherwise (including untyped handlers and lambdas), it's an exception handler.
 
-As the hint is resolved at runtime, `ModelResponse` needs to be imported at runtime rather than only under `if TYPE_CHECKING:`. If it can't be resolved, a `UserError` is raised instead of the handler being silently treated as an exception handler.
+As the hints are resolved at runtime, every annotated type in the handler signature must be imported at runtime rather than only under `if TYPE_CHECKING:`. If any annotation can't be resolved, a `UserError` is raised instead of the handler being silently treated as an exception handler.
 
 #### Finish Reason Example
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -410,7 +410,7 @@ The `fallback_on` parameter accepts:
 
 Handler type is auto-detected by inspecting type hints on the first parameter. If the first parameter is hinted as [`ModelResponse`][pydantic_ai.messages.ModelResponse], it's a response handler. Otherwise (including untyped handlers and lambdas), it's an exception handler.
 
-As the hints are resolved at runtime, every annotated type in the handler signature must be imported at runtime rather than only under `if TYPE_CHECKING:`. If any annotation can't be resolved, a `UserError` is raised instead of the handler being silently treated as an exception handler.
+As the hints are resolved at runtime, every annotated type in the handler signature must be imported at runtime rather than only under `if TYPE_CHECKING:`. If any annotation can't be resolved, a [`UserError`][pydantic_ai.exceptions.UserError] is raised instead of the handler being silently treated as an exception handler.
 
 #### Finish Reason Example
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -410,6 +410,8 @@ The `fallback_on` parameter accepts:
 
 Handler type is auto-detected by inspecting type hints on the first parameter. If the first parameter is hinted as [`ModelResponse`][pydantic_ai.messages.ModelResponse], it's a response handler. Otherwise (including untyped handlers and lambdas), it's an exception handler.
 
+As the hint is resolved at runtime, `ModelResponse` needs to be imported at runtime rather than only under `if TYPE_CHECKING:`. If it can't be resolved, a `UserError` is raised instead of the handler being silently treated as an exception handler.
+
 #### Finish Reason Example
 
 A simple use case is checking the model's finish reason — for example, falling back if the response was truncated due to length limits:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -674,6 +674,9 @@ def takes_run_context(callable_obj: Callable[..., Any]) -> bool:
 
     Returns:
         `True` if the callable takes a `RunContext` as first argument, `False` otherwise.
+
+    Raises:
+        UserError: If the callable has annotations that cannot be resolved at runtime.
     """
     from ._run_context import RunContext
 
@@ -693,7 +696,11 @@ def get_first_param_type(callable_obj: Callable[..., Any]) -> Any | None:
         callable_obj: The callable to inspect.
 
     Returns:
-        The type annotation of the first parameter, or None if it cannot be determined.
+        The type annotation of the first parameter, or None if the callable has no introspectable
+            annotations.
+
+    Raises:
+        UserError: If the callable has annotations that cannot be resolved at runtime.
     """
     try:
         sig = inspect.signature(callable_obj)
@@ -707,16 +714,29 @@ def get_first_param_type(callable_obj: Callable[..., Any]) -> Any | None:
 
     # See https://github.com/pydantic/pydantic/pull/11451 for a similar implementation in Pydantic
     callable_for_hints = callable_obj
+    name = get_callable_name(callable_obj)
     if not isinstance(callable_obj, _decorators._function_like):  # pyright: ignore[reportPrivateUsage]
         call_func = getattr(type(callable_obj), '__call__', None)
         if call_func is not None:
             callable_for_hints = call_func
+            # Name the class rather than the (address-bearing) repr of the instance.
+            name = type(callable_obj).__name__
         else:
             return None  # pragma: no cover
 
     try:
         type_hints = _typing_extra.get_function_type_hints(_decorators.unwrap_wrapped_function(callable_for_hints))
-    except (NameError, TypeError, AttributeError):
+    except NameError as e:
+        # A `NameError` means the callable does have annotations, we just can't resolve them. Treating that
+        # like "no annotations" would silently pick the wrong calling convention, so we surface it instead.
+        raise UserError(
+            f'Unable to resolve the type annotations of {name!r}: {e}. '
+            'This typically happens when a type is imported inside an `if TYPE_CHECKING:` block '
+            'in a module that uses `from __future__ import annotations`. '
+            'Pydantic AI resolves these annotations at runtime to determine how to call the function, '
+            'so every type used in its signature needs to be imported at runtime as well.'
+        ) from e
+    except (TypeError, AttributeError):
         return None
 
     return type_hints.get(first_param_name)

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import timezone
@@ -27,6 +27,7 @@ from pydantic_ai import (
     ToolCallPart,
     ToolDefinition,
     ToolReturnPart,
+    UserError,
     UserPromptPart,
 )
 from pydantic_ai._agent_graph import ModelRequestNode
@@ -1646,28 +1647,40 @@ def test_callable_class_exception_handler() -> None:
     assert result.output == 'success'
 
 
-def test_unresolvable_forward_ref_treated_as_exception_handler() -> None:
-    """A handler with unresolvable forward refs is treated as an exception handler."""
-    # Create a function whose type hints can't be resolved (triggers except branch in get_first_param_type)
-    exec_globals: dict[str, object] = {}
-    exec(  # nosec - test-only dynamic function creation for unresolvable forward ref
-        """
-def handler(x: "NonExistentType") -> bool:
-    return isinstance(x, Exception)
-""",
-        exec_globals,
-    )
-    handler = exec_globals['handler']
+@pytest.mark.parametrize('callable_class', [False, True])
+def test_unresolvable_annotations_handler_error(create_module: Callable[[str], Any], callable_class: bool) -> None:
+    """A handler whose annotations can't be resolved raises instead of being silently ignored.
 
-    # Classified as exception handler (forward ref can't resolve), so responses pass through
-    fallback = FallbackModel(
-        primary_model,
-        fallback_model_impl,
-        fallback_on=handler,  # type: ignore[arg-type]
-    )
-    agent = Agent(model=fallback)
-    result = agent.run_sync('hello')
-    assert result.output == 'primary response'
+    `ModelResponse` imported under `if TYPE_CHECKING:` in a module using `from __future__ import
+    annotations` used to make the handler look like an exception handler, so it was never called
+    for responses and the user's rejection policy silently became a no-op. Callable classes are
+    named by their class, not by the address-bearing repr of the instance.
+    """
+    mod = create_module("""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic_ai import ModelResponse
+
+
+def reject_primary(response: ModelResponse) -> bool:
+    return 'primary' in str(response)
+
+
+class RejectPrimary:
+    def __call__(self, response: ModelResponse) -> bool:
+        return 'primary' in str(response)
+""")
+    handler = mod.RejectPrimary() if callable_class else mod.reject_primary
+    name = 'RejectPrimary' if callable_class else 'reject_primary'
+
+    with pytest.raises(
+        UserError,
+        match=rf"Unable to resolve the type annotations of '{name}': name 'ModelResponse' is not defined\.",
+    ):
+        FallbackModel(primary_model, fallback_model_impl, fallback_on=handler)
 
 
 def test_fallback_on_single_exception_type_direct() -> None:
@@ -1688,8 +1701,6 @@ def test_fallback_on_single_exception_type_direct() -> None:
 
 def test_empty_fallback_on_list_error() -> None:
     """Test that empty fallback_on list raises UserError."""
-    from pydantic_ai.exceptions import UserError
-
     with pytest.raises(UserError, match='empty fallback_on'):
         FallbackModel(
             primary_model,
@@ -1700,8 +1711,6 @@ def test_empty_fallback_on_list_error() -> None:
 
 def test_empty_fallback_on_tuple_error() -> None:
     """Test that empty fallback_on tuple raises UserError."""
-    from pydantic_ai.exceptions import UserError
-
     with pytest.raises(UserError, match='empty fallback_on'):
         FallbackModel(
             primary_model,

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -1,6 +1,6 @@
 import re
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from copy import deepcopy
 from dataclasses import replace
 from typing import Any
@@ -27,7 +27,7 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RequestUsage
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsStr
+from .conftest import IsDatetime, IsInstance, IsStr
 
 pytestmark = [pytest.mark.anyio]
 
@@ -2024,12 +2024,57 @@ async def test_history_processor_insert_and_replace_resumed_request_excludes_res
     assert not _user_request_present(result.new_messages())
 
 
-def test_takes_ctx_returns_false_for_untyped_processor():
-    """takes_run_context returns False when the processor's first param has no type annotation."""
-    from pydantic_ai._utils import takes_run_context
+@pytest.mark.parametrize('is_async', [False, True])
+async def test_history_processor_without_annotations(function_model: FunctionModel, is_async: bool):
+    """A processor with no annotations at all keeps being called with just the messages.
 
-    def untyped_processor(messages) -> list[ModelMessage]:  # pyright: ignore[reportUnknownParameterType,reportMissingParameterType]
-        return messages  # pyright: ignore[reportUnknownVariableType] # pragma: no cover
+    This is the documented no-context form, so an unannotated first parameter must not be mistaken
+    for one that takes a `RunContext`.
+    """
+    received: list[Any] = []
 
-    # When first param has no type annotation, takes_run_context returns False
-    assert takes_run_context(untyped_processor) is False  # pyright: ignore[reportUnknownArgumentType]
+    def sync_processor(messages):  # pyright: ignore[reportUnknownParameterType,reportMissingParameterType]
+        received.append(messages)
+        return messages  # pyright: ignore[reportUnknownVariableType]
+
+    async def async_processor(messages):  # pyright: ignore[reportUnknownParameterType,reportMissingParameterType]
+        received.append(messages)
+        return messages  # pyright: ignore[reportUnknownVariableType]
+
+    processor: Any = async_processor if is_async else sync_processor  # pyright: ignore[reportUnknownVariableType]
+    agent = Agent(function_model, capabilities=[ProcessHistory(processor)])
+
+    result = await agent.run('Hello')
+    assert result.output == 'Provider response'
+    # The message list, not a `RunContext`, is what the processor got.
+    assert received == [[IsInstance(ModelRequest)]]
+
+
+async def test_history_processor_unresolvable_annotations(
+    function_model: FunctionModel, create_module: Callable[[str], Any]
+):
+    """A processor whose annotations can't be resolved raises instead of being silently mis-bound.
+
+    `RunContext` imported under `if TYPE_CHECKING:` in a module using `from __future__ import
+    annotations` used to make the processor look like it takes no context, so it was called as
+    `processor(messages)` and the message list ended up bound to `ctx`.
+    """
+    mod = create_module("""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic_ai import ModelMessage, RunContext
+
+
+def drop_first(ctx: RunContext[None], messages: list[ModelMessage]) -> list[ModelMessage]:
+    return messages[1:]
+""")
+    agent = Agent(function_model, capabilities=[ProcessHistory(mod.drop_first)])
+
+    with pytest.raises(
+        UserError,
+        match=r"Unable to resolve the type annotations of 'drop_first': name 'RunContext' is not defined\.",
+    ):
+        await agent.run('Hello')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,7 @@ from pydantic_ai._utils import (
     check_object_json_schema,
     dataclasses_no_defaults_repr,
     format_inlined_text_file,
+    get_first_param_type,
     group_by_temporal,
     is_async_callable,
     merge_json_schema_defs,
@@ -38,6 +39,18 @@ from .conftest import undrivable_event_loop
 from .models.mock_async_stream import MockAsyncStream
 
 pytestmark = pytest.mark.anyio
+
+
+def test_get_first_param_type_annotation_type_error():
+    """An annotation that can't be evaluated at all stays a silent `None`, unlike an unresolvable name."""
+
+    def function(value: int) -> None:
+        pass
+
+    # Not every resolution failure is a `NameError`: this one raises `TypeError` when evaluated.
+    function.__annotations__['value'] = 'int | 5'
+
+    assert get_first_param_type(function) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Closes #6949

`_utils.get_first_param_type` swallowed `NameError` and returned `None`, conflating "this callable has no annotations" with "this callable has annotations we failed to resolve". Both callers then silently picked the wrong calling convention:

- `ProcessHistory`: a processor declared as `(ctx: RunContext[None], messages: ...)` was called as `processor(messages)`, so the message list got bound to `ctx` — and the run completed with no error at all.
- `FallbackModel(fallback_on=...)`: a response handler was misclassified as an exception handler and never invoked, silently turning the user's rejection policy into a no-op.

The trigger is the ordinary, lint-encouraged `from __future__ import annotations` + `if TYPE_CHECKING:` import idiom. A *tool* function with the identical signature already fails loudly with `NameError: name 'RunContext' is not defined` at schema build, so the codebase already treats this as an error worth surfacing — just not on these two paths.

`NameError` now raises a `UserError` naming the callable and explaining the interaction:

> Unable to resolve the type annotations of `'my_processor'`: name `'RunContext'` is not defined. This typically happens when a type is imported inside an `if TYPE_CHECKING:` block in a module that uses `from __future__ import annotations`. Pydantic AI resolves these annotations at runtime to determine how to call the function, so every type used in its signature needs to be imported at runtime as well.

`TypeError`/`AttributeError` on callables with no introspectable signature keep returning `None`, and so does a callable with no annotations at all — that's the documented no-context history-processor form and the plain-exception-handler form for `FallbackModel`.

`tests/models/test_fallback.py::test_unresolvable_forward_ref_treated_as_exception_handler` asserted the old swallowing behavior (an `exec`'d function with a bogus forward ref, classified as an exception handler). It's replaced by a test of the same code path using the realistic `TYPE_CHECKING` trigger, parametrized over plain functions and callable classes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

