### PR TITLE
Run `after_tool_validate` when an `args_validator` defers the call

### DIFF
--- a/docs/capabilities/custom.md
+++ b/docs/capabilities/custom.md
@@ -578,6 +578,8 @@ All tool hooks receive a `tool_def` parameter with the [`ToolDefinition`][pydant
 
 To skip validation and provide pre-validated args, raise [`SkipToolValidation(args)`][pydantic_ai.exceptions.SkipToolValidation] from `before_tool_validate` or `wrap_tool_validate`.
 
+`after_tool_validate` is a gate on validated arguments, so it also runs when a tool's [`args_validator`](../tools-advanced.md#args-validator) [deferred](../deferred-tools.md) the call: rejecting there (with `ModelRetry` or [`ToolFailed`][pydantic_ai.exceptions.ToolFailed]) wins over the deferral, and the args it returns are the ones the deferred call carries.
+
 **Execution hooks** — `args` is always the validated `dict[str, Any]`:
 
 | Hook | Signature | Purpose |

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -712,6 +712,12 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
         Raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to reject the validated args
         and ask the model to redo the tool call.
+
+        This also runs when the tool's `args_validator` deferred the call with
+        [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or
+        [`CallDeferred`][pydantic_ai.exceptions.CallDeferred], so the hook stays a reliable gate on
+        validated arguments: rejecting here wins over the deferral, and the args returned here are
+        the ones the deferred call carries.
         """
         return args
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -329,10 +329,18 @@ class ToolManager(Generic[AgentDepsT]):
             raw_args = await cap.before_tool_validate(ctx, call=call, tool_def=tool_def, args=raw_args)
 
             # wrap_tool_validate wraps the validation; on_tool_validate_error on failure
+            deferral: _ValidationDeferral | None = None
             try:
                 validated_args = await cap.wrap_tool_validate(
                     ctx, call=call, tool_def=tool_def, args=raw_args, handler=do_validate
                 )
+            except _ValidationDeferral as e:
+                # The `args_validator` deferred the call. Hold the deferral rather than letting it
+                # escape: `after_tool_validate` is a policy gate on validated arguments and has to
+                # run — and keep the ability to reject — before a call is queued for approval or
+                # external execution.
+                deferral = e
+                validated_args = e.validated_args
             except (ValidationError, ModelRetry) as e:
                 validated_args = await cap.on_tool_validate_error(
                     ctx, call=call, tool_def=tool_def, args=raw_args, error=e
@@ -340,6 +348,11 @@ class ToolManager(Generic[AgentDepsT]):
 
             # after_tool_validate
             validated_args = await cap.after_tool_validate(ctx, call=call, tool_def=tool_def, args=validated_args)
+
+            if deferral is not None:
+                # The hook accepted the call, so the deferral stands. It carries the hook's args:
+                # they're what a call that wasn't deferred would have proceeded with.
+                raise _ValidationDeferral(deferral.deferral, validated_args) from deferral
         else:
             validated_args = await do_validate(call.args if call.args is not None else {})
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -82,6 +82,7 @@ from pydantic_ai.messages import (
     BinaryImage,
     EnqueuedMessagesEvent,
     FilePart,
+    FunctionToolCallEvent,
     ImageUrl,
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
@@ -10945,8 +10946,9 @@ class TestToolValidateErrorHooks:
     async def test_args_validator_deferral_is_not_a_validate_error(self):
         """A deferral raised by an `args_validator` passes through the validate hooks as control flow.
 
-        Like an execute-stage deferral, it's not an error: `on_tool_validate_error` doesn't fire, the
-        hooks that run after successful validation don't either, and the tool is never executed.
+        Like an execute-stage deferral, it's not an error, so `on_tool_validate_error` doesn't fire
+        and the tool is never executed. `after_tool_validate` still runs: it guards validated
+        arguments, and a deferred call is queued with exactly those.
         """
         cap = LoggingCapability()
 
@@ -10962,8 +10964,146 @@ class TestToolValidateErrorHooks:
         result = await agent.run('call the tool')
         assert isinstance(result.output, DeferredToolRequests)
         assert [entry for entry in cap.log if 'tool_validate' in entry or 'tool_execute' in entry] == snapshot(
-            ['before_tool_validate:my_tool', 'wrap_tool_validate:my_tool:before']
+            ['before_tool_validate:my_tool', 'wrap_tool_validate:my_tool:before', 'after_tool_validate:my_tool']
         )
+
+
+# --- `after_tool_validate` as a policy gate on deferred calls ---
+
+
+@dataclass
+class ArgsGateCap(AbstractCapability[Any]):
+    """An `after_tool_validate` policy gate: records the args it sees, and can reject or rewrite them."""
+
+    reject_first: bool = False
+    rewrite: dict[str, Any] | None = None
+    seen: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
+
+    async def after_tool_validate(
+        self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.seen.append(dict(args))
+        if self.reject_first and len(self.seen) == 1:
+            raise ModelRetry('policy says no')
+        return self.rewrite if self.rewrite is not None else args
+
+
+class TestAfterToolValidateOnDeferral:
+    """`after_tool_validate` guards validated arguments, so a deferral must not bypass it.
+
+    Before this was fixed, an `args_validator` deferral escaped `wrap_tool_validate` and skipped the
+    hook entirely, so a deployment using it as an authorization gate had a privileged call queued for
+    approval without ever passing the gate.
+    """
+
+    async def test_runs_when_args_validator_defers(self):
+        """The gate sees the validated args, and the call is still deferred once it passes."""
+        cap = ArgsGateCap()
+        agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], capabilities=[cap])
+
+        def my_validator(ctx: RunContext[Any], x: int) -> None:
+            raise ApprovalRequired(metadata={'from': 'args_validator'})
+
+        # `retries=0` pins that the deferral still doesn't consume the retry budget.
+        @agent.tool(args_validator=my_validator, retries=0)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            return x
+
+        events: list[AgentStreamEvent | AgentRunResultEvent[Any]] = []
+        async with agent.run_stream_events('call the tool') as stream:
+            async for event in stream:
+                events.append(event)
+
+        result = events[-1]
+        assert isinstance(result, AgentRunResultEvent)
+        assert result.result.output == snapshot(
+            DeferredToolRequests(
+                approvals=[
+                    ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id='pyd_ai_tool_call_id__my_tool')
+                ],
+                metadata={'pyd_ai_tool_call_id__my_tool': {'from': 'args_validator'}},
+            )
+        )
+        assert cap.seen == snapshot([{'x': 0}])
+        assert [e.args_valid for e in events if isinstance(e, FunctionToolCallEvent)] == [True]
+
+    async def test_rejection_wins_over_the_deferral(self):
+        """A gate that rejects is honored: the model gets the retry, not a queued approval request."""
+        cap = ArgsGateCap(reject_first=True)
+        agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], capabilities=[cap])
+
+        def my_validator(ctx: RunContext[Any], x: int) -> None:
+            raise ApprovalRequired()
+
+        @agent.tool(args_validator=my_validator, retries=1)
+        def my_tool(ctx: RunContext[Any], x: int) -> int:  # pragma: no cover
+            return x
+
+        result = await agent.run('call the tool')
+        retries = [
+            part.content
+            for msg in result.all_messages()
+            if isinstance(msg, ModelRequest)
+            for part in msg.parts
+            if isinstance(part, RetryPromptPart)
+        ]
+        assert retries == snapshot(['policy says no'])
+        # The second attempt passes the gate, so that one defers.
+        assert isinstance(result.output, DeferredToolRequests)
+        assert cap.seen == snapshot([{'x': 0}, {'x': 0}])
+
+    async def test_still_runs_after_a_recovered_validation_failure(self):
+        """Regression pin: the failure path already ran the gate, via `on_tool_validate_error`."""
+
+        @dataclass
+        class RecoverCap(AbstractCapability[Any]):
+            async def on_tool_validate_error(
+                self, ctx: RunContext[Any], *, call: ToolCallPart, tool_def: ToolDefinition, args: Any, error: Any
+            ) -> dict[str, Any]:
+                return {'name': 'recovered'}
+
+        def bad_args_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            for msg in messages:
+                for part in msg.parts:
+                    if isinstance(part, ToolReturnPart):
+                        return make_text_response(f'got: {part.content}')
+            return ModelResponse(parts=[ToolCallPart(tool_name='greet', args='{"wrong": 1}', tool_call_id='call-1')])
+
+        gate = ArgsGateCap()
+        agent = Agent(FunctionModel(bad_args_model), capabilities=[RecoverCap(), gate])
+
+        @agent.tool_plain
+        def greet(name: str) -> str:
+            return f'hello {name}'
+
+        result = await agent.run('greet someone')
+        assert result.output == snapshot('got: hello recovered')
+        assert gate.seen == snapshot([{'name': 'recovered'}])
+
+    async def test_deferral_carries_the_hooks_args(self):
+        """A deferred call carries `after_tool_validate`'s output — what a non-deferred call would use.
+
+        `ValidatedToolCall.validated_args` has no public observable on the deferral path (the request
+        holds the model's original `ToolCallPart`, and resuming re-validates from it), so the
+        contract is pinned directly on the tool manager.
+        """
+        toolset = FunctionToolset[None]()
+
+        def my_validator(ctx: RunContext[None], x: int) -> None:
+            raise ApprovalRequired()
+
+        @toolset.tool(args_validator=my_validator)
+        def my_tool(ctx: RunContext[None], x: int) -> int:  # pragma: no cover
+            return x
+
+        cap = ArgsGateCap(rewrite={'x': 99})
+        manager = await ToolManager[None](toolset=toolset, root_capability=cap).for_run_step(_build_run_context())
+
+        validated = await manager.validate_tool_call(ToolCallPart('my_tool', {'x': 0}, tool_call_id='call-1'))
+        assert validated.args_valid is True
+        assert isinstance(validated.deferral, ApprovalRequired)
+        assert validated.validated_args == snapshot({'x': 99})
+        assert cap.seen == snapshot([{'x': 0}])
 
 
 # --- Tool execute error hook tests ---


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

Fixes a hook-bypass introduced by #6897, reported by a Codex security review (Medium) and verified against merged `main`. No existing issue.

### The finding

> `_ValidationDeferral` propagates out of `wrap_tool_validate` and is not in the `except (ValidationError, ModelRetry)` clause, so `after_tool_validate` never runs when an `args_validator` defers. Meanwhile `validate_tool_call` reports `args_valid=True` and the deferral is surfaced as an approval/external request.

Verified: with a capability whose `after_tool_validate` records what it sees, an `args_validator` raising `ApprovalRequired` produced a `DeferredToolRequests` with the hook never called. A deployment using `after_tool_validate` as an argument-policy or authorization gate was bypassed, and a privileged operation was queued for a human without passing it.

What makes this a real inconsistency rather than an existing pattern: on the **failure** path, `on_tool_validate_error` returns args and flow falls through, so `after_tool_validate` *does* run. `_ValidationDeferral` was the only exit that skipped it. And before #6897 that path raised a bare exception — fail-closed — so #6897 turned a crash into a hook-skipping path.

### The fix

`_run_validate_hooks` catches `_ValidationDeferral` around `cap.wrap_tool_validate`, holds it, runs `after_tool_validate` with the validated args the deferral carries, and re-raises afterwards. One `after_tool_validate` call site still, and `ValidatedToolCall` is unchanged.

### Semantics

- **A rejection from `after_tool_validate` wins over the deferral.** Because the hook is called before the deferral is re-raised, a `ModelRetry` / `ValidationError` / `ToolFailed` from it propagates normally and the deferral is dropped: policy can refuse before a privileged operation is queued for a human. Pinned by a test asserting the model actually receives the retry prompt (`'policy says no'` lands as a `RetryPromptPart`), i.e. the rejection is routed like any post-validation rejection rather than swallowed.
- **If the hook mutates the args, the deferral carries the hook's output** — that's what a call which wasn't deferred would have proceeded with, so the deferred call is described by the same arguments the gate approved. Note this is internal state (`ValidatedToolCall.validated_args`): the emitted `DeferredToolRequests` holds the model's original `ToolCallPart`, and resuming re-validates from it. The contract is pinned directly on the tool manager for that reason.
- **A hook deferral beats a validator deferral.** Not reachable on `main` today (a bare `ApprovalRequired` from `after_tool_validate` still propagates), but it becomes reachable with #6951, which lets post-validation hooks defer. The shape here gives that for free: the hook is invoked *before* the held deferral is re-raised, so if the hook raises its own deferral it replaces the validator's. The hook runs later and is the policy layer, so its decision should win.

Everything else is unchanged: `args_valid` stays `True`, the retry budget is untouched (the tests use `retries=0`), `on_tool_validate_error` still doesn't fire for deferrals, and the deferral still routes into the run's `DeferredToolRequests` with its metadata.

### Tests

- `TestAfterToolValidateOnDeferral::test_runs_when_args_validator_defers` — the gate sees the validated args and the call is still deferred, with `args_valid=True` on the event.
- `::test_rejection_wins_over_the_deferral` — the gate's `ModelRetry` reaches the model as a retry prompt instead of an approval request.
- `::test_still_runs_after_a_recovered_validation_failure` — regression pin for the failure path, which already ran the gate.
- `::test_deferral_carries_the_hooks_args` — the mutation contract, asserted on `ToolManager` since it has no public observable.
- `test_args_validator_deferral_is_not_a_validate_error` (from #6897) now expects `after_tool_validate` in the hook log — that snapshot flipping is the regression evidence.

### Note for the reviewer

#6951 (validation-hook deferrals) touches this same function and will be rebased on top of this; I'll resolve that conflict rather than leaving it. This PR is deliberately independent so it can land without waiting on #6951's open design question.

Verified: full `uv run pytest` (6444 passed), `pyright` clean on the changed files, `tests/test_capabilities.py` back at 100% coverage.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

