### PR TITLE
Fail the workflow on `HookTimeoutError` and `FallbackExceptionGroup` instead of retrying forever

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -152,7 +152,7 @@ async def main():
 5. `agent.run()` works as usual; inside the workflow, model requests, tool calls, and MCP server communication are routed through Temporal activities.
 6. We connect to the Temporal server which keeps track of workflow and activity execution.
 7. This assumes the Temporal server is [running locally](https://github.com/temporalio/temporal#download-and-start-temporal-server-locally).
-8. The [`PydanticAIPlugin`][pydantic_ai.durable_exec.temporal.PydanticAIPlugin] tells Temporal to use Pydantic for serialization and deserialization, treats [`UserError`][pydantic_ai.exceptions.UserError] exceptions as non-retryable, and automatically registers activities for agents listed in `__pydantic_ai_agents__`.
+8. The [`PydanticAIPlugin`][pydantic_ai.durable_exec.temporal.PydanticAIPlugin] tells Temporal to use Pydantic for serialization and deserialization, and automatically registers activities for agents listed in `__pydantic_ai_agents__`. Activity retry policies treat [`UserError`][pydantic_ai.exceptions.UserError], `PydanticUserError`, [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior], and [`FallbackExceptionGroup`][pydantic_ai.exceptions.FallbackExceptionGroup] as non-retryable, while the worker registers `UserError`, `PydanticUserError`, [`AgentRunError`][pydantic_ai.exceptions.AgentRunError], and `UnsupportedEventLoopError` as `workflow_failure_exception_types`.
 9. We start the worker that will listen on the specified task queue and run workflows and activities. In a real world application, this might be run in a separate service.
 10. We call on the server to execute the workflow on a worker that's listening on the specified task queue.
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
 import anyio
 from pydantic import ValidationError
 
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import AgentRunError, ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import AgentDepsT, DeferredToolRequests, DeferredToolResults, RunContext, ToolDefinition
 
@@ -61,7 +61,7 @@ _FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
 # --- Timeout exception ---
 
 
-class HookTimeoutError(TimeoutError):
+class HookTimeoutError(AgentRunError, TimeoutError):
     """Raised when a hook function exceeds its configured timeout."""
 
     def __init__(self, hook_name: str, func_name: str, timeout: float):

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -23,7 +23,7 @@ from pydantic_ai.durable_exec._toolset import (
     unwrap_tool_call_result,
     wrap_tool_call_result,
 )
-from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
+from pydantic_ai.exceptions import FallbackExceptionGroup, UnexpectedModelBehavior, UserError
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
@@ -142,7 +142,12 @@ def with_non_retryable_errors(retry_policy: RetryPolicy | None) -> RetryPolicy:
     """Return a copy of `retry_policy` with the framework's non-retryable errors ensured."""
     retry_policy = copy.copy(retry_policy) if retry_policy else RetryPolicy()
     existing = retry_policy.non_retryable_error_types or []
-    additional = [UserError.__name__, PydanticUserError.__name__, UnexpectedModelBehavior.__name__]
+    additional = [
+        UserError.__name__,
+        PydanticUserError.__name__,
+        UnexpectedModelBehavior.__name__,
+        FallbackExceptionGroup.__name__,
+    ]
     retry_policy.non_retryable_error_types = [*existing, *(name for name in additional if name not in existing)]
     return retry_policy
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -66,6 +66,7 @@ from pydantic_ai.capabilities.combined import CombinedCapability
 from pydantic_ai.capabilities.hooks import Hooks, HookTimeoutError
 from pydantic_ai.capabilities.native_tool import NativeTool as NativeToolCap
 from pydantic_ai.exceptions import (
+    AgentRunError,
     ApprovalRequired,
     CallDeferred,
     ModelRetry,
@@ -11324,6 +11325,8 @@ class TestHooksCapability:
         assert exc_info.value.hook_name == 'before_model_request'
         assert exc_info.value.func_name == 'slow_hook'
         assert exc_info.value.timeout == 0.01
+        assert isinstance(exc_info.value, AgentRunError)
+        assert isinstance(exc_info.value, TimeoutError)
 
     async def test_has_wrap_node_run(self):
         hooks = Hooks()

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -6258,6 +6258,7 @@ def test_durability_activity_config_not_mutated():
         'UserError',
         'PydanticUserError',
         'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
     ]
 
 
@@ -6298,6 +6299,7 @@ def test_durability_custom_retry_policy_keeps_non_retryable_errors():
         'UserError',
         'PydanticUserError',
         'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
     ]
 
     toolset_wrapper = bound._toolsets_by_id['my_toolset']  # pyright: ignore[reportPrivateUsage]
@@ -6310,6 +6312,7 @@ def test_durability_custom_retry_policy_keeps_non_retryable_errors():
         'UserError',
         'PydanticUserError',
         'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
     ]
 
 
@@ -6330,6 +6333,7 @@ def test_durability_event_stream_handler_activity_config_keeps_non_retryable_err
         'UserError',
         'PydanticUserError',
         'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
     ]
 
 
@@ -7096,6 +7100,7 @@ def test_resolve_tool_activity_config_reads_metadata():
         'UserError',
         'PydanticUserError',
         'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
     ]
 
     inherited_retry_policy = RetryPolicy(maximum_attempts=7)
@@ -7152,7 +7157,12 @@ def test_resolve_tool_activity_config_restores_round_tripped_types():
     assert retry_policy is not None
     assert retry_policy.initial_interval == timedelta(seconds=1)
     assert retry_policy.maximum_attempts == 2
-    assert retry_policy.non_retryable_error_types == ['UserError', 'PydanticUserError', 'UnexpectedModelBehavior']
+    assert retry_policy.non_retryable_error_types == [
+        'UserError',
+        'PydanticUserError',
+        'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
+    ]
 
 
 def test_resolve_tool_activity_config_rejects_unusable_config():


### PR DESCRIPTION
Fixes #6975

Two Pydantic AI exception types fell outside the sets `PydanticAIPlugin` registers with Temporal, so raising them retried forever instead of failing.

## `HookTimeoutError` — workflow-side, retried forever

`HookTimeoutError` subclassed only `TimeoutError`, which is in neither `workflow_failure_exception_types` nor the activity non-retryable list. Capability hooks run in **workflow** code, so a hook that tripped its `timeout=` inside a workflow raised a type Temporal treats as a workflow-**task** failure and retried indefinitely — the workflow never went terminal, and only a redeploy cleared it.

It now subclasses `AgentRunError` as well as `TimeoutError`, so it's covered by the existing registration while `except TimeoutError` keeps working. The constructor, message, and timeout metadata are unchanged.

## `FallbackExceptionGroup` — activity-side, retried the activity forever

`FallbackModel` runs inside the model activity, so an all-models-failed group surfaced as an `ActivityError`. It wasn't in the activity non-retryable list, so it retried indefinitely under the default retry policy. Added to that list; the base class is unchanged so `except*` handling still works.

## Docs

The `PydanticAIPlugin` annotation named only `UserError` and conflated activity-level `retry_policy.non_retryable_error_types` with worker-level `workflow_failure_exception_types` — the latter appeared nowhere in the docs. This is what caused #6913, where a user carried a redundant worker-side registration for four releases. It now distinguishes the two mechanisms and names what's registered in each.

## Tests

Extended the existing hook-timeout test to assert both base classes, and the existing Temporal retry-policy assertions to cover `FallbackExceptionGroup`.

`tests/test_capabilities.py` + `tests/models/test_fallback.py`: 920 passed. `tests/test_temporal.py`: 219 passed, 2 skipped. pyright and ruff clean.

## Checklist

- [ ] I have added tests for the changes
- [ ] I have updated the documentation
- [ ] AI generated code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

