### PR TITLE
Retry dynamic tool `ValidationError` in durable runs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, cast
 
 from pydantic import Discriminator, Tag, ValidationError
+from pydantic_core import PydanticCustomError
 from typing_extensions import Self, assert_never
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
@@ -196,7 +197,16 @@ def unwrap_tool_call_result(result: CallToolResult) -> Any:
     if isinstance(result, _ModelRetry):
         raise ModelRetry(result.message)
     if isinstance(result, _ValidationError):
-        raise ValidationError.from_exception_data(result.title, json.loads(result.errors_json))
+        errors = json.loads(result.errors_json)
+        try:
+            raise ValidationError.from_exception_data(result.title, errors)
+        except KeyError:
+            for error in errors:
+                try:
+                    ValidationError.from_exception_data(result.title, [error])
+                except KeyError:
+                    error['type'] = PydanticCustomError(error['type'], error['msg'])
+            raise ValidationError.from_exception_data(result.title, errors)
     if isinstance(result, _ToolFailed):
         raise ToolFailed(result.message)
     assert_never(result)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import copy
+import json
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, cast
 
-from pydantic import Discriminator, Tag
+from pydantic import Discriminator, Tag, ValidationError
 from typing_extensions import Self, assert_never
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
@@ -120,6 +121,13 @@ class _ModelRetry:
 
 
 @dataclass
+class _ValidationError:
+    title: str
+    errors_json: str
+    kind: Literal['validation_error'] = 'validation_error'
+
+
+@dataclass
 class _ToolFailed:
     message: str
     kind: Literal['tool_failed'] = 'tool_failed'
@@ -155,7 +163,7 @@ class _ToolContentResult:
 
 
 CallToolResult = Annotated[
-    _ApprovalRequired | _CallDeferred | _ModelRetry | _ToolReturn | _ToolContentResult | _ToolFailed,
+    _ApprovalRequired | _CallDeferred | _ModelRetry | _ValidationError | _ToolReturn | _ToolContentResult | _ToolFailed,
     Discriminator('kind'),
 ]
 
@@ -172,6 +180,8 @@ async def wrap_tool_call_result(coro: Awaitable[Any]) -> CallToolResult:
         return _CallDeferred(metadata=exc.metadata)
     except ModelRetry as exc:
         return _ModelRetry(message=exc.message)
+    except ValidationError as exc:
+        return _ValidationError(title=exc.title, errors_json=exc.json())
     except ToolFailed as exc:
         return _ToolFailed(message=exc.message)
 
@@ -185,6 +195,8 @@ def unwrap_tool_call_result(result: CallToolResult) -> Any:
         raise CallDeferred(metadata=result.metadata)
     if isinstance(result, _ModelRetry):
         raise ModelRetry(result.message)
+    if isinstance(result, _ValidationError):
+        raise ValidationError.from_exception_data(result.title, json.loads(result.errors_json))
     if isinstance(result, _ToolFailed):
         raise ToolFailed(result.message)
     assert_never(result)
@@ -240,7 +252,14 @@ def unwrap_recorded_tool_call_result(result: Any) -> Any:
     values; those recordings are the raw tool result and are returned unchanged.
     """
     if isinstance(
-        result, _ToolReturn | _ToolContentResult | _ApprovalRequired | _CallDeferred | _ModelRetry | _ToolFailed
+        result,
+        _ToolReturn
+        | _ToolContentResult
+        | _ApprovalRequired
+        | _CallDeferred
+        | _ModelRetry
+        | _ValidationError
+        | _ToolFailed,
     ):
         return unwrap_tool_call_result(result)
     return result

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2393,6 +2393,58 @@ async def test_dbos_dynamic_tool_model_retry_crosses_step_without_engine_retries
     assert await run_workflow() == 1
 
 
+async def test_dbos_dynamic_tool_validation_error_retries_model_once(dbos: DBOS) -> None:
+    async def dynamic_tool(value: int) -> str:
+        return str(value)
+
+    async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('dynamic_tool', {'value': 'wrong'}, tool_call_id='call-1')])
+        if len(messages) == 3:
+            return ModelResponse(parts=[ToolCallPart('dynamic_tool', {'value': 1}, tool_call_id='call-2')])
+        return ModelResponse(parts=[TextPart('done')])
+
+    def make_agent(*, durable: bool) -> Agent[None, str]:
+        dynamic = DynamicToolset(lambda ctx: FunctionToolset([dynamic_tool]), id='dynamic_validation')
+        toolset = (
+            dbosify_dynamic_toolset(
+                dynamic,
+                step_name_prefix='dbos_dynamic_validation_durable',
+                step_config=StepConfig(retries_allowed=True, max_attempts=3),
+            )
+            if durable
+            else dynamic
+        )
+        return Agent(
+            FunctionModel(model_function),
+            name=f'dbos_dynamic_validation_{"durable" if durable else "inline"}',
+            toolsets=[toolset],
+        )
+
+    inline_result = await make_agent(durable=False).run('run')
+    inline_retry = next(
+        part for message in inline_result.all_messages() for part in message.parts if isinstance(part, RetryPromptPart)
+    )
+
+    @DBOS.workflow()
+    async def run_workflow() -> tuple[str, list[Any] | str]:
+        result = await make_agent(durable=True).run('run')
+        retry = next(
+            part for message in result.all_messages() for part in message.parts if isinstance(part, RetryPromptPart)
+        )
+        return result.output, retry.content
+
+    workflow_id = str(uuid.uuid4())
+    with SetWorkflowID(workflow_id):
+        output, durable_retry_content = await run_workflow()
+    steps = await dbos.list_workflow_steps_async(workflow_id)
+    call_tool_steps = [step for step in steps if step['function_name'].endswith('.call_tool')]
+
+    assert output == 'done'
+    assert len(call_tool_steps) == 2
+    assert durable_retry_content == inline_retry.content
+
+
 async def test_dbos_mcp_step_rejects_enqueue_in_workflow(dbos: DBOS, monkeypatch: pytest.MonkeyPatch) -> None:
     """The MCP step path guards enqueue too: a `process_tool_call=` hook receives the run context."""
     mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='enqueue_mcp')

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -10,11 +10,12 @@ from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterator, S
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
 import pytest
 from httpx import AsyncClient
-from pydantic import BaseModel
+from pydantic import BaseModel, BeforeValidator
+from pydantic_core import PydanticCustomError
 
 from pydantic_ai import (
     Agent,
@@ -2393,9 +2394,23 @@ async def test_dbos_dynamic_tool_model_retry_crosses_step_without_engine_retries
     assert await run_workflow() == 1
 
 
-async def test_dbos_dynamic_tool_validation_error_retries_model_once(dbos: DBOS) -> None:
+@pytest.mark.parametrize('error_kind', ['custom', 'value_error'])
+async def test_dbos_dynamic_tool_validation_error_retries_model_once(dbos: DBOS, error_kind: str) -> None:
+    def validate_value(value: Any) -> Any:
+        if value == 'wrong':
+            if error_kind == 'custom':
+                raise PydanticCustomError(
+                    'invalid_dynamic_arg',
+                    'Value {value} is not allowed; literal {brace}',
+                    {'value': value},
+                )
+            raise ValueError('The dynamic argument is invalid')
+        return value
+
     async def dynamic_tool(value: int) -> str:
         return str(value)
+
+    dynamic_tool.__annotations__['value'] = Annotated[int, BeforeValidator(validate_value)]
 
     async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if len(messages) == 1:
@@ -2443,6 +2458,8 @@ async def test_dbos_dynamic_tool_validation_error_retries_model_once(dbos: DBOS)
     assert output == 'done'
     assert len(call_tool_steps) == 2
     assert durable_retry_content == inline_retry.content
+    if error_kind == 'custom':
+        assert 'Value wrong is not allowed; literal {brace}' in str(durable_retry_content)
 
 
 async def test_dbos_mcp_step_rejects_enqueue_in_workflow(dbos: DBOS, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import BaseModel, BeforeValidator, Field
 from pydantic.errors import PydanticUserError
+from pydantic_core import PydanticCustomError
 
 from pydantic_ai import (
     Agent,
@@ -3233,6 +3234,11 @@ async def test_prefect_dynamic_tool_validation_error_retries_model_once() -> Non
         nonlocal validation_attempts
         if value == 'wrong':
             validation_attempts += 1
+            raise PydanticCustomError(
+                'invalid_dynamic_arg',
+                'Value {value} is not allowed; literal {brace}',
+                {'value': value},
+            )
         return value
 
     async def dynamic_tool(value: int) -> str:
@@ -3276,6 +3282,7 @@ async def test_prefect_dynamic_tool_validation_error_retries_model_once() -> Non
     assert output == 'done'
     assert validation_attempts == 1
     assert durable_retry_content == inline_retry.content
+    assert 'Value wrong is not allowed; literal {brace}' in str(durable_retry_content)
 
 
 async def test_prefect_with_non_retryable_errors_condition() -> None:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -8,11 +8,11 @@ from collections.abc import AsyncIterable, AsyncIterator, Callable, Generator, I
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, BeforeValidator, Field
 
 from pydantic_ai import (
     Agent,
@@ -3154,6 +3154,58 @@ async def test_prefect_dynamic_tool_model_retry_is_not_retried_by_task_engine() 
 
     await run_agent()
     assert calls == 2
+
+
+async def test_prefect_dynamic_tool_validation_error_retries_model_once() -> None:
+    validation_attempts = 0
+
+    def count_invalid(value: Any) -> Any:
+        nonlocal validation_attempts
+        if value == 'wrong':
+            validation_attempts += 1
+        return value
+
+    async def dynamic_tool(value: int) -> str:
+        return str(value)
+
+    dynamic_tool.__annotations__['value'] = Annotated[int, BeforeValidator(count_invalid)]
+
+    async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('dynamic_tool', {'value': 'wrong'}, tool_call_id='call-1')])
+        if len(messages) == 3:
+            return ModelResponse(parts=[ToolCallPart('dynamic_tool', {'value': 1}, tool_call_id='call-2')])
+        return ModelResponse(parts=[TextPart('done')])
+
+    def make_agent(*, durable: bool) -> Agent[None, str]:
+        capabilities = [PrefectDurability(tool_task_config={'retries': 3})] if durable else []
+        return Agent(
+            FunctionModel(model_function),
+            name=f'prefect_dynamic_validation_{"durable" if durable else "inline"}',
+            toolsets=[DynamicToolset(lambda ctx: FunctionToolset([dynamic_tool]), id='dynamic_validation')],
+            capabilities=capabilities,
+        )
+
+    inline_result = await make_agent(durable=False).run('run')
+    inline_retry = next(
+        part for message in inline_result.all_messages() for part in message.parts if isinstance(part, RetryPromptPart)
+    )
+    validation_attempts = 0
+
+    @flow
+    async def run_agent() -> tuple[str, list[Any] | str]:
+        agent = make_agent(durable=True)
+        result = await agent.run('run')
+        retry = next(
+            part for message in result.all_messages() for part in message.parts if isinstance(part, RetryPromptPart)
+        )
+        return result.output, retry.content
+
+    output, durable_retry_content = await run_agent()
+
+    assert output == 'done'
+    assert validation_attempts == 1
+    assert durable_retry_content == inline_retry.content
 
 
 async def test_prefect_with_non_retryable_errors_condition() -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import re
 import sys
@@ -13,13 +14,13 @@ from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 from unittest.mock import patch
 
 import anyio
 import httpx
 import pytest
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, BeforeValidator, TypeAdapter
 from pydantic_core import PydanticSerializationError
 
 from pydantic_ai import (
@@ -2021,6 +2022,80 @@ async def test_dynamic_toolset_outside_workflow():
         'Get the weather for Paris', deps=DynamicToolsetDeps(user_name='Bob')
     )
     assert result.output == snapshot('{"get_dynamic_weather":"Weather in a for Bob: sunny."}')
+
+
+_dynamic_validation_attempts = 0
+
+
+def _count_invalid_dynamic_arg(value: Any) -> Any:
+    global _dynamic_validation_attempts
+    if value == 'wrong':
+        _dynamic_validation_attempts += 1
+    return value
+
+
+async def _dynamic_validation_tool(value: Annotated[int, BeforeValidator(_count_invalid_dynamic_arg)]) -> str:
+    return str(value)
+
+
+def _dynamic_validation_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    if len(messages) == 1:
+        return ModelResponse(
+            parts=[ToolCallPart('_dynamic_validation_tool', {'value': 'wrong'}, tool_call_id='call-1')]
+        )
+    if len(messages) == 3:
+        return ModelResponse(parts=[ToolCallPart('_dynamic_validation_tool', {'value': 1}, tool_call_id='call-2')])
+    return ModelResponse(parts=[TextPart('done')])
+
+
+_dynamic_validation_agent = Agent(
+    FunctionModel(_dynamic_validation_model),
+    name='temporal_dynamic_validation',
+    toolsets=[DynamicToolset(lambda ctx: FunctionToolset([_dynamic_validation_tool]), id='dynamic_validation')],
+)
+_dynamic_validation_temporal_agent = TemporalAgent(  # pyright: ignore[reportDeprecated]
+    _dynamic_validation_agent,
+    activity_config=ActivityConfig(
+        start_to_close_timeout=timedelta(seconds=60),
+        retry_policy=RetryPolicy(maximum_attempts=3),
+    ),
+)
+
+
+@workflow.defn
+class DynamicValidationWorkflow:
+    @workflow.run
+    async def run(self) -> tuple[str, str]:
+        result = await _dynamic_validation_temporal_agent.run('run')
+        retry = next(
+            part for message in result.all_messages() for part in message.parts if isinstance(part, RetryPromptPart)
+        )
+        return result.output, json.dumps(retry.content)
+
+
+async def test_temporal_dynamic_tool_validation_error_retries_model_once(client: Client) -> None:
+    global _dynamic_validation_attempts
+    inline_result = await _dynamic_validation_agent.run('run')
+    inline_retry = next(
+        part for message in inline_result.all_messages() for part in message.parts if isinstance(part, RetryPromptPart)
+    )
+    _dynamic_validation_attempts = 0
+
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[DynamicValidationWorkflow],
+        plugins=[AgentPlugin(_dynamic_validation_temporal_agent)],
+    ):
+        output, durable_retry_content = await client.execute_workflow(
+            DynamicValidationWorkflow.run,
+            id='test_temporal_dynamic_validation',
+            task_queue=TASK_QUEUE,
+        )
+
+    assert output == 'done'
+    assert _dynamic_validation_attempts == 1
+    assert durable_retry_content == json.dumps(inline_retry.content)
 
 
 # --- DynamicToolset.get_instructions test (issue #5282) ---

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -21,7 +21,7 @@ import anyio
 import httpx
 import pytest
 from pydantic import BaseModel, BeforeValidator, TypeAdapter
-from pydantic_core import PydanticSerializationError
+from pydantic_core import PydanticCustomError, PydanticSerializationError
 
 from pydantic_ai import (
     AbstractToolset,
@@ -2031,6 +2031,7 @@ def _count_invalid_dynamic_arg(value: Any) -> Any:
     global _dynamic_validation_attempts
     if value == 'wrong':
         _dynamic_validation_attempts += 1
+        raise PydanticCustomError('invalid_dynamic_arg', 'The dynamic argument is invalid')
     return value
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2031,7 +2031,11 @@ def _count_invalid_dynamic_arg(value: Any) -> Any:
     global _dynamic_validation_attempts
     if value == 'wrong':
         _dynamic_validation_attempts += 1
-        raise PydanticCustomError('invalid_dynamic_arg', 'The dynamic argument is invalid')
+        raise PydanticCustomError(
+            'invalid_dynamic_arg',
+            'Value {value} is not allowed; literal {brace}',
+            {'value': value},
+        )
     return value
 
 
@@ -2097,6 +2101,7 @@ async def test_temporal_dynamic_tool_validation_error_retries_model_once(client:
     assert output == 'done'
     assert _dynamic_validation_attempts == 1
     assert durable_retry_content == json.dumps(inline_retry.content)
+    assert 'Value wrong is not allowed; literal {brace}' in durable_retry_content
 
 
 # --- DynamicToolset.get_instructions test (issue #5282) ---


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

- Closes #6979

Dynamic tool argument validation now crosses a durable unit as a successful `validation_error` result, then reconstructs and raises the `ValidationError` on the workflow/flow side so the existing `ToolManager` retry path handles it.

The wire variant carries the validation title and `ValidationError.json()` output. Reconstructing with `ValidationError.from_exception_data()` preserves the model-facing retry prompt exactly, including for `PydanticCustomError` custom error types: `type`, `loc`, `msg`, and `input` are equal to the non-durable prompt. Unknown custom types are rebuilt with `PydanticCustomError(type, rendered_message)`; already-rendered placeholders and literal braces are preserved without re-interpolation. JSON serialization stringifies exception objects in `ctx` and omits Python object identity, but `ToolManager` deliberately builds retry content with `include_context=False` and `include_url=False`, so nothing shown to the model is lost.

Engine verification with retry policies enabled:

- Temporal: invalid call activity attempted once; workflow succeeded after correction.
- DBOS: invalid call step attempted once; workflow succeeded after correction.
- Prefect: invalid call task attempted once; flow succeeded after correction.

Static `FunctionToolset` tools are unaffected: their real validator runs workflow-side before the durable call unit, so this new result is only produced by the dynamic toolset path.

Rolling/in-flight compatibility:

- Old worker -> new workflow code: compatible. Old workers only emit the existing variants, which the expanded union still decodes.
- New worker -> old workflow code: not compatible when the new `validation_error` variant is emitted; the old discriminated union cannot decode that unknown variant. Deploy workflow code before or with workers that can emit it, and do not roll workflow code back while histories may contain it.
- Temporal histories containing an old result shape replay cleanly on new workers because all existing variants and their wire shapes are unchanged. A history containing the new variant cannot replay on old workflow code.
- The equivalent downgrade hazard applies to DBOS/Prefect persisted results containing the new variant; upgraded code continues to accept their older raw or wrapped results.

PR #6906 moves validation into a dedicated durable unit wrapped by the same `wrap_tool_call_result`; if it merges second, it must retain/pick up this `ValidationError` variant for that new unit.

The three regression tests were each verified against unpatched `main`: Temporal and DBOS exhausted three attempts and failed, while Prefect exhausted its configured retries before recovering wastefully.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


