### PR TITLE
Preserve the host's Logfire configuration in the Temporal `LogfirePlugin`

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -414,7 +414,7 @@ async def main():
     )
 ```
 
-By default, the `LogfirePlugin` will instrument Temporal (including metrics) and Pydantic AI and send all data to Logfire. To customize Logfire configuration and instrumentation, you can pass a `logfire_setup` function to the `LogfirePlugin` constructor and return a custom `Logfire` instance (i.e. the result of `logfire.configure()`). To disable sending Temporal metrics to Logfire, you can pass `metrics=False` to the `LogfirePlugin` constructor.
+By default, the `LogfirePlugin` will instrument Temporal (including metrics) and Pydantic AI and send all data to Logfire. If your application already called `logfire.configure()` itself, the plugin keeps that configuration instead of replacing it, so your scrubbing options, exporters, sampling, and console settings are left alone. To customize Logfire configuration and instrumentation, you can pass a `setup_logfire` function to the `LogfirePlugin` constructor and return a custom `Logfire` instance (i.e. the result of `logfire.configure()`). To disable sending Temporal metrics to Logfire, you can pass `metrics=False` to the `LogfirePlugin` constructor.
 
 ## Known Issues
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
@@ -14,7 +14,15 @@ if TYPE_CHECKING:
 def _default_setup_logfire() -> Logfire:
     import logfire
 
-    instance = logfire.configure()
+    instance = logfire.DEFAULT_LOGFIRE_INSTANCE
+    # `logfire.configure()` is a reset, not an additive call: it re-derives every unspecified argument
+    # from the environment and shuts down the existing tracer provider, so calling it unconditionally on
+    # every `Client.connect()` would silently discard the host's own configuration (scrubbing patterns,
+    # console settings, additional span processors, service name, sampling). Only configure if the host
+    # hasn't already. Logfire exposes no public way to ask whether it's been configured; replace this
+    # with a public accessor (e.g. `is_configured()`) if one is added.
+    if not instance.config._initialized:  # pyright: ignore[reportPrivateUsage]
+        instance = logfire.configure()
     instance.instrument_pydantic_ai()
     return instance
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -183,6 +183,7 @@ if sys.version_info >= (3, 14):
 try:
     import logfire
     from logfire import Logfire
+    from logfire._internal.config import LogfireConfig
     from logfire._internal.tracer import _ProxyTracer  # pyright: ignore[reportPrivateUsage]
     from logfire.testing import CaptureLogfire
     from opentelemetry.trace import ProxyTracer
@@ -3269,6 +3270,43 @@ async def test_logfire_plugin(client: Client):
     plugin = LogfirePlugin(lambda: setup_logfire(metrics=False))
     new_client = await Client.connect(client.service_client.config.target_host, plugins=[plugin])
     assert new_client.service_client.config.runtime is None
+
+
+@pytest.mark.parametrize('already_configured', [True, False])
+async def test_logfire_plugin_default_setup(client: Client, monkeypatch: pytest.MonkeyPatch, already_configured: bool):
+    """The default setup only calls `logfire.configure()` when Logfire isn't configured yet.
+
+    `logfire.configure()` is a reset rather than an additive call: it re-derives every unspecified
+    argument from the environment and shuts down the existing tracer provider. Calling it on every
+    `Client.connect()` silently discarded a host's own scrubbing patterns, additional span processors,
+    console settings, and service name. Pydantic AI is instrumented either way.
+
+    `logfire.DEFAULT_LOGFIRE_INSTANCE` is swapped for a stand-in so the assertions don't depend on
+    (or disturb) whatever configuration the rest of the test session has installed globally.
+    """
+    instance = (
+        logfire.configure(local=True, send_to_logfire=False) if already_configured else Logfire(config=LogfireConfig())
+    )
+    assert instance.config._initialized is already_configured  # pyright: ignore[reportPrivateUsage]
+    monkeypatch.setattr(logfire, 'DEFAULT_LOGFIRE_INSTANCE', instance)
+
+    configure_calls: list[dict[str, Any]] = []
+    instrumented: list[Logfire] = []
+
+    def configure(**kwargs: Any) -> Logfire:
+        configure_calls.append(kwargs)
+        return instance
+
+    def instrument_pydantic_ai(self: Logfire, *args: Any, **kwargs: Any) -> None:
+        instrumented.append(self)
+
+    monkeypatch.setattr(logfire, 'configure', configure)
+    monkeypatch.setattr(Logfire, 'instrument_pydantic_ai', instrument_pydantic_ai)
+
+    await Client.connect(client.service_client.config.target_host, plugins=[LogfirePlugin()])
+
+    assert configure_calls == ([] if already_configured else [{}])
+    assert instrumented == [instance]
 
 
 hitl_agent = Agent(


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Closes #6915

`LogfirePlugin`'s default `setup_logfire` called a bare `logfire.configure()`, and `connect_service_client` runs it on every `Client.connect()`. `logfire.configure()` is a reset, not an additive call: it sets `_initialized = False`, re-derives every unspecified argument from the environment and defaults, and calls `shutdown()` on the current tracer provider before installing a fresh one.

So an application that had already configured Logfire lost that configuration the moment a Temporal client connected. Running the real `_default_setup_logfire()` against a host that configured Logfire first:

```
BEFORE: ('host-api', '1.2.3', console=False, ScrubbingOptions(callback=None, extra_patterns=['my_secret']))
AFTER : ('',        '<git sha>', ConsoleOptions(...),  ScrubbingOptions(callback=None, extra_patterns=None))

service_name preserved:    False
service_version preserved: False
console preserved:         False
scrubbing preserved:       False
tracer provider preserved: False
```

The one to weigh most is `scrubbing`: a host that set `ScrubbingOptions(extra_patterns=[...])` for PII silently lost those patterns, so adding a Temporal plugin became a data-handling regression. `additional_span_processors` go the same way — a host exporting to its own OTLP collector just stops. And because the tracer provider is shut down mid-process, a second `Client.connect()` in the same process also tears down the provider the first one installed.

The reporter hit it as workflow threads console-exporting whole span trees, which pushed activations past Temporal's deadlock-detection ceiling: 41+ `TMPRL1101` workflow-task failures in one day, from what is nominally just telemetry setup.

The default now only configures Logfire when it isn't configured yet:

```python
instance = logfire.DEFAULT_LOGFIRE_INSTANCE
if not instance.config._initialized:
    instance = logfire.configure()
instance.instrument_pydantic_ai()
```

Pydantic AI is instrumented either way, so the plugin still does the thing you added it for.

### On the private attribute

There is no public way to ask Logfire whether it has been configured — no `is_configured()` or equivalent on `LogfireConfig` from our declared floor (`logfire>=4.16.0`) through current (4.37.0); I checked the 4.16.0 wheel directly, where `_initialized` is present and used the same way. There's a comment at the call site explaining this and pointing at a public accessor as the replacement if Logfire adds one.

### Behavior change worth calling out

This is the correct direction but it is a visible change, not a pure bug fix. Today, a host that configured Logfire with `send_to_logfire=False` still gets Temporal metrics shipped, because the plugin's own `configure()` re-reads `LOGFIRE_TOKEN` / `LOGFIRE_SEND_TO_LOGFIRE` from the environment and can end up with a token. After this change the plugin honours the host's config, so `send_to_logfire=False` means the metrics block is skipped too. Anyone relying on that (probably accidentally) can restore it by passing their own `setup_logfire` callable.

### Also in here

The docs called the escape-hatch keyword `logfire_setup`, but the actual keyword is `setup_logfire` — copy-pasting the documented snippet raised a `TypeError`. Fixed, and the same paragraph now says that the default leaves an already-configured Logfire alone.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

