### PR TITLE
Resolve the output mode before `customize_request_parameters` transforms JSON schemas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -396,6 +396,13 @@ class Model(ABC, Generic[InterfaceClient]):
         This method can be overridden by subclasses to modify the request parameters before sending them to the model.
         In particular, this method can be used to make modifications to the generated tool JSON schemas if necessary
         for vendor/model-specific reasons.
+
+        Don't change `output_mode` here: `prepare_request` resolves it before calling this method, so that only the
+        schemas the resolved mode actually sends are transformed. A `prepare_request` override that resolves the mode
+        before calling `super().prepare_request()` is the place for that, as
+        [`AnthropicModel`][pydantic_ai.models.anthropic.AnthropicModel],
+        [`BedrockConverseModel`][pydantic_ai.models.bedrock.BedrockConverseModel] and
+        [`GoogleModel`][pydantic_ai.models.google.GoogleModel] do.
         """
         if transformer := self.profile.get('json_schema_transformer'):
             model_request_parameters = replace(
@@ -426,7 +433,11 @@ class Model(ABC, Generic[InterfaceClient]):
         """
         model_settings = merge_model_settings(self.settings, model_settings)
 
-        params = self.customize_request_parameters(model_request_parameters)
+        # Resolve the output mode and drop the losing channel *before* `customize_request_parameters` runs, so a
+        # JSON schema transformer only walks the output schema the resolved mode actually sends, instead of both.
+        params = _resolve_output_mode(model_request_parameters, self.profile)
+
+        params = self.customize_request_parameters(params)
         params = _prepare_return_schemas(params, self.profile)
 
         # Resolve unified thinking setting and strip from model_settings
@@ -447,15 +458,9 @@ class Model(ABC, Generic[InterfaceClient]):
                 native_tools=list({tool.unique_id: tool for tool in native_tools}.values()),
             )
 
-        params = params.with_default_output_mode(self.profile.get('default_structured_output_mode', 'tool'))
-
-        # Reset irrelevant fields
-        if params.output_tools and params.output_mode != 'tool':
-            params = replace(params, output_tools=[])
-        if params.output_object and params.output_mode not in ('native', 'prompted'):
-            params = replace(params, output_object=None)
-        if params.prompted_output_template and params.output_mode not in ('prompted', 'native'):
-            params = replace(params, prompted_output_template=None)  # pragma: no cover
+        # Normally a no-op, as the mode was already resolved above, but a `customize_request_parameters` override
+        # that changes it anyway shouldn't be able to leave the parameters internally inconsistent.
+        params = _resolve_output_mode(params, self.profile)
 
         # Set default prompted output template
         if (
@@ -1608,6 +1613,25 @@ def _resolve_tool_search_native_for_capability_owned_corpus(
             t = replace(t, strategy='custom')
         resolved_natives.append(t)
     return _ToolSearchNativeResolution(resolved_natives, keep_search_tools_local=keep_search_tools_local)
+
+
+def _resolve_output_mode(params: ModelRequestParameters, profile: ModelProfile) -> ModelRequestParameters:
+    """Resolve an `'auto'` output mode to the profile default and drop the fields the resolved mode doesn't use.
+
+    The output schema is built into both `output_tools` and `output_object` while the mode is still `'auto'`, so
+    exactly one of them is dead weight once the mode is known. Idempotent, so `Model.prepare_request` can run this
+    both before and after `customize_request_parameters`.
+    """
+    params = params.with_default_output_mode(profile.get('default_structured_output_mode', 'tool'))
+
+    if params.output_tools and params.output_mode != 'tool':
+        params = replace(params, output_tools=[])
+    if params.output_object and params.output_mode not in ('native', 'prompted'):
+        params = replace(params, output_object=None)
+    if params.prompted_output_template and params.output_mode not in ('prompted', 'native'):
+        params = replace(params, prompted_output_template=None)  # pragma: no cover
+
+    return params
 
 
 def _prepare_return_schemas(params: ModelRequestParameters, profile: ModelProfile) -> ModelRequestParameters:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,11 +1,16 @@
 import os
 import warnings
+from collections.abc import Callable
+from dataclasses import replace
 from importlib import import_module
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
-from pydantic_ai import UserError
+from pydantic_ai import Agent, UserError
+from pydantic_ai._json_schema import JsonSchemaTransformer
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.messages import (
     ModelMessage,
@@ -13,10 +18,21 @@ from pydantic_ai.messages import (
     ModelResponse,
     SystemPromptPart,
     TextPart,
+    ToolCallPart,
     UserPromptPart,
 )
-from pydantic_ai.models import DEFAULT_PROFILE, Model, infer_model, infer_model_profile, parse_model_id
+from pydantic_ai.models import (
+    DEFAULT_PROFILE,
+    Model,
+    ModelRequestParameters,
+    ToolDefinition,
+    infer_model,
+    infer_model_profile,
+    parse_model_id,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.output import OutputObjectDefinition, StructuredOutputMode
 from pydantic_ai.profiles import ModelProfile
 
 from ..conftest import try_import
@@ -487,3 +503,128 @@ def test_prepare_messages_system_prompt_wrapping(
 ):
     model = TestModel(profile=ModelProfile(supports_inline_system_prompts=supports_inline))
     assert _request_parts(model.prepare_messages(messages)) == expected
+
+
+class _Answer(BaseModel):
+    answer: str
+
+
+def _double(x: int) -> int:
+    return x * 2
+
+
+def _schema_recording_transformer(walked: list[list[str]]) -> type[JsonSchemaTransformer]:
+    """Build a transformer that records the property names of every schema it walks."""
+
+    class _RecordingTransformer(JsonSchemaTransformer):
+        def walk(self) -> dict[str, Any]:
+            walked.append(sorted(self.schema.get('properties', {})))
+            return super().walk()
+
+        def transform(self, schema: dict[str, Any]) -> dict[str, Any]:
+            return schema
+
+    return _RecordingTransformer
+
+
+@pytest.mark.parametrize('default_structured_output_mode', ['tool', 'native', 'prompted'])
+def test_prepare_request_transforms_only_the_output_channel_the_resolved_mode_uses(
+    default_structured_output_mode: StructuredOutputMode,
+):
+    """The output schema is walked once per request, for the channel the resolved output mode actually sends.
+
+    The agent graph populates both `output_tools` and `output_object` while `output_mode` is still `'auto'`, and
+    `prepare_request` drops whichever one the resolved mode doesn't use. Resolving the mode *before*
+    `customize_request_parameters` means the JSON schema transformer never walks the schema about to be discarded.
+
+    A unit test because the saved work is invisible on the wire: the discarded channel never reached the provider
+    under either ordering, so no cassette can tell them apart.
+    """
+    walked: list[list[str]] = []
+    prepared: list[ModelRequestParameters] = []
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        prepared.append(info.model_request_parameters)
+        if len(prepared) == 1:
+            return ModelResponse(parts=[ToolCallPart('_double', {'x': 21})])
+        if info.output_tools:
+            return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, {'answer': 'ok'})])
+        return ModelResponse(parts=[TextPart('{"answer": "ok"}')])
+
+    model = FunctionModel(
+        respond,
+        profile=ModelProfile(
+            json_schema_transformer=_schema_recording_transformer(walked),
+            default_structured_output_mode=default_structured_output_mode,
+            supports_json_schema_output=True,
+        ),
+    )
+    result = Agent(model, output_type=_Answer, tools=[_double]).run_sync('hello')
+    assert result.output == _Answer(answer='ok')
+
+    # Per request: the function tool and exactly one output channel — never the output tool *and* the output object.
+    assert walked == [['x'], ['answer'], ['x'], ['answer']]
+
+    params = prepared[0]
+    assert params.output_mode == default_structured_output_mode
+    assert [t.name for t in params.output_tools] == (
+        ['final_result'] if default_structured_output_mode == 'tool' else []
+    )
+    assert (params.output_object is not None) is (default_structured_output_mode != 'tool')
+
+
+def _empty_output_object() -> OutputObjectDefinition:
+    return OutputObjectDefinition(json_schema={'type': 'object', 'properties': {}})
+
+
+def _switch_to_prompted(params: ModelRequestParameters) -> ModelRequestParameters:
+    return replace(params, output_mode='prompted', allow_text_output=True, output_object=_empty_output_object())
+
+
+def _reset_to_auto(params: ModelRequestParameters) -> ModelRequestParameters:
+    return replace(params, output_mode='auto', allow_text_output=True)
+
+
+@pytest.mark.parametrize(
+    'customize,expected_mode,expected_allow_text',
+    [
+        pytest.param(_switch_to_prompted, 'prompted', True, id='switches-to-prompted'),
+        pytest.param(_reset_to_auto, 'tool', False, id='resets-to-auto'),
+    ],
+)
+def test_prepare_request_re_resolves_output_mode_changed_by_customize_request_parameters(
+    customize: Callable[[ModelRequestParameters], ModelRequestParameters],
+    expected_mode: StructuredOutputMode,
+    expected_allow_text: bool,
+):
+    """A `customize_request_parameters` override that changes the output mode still gets consistent parameters.
+
+    `prepare_request` resolves the output mode before calling `customize_request_parameters`, but deliberately
+    resolves again afterwards. That second pass is normally a no-op, and it's what keeps an override that changes
+    the mode anyway from leaving `output_mode`, `allow_text_output` and the output channels describing a mode that
+    is no longer in effect.
+
+    A unit test because no in-repo model changes the output mode there — this pins the guarantee for the
+    third-party overrides that make it possible.
+    """
+
+    class _ModeChangingModel(TestModel):
+        def customize_request_parameters(
+            self, model_request_parameters: ModelRequestParameters
+        ) -> ModelRequestParameters:
+            return customize(model_request_parameters)
+
+    model = _ModeChangingModel(profile=ModelProfile(default_structured_output_mode='tool'))
+    _, params = model.prepare_request(
+        None,
+        ModelRequestParameters(
+            output_mode='auto',
+            output_tools=[ToolDefinition(name='final_result')],
+            output_object=_empty_output_object(),
+        ),
+    )
+
+    assert params.output_mode == expected_mode
+    assert params.allow_text_output is expected_allow_text
+    assert params.output_tools == ([ToolDefinition(name='final_result')] if expected_mode == 'tool' else [])
+    assert (params.output_object is not None) is (expected_mode != 'tool')


### PR DESCRIPTION
Part of #6920 — the smallest of the four levers identified in [the investigation comment](https://github.com/pydantic/pydantic-ai/issues/6920#issuecomment-5136186866). The other three (intra-walk memoization, cross-request memoization, and the `Instrumentation` double-prepare) are deliberately left open.

### The problem

`Model.prepare_request` called `customize_request_parameters()` — which walks every tool and output JSON schema through the profile's `JsonSchemaTransformer` — and only *then* resolved an `'auto'` output mode and dropped whichever of `output_tools` / `output_object` the resolved mode doesn't use.

The agent graph always populates *both* channels while `output_mode` is still `'auto'`, so exactly one of the two output schemas was transformed and immediately thrown away, on every single request.

### The fix

```
prepare_request:
    merge settings
    resolve output mode + drop the losing channel   # hoisted above
    customize_request_parameters()                  # transforms only what will be sent
    ...
    resolve output mode + drop the losing channel   # KEPT — now normally a no-op
```

### Why the late resolve/reset block is deliberately retained

Both `prepare_request` and `customize_request_parameters` are public and overridable. Nothing in this repo changes the output mode inside `customize_request_parameters` — `AnthropicModel`, `BedrockConverseModel` and `GoogleModel` all resolve it in their own `prepare_request` override *before* calling `super()`, and `CerebrasModel`/`ZaiModel`/`OpenRouterModel` call `super()` first and return its parameters unmodified — but a third-party model may.

Keeping the second pass means such an override still can't produce parameters where `output_mode`, `allow_text_output` and the surviving output channel disagree. The cost is two idempotent dataclass `replace`s per request; the resolve/reset logic is now a single `_resolve_output_mode` helper called from both places.

`customize_request_parameters`' docstring now says not to change `output_mode` there, and points at the `prepare_request`-override pattern the three in-repo models use.

### Measured

Counting `JsonSchemaTransformer.walk()` calls for a request with one function tool and a structured output type:

| | before | after |
|---|---|---|
| per `prepare_request` (`tool`, `native` or `prompted` profile default) | 3 walks / 9 `transform` calls | **2 walks / 6 `transform` calls** |
| per model request under `Instrumentation()`, which prepares twice (Finding 1 in #6920, not addressed here) | 6 walks | **4 walks** |

### Tests

- `test_prepare_request_transforms_only_the_output_channel_the_resolved_mode_uses` — a recording `JsonSchemaTransformer` proves that a profile-defaulted `native`/`prompted` mode never walks the output tool's schema, and a `tool` mode never walks the output object's. Fails on `main` for all three modes.
- `test_prepare_request_re_resolves_output_mode_changed_by_customize_request_parameters` — a model whose `customize_request_parameters` *does* change the output mode (switching to `prompted`, and resetting to `'auto'`) still ends up with consistent parameters. Both cases fail if the retained late block is deleted, so the safety property is genuinely covered.
- The existing #6521 / #6539 regression tests (Anthropic and Bedrock with `profile={'default_structured_output_mode': 'native'}`) still pass; those hoists run before `super()` entirely and `with_default_output_mode` is idempotent.

- Part of #6920

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

