### PR TITLE
Drop the inert `merge=ours` attribute from the `gh-aw` lock files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-.github/workflows/*.lock.yml linguist-generated=true merge=ours
+.github/workflows/*.lock.yml linguist-generated=true


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David directed this change after I surfaced the finding; he has not reviewed the diff line-by-line.

`ours` is not one of git's built-in merge drivers (`text`, `binary`, `union` are), and nothing in this repository defines one — so half of

```
.github/workflows/*.lock.yml linguist-generated=true merge=ours
```

has done nothing since it landed in #5569.

**That inertness is the only reason it has been harmless.** The attribute's intended effect is the wrong one for a generated file: with `merge.ours.driver=true` configured, a lock conflict resolves to our side and exits 0, so the committed `*.lock.yml` no longer matches what `gh aw compile` produces from the merged `*.md`.

Nothing downstream catches that. The `lock-not-regenerated` policy check verifies that a source and its lock **changed together**, not that the lock was recompiled — and a merge resolution satisfies exactly that.

Setting the driver is not an exotic thing to do; it is the standard recipe people apply globally for `package-lock.json`, `Cargo.lock` and friends. Leaving the attribute in place means a reasonable global git config silently corrupts this repository's locks.

<details>
<summary>Verified behaviour, both ways</summary>

```
# no driver configured (today)
$ git merge other
CONFLICT (content): Merge conflict in a.lock.yml     # exit 1, ordinary text merge

# with merge.ours.driver=true
$ git config merge.ours.driver true
$ git merge other                                     # exit 0
$ cat a.lock.yml
OURS                                                  # theirs silently discarded
```

</details>

`linguist-generated=true` is deliberately kept: the locks are ~20k lines across 11 files, and it is what keeps them collapsed in diffs and out of language statistics.

Trivial CI-config fix, so no linked issue per the template.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

