### PR TITLE
Inline every `$ref` to a union `$def`, not just the first one

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -77,9 +77,9 @@ class JsonSchemaTransformer(ABC):
             defs = {key: deepcopy(self._walked_def(key)) for key in self.recursive_refs}
             root_ref = self.schema.get('$ref')
             root_key = None if root_ref is None else re.sub(r'^#/\$defs/', '', root_ref)
-            if root_key is None:  # pragma: no cover
+            if root_key is None:
                 root_key = self.schema.get('title', 'root')
-                while root_key in defs:
+                while root_key in defs:  # pragma: no cover
                     # Modify the root key until it is not already in use
                     root_key = f'{root_key}_root'
 

--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -49,6 +49,7 @@ class JsonSchemaTransformer(ABC):
         self.defs: dict[str, JsonSchema] = deepcopy(self.schema.get('$defs', {}))
         self.refs_stack: list[str] = []
         self.recursive_refs = set[str]()
+        self._walked_defs: dict[str, JsonSchema] = {}
 
     @abstractmethod
     def transform(self, schema: JsonSchema) -> JsonSchema:
@@ -70,7 +71,7 @@ class JsonSchemaTransformer(ABC):
             # If we are preferring inlined defs and there are recursive refs, we _have_ to use a $defs+$ref structure
             # We try to use whatever the original root key was, but if it is already in use,
             # we modify it to avoid collisions.
-            defs = {key: self.defs[key] for key in self.recursive_refs}
+            defs = {key: deepcopy(self._walked_def(key)) for key in self.recursive_refs}
             root_ref = self.schema.get('$ref')
             root_key = None if root_ref is None else re.sub(r'^#/\$defs/', '', root_ref)
             if root_key is None:  # pragma: no cover
@@ -88,26 +89,20 @@ class JsonSchemaTransformer(ABC):
         if isinstance(schema, bool):
             return schema
 
-        nested_refs = 0
-        if self.prefer_inlined_defs:
-            while ref := schema.get('$ref'):
-                key = re.sub(r'^#/\$defs/', '', ref)
-                if key in self.recursive_refs:
-                    break
-                if key in self.refs_stack:
-                    self.recursive_refs.add(key)
-                    break  # recursive ref can't be unpacked
-                self.refs_stack.append(key)
-                nested_refs += 1
-
-                def_schema = self.defs.get(key)
-                if def_schema is None:  # pragma: no cover
-                    raise UserError(f'Could not find $ref definition for {key}')
+        if self.prefer_inlined_defs and (ref := schema.get('$ref')):
+            key = re.sub(r'^#/\$defs/', '', ref)
+            if key in self.refs_stack:
+                # A recursive ref can't be unpacked; `walk()` emits the definition and the `$ref` stays put.
+                self.recursive_refs.add(key)
+            elif key not in self.recursive_refs:
                 # Keywords sitting alongside the `$ref` (e.g. a field-level `description`
                 # or `default`) are part of the field's own schema and must survive
                 # inlining, so merge them over the referenced definition.
-                siblings = {k: v for k, v in schema.items() if k != '$ref'}
-                schema = {**def_schema, **siblings} if siblings else def_schema
+                if siblings := {k: v for k, v in schema.items() if k != '$ref'}:
+                    # `transform()` sees the merged schema, so the result is specific to this reference
+                    # site and can't come from (or go into) the shared walked-definition cache.
+                    return self._walk_def(key, siblings)
+                return deepcopy(self._walked_def(key))
 
         # Handle the schema based on its type / structure
         type_ = schema.get('type')
@@ -125,12 +120,32 @@ class JsonSchemaTransformer(ABC):
                 if members := schema.get(union_kind):
                     schema[union_kind] = [self._handle(member) for member in members]
         # Apply the base transform
-        schema = self.transform(schema)
+        return self.transform(schema)
 
-        if nested_refs > 0:
-            self.refs_stack = self.refs_stack[:-nested_refs]
+    def _walked_def(self, key: str) -> JsonSchema:
+        """The definition `key` refers to, walked once per transformer and cached.
 
-        return schema
+        Inlining a definition means walking its whole subtree at every reference site, and the result
+        is the same at each of them, so the walk is done once and callers get a `deepcopy` of it. This
+        also keeps the inlined copies independent of each other: the walk transforms schemas in place,
+        so handing out the same object at multiple sites would let each site corrupt the next.
+        """
+        if (walked := self._walked_defs.get(key)) is None:
+            self._walked_defs[key] = walked = self._walk_def(key, {})
+        return walked
+
+    def _walk_def(self, key: str, siblings: JsonSchema) -> JsonSchema:
+        """Walk the definition `key` refers to, with `$ref` sibling keywords merged over it."""
+        def_schema = self.defs.get(key)
+        if def_schema is None:  # pragma: no cover
+            raise UserError(f'Could not find $ref definition for {key}')
+
+        self.refs_stack.append(key)
+        walked = self._handle({**deepcopy(def_schema), **siblings})
+        self.refs_stack.pop()
+
+        assert not isinstance(walked, bool)
+        return walked
 
     def _handle_object(self, schema: JsonSchema) -> JsonSchema:
         if properties := schema.get('properties'):

--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -79,7 +79,7 @@ class JsonSchemaTransformer(ABC):
             root_key = None if root_ref is None else re.sub(r'^#/\$defs/', '', root_ref)
             if root_key is None:
                 root_key = self.schema.get('title', 'root')
-                while root_key in defs:  # pragma: no cover
+                while root_key in defs:
                     # Modify the root key until it is not already in use
                     root_key = f'{root_key}_root'
 

--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -59,6 +59,9 @@ class JsonSchemaTransformer(ABC):
     def walk(self) -> JsonSchema:
         schema = deepcopy(self.schema)
 
+        self.recursive_refs.clear()
+        self._walked_defs.clear()
+
         # First, handle everything but $defs:
         schema.pop('$defs', None)
         handled = self._handle(schema)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -480,3 +480,31 @@ def test_inline_defs_recursive_ref():
         },
         '$ref': '#/$defs/Wrapper',
     }
+
+
+def test_inline_defs_recursive_ref_root_key_collides_with_a_def():
+    """A root whose title already names a recursive `$def` gets a distinct key, not an overwrite.
+
+    With recursive refs the output has to be `$defs` + `$ref`, and the root's key is derived from
+    its `title` when it has no `$ref` of its own. If that title happens to match a definition, the
+    root would otherwise clobber the definition it points at.
+    """
+    schema = {
+        'type': 'object',
+        'title': 'Node',
+        'properties': {'child': {'$ref': '#/$defs/Node'}},
+        '$defs': {
+            'Node': {
+                'type': 'object',
+                'title': 'Node',
+                'properties': {'child': {'$ref': '#/$defs/Node'}},
+            }
+        },
+    }
+
+    result = InlineDefsJsonSchemaTransformer(deepcopy(schema)).walk()
+
+    assert result['$ref'] == '#/$defs/Node_root'
+    assert set(result['$defs']) == {'Node', 'Node_root'}
+    # The definition the root points at is intact, not overwritten by the root.
+    assert result['$defs']['Node']['properties']['child'] == {'$ref': '#/$defs/Node'}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -388,6 +388,29 @@ def test_inline_defs_walks_each_def_once():
     assert transformed == ['Meow', 'Cat', 'Woof', 'Dog', 'Args']
 
 
+def test_inline_defs_rewalks_defs_on_each_walk():
+    """Each `walk()` transforms definitions using the transformer's current state."""
+
+    class _StrictTitleTransformer(InlineDefsJsonSchemaTransformer):
+        def transform(self, schema: dict[str, Any]) -> dict[str, Any]:
+            if self.strict and (title := schema.get('title')):
+                schema['title'] = title.upper()
+            return schema
+
+    schema = {
+        'type': 'object',
+        'properties': {'value': {'$ref': '#/$defs/Value'}},
+        '$defs': {'Value': {'type': 'string', 'title': 'Value'}},
+    }
+    transformer = _StrictTitleTransformer(schema, strict=False)
+
+    assert transformer.walk()['properties']['value']['title'] == 'Value'
+
+    transformer.strict = True
+
+    assert transformer.walk()['properties']['value']['title'] == 'VALUE'
+
+
 def test_inline_defs_repeated_ref_with_siblings():
     """`$ref` sibling keywords apply to their own site only, never to the shared definition."""
     schema = {

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -282,3 +282,178 @@ def test_inline_defs_preserves_ref_sibling_keywords():
     # ...and the sibling keywords are preserved rather than dropped.
     assert field['description'] == 'field-level description'
     assert field['default'] is None
+
+
+# The schema pydantic emits for `Pet = TypeAliasType('Pet', Union[Cat, Dog])` used as two fields of one
+# model: a union-typed `$def` referenced more than once.
+SHARED_UNION_DEF_SCHEMA: dict[str, Any] = {
+    'type': 'object',
+    'title': 'Args',
+    'properties': {
+        'first': {'$ref': '#/$defs/Pet'},
+        'second': {'$ref': '#/$defs/Pet'},
+    },
+    'required': ['first', 'second'],
+    '$defs': {
+        'Cat': {
+            'type': 'object',
+            'title': 'Cat',
+            'properties': {'meow': {'type': 'string', 'title': 'Meow'}},
+            'required': ['meow'],
+        },
+        'Dog': {
+            'type': 'object',
+            'title': 'Dog',
+            'properties': {'woof': {'type': 'string', 'title': 'Woof'}},
+            'required': ['woof'],
+        },
+        'Pet': {'anyOf': [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}]},
+    },
+}
+
+INLINED_PET: dict[str, Any] = {
+    'anyOf': [
+        {
+            'type': 'object',
+            'title': 'Cat',
+            'properties': {'meow': {'type': 'string', 'title': 'Meow'}},
+            'required': ['meow'],
+        },
+        {
+            'type': 'object',
+            'title': 'Dog',
+            'properties': {'woof': {'type': 'string', 'title': 'Woof'}},
+            'required': ['woof'],
+        },
+    ]
+}
+
+
+def test_inline_defs_repeated_union_ref():
+    """Every `$ref` to a union `$def` inlines the whole definition, not just the first one.
+
+    The first inline site used to walk the stored definition in place and pop its `anyOf` off it, so
+    every later `$ref` to the same definition inlined `{}` — a schema meaning "anything", silently
+    sent to the model. Unit test: the corruption is in the walker itself, and a cassette would only
+    pin one provider's copy of the resulting payload.
+    """
+    result = InlineDefsJsonSchemaTransformer(deepcopy(SHARED_UNION_DEF_SCHEMA)).walk()
+
+    assert result['properties']['first'] == INLINED_PET
+    assert result['properties']['second'] == INLINED_PET
+
+
+def test_inlined_defs_are_independent_objects():
+    """Each inline site gets its own objects, so mutating one doesn't reach through to the others.
+
+    The missing copy that emptied union definitions also left object subtrees aliased across sites.
+    """
+    result = InlineDefsJsonSchemaTransformer(deepcopy(SHARED_UNION_DEF_SCHEMA)).walk()
+    first = result['properties']['first']
+    second = result['properties']['second']
+
+    assert first is not second
+    first['anyOf'][0]['properties']['meow']['type'] = 'integer'
+    assert second['anyOf'][0]['properties']['meow']['type'] == 'string'
+
+
+def test_inline_defs_does_not_mutate_defs():
+    """Inlining reads the stored definitions without walking or transforming them in place."""
+    schema = deepcopy(SHARED_UNION_DEF_SCHEMA)
+    transformer = InlineDefsJsonSchemaTransformer(schema)
+    transformer.walk()
+
+    assert schema == SHARED_UNION_DEF_SCHEMA
+    assert transformer.defs == SHARED_UNION_DEF_SCHEMA['$defs']
+
+
+def test_inline_defs_walks_each_def_once():
+    """A `$def` is walked once per `walk()`, however many times it's referenced.
+
+    Inlining correctly means expanding the definition's whole subtree at every reference site, which
+    without this would repeat the walk once per site (and, transitively, once per nested `$ref`).
+    """
+    transformed: list[str] = []
+
+    class _TitleRecordingTransformer(InlineDefsJsonSchemaTransformer):
+        def transform(self, schema: dict[str, Any]) -> dict[str, Any]:
+            if title := schema.get('title'):
+                transformed.append(title)
+            return schema
+
+    _TitleRecordingTransformer(deepcopy(SHARED_UNION_DEF_SCHEMA)).walk()
+
+    # `Cat` and `Dog` are each walked once even though `Pet` — itself walked once for both fields —
+    # references them, and each field inlines a copy of the result.
+    assert transformed == ['Meow', 'Cat', 'Woof', 'Dog', 'Args']
+
+
+def test_inline_defs_repeated_ref_with_siblings():
+    """`$ref` sibling keywords apply to their own site only, never to the shared definition."""
+    schema = {
+        'type': 'object',
+        'properties': {
+            'described': {'$ref': '#/$defs/Pet', 'description': 'field-level description'},
+            'plain': {'$ref': '#/$defs/Pet'},
+            'defaulted': {'$ref': '#/$defs/Pet', 'default': None},
+        },
+        '$defs': {'Pet': {'anyOf': [{'type': 'string'}, {'type': 'integer'}]}},
+    }
+
+    result = InlineDefsJsonSchemaTransformer(deepcopy(schema)).walk()
+
+    pet = {'anyOf': [{'type': 'string'}, {'type': 'integer'}]}
+    assert result['properties']['described'] == {**pet, 'description': 'field-level description'}
+    assert result['properties']['plain'] == pet
+    assert result['properties']['defaulted'] == {**pet, 'default': None}
+
+
+def test_inline_defs_recursive_ref():
+    """A recursive `$def` is emitted as `$defs` + `$ref`, walked and transformed like the rest.
+
+    The definition emitted alongside the `$ref` used to be the object the walk had transformed in
+    place; now that inlining copies instead, it comes from the same walked-once definition the inline
+    sites are copied from. The transformer uppercases titles so a raw, unwalked definition would show.
+    """
+
+    class _TitleUpperTransformer(InlineDefsJsonSchemaTransformer):
+        def transform(self, schema: dict[str, Any]) -> dict[str, Any]:
+            if title := schema.get('title'):
+                schema['title'] = title.upper()
+            return schema
+
+    schema = {
+        'type': 'object',
+        'title': 'Wrapper',
+        'properties': {'a': {'$ref': '#/$defs/Node'}, 'b': {'$ref': '#/$defs/Node'}},
+        '$defs': {
+            'Node': {
+                'type': 'object',
+                'title': 'Node',
+                'properties': {'children': {'type': 'array', 'title': 'Children', 'items': {'$ref': '#/$defs/Node'}}},
+            }
+        },
+    }
+
+    transformer = _TitleUpperTransformer(deepcopy(schema))
+    result = transformer.walk()
+
+    assert transformer.recursive_refs == {'Node'}
+    walked_node = {
+        'type': 'object',
+        'title': 'NODE',
+        'properties': {'children': {'type': 'array', 'title': 'CHILDREN', 'items': {'$ref': '#/$defs/Node'}}},
+    }
+    assert result == {
+        '$defs': {
+            'Node': walked_node,
+            'Wrapper': {
+                'type': 'object',
+                'title': 'WRAPPER',
+                # The first site unpacks one level of the recursion; from then on `Node` is known to
+                # be recursive, so the second site keeps its `$ref`.
+                'properties': {'a': walked_node, 'b': {'$ref': '#/$defs/Node'}},
+            },
+        },
+        '$ref': '#/$defs/Wrapper',
+    }


### PR DESCRIPTION
- Closes #6948

`InlineDefsJsonSchemaTransformer` (and every profile with `prefer_inlined_defs=True`) silently sent `{}` to the model for the second and every later `$ref` to a union-typed `$def`.

`_handle` bound `schema` to the live `self.defs[key]` object whenever a `$ref` had no sibling keywords, and `_handle_union` then `pop`ped `anyOf`/`oneOf`/`allOf` straight off it. The first reference site inlined correctly and destroyed the stored definition as a side effect; every later site found an empty dict. `{}` is a valid JSON Schema meaning "anything", so there was no error, no warning, and nothing in the response to show the model had been handed a worse schema than the one declared. `_handle_object` mutated in place too, which is why inlined object subtrees came out aliased across sites.

This hits Amazon Nova, Llama, Qwen, the OpenRouter Google transformer, and `StructuredDict` on *every* model.

### The fix

Definitions are walked on a `deepcopy` and never in place, so `self.defs` stays pristine. The walked definition is cached for the duration of the `walk()` and a `deepcopy` is handed out per reference site.

The cache is not just an optimization here — it is what makes the fix affordable. Correct inlining means expanding a definition's whole subtree at every site, which the naive `deepcopy(def_schema)`-per-site fix multiplies out once per site *and* transitively once per nested `$ref`. Walking each definition once and copying the result collapses that back down.

Deliberately *not* included: any cross-`walk()` or cross-request cache. That would require declaring the public, subclassable `JsonSchemaTransformer.transform` contractually pure, which is a separate decision. This cache lives on the transformer instance and dies with it, so it only requires `transform` to be deterministic for the duration of one walk.

Sites carrying sibling keywords (a field-level `description`, `default`, …) are still walked with the siblings merged in *before* the walk, exactly as today, because `transform()` sees the merged schema — the OpenRouter Google transformer strips a `title` it finds there, for instance. Those sites therefore neither read from nor write to the cache, so a site's siblings can never leak into another site's copy. They still benefit from the cache for their nested `$ref`s.

Recursive refs are unchanged: the `recursive_refs` check still comes before any inlining, so a definition known to be recursive is never expanded from the cache, and a partially-walked subtree can never be cached (a key on `refs_stack` is by definition still being walked, and that check comes first too). `walk()` now emits the recursive definition from the same walked-once definition the inline sites are copied from; previously it emitted `self.defs[key]`, which happened to be walked only because the walk had mutated it in place.

### Measurements

`transform` call count and wall time on a schema with a union `$def` (`anyOf: [Cat, Dog]`) shared across nested object definitions, `width` fields per object and `depth` levels of nesting. "Inlined `Cat`s" counts how many times the union's first member actually reached the output — the ground truth for whether the schema is intact.

| | transform calls | time | output bytes | inlined `Cat`s |
|---|---|---|---|---|
| **before** (`main`, corrupt) | 4,579 | 1.5 ms | 204,357 | 216 ❌ |
| naive fix (`deepcopy` per site, no cache) | 19,699 | 25.6 ms | 1,082,397 | 1,296 ✅ |
| **after** (this PR) | **19** | **17.8 ms** | 1,082,397 | 1,296 ✅ |

(`width=6, depth=3`; best of 5 runs. At `width=5, depth=2`: 456 → 1,656 → **16** calls, 0.2 → 2.1 → **1.5** ms.)

`main` looks fast only because it emits a schema 5x too small and 6x short on inlined union members. Against the naive correct fix — the only apples-to-apples comparison — this is 1,037x fewer `transform` calls and a 30% faster walk; the remaining time is the `deepcopy` of an output that is legitimately that much bigger now that it is correct.

### Tests

Five new tests in `tests/test_json_schema.py`, four of which fail on `main`: repeated `$ref` to a union `$def` inlines fully at every site; the inlined sites are independent objects; `self.defs` is not mutated; sibling keywords apply per-site only. The fifth pins that each definition is walked once — it passes on `main` (which walks once by accident, since it corrupts the definition) and fails against the naive fix, so it is the guard on the performance half. A sixth pins the recursive-`$ref` path, which behaves identically before and after.

**No snapshot changes anywhere.** The full suite is green (5 pre-existing `inline_snapshot` `UsageError`s on my local Python 3.14, identical on `main`), including `tests/models/test_bedrock.py`, `tests/providers/`, `tests/profiles/`, `tests/models/google/`, `tests/models/test_openai.py`, `tests/test_agent.py` and `tests/test_ref_sibling_wire_contract.py`. Coverage of `_json_schema.py` stays at 100%.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

