### PR TITLE
Cancel sync-bridge guard before `run_until_complete()` assertion

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1330,6 +1330,7 @@ def test_sync_stream_bridge_pump_propagates_base_exception_without_hanging(error
         with pytest.raises(error_type) as exc_info:
             while True:
                 next(stream)
+        stop_handle.cancel()
         assert exc_info.value is error
         assert not forced_stop
         assert bridge._owner_task.done()  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

This addresses only the Python 3.14 sync-bridge test flake tracked in #6967. It cancels the one-second anti-hang timer immediately after the expected base exception propagates, before postconditions and the final event-loop reuse assertion; the existing `finally` cancellation remains as a defensive cleanup path. The guard still covers the operation it exists to protect.

The Temporal `TMPRL1101` flake (symptom A in #6967) remains undetermined and open. This PR does not change Temporal tests or production code.

- Python 3.14 repeat: 400/400 passed (200 `KeyboardInterrupt`, 200 `SystemExit`)
- Deliberate-hang probe: guard failed fast after 1.002 seconds
- `uv run pytest tests/test_streaming.py`: 180 passed, 3 xfailed
- `uv run ruff check`: passed
- `uv run ruff format --check`: passed

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

