### PR TITLE
Fix Temporal `ActivityConfig` validation on Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,30 @@ jobs:
           path: .coverage
           include-hidden-files: true
 
+  test-temporal-latest:
+    name: test Temporal latest on Python 3.10
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.10"
+          enable-cache: true
+          cache-suffix: temporal-latest
+
+      - run: uv sync --extra temporal --upgrade-package temporalio
+        env:
+          UV_FROZEN: "0"
+
+      - run: >-
+          uv run --no-sync pytest
+          tests/test_temporal.py::test_durability_rejects_unknown_activity_config_keys
+          tests/test_temporal.py::test_durability_coerces_activity_config_values
+
   test-examples:
     name: test examples on ${{ matrix.python-version }}
     runs-on: ubuntu-latest
@@ -412,6 +436,7 @@ jobs:
       - docs
       - test
       - test-lowest-versions
+      - test-temporal-latest
       - test-examples
       - coverage
     runs-on: ubuntu-latest

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -6,14 +6,14 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast, get_type_hints
 
 from pydantic import ConfigDict, TypeAdapter, ValidationError, with_config
 from pydantic.errors import PydanticUserError
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityConfig
-from typing_extensions import Self
+from typing_extensions import Self, TypedDict
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
 from pydantic_ai.durable_exec._toolset import (
@@ -152,16 +152,23 @@ def with_non_retryable_errors(retry_policy: RetryPolicy | None) -> RetryPolicy:
     return retry_policy
 
 
-@with_config(ConfigDict(extra='forbid'))
-class _ValidatedActivityConfig(ActivityConfig):
-    """`ActivityConfig` with validation settings attached, for `_activity_config_adapter`.
+_ValidatedActivityConfig = with_config(ConfigDict(extra='forbid'))(
+    TypedDict(
+        '_ValidatedActivityConfig',
+        # The functional syntax is intentionally dynamic so new Temporal keys are included.
+        get_type_hints(ActivityConfig, include_extras=True),  # pyright: ignore[reportArgumentType]
+        total=ActivityConfig.__total__,
+    )
+)
+"""A `typing_extensions.TypedDict` copy of `ActivityConfig` with unknown keys forbidden.
 
-    `extra='forbid'` so a misspelled key is reported rather than dropped: without it, validation
-    would silently swallow the typo that `workflow.execute_activity(**config)` currently rejects.
-    """
+The copy is derived so it stays in sync when Temporal adds keys. `typing_extensions.TypedDict` is
+required because Pydantic cannot generate schemas for `typing.TypedDict` on Python before 3.12.
+"""
 
 
-_activity_config_adapter: TypeAdapter[ActivityConfig] = TypeAdapter(_ValidatedActivityConfig)
+# Pyright cannot see that the dynamic `TypedDict` has the exact `ActivityConfig` annotations.
+_activity_config_adapter = cast('TypeAdapter[ActivityConfig]', TypeAdapter(_ValidatedActivityConfig))
 
 
 def validate_activity_config(config: ActivityConfig, source: str) -> ActivityConfig:


### PR DESCRIPTION
- Closes #6988

### Changes

- derive the validated config from Temporal's `ActivityConfig` using `typing_extensions.TypedDict`
- preserve unknown-key rejection and value coercion across supported Python and Temporal versions
- test the latest resolvable Temporal SDK on Python 3.10 in CI

### Verification

- reproduced the import failure on Python 3.10 with `temporalio==1.30.0` before the fix
- confirmed the same import succeeds after the fix
- passed the focused activity-config validation tests on Python 3.10 with `temporalio==1.30.0`
- passed focused Pyright, Ruff check, and Ruff format checks

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

