### PR TITLE
Pass the unprepared request to the wrapped model in `InstrumentedModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -330,10 +330,13 @@ class InstrumentedModel(WrapperModel):
             model_settings=model_settings,
             model_request_parameters=model_request_parameters,
         )
-        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, prepared_rc):
-            response = await self.wrapped.request(
-                prepared_rc.messages, prepared_rc.model_settings, prepared_rc.model_request_parameters
-            )
+        # The span's prepared context is for its attributes only. The wrapped model prepares again
+        # itself, and `prepare_request` is not idempotent — a second pass appends the prompted-output
+        # instructions a second time and re-walks an already-transformed JSON schema — so it has to
+        # be handed the originals. `Instrumentation.wrap_model_request` and `FallbackModel.request`
+        # do the same.
+        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, _):
+            response = await self.wrapped.request(messages, model_settings, model_request_parameters)
             finish(response)
             return response
 
@@ -351,7 +354,9 @@ class InstrumentedModel(WrapperModel):
             model_settings=model_settings,
             model_request_parameters=model_request_parameters,
         )
-        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, prepared_rc):
+        # See `request()`: the prepared context is for span attributes only, and the wrapped model
+        # must be handed the originals because `prepare_request` is not idempotent.
+        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, _):
             response_stream: StreamedResponse | None = None
             # Stamp the request-issue instant before the wrapped model opens the stream, so the
             # `time_to_first_chunk` delta spans from when we issue the request to when the first
@@ -359,9 +364,9 @@ class InstrumentedModel(WrapperModel):
             request_start = time.perf_counter()
             try:
                 async with self.wrapped.request_stream(
-                    prepared_rc.messages,
-                    prepared_rc.model_settings,
-                    prepared_rc.model_request_parameters,
+                    messages,
+                    model_settings,
+                    model_request_parameters,
                     run_context,
                 ) as response_stream:
                     yield response_stream

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -2331,3 +2331,38 @@ async def test_instrumented_model_request_error(capfire: CaptureLogfire):
     # finish() was never called, so response-specific attributes are absent
     assert 'gen_ai.response.id' not in spans[0]['attributes']
     assert 'gen_ai.usage.input_tokens' not in spans[0]['attributes']
+
+
+async def test_wrapped_model_receives_unprepared_request():
+    """The wrapped model must be handed the originals, not the span's prepared context.
+
+    `prepare_request` is not idempotent: every model re-prepares whatever it is given, so forwarding
+    an already-prepared context makes the second pass append the prompted-output instructions again
+    and re-walk an already-transformed JSON schema. Regression test for the behaviour introduced in
+    #5429 and released in v1.100.0.
+    """
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+    from pydantic_ai.output import OutputObjectDefinition
+    from pydantic_ai.profiles import ModelProfile
+
+    seen: list[int] = []
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen.append(len(info.instructions or ''))
+        return ModelResponse(parts=[TextPart('{"answer": "x"}')])
+
+    wrapped = FunctionModel(respond, profile=ModelProfile(default_structured_output_mode='prompted'))
+    params = ModelRequestParameters(
+        output_mode='auto',
+        output_object=OutputObjectDefinition(json_schema={'type': 'object', 'properties': {}}),
+        allow_text_output=True,
+    )
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('hi')])]
+
+    await wrapped.request(messages, None, params)
+    baseline = seen[-1]
+
+    await InstrumentedModel(wrapped, InstrumentationSettings(tracer_provider=NoOpTracerProvider())).request(
+        messages, None, params
+    )
+    assert seen[-1] == baseline, 'instrumentation changed the instructions the wrapped model received'


### PR DESCRIPTION
Fixes #6980

`InstrumentedModel.request` / `request_stream` forwarded the span's **already-prepared** context into the wrapped model, which re-prepares whatever it is handed as the first statement of its own `request()`. `prepare_request` is not idempotent, so the second pass corrupted the request that went on the wire.

Regression from `b7806da2e` (#5429, 2026-05-13), first released in **v1.100.0**.

## Symptoms

**Prompted output — the JSON schema instructions were sent twice.** `prepare_request` appends `prompted_output_instructions` on every pass:

```
pass 1: instruction_parts=1  total_chars=257
pass 2: instruction_parts=2  total_chars=514
pass 3: instruction_parts=3  total_chars=771
```

**Inline-defs profiles with a recursive schema — the schema grew without bound.** Affects `profiles/amazon.py` (Nova/Bedrock), `profiles/meta.py` (Llama), `profiles/qwen.py`, and OpenRouter's Google transformer. Before #6960 the second walk produced a self-referential dict and raised `ValueError: Circular reference detected`; #6960 downgraded that crash to silent unbounded growth, so this is worth landing promptly on top of it.

## Fix

Pass the original `messages`, `model_settings`, and `model_request_parameters` to the wrapped model, keeping the prepared context for span attributes only. This restores the pre-#5429 behaviour and matches the two in-tree precedents that already do exactly this — `Instrumentation.wrap_model_request` passes the original `request_context` to the handler, and `FallbackModel.request` prepares for span attributes then passes originals to `model.request`.

Span attributes are unchanged: they still come from the prepared context.

## Blast radius

`Agent` unwraps `InstrumentedModel` and injects the `Instrumentation` capability instead (`agent/__init__.py:1319`), so ordinary agent runs were unaffected. What was affected: `direct.model_request` / `direct.model_request_stream` with `instrument=` (including via `logfire.instrument_pydantic_ai()` and `Agent.instrument_all()`), and nested wrappers the top-level unwrap doesn't see, such as `FallbackModel(InstrumentedModel(...))`.

## Tests

`test_wrapped_model_receives_unprepared_request` asserts the wrapped model receives the same instructions with and without instrumentation. Verified it fails on the unfixed code (`assert 340 == 168` — exactly doubled).

`tests/models/test_instrumented.py`, `test_direct.py`, `test_logfire.py`, `test_fallback.py`, `test_model_settings.py`: 239 passed, 1 skipped. Full suite: 6449 passed, 5 pre-existing `inline_snapshot` `UsageError` failures unrelated to this change. pyright and ruff clean.

## Follow-ups (not in this PR)

- #6973 — the *cost* of preparing twice, and the memoization fix for it.
- `FallbackModel.request` prepares twice as well, independent of instrumentation — same idempotency assumption.

## Checklist

- [ ] I have added tests for the changes
- [ ] I have updated the documentation
- [ ] AI generated code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

