### PR TITLE
Heartbeat in tool, MCP, dynamic-toolset, and event-stream Temporal activities

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -247,7 +247,7 @@ Some providers can pause a model turn mid-flight (Anthropic `pause_turn`) or run
 
 This has a few operational implications:
 
-- **Timeouts and heartbeats**: size `start_to_close_timeout` and `heartbeat_timeout` for one provider round trip. Activities heartbeat automatically, with a default `heartbeat_timeout` of 30 seconds.
+- **Timeouts and heartbeats**: size `start_to_close_timeout` and `heartbeat_timeout` for one provider round trip. Model request activities are given a default `heartbeat_timeout` of 30 seconds; see [Activity Configuration](#activity-configuration) for how heartbeating works across the other activities.
 - **Retries and waits**: a failed segment retries independently. Delays between background polls use durable Temporal timers and do not consume activity wall-clock time.
 - **Cancellation**: if an error abandons a suspended job, its provider teardown runs in a dedicated cancellation activity.
 - **Payload size**: whenever [streaming](#streaming) is used — an `event_stream_handler`, a `ProcessEventStream` capability, or a per-run `event_stream_handler` — each segment's buffered events are shipped back to the workflow and must fit within Temporal's 2MB payload limit.
@@ -338,6 +338,11 @@ Temporal activity configuration, like timeouts and retry policies, can be custom
 - `toolset_activity_config`: The Temporal activity config to use for get-tools and call-tool activities for specific toolsets identified by ID. This is merged with the base activity config.
 
 Per-tool activity config lives on the tool itself — see [Per-tool activity config](#per-tool-activity-config) below.
+
+Every activity Pydantic AI registers heartbeats in the background while it runs, so that a long-but-healthy activity isn't mistaken for a crashed worker and so [workflow cancellation](#streaming) can be delivered to it. Only model request activities get a `heartbeat_timeout` by default, of 30 seconds; setting one on any other activity is up to you.
+
+!!! warning "Don't set a `heartbeat_timeout` on activities that can block the event loop"
+    Heartbeats are emitted from a background task, so an activity that occupies the event loop without yielding — a CPU-bound tool function, say — stops beating and has its attempt failed once the timeout elapses. Such an activity is better served by `start_to_close_timeout` alone.
 
 ### Per-tool activity config
 

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -339,7 +339,7 @@ Temporal activity configuration, like timeouts and retry policies, can be custom
 
 Per-tool activity config lives on the tool itself — see [Per-tool activity config](#per-tool-activity-config) below.
 
-Every activity Pydantic AI registers heartbeats in the background while it runs, so that a long-but-healthy activity isn't mistaken for a crashed worker and so [workflow cancellation](#streaming) can be delivered to it. Only model request activities get a `heartbeat_timeout` by default, of 30 seconds; setting one on any other activity is up to you.
+Every activity Pydantic AI registers heartbeats in the background while it runs, so that a long-but-healthy activity isn't mistaken for a crashed worker and so that cancelling the Temporal workflow can be delivered to it — see [Streaming](#streaming) for how that stops an in-flight model request. Only model request activities get a `heartbeat_timeout` by default, of 30 seconds; setting one on any other activity is up to you.
 
 !!! warning "Don't set a `heartbeat_timeout` on activities that can block the event loop"
     Heartbeats are emitted from a background task, so an activity that occupies the event loop without yielding — a CPU-bound tool function, say — stops beating and has its attempt failed once the timeout elapses. Such an activity is better served by `start_to_close_timeout` alone.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import asyncio
-from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
-from contextlib import asynccontextmanager, nullcontext, suppress
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, ClassVar, TypeAlias, cast
@@ -49,6 +48,7 @@ from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
     TemporalWrapperToolset,
+    heartbeating,
     temporalize_toolset as _default_temporalize_toolset,
     toolset_temporal_activities,
     with_non_retryable_errors,
@@ -92,50 +92,11 @@ _DEFAULT_MODEL_HEARTBEAT_TIMEOUT = timedelta(seconds=30)
 """Default `heartbeat_timeout` for the model-request activities.
 
 A model request activity can legitimately run for a long time while waiting for one
-provider round trip. Heartbeating lets Temporal distinguish that long-but-healthy
-activity from a crashed worker, and makes workflow cancellation deliverable
-mid-request (cancellation reaches an activity as a response to a heartbeat).
+provider round trip, and heartbeating (see `heartbeating`) lets Temporal distinguish that
+long-but-healthy activity from a crashed worker. Tool activities deliberately get no default:
+a CPU-bound tool can starve the heartbeat task, and failing it for a missed heartbeat would
+be a regression against no timeout at all.
 """
-
-
-@asynccontextmanager
-async def _heartbeating() -> AsyncGenerator[None]:
-    """Emit periodic activity heartbeats in the background while the wrapped request runs.
-
-    The beat interval is derived from the activity's configured `heartbeat_timeout` so a
-    custom (shorter or longer) timeout keeps working; the SDK additionally throttles
-    outgoing heartbeats on its own. Without a configured timeout, heartbeats are inert but
-    harmless, so a plain 5-second cadence is fine.
-
-    The heartbeat task is supervised: if `beat()` itself crashes, the failure surfaces
-    once the wrapped request completes, so the activity fails loudly instead of having
-    silently run without heartbeats (the server would have failed the attempt via
-    `heartbeat_timeout` anyway had the crash come early). An exception from the wrapped
-    request always wins — a heartbeat failure never replaces it.
-    """
-
-    async def beat() -> None:
-        timeout = activity.info().heartbeat_timeout
-        interval = timeout.total_seconds() / 2 if timeout else 5.0
-        while True:
-            activity.heartbeat()
-            await asyncio.sleep(interval)
-
-    task = asyncio.create_task(beat())
-    try:
-        yield
-    except BaseException:
-        # The request's exception is already propagating; a heartbeat failure must not
-        # replace it.
-        task.cancel()
-        with suppress(BaseException):
-            await task
-        raise
-    else:
-        task.cancel()
-        with suppress(asyncio.CancelledError):
-            # Anything but our own cancellation is a `beat()` crash — propagate it.
-            await task
 
 
 @dataclass(init=False)
@@ -251,8 +212,9 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         )
         activity_config['retry_policy'] = with_non_retryable_errors(activity_config.get('retry_policy'))
         self.activity_config = activity_config
-        # The model activities heartbeat in the background (see `_heartbeating`), so give them a
-        # heartbeat timeout by default; an explicit `heartbeat_timeout` in either config wins.
+        # All activities heartbeat in the background (see `heartbeating`), but only the model
+        # ones get a heartbeat timeout by default; an explicit `heartbeat_timeout` in either
+        # config wins.
         self._model_activity_config: ActivityConfig = {
             'heartbeat_timeout': _DEFAULT_MODEL_HEARTBEAT_TIMEOUT,
             **activity_config,
@@ -314,7 +276,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                 run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
             )
             model_for_request = await self._resolve_model_for_request(params.model_id, run_context)
-            async with _heartbeating():
+            async with heartbeating():
                 with set_current_run_context(run_context):
                     return await model_for_request.request(
                         params.messages,
@@ -330,7 +292,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                 run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
             )
             model_for_request = await self._resolve_model_for_request(params.model_id, run_context)
-            async with _heartbeating():
+            async with heartbeating():
                 with set_current_run_context(run_context):
                     async with model_for_request.request_stream(
                         params.messages,
@@ -354,10 +316,11 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             handler = self._event_stream_handler
 
             async def event_stream_handler_activity(params: _EventStreamHandlerParams, deps: Any) -> None:
-                run_context = deserialize_run_context(
-                    run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
-                )
-                await handler(run_context, self._single_event_stream(params.event))
+                async with heartbeating():
+                    run_context = deserialize_run_context(
+                        run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
+                    )
+                    await handler(run_context, self._single_event_stream(params.event))
 
             self.event_stream_handler_activity = register_activity(
                 event_stream_handler_activity, name=f'{activity_name_prefix}__event_stream_handler'
@@ -378,7 +341,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                 model = await self._resolve_model_for_request(params.model_id, run_context)
             # The cancel activity shares `_model_activity_config`, whose default `heartbeat_timeout`
             # would otherwise fail a slow provider-teardown call for missed heartbeats.
-            async with _heartbeating():
+            async with heartbeating():
                 with nullcontext() if run_context is None else set_current_run_context(run_context):
                     await model.cancel_suspended_response(params.response)
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
@@ -26,6 +26,7 @@ from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
     CallToolParams,
     GetToolsParams,
+    heartbeating,
     resolve_tool_activity_config,
 )
 
@@ -50,8 +51,9 @@ def temporalize_dynamic_toolset(
     """
 
     async def get_tools_activity(params: GetToolsParams, deps: AgentDepsT) -> DynamicToolsResult:
-        ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-        return await get_dynamic_tools(toolset, ctx)
+        async with heartbeating():
+            ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
+            return await get_dynamic_tools(toolset, ctx)
 
     get_tools_activity.__annotations__['deps'] = deps_type
     registered_get_tools = activity.defn(name=f'{activity_name_prefix}__dynamic_toolset__{toolset.id}__get_tools')(
@@ -59,8 +61,9 @@ def temporalize_dynamic_toolset(
     )
 
     async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
-        ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-        return await wrap_tool_call_result(call_dynamic_tool(toolset, params.name, params.tool_args, ctx))
+        async with heartbeating():
+            ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
+            return await wrap_tool_call_result(call_dynamic_tool(toolset, params.name, params.tool_args, ctx))
 
     call_tool_activity.__annotations__['deps'] = deps_type
     registered_call_tool = activity.defn(name=f'{activity_name_prefix}__dynamic_toolset__{toolset.id}__call_tool')(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
@@ -19,7 +19,7 @@ from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
-from ._toolset import CallToolParams, call_tool_in_activity, resolve_tool_activity_config
+from ._toolset import CallToolParams, call_tool_in_activity, heartbeating, resolve_tool_activity_config
 
 if TYPE_CHECKING:
     from pydantic_ai.agent.abstract import AbstractAgent
@@ -36,22 +36,23 @@ def temporalize_function_toolset(
     agent: AbstractAgent[AgentDepsT, Any] | None = None,
 ) -> DurableFunctionToolset[AgentDepsT]:
     async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
-        ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-        try:
-            if params.tool_def is not None:
-                # Rebuild the tool from the definition the workflow prepared, so a tool's `prepare`
-                # function isn't run a second time here against the activity's limited run context.
-                tool = toolset.tool_for_tool_def(params.tool_def, params.original_name)
-            else:
-                # Only reachable for an activity scheduled by a worker predating `tool_def` on these
-                # params; re-prepare so in-flight executions still complete across the upgrade.
-                tool = (await toolset.get_tools(ctx))[params.name]
-        except KeyError as exc:
-            raise UserError(
-                f'Tool {params.name!r} not found in toolset {toolset.id!r}. '
-                'Removing or renaming tools during an agent run is not supported with Temporal.'
-            ) from exc
-        return await call_tool_in_activity(toolset, params.name, params.tool_args, ctx, tool)
+        async with heartbeating():
+            ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
+            try:
+                if params.tool_def is not None:
+                    # Rebuild the tool from the definition the workflow prepared, so a tool's `prepare`
+                    # function isn't run a second time here against the activity's limited run context.
+                    tool = toolset.tool_for_tool_def(params.tool_def, params.original_name)
+                else:
+                    # Only reachable for an activity scheduled by a worker predating `tool_def` on these
+                    # params; re-prepare so in-flight executions still complete across the upgrade.
+                    tool = (await toolset.get_tools(ctx))[params.name]
+            except KeyError as exc:
+                raise UserError(
+                    f'Tool {params.name!r} not found in toolset {toolset.id!r}. '
+                    'Removing or renaming tools during an agent run is not supported with Temporal.'
+                ) from exc
+            return await call_tool_in_activity(toolset, params.name, params.tool_args, ctx, tool)
 
     call_tool_activity.__annotations__['deps'] = deps_type
     registered_activity = activity.defn(name=f'{activity_name_prefix}__toolset__{toolset.id}__call_tool')(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
@@ -21,7 +21,7 @@ from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
 from ._activity_execution import execute_activity
 from ._run_context import TemporalRunContext, deserialize_run_context
-from ._toolset import CallToolParams, GetToolsParams, resolve_tool_activity_config
+from ._toolset import CallToolParams, GetToolsParams, heartbeating, resolve_tool_activity_config
 
 if TYPE_CHECKING:
     from pydantic_ai.agent.abstract import AbstractAgent
@@ -45,22 +45,25 @@ def temporalize_mcp_toolset(
             )
 
     async def get_tools_activity(params: GetToolsParams, deps: AgentDepsT) -> dict[str, ToolDefinition]:
-        ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-        return {name: tool.tool_def for name, tool in (await toolset.get_tools(ctx)).items()}
+        async with heartbeating():
+            ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
+            return {name: tool.tool_def for name, tool in (await toolset.get_tools(ctx)).items()}
 
     async def get_instructions_activity(
         params: GetToolsParams, deps: AgentDepsT
     ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
-        ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-        async with toolset:
-            return await toolset.get_instructions(ctx)
+        async with heartbeating():
+            ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
+            async with toolset:
+                return await toolset.get_instructions(ctx)
 
     async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
-        ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-        assert isinstance(params.tool_def, ToolDefinition)
-        return await wrap_tool_call_result(
-            toolset.call_tool(params.name, params.tool_args, ctx, toolset.tool_for_tool_def(params.tool_def))
-        )
+        async with heartbeating():
+            ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
+            assert isinstance(params.tool_def, ToolDefinition)
+            return await wrap_tool_call_result(
+                toolset.call_tool(params.name, params.tool_args, ctx, toolset.tool_for_tool_def(params.tool_def))
+            )
 
     for activity_func in (get_tools_activity, get_instructions_activity, call_tool_activity):
         activity_func.__annotations__['deps'] = deps_type

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import ConfigDict, with_config
 from pydantic.errors import PydanticUserError
-from temporalio import workflow
+from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityConfig
 from typing_extensions import Self
@@ -46,6 +48,49 @@ class CallToolParams:
     tool_def: ToolDefinition | None
     original_name: str | None = None
     """The name the toolset holds the tool under, when a `prepare` function renamed it in `tool_def.name`."""
+
+
+@asynccontextmanager
+async def heartbeating() -> AsyncGenerator[None]:
+    """Emit periodic activity heartbeats in the background while the wrapped activity body runs.
+
+    Every activity we register beats, so that a long-but-healthy activity isn't mistaken for a
+    crashed worker, and so workflow cancellation stays deliverable (cancellation reaches an
+    activity as a response to a heartbeat).
+
+    The beat interval is derived from the activity's configured `heartbeat_timeout` so a
+    custom (shorter or longer) timeout keeps working; the SDK additionally throttles
+    outgoing heartbeats on its own. Without a configured timeout, heartbeats are inert but
+    harmless, so a plain 5-second cadence is fine.
+
+    The heartbeat task is supervised: if `beat()` itself crashes, the failure surfaces
+    once the wrapped body completes, so the activity fails loudly instead of having
+    silently run without heartbeats (the server would have failed the attempt via
+    `heartbeat_timeout` anyway had the crash come early). An exception from the wrapped
+    body always wins — a heartbeat failure never replaces it.
+    """
+
+    async def beat() -> None:
+        timeout = activity.info().heartbeat_timeout
+        interval = timeout.total_seconds() / 2 if timeout else 5.0
+        while True:
+            activity.heartbeat()
+            await asyncio.sleep(interval)
+
+    task = asyncio.create_task(beat())
+    try:
+        yield
+    except BaseException:
+        # The body's exception is already propagating; a heartbeat failure must not replace it.
+        task.cancel()
+        with suppress(BaseException):
+            await task
+        raise
+    else:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            # Anything but our own cancellation is a `beat()` crash — propagate it.
+            await task
 
 
 class TemporalWrapperToolset(WrapperToolset[AgentDepsT], ABC):

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -127,7 +127,7 @@ try:
     from temporalio.contrib.pydantic import PydanticPayloadConverter, pydantic_data_converter
     from temporalio.converter import DataConverter, DefaultPayloadConverter, PayloadCodec
     from temporalio.exceptions import ApplicationError, CancelledError as TemporalCancelledError
-    from temporalio.testing import WorkflowEnvironment
+    from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
     from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
     from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
     from temporalio.workflow import ActivityCancellationType, ActivityConfig
@@ -151,7 +151,8 @@ try:
     )
     from pydantic_ai.durable_exec.temporal._durability import (
         _CancelParams,  # pyright: ignore[reportPrivateUsage]
-        _heartbeating,  # pyright: ignore[reportPrivateUsage]
+        _EventStreamHandlerParams,  # pyright: ignore[reportPrivateUsage]
+        _RequestParams,  # pyright: ignore[reportPrivateUsage]
         _StreamedActivityPayload,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.durable_exec.temporal._dynamic_toolset import temporalize_dynamic_toolset
@@ -164,7 +165,9 @@ try:
     from pydantic_ai.durable_exec.temporal._run_context import TemporalRunContext
     from pydantic_ai.durable_exec.temporal._toolset import (
         CallToolParams,
+        GetToolsParams,
         TemporalWrapperToolset,
+        heartbeating,
         resolve_tool_activity_config,
         toolset_temporal_activities,
     )
@@ -9229,7 +9232,7 @@ async def test_durability_streaming_continuation_resume_from_history(client: Cli
 
 
 # --- Heartbeat supervision ---
-# Unit tests on the private `_heartbeating` helper: a `beat()` crash requires simulating an
+# Unit tests on the internal `heartbeating` helper: a `beat()` crash requires simulating an
 # SDK failure that no workflow-level test can trigger, and the exception-precedence contract
 # (request error wins; beat crash surfaces after a successful request) is exactly the kind of
 # internal invariant a VCR/workflow test would silently miss.
@@ -9241,7 +9244,7 @@ async def test_heartbeating_beats_and_stops(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr('temporalio.activity.info', lambda: SimpleNamespace(heartbeat_timeout=timedelta(seconds=0.02)))
     monkeypatch.setattr('temporalio.activity.heartbeat', lambda: beats.append(None))
 
-    async with _heartbeating():
+    async with heartbeating():
         await asyncio.sleep(0.05)
 
     assert beats  # at least the immediate first beat, then every ~10ms
@@ -9260,7 +9263,7 @@ async def test_heartbeating_beat_crash_surfaces_after_body(monkeypatch: pytest.M
     monkeypatch.setattr('temporalio.activity.heartbeat', broken_heartbeat)
 
     with pytest.raises(RuntimeError, match='heartbeat exploded'):
-        async with _heartbeating():
+        async with heartbeating():
             await asyncio.sleep(0.01)
 
 
@@ -9274,9 +9277,270 @@ async def test_heartbeating_body_error_wins_over_beat_crash(monkeypatch: pytest.
     monkeypatch.setattr('temporalio.activity.heartbeat', broken_heartbeat)
 
     with pytest.raises(ValueError, match='request failed'):
-        async with _heartbeating():
+        async with heartbeating():
             await asyncio.sleep(0.01)
             raise ValueError('request failed')
+
+
+# --- Every registered activity heartbeats ---
+
+
+async def heartbeat_probe_tool() -> str:
+    """A tool that yields to the event loop, giving the heartbeat task a chance to run."""
+    await asyncio.sleep(0.01)
+    return 'probe tool ran'
+
+
+async def heartbeat_probe_agent_tool() -> str:
+    """The same, for the agent's own implicit toolset, which registers its own activity."""
+    await asyncio.sleep(0.01)
+    return 'probe agent tool ran'
+
+
+_heartbeat_function_toolset = FunctionToolset[None](tools=[heartbeat_probe_tool], id='hb_tools')
+_heartbeat_mcp_toolset = MCPToolset(
+    StdioTransport(command='python', args=['-m', 'tests.mcp_server']),
+    id='hb_mcp',
+    init_timeout=20,
+    # Without this, the test's own `get_tools()` warms the cache and the `get_tools` activity
+    # returns without ever awaiting the server, leaving no window for a heartbeat to be observed.
+    cache_tools=False,
+)
+
+
+async def _heartbeat_dynamic_toolset(ctx: RunContext[None]) -> AbstractToolset[None]:
+    await asyncio.sleep(0.01)
+    return FunctionToolset[None](tools=[heartbeat_probe_tool], id='hb_dynamic_inner')
+
+
+async def _heartbeat_event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+    async for _ in stream:
+        await asyncio.sleep(0.01)
+
+
+async def _heartbeat_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    await asyncio.sleep(0.01)
+    return ModelResponse(parts=[TextPart('probe model response')])
+
+
+async def _heartbeat_stream_model_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+    await asyncio.sleep(0.01)
+    yield 'probe model response'
+
+
+class _HeartbeatProbeModel(FunctionModel):
+    async def cancel_suspended_response(self, response: ModelResponse) -> None:
+        await asyncio.sleep(0.01)
+
+
+_heartbeat_agent = Agent(
+    _HeartbeatProbeModel(_heartbeat_model_fn, stream_function=_heartbeat_stream_model_fn),
+    name='heartbeat_probe_agent',
+    deps_type=type(None),
+    tools=[heartbeat_probe_agent_tool],
+    toolsets=[
+        _heartbeat_function_toolset,
+        _heartbeat_mcp_toolset,
+        DynamicToolset(_heartbeat_dynamic_toolset, id='hb_dynamic'),
+    ],
+    capabilities=[TemporalDurability(event_stream_handler=_heartbeat_event_stream_handler)],
+)
+
+
+async def _heartbeats_during_activity(activity_fn: Callable[..., Any], args: Sequence[Any]) -> list[tuple[Any, ...]]:
+    """Run an activity body inside an activity context, recording the heartbeats it emits."""
+    beats: list[tuple[Any, ...]] = []
+    env = ActivityEnvironment()
+    env.info = replace(env.info, heartbeat_timeout=timedelta(seconds=0.02))
+    env.on_heartbeat = lambda *details: beats.append(details)
+    await env.run(activity_fn, *args)
+    return beats
+
+
+async def test_every_registered_activity_heartbeats(allow_model_requests: None):
+    """Every activity Pydantic AI registers beats while it runs, not just the model ones (#6914).
+
+    Heartbeats have no observable effect unless a `heartbeat_timeout` is configured and the
+    activity outlives it, so a workflow-level test can only cover one activity kind at a time,
+    and only slowly (see the test below for the user-visible consequence). Running each
+    registered body in an `ActivityEnvironment` pins the property for all of them at once, and
+    the exhaustiveness assertion means a newly registered activity has to be listed here — and
+    so wrapped in `heartbeating()` — deliberately.
+    """
+    durability = TemporalDurability.from_agent(_heartbeat_agent)
+    assert durability is not None
+
+    ctx = RunContext[None](deps=None, model=TestModel(), usage=RunUsage(), run_id='hb-run')
+    serialized_run_context = TemporalRunContext.serialize_run_context(ctx)
+    request_params = _RequestParams(
+        messages=[ModelRequest(parts=[UserPromptPart('hello')])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+        serialized_run_context=serialized_run_context,
+    )
+    get_tools_params = GetToolsParams(serialized_run_context=serialized_run_context)
+
+    async with _heartbeat_mcp_toolset:
+        agent_toolset = durability._toolsets_by_id['<agent>']  # pyright: ignore[reportPrivateUsage]
+        agent_tool_def = (await agent_toolset.get_tools(ctx))['heartbeat_probe_agent_tool'].tool_def
+        function_tool_def = (await _heartbeat_function_toolset.get_tools(ctx))['heartbeat_probe_tool'].tool_def
+        mcp_tool_def = (await _heartbeat_mcp_toolset.get_tools(ctx))['get_none'].tool_def
+
+        prefix = 'agent__heartbeat_probe_agent'
+        args_by_activity_name: dict[str, list[Any]] = {
+            f'{prefix}__toolset__<agent>__call_tool': [
+                CallToolParams(
+                    name='heartbeat_probe_agent_tool',
+                    tool_args={},
+                    serialized_run_context=serialized_run_context,
+                    tool_def=agent_tool_def,
+                ),
+                None,
+            ],
+            f'{prefix}__model_request': [request_params, None],
+            f'{prefix}__model_request_stream': [request_params, None],
+            f'{prefix}__model_cancel_suspended_response': [
+                _CancelParams(
+                    response=ModelResponse(parts=[TextPart('suspended')]),
+                    serialized_run_context=serialized_run_context,
+                ),
+                None,
+            ],
+            f'{prefix}__event_stream_handler': [
+                _EventStreamHandlerParams(
+                    event=PartStartEvent(index=0, part=TextPart('probe')),
+                    serialized_run_context=serialized_run_context,
+                ),
+                None,
+            ],
+            f'{prefix}__toolset__hb_tools__call_tool': [
+                CallToolParams(
+                    name='heartbeat_probe_tool',
+                    tool_args={},
+                    serialized_run_context=serialized_run_context,
+                    tool_def=function_tool_def,
+                ),
+                None,
+            ],
+            f'{prefix}__mcp_server__hb_mcp__get_tools': [get_tools_params, None],
+            f'{prefix}__mcp_server__hb_mcp__get_instructions': [get_tools_params, None],
+            f'{prefix}__mcp_server__hb_mcp__call_tool': [
+                CallToolParams(
+                    name='get_none',
+                    tool_args={},
+                    serialized_run_context=serialized_run_context,
+                    tool_def=mcp_tool_def,
+                ),
+                None,
+            ],
+            f'{prefix}__dynamic_toolset__hb_dynamic__get_tools': [get_tools_params, None],
+            f'{prefix}__dynamic_toolset__hb_dynamic__call_tool': [
+                CallToolParams(
+                    name='heartbeat_probe_tool',
+                    tool_args={},
+                    serialized_run_context=serialized_run_context,
+                    tool_def=function_tool_def,
+                ),
+                None,
+            ],
+        }
+
+        activities_by_name: dict[str, Callable[..., Any]] = {}
+        for activity_fn in durability.temporal_activities:
+            activity_name = ActivityDefinition.must_from_callable(activity_fn).name  # pyright: ignore[reportUnknownMemberType]
+            assert activity_name is not None
+            activities_by_name[activity_name] = activity_fn
+        assert activities_by_name.keys() == args_by_activity_name.keys()
+
+        for name, activity_fn in activities_by_name.items():
+            beats = await _heartbeats_during_activity(activity_fn, args_by_activity_name[name])
+            assert beats, f'activity {name!r} ran without heartbeating'
+
+
+def test_tool_activities_get_no_default_heartbeat_timeout():
+    """Only model activities get a default `heartbeat_timeout`; tool activities deliberately don't.
+
+    A `heartbeat_timeout` fails the attempt as soon as the beats stop, and a CPU-bound tool can
+    occupy the event loop and starve the heartbeat task — so defaulting one would kill tools that
+    run indefinitely today. Users who want one set it themselves.
+    """
+    agent = Agent(
+        TestModel(),
+        name='heartbeat_default_agent',
+        deps_type=type(None),
+        toolsets=[FunctionToolset[None](tools=[heartbeat_probe_tool], id='hb_default_tools')],
+        capabilities=[TemporalDurability()],
+    )
+    bound = TemporalDurability.from_agent(agent)
+    assert bound is not None
+
+    assert bound._model_activity_config.get('heartbeat_timeout') == timedelta(seconds=30)  # pyright: ignore[reportPrivateUsage]
+    assert 'heartbeat_timeout' not in bound.activity_config
+
+    toolset_wrapper = bound._toolsets_by_id['hb_default_tools']  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(toolset_wrapper, TemporalFunctionToolset)
+    assert toolset_wrapper.durable_config is not None
+    assert 'heartbeat_timeout' not in toolset_wrapper.durable_config
+
+
+async def slow_heartbeat_tool() -> str:
+    """Outlive the `heartbeat_timeout` the agent below configures for all of its activities."""
+    await asyncio.sleep(2)
+    return 'slow tool finished'
+
+
+def _slow_tool_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    for message in messages:
+        for part in message.parts:
+            if isinstance(part, ToolReturnPart):
+                return ModelResponse(parts=[TextPart(str(part.content))])
+    return ModelResponse(parts=[ToolCallPart('slow_heartbeat_tool', {})])
+
+
+_slow_tool_agent = Agent(
+    FunctionModel(_slow_tool_model_fn),
+    name='slow_tool_agent',
+    deps_type=type(None),
+    toolsets=[FunctionToolset[None](tools=[slow_heartbeat_tool], id='slow_tools')],
+    capabilities=[
+        TemporalDurability(
+            activity_config=ActivityConfig(
+                start_to_close_timeout=timedelta(seconds=30),
+                heartbeat_timeout=timedelta(seconds=1),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        )
+    ],
+)
+
+
+@workflow.defn
+class SlowToolHeartbeatWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return (await _slow_tool_agent.run('call the slow tool')).output
+
+
+async def test_tool_outliving_configured_heartbeat_timeout_survives(client: Client):
+    """A tool that runs longer than the `heartbeat_timeout` its user set completes (#6914).
+
+    Setting a `heartbeat_timeout` — on the base config here, but `toolset_activity_config` and
+    per-tool metadata reach the same activity — used to arm a kill switch: the tool activity
+    never beat, so the server failed the attempt the moment the timeout elapsed.
+    """
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[SlowToolHeartbeatWorkflow],
+        plugins=[AgentPlugin(_slow_tool_agent)],
+    ):
+        output = await client.execute_workflow(
+            SlowToolHeartbeatWorkflow.run,
+            id=f'{SlowToolHeartbeatWorkflow.__name__}-{uuid.uuid4()}',
+            task_queue=TASK_QUEUE,
+        )
+
+    assert output == snapshot('slow tool finished')
 
 
 # --- Usage mutated inside an activity ---


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Closes #6914

`heartbeating()` (formerly `_heartbeating()`) was applied to three activity bodies — model request, model request stream, and cancel-suspended-response. The other seven — the agent's own and each `FunctionToolset`'s call-tool, MCP call-tool/get-tools/get-instructions, dynamic-toolset get-tools/call-tool, and the event stream handler — ran without ever beating.

Two consequences:

- **Conditional but fatal.** No `heartbeat_timeout` reaches tool activities by default, but a user-set one does — via the base `activity_config`, `toolset_activity_config`, or per-tool `metadata={'temporal': ActivityConfig(...)}`. On a non-heartbeating activity that's a kill switch rather than a safety net: the server failed the attempt the moment the window elapsed, and the tool retried to `RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED`.
- **Unconditional.** Temporal delivers a server-initiated cancel as the response to a heartbeat, so a long-running tool activity could not receive workflow cancellation at all, on every configuration including the default one. Our own docs assert that mechanism.

## What changed

- Moved the helper from `_durability.py` to `_toolset.py` and dropped its underscore, since it's now shared across modules rather than private to one. The four toolset modules already import from `_toolset.py`, and `_durability.py` imports from it too, so there's no cycle.
- Wrapped all seven remaining activity bodies in `async with heartbeating():`.
- **No default `heartbeat_timeout` for tool activities.** A CPU-bound async tool starves the beat task, so a 30-second default would kill activities that survive indefinitely today. The 30-second default stays model-only, as the reporter asked.
- Docs: `temporal.md` claimed "Activities heartbeat automatically, with a default `heartbeat_timeout` of 30 seconds", which was wrong before this change (only model activities beat) and would still be wrong after it (heartbeating becomes universal, the default does not). Reworded, and the Activity Configuration section now spells out both halves plus the reason not to set a `heartbeat_timeout` on an activity that can block the event loop.

## Tests

- `test_every_registered_activity_heartbeats` runs each registered activity body in a `temporalio.testing.ActivityEnvironment` and asserts it beats. It also asserts the set of registered activity names equals the set it knows how to call, so a newly registered activity has to be added — and wrapped — deliberately. Verified it fails on each unwrapped body before the fix.
- `test_tool_outliving_configured_heartbeat_timeout_survives` is the workflow-level regression net: a tool that sleeps past a configured 1-second `heartbeat_timeout`. Before the fix it fails with `TimeoutError: activity Heartbeat timeout`.
- `test_tool_activities_get_no_default_heartbeat_timeout` pins the deliberate absence of the default on the base and toolset configs, against the model config's 30 seconds.

Full `tests/test_temporal.py` passes locally (213 passed, 2 skipped).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

