### PR TITLE
Pass `pydantic_graph` through Temporal workflow sandboxes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -85,6 +85,7 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
         runner,
         restrictions=runner.restrictions.with_passthrough_modules(
             'pydantic_ai',
+            'pydantic_graph',
             'pydantic',
             'pydantic_core',
             'pydantic_monty',

--- a/tests/temporal_sandbox_workflow.py
+++ b/tests/temporal_sandbox_workflow.py
@@ -1,0 +1,8 @@
+from temporalio import workflow
+
+
+@workflow.defn
+class PydanticAIPluginSandboxWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return 'sandboxed'

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -172,6 +172,8 @@ try:
         resolve_tool_activity_config,
         toolset_temporal_activities,
     )
+
+    from .temporal_sandbox_workflow import PydanticAIPluginSandboxWorkflow
 except ImportError:  # pragma: lax no cover
     pytest.skip('temporal not installed', allow_module_level=True)
 
@@ -5586,6 +5588,24 @@ def test_pydantic_ai_plugin_passes_pydantic_monty_through_sandbox() -> None:
     configured_runner = result['workflow_runner']
     assert isinstance(configured_runner, SandboxedWorkflowRunner)
     assert 'pydantic_monty' in configured_runner.restrictions.passthrough_modules
+
+
+async def test_pydantic_ai_plugin_runs_workflow_in_sandbox(temporal_env: WorkflowEnvironment) -> None:
+    client = await Client.connect(f'localhost:{TEMPORAL_PORT}')
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[PydanticAIPluginSandboxWorkflow],
+        plugins=[PydanticAIPlugin()],
+        workflow_runner=SandboxedWorkflowRunner(),
+    ):
+        result = await client.execute_workflow(
+            PydanticAIPluginSandboxWorkflow.run,
+            id=f'{PydanticAIPluginSandboxWorkflow.__name__}-{uuid.uuid4()}',
+            task_queue=TASK_QUEUE,
+        )
+
+    assert result == 'sandboxed'
 
 
 def test_pydantic_ai_plugin_with_pydantic_payload_converter_unchanged() -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Closes #6986

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

