### PR TITLE
Make a maintainer reopen durable in `pr-guard` and drop the dead `ORG_READ_TOKEN` block

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -80,19 +80,6 @@ jobs:
               ;;
           esac
 
-          # Private-membership bypass. The `author_association` in the webhook only
-          # reflects *public* org membership, so a private member of the org that
-          # owns this repo is reported as CONTRIBUTOR and misses the bypass above.
-          # Confirm real membership via the API, which sees private members when the
-          # token has `read:org` — the default `github.token` cannot, so this uses
-          # `ORG_READ_TOKEN` (an existing org-scoped secret). Fails open: if that
-          # token is unset or lacks the scope the API call errors and the existing
-          # policy applies unchanged, so no unlinked PR is ever wrongly kept open.
-          if [ -n "${ORG_READ_TOKEN:-}" ] && GH_TOKEN="$ORG_READ_TOKEN" gh api "orgs/${REPO%/*}/members/${PR_AUTHOR}" >/dev/null 2>&1; then
-            echo "Author ${PR_AUTHOR} is an org member (confirmed via API, incl. private membership); skipping checks."
-            exit 0
-          fi
-
           # Trusted-actor bypass. AUTHOR_ASSOCIATION above is the PR *author's*
           # relationship to the repo, so without this the guard re-closes a
           # contributor PR every time a maintainer acts on it: reopening it, or
@@ -126,6 +113,35 @@ jobs:
                 ;;
             esac
           fi
+
+          # Durable-reopen bypass. The bypass above only holds while the trusted
+          # actor is the one triggering the run, so a maintainer's reopen survives
+          # exactly until the author touches their own PR again: that `edited` event
+          # arrives with `sender == author`, the block above is skipped, and the
+          # guard closes the PR a maintainer deliberately reopened (observed on
+          # #6885, re-closed 46s after the author renamed it). A reopen is a
+          # decision about the PR, not about the event that carried it, so it has to
+          # outlive its own run: once a trusted actor has reopened this PR, the
+          # guard never closes it again. The timeline is that decision's only
+          # durable record — look for a `reopened` event whose actor has
+          # triage-or-higher access on *this* repo (the same `role_name` signal the
+          # bypasses above use; a collaborator on the contributor's fork can reopen
+          # too, and must not count). Fails open toward *checking*: an unreadable
+          # timeline or role continues the checks, so no unlinked PR is kept open by
+          # a transient API error.
+          REOPEN_ACTORS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" --paginate --jq '.[] | select(.event == "reopened") | .actor.login' 2>/dev/null | sort -u || true)
+          for REOPEN_ACTOR in $REOPEN_ACTORS; do
+            REOPEN_ROLE=$(gh api "repos/${REPO}/collaborators/${REOPEN_ACTOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
+            case "$REOPEN_ROLE" in
+              triage | write | maintain | admin)
+                echo "PR was previously reopened by ${REOPEN_ACTOR} (role: ${REOPEN_ROLE}); a trusted collaborator deliberately kept this PR open, skipping checks."
+                exit 0
+                ;;
+              *)
+                echo "PR was previously reopened by ${REOPEN_ACTOR} (role: ${REOPEN_ROLE}, no triage access); continuing checks."
+                ;;
+            esac
+          done
 
           # pydanty is the autonomous agent that opens PRs from issues. Its PRs are
           # never auto-closed for duplication; instead a pydanty PR supersedes a
@@ -405,10 +421,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
-          # Read-only org-scoped token, used solely to confirm private org
-          # membership (see the private-membership bypass). Falls back to empty
-          # when unset, which the bypass handles by failing open.
-          ORG_READ_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           GITHUB_EVENT_SENDER_LOGIN: ${{ github.event.sender.login }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -20,11 +20,6 @@ rules:
       - ci.yml
       - docs-preview.yml
       - manually-deploy-docs.yml
-      # `pr-guard.yml` reads `GH_AW_GITHUB_TOKEN` as job-level env solely to
-      # confirm private org membership via `gh api orgs/.../members/{author}`;
-      # it's used as a `gh` credential, never interpolated into a run script,
-      # and the job checks out no fork code, so shell-injection exposure is nil.
-      - pr-guard.yml
       # gh-aw-generated agentic workflow lockfiles (see
       # .github/workflows/README-pydantic-ai-agents.md). gh-aw injects API /
       # GitHub secrets as job-level env by design; they are held by the AWF


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David set the scope and chose both approaches (timeline lookup over the sticky label; removing the dead block over wiring the secret). He has not line-reviewed the diff.

- Closes #6950

## Root cause

`pr-guard.yml`'s trusted-actor bypass is gated on `sender != author`, so it only holds while the *maintainer* is the one triggering the run. A reopen is a decision about the PR, but the bypass treats it as a property of the event that carried it — so it evaporates on the next event. The author's next `edited` (a title rename counts) arrives with `sender == author`, the whole bypass block is skipped, and the guard closes the PR a maintainer deliberately reopened.

Confirmed on #6885 — the author changed nothing but the title, and the guard re-closed it 46s later:

```
2026-07-29T22:11:27Z  closed    by github-actions[bot]   # correct — no linked issue
2026-07-29T23:40:39Z  reopened  by DouweM                # trusted-actor bypass worked
2026-07-30T00:04:40Z  renamed   by ZacharyHampton        # author edits the title
2026-07-30T00:05:26Z  closed    by github-actions[bot]   # bypass skipped: sender == author
```

From a fork the author couldn't reopen, so the PR was dead — he refiled as #6900/#6901 and the original review history was stranded.

## Fix 1 — durable-reopen bypass

Encode the invariant the guard was missing: **once a trusted actor has reopened this PR, the guard never closes it again.** The timeline is that decision's only durable record, so before the guard can close anything it looks for a `reopened` event whose actor has triage-or-higher access on *this* repo.

It fires regardless of who triggered the current event — that is the whole point, since the broken path is the one where the author is the sender. Design details, all inherited from the bypasses already in the file:

- Role comes from `role_name`, not the legacy `permission` (which collapses `triage` into `read`), so a triager who can legitimately reopen still counts.
- The role is checked against the **base** repo, so a collaborator on the contributor's fork — who can also reopen a PR — does not count.
- Actors are de-duplicated (`sort -u`) so a repeatedly-reopened PR costs one permission call per distinct actor, not one per event.
- Fails open toward *checking*: an unreadable timeline or role continues the checks, so no unlinked PR is ever kept open by a transient API error.

It's placed after the existing sender-based bypass, so a maintainer-triggered event still exits before paying for the timeline pagination. Like every other bypass in this file it `exit 0`s wholesale rather than gating only the three `gh pr close` sites — same shape as its siblings, and consistent with the invariant.

## Fix 2 — remove the dead `ORG_READ_TOKEN` block

`secrets.GH_AW_GITHUB_TOKEN` is unset for this workflow, so the private-org-membership bypass never executed — it read as protection that wasn't there. Removed, along with its `env:` entry and its explanatory comment. With no secret left in the job's `env:`, `pr-guard.yml`'s `secrets-outside-env` suppression in `.github/zizmor.yml` is dead config too, so it goes with it (`zizmor` still passes on the file).

## Verification — and its honest limit

**This change cannot be integration-tested on its own PR.** `pr-guard.yml` runs on `pull_request_target`, which GitHub always executes from the base branch, so this PR is guarded by `main`'s copy. Proof here is logic plus post-merge observation.

What was verified: YAML parse and `check-yaml`, `bash -n` on the extracted script, `zizmor` clean. Then the script was extracted and run under a stubbed `gh` replaying #6885's real timeline, across four scenarios:

<details><summary>Simulated runs</summary>

```
A. #6885 replay: author renames title AFTER DouweM reopened
   Author ZacharyHampton repo role: none; continuing checks.
   PR was previously reopened by DouweM (role: maintain); a trusted collaborator
     deliberately kept this PR open, skipping checks.
   → does NOT close  ✅ (this is the bug)

B. control: same author edit, NO prior reopen
   No linked issues found in PR body.
   Closing PR #6885 — no linked issue.
   → still closes  ✅ (policy intact)

C. prior reopen by a NON-privileged actor
   PR was previously reopened by randomdrive-by (role: none, no triage access);
     continuing checks.
   Closing PR #6885 — no linked issue.
   → still closes  ✅ (fork collaborator can't grant a bypass)

D. maintainer-triggered edit, no prior reopen
   Event triggered by DouweM (role: maintain); a trusted collaborator acted on
     this PR, skipping checks.
   → does NOT close  ✅ (existing bypass unregressed)
```

</details>

The jq filter and `--paginate` were also run against the live API: `#6885` yields exactly `DouweM`, and a 135-event PR timeline (#4338) paginates in ~2.4s.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

