### PR TITLE
Make Vercel AI `ToolApprovalResponded.approved` a `StrictBool`

### DIFF
--- a/docs/ui/vercel-ai.md
+++ b/docs/ui/vercel-ai.md
@@ -167,7 +167,7 @@ When `sdk_version=6`, the adapter will:
 
 On the frontend, AI SDK UI's [`useChat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) hook handles the approval flow. You can use the [`Confirmation`](https://ai-sdk.dev/elements/components/confirmation) component from AI Elements for a pre-built approval UI, or build your own using the hook's `addToolApprovalResponse` function.
 
-Tool approval responses are trusted from the request by design, matching the protocol's round-trip through `useChat`'s `addToolApprovalResponse` and the reference Next.js backend. The decision itself must be an actual JSON boolean: `approved` is strictly typed, so a truthy stand-in like `1` or `"true"` fails request validation instead of being coerced into an approval. If your application needs the approval decision tied to server-side state rather than the request, intercept [`DeferredToolRequests`][pydantic_ai.DeferredToolRequests], persist the approval IDs server-side, and pass explicit `deferred_tool_results` when resuming.
+Tool approval responses are trusted from the request by design, matching the protocol's round-trip through `useChat`'s `addToolApprovalResponse` and the reference Next.js backend. The decision itself must be an actual JSON boolean: `approved` is strictly typed, so any stand-in — `1` or `"true"` as much as `0` or `"false"` — fails request validation rather than being coerced into a decision. If your application needs the approval decision tied to server-side state rather than the request, intercept [`DeferredToolRequests`][pydantic_ai.DeferredToolRequests], persist the approval IDs server-side, and pass explicit `deferred_tool_results` when resuming.
 
 ## Tool input validation
 

--- a/docs/ui/vercel-ai.md
+++ b/docs/ui/vercel-ai.md
@@ -167,7 +167,7 @@ When `sdk_version=6`, the adapter will:
 
 On the frontend, AI SDK UI's [`useChat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) hook handles the approval flow. You can use the [`Confirmation`](https://ai-sdk.dev/elements/components/confirmation) component from AI Elements for a pre-built approval UI, or build your own using the hook's `addToolApprovalResponse` function.
 
-Tool approval responses are trusted from the request by design, matching the protocol's round-trip through `useChat`'s `addToolApprovalResponse` and the reference Next.js backend. If your application needs the approval decision tied to server-side state rather than the request, intercept [`DeferredToolRequests`][pydantic_ai.DeferredToolRequests], persist the approval IDs server-side, and pass explicit `deferred_tool_results` when resuming.
+Tool approval responses are trusted from the request by design, matching the protocol's round-trip through `useChat`'s `addToolApprovalResponse` and the reference Next.js backend. The decision itself must be an actual JSON boolean: `approved` is strictly typed, so a truthy stand-in like `1` or `"true"` fails request validation instead of being coerced into an approval. If your application needs the approval decision tied to server-side state rather than the request, intercept [`DeferredToolRequests`][pydantic_ai.DeferredToolRequests], persist the approval IDs server-side, and pass explicit `deferred_tool_results` when resuming.
 
 ## Tool input validation
 

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -9,7 +9,7 @@ Tool approval types (`ToolApprovalRequested`, `ToolApprovalResponded`) require A
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import Discriminator, Field
+from pydantic import Discriminator, Field, StrictBool
 
 from ._models import CamelBaseModel
 
@@ -125,8 +125,15 @@ class ToolApprovalResponded(CamelBaseModel):
     id: str
     """The approval request ID."""
 
-    approved: bool
-    """Whether the user approved the tool call."""
+    approved: StrictBool
+    """Whether the user approved the tool call.
+
+    Deliberately strict: in Pydantic's default lax mode `{'approved': 1}` or `{'approved': 'true'}`
+    would coerce to an approval, and this field is the client-controlled gate on tools declared
+    `requires_approval=True`. A non-boolean value fails validation — and so rejects the whole
+    request — instead of silently executing the call
+    ([#6922](https://github.com/pydantic/pydantic-ai/issues/6922)).
+    """
 
     reason: str | None = None
     """Optional reason for the approval or denial."""

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -133,6 +133,10 @@ class ToolApprovalResponded(CamelBaseModel):
     `requires_approval=True`. A non-boolean value fails validation — and so rejects the whole
     request — instead of silently executing the call
     ([#6922](https://github.com/pydantic/pydantic-ai/issues/6922)).
+
+    `ToolApproval` is an undiscriminated union, so rejecting here only denies because
+    `CamelBaseModel`'s `extra='forbid'` stops the part re-matching `ToolApprovalRequested`
+    (which upstream declares `approved?: never`). Relaxing either would reopen the gate.
     """
 
     reason: str | None = None

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3557,34 +3557,34 @@ async def test_tool_approval_denial_with_reason():
     assert approvals['delete_3'] is True
 
 
-def _approval_request_body(approved: object) -> bytes:
-    """A client request resolving one pending approval, as raw JSON off the wire."""
+def _approval_request_body(approved: object, part_type: str) -> bytes:
+    """A client request resolving one pending approval, as raw JSON off the wire.
+
+    `part_type` picks between the two part families the protocol defines for the same
+    `approval-responded` state: `tool-<name>` for a statically declared tool, `dynamic-tool`
+    for one the client names at runtime.
+    """
+    part: dict[str, object] = {
+        'type': part_type,
+        'toolCallId': 'delete_1',
+        'state': 'approval-responded',
+        'input': {'path': 'important.txt'},
+        'approval': {'id': 'approval-1', 'approved': approved},
+    }
+    if part_type == 'dynamic-tool':
+        part['toolName'] = 'delete_file'
     return json.dumps(
         {
             'trigger': 'submit-message',
             'id': 'foo',
-            'messages': [
-                {
-                    'id': 'assistant-1',
-                    'role': 'assistant',
-                    'parts': [
-                        {
-                            'type': 'dynamic-tool',
-                            'toolName': 'delete_file',
-                            'toolCallId': 'delete_1',
-                            'state': 'approval-responded',
-                            'input': {'path': 'important.txt'},
-                            'approval': {'id': 'approval-1', 'approved': approved},
-                        }
-                    ],
-                }
-            ],
+            'messages': [{'id': 'assistant-1', 'role': 'assistant', 'parts': [part]}],
         }
     ).encode()
 
 
+@pytest.mark.parametrize('part_type', ['tool-delete_file', 'dynamic-tool'])
 @pytest.mark.parametrize('approved', [1, 0, 1.0, 'true', 'false', 'yes'])
-def test_tool_approval_rejects_coercible_approved(approved: object):
+def test_tool_approval_rejects_coercible_approved(approved: object, part_type: str):
     """A non-boolean `approved` is rejected at the client->server boundary, never coerced.
 
     `ToolApprovalResponded.approved` is a `StrictBool`, so lax-mode coercion can't turn
@@ -3592,9 +3592,13 @@ def test_tool_approval_rejects_coercible_approved(approved: object):
     tool. The whole request fails validation rather than the field quietly denying: `approved`
     also can't fall through to `ToolApprovalRequested` (the other member of the `ToolApproval`
     union), because `extra='forbid'` rejects the unexpected key there.
+
+    Both part families are pinned: they route to the same `ToolApproval` union but discriminate
+    differently (a `type` literal vs a `^tool-` pattern), so identical error sets are worth
+    asserting rather than assuming.
     """
     with pytest.raises(ValidationError) as exc_info:
-        VercelAIAdapter.build_run_input(_approval_request_body(approved))
+        VercelAIAdapter.build_run_input(_approval_request_body(approved, part_type))
 
     # `UIMessagePart` is an undiscriminated union, so every member that fails to match reports its
     # own errors; only the ones located on `approved` itself say why the approval was rejected.
@@ -3602,8 +3606,9 @@ def test_tool_approval_rejects_coercible_approved(approved: object):
     assert errors == snapshot({'bool_type', 'extra_forbidden'})
 
 
+@pytest.mark.parametrize('part_type', ['tool-delete_file', 'dynamic-tool'])
 @pytest.mark.parametrize('approved', [True, False])
-def test_tool_approval_accepts_literal_bools(approved: bool):
+def test_tool_approval_accepts_literal_bools(approved: bool, part_type: str):
     """Literal JSON `true`/`false` still round-trip into the approval a spec-conforming client meant."""
     agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
 
@@ -3611,7 +3616,7 @@ def test_tool_approval_accepts_literal_bools(approved: bool):
     def delete_file(path: str) -> str:
         return f'Deleted {path}'  # pragma: no cover
 
-    run_input = VercelAIAdapter.build_run_input(_approval_request_body(approved))
+    run_input = VercelAIAdapter.build_run_input(_approval_request_body(approved, part_type))
     adapter = VercelAIAdapter(agent, run_input, sdk_version=6)
 
     assert adapter.deferred_tool_results == snapshot(DeferredToolResults(approvals={'delete_1': approved}))

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3619,7 +3619,7 @@ def test_tool_approval_accepts_literal_bools(approved: bool, part_type: str):
     run_input = VercelAIAdapter.build_run_input(_approval_request_body(approved, part_type))
     adapter = VercelAIAdapter(agent, run_input, sdk_version=6)
 
-    assert adapter.deferred_tool_results == snapshot(DeferredToolResults(approvals={'delete_1': approved}))
+    assert adapter.deferred_tool_results == DeferredToolResults(approvals={'delete_1': approved})
 
 
 async def test_tool_approval_ignores_output_denied_parts():

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3557,6 +3557,66 @@ async def test_tool_approval_denial_with_reason():
     assert approvals['delete_3'] is True
 
 
+def _approval_request_body(approved: Any) -> bytes:
+    """A client request resolving one pending approval, as raw JSON off the wire."""
+    return json.dumps(
+        {
+            'trigger': 'submit-message',
+            'id': 'foo',
+            'messages': [
+                {
+                    'id': 'assistant-1',
+                    'role': 'assistant',
+                    'parts': [
+                        {
+                            'type': 'dynamic-tool',
+                            'toolName': 'delete_file',
+                            'toolCallId': 'delete_1',
+                            'state': 'approval-responded',
+                            'input': {'path': 'important.txt'},
+                            'approval': {'id': 'approval-1', 'approved': approved},
+                        }
+                    ],
+                }
+            ],
+        }
+    ).encode()
+
+
+@pytest.mark.parametrize('approved', [1, 0, 1.0, 'true', 'false', 'yes'])
+def test_tool_approval_rejects_coercible_approved(approved: Any):
+    """A non-boolean `approved` is rejected at the client->server boundary, never coerced.
+
+    `ToolApprovalResponded.approved` is a `StrictBool`, so lax-mode coercion can't turn
+    `{'approved': 1}` or `{'approved': 'true'}` into an approval of a `requires_approval=True`
+    tool. The whole request fails validation rather than the field quietly denying: `approved`
+    also can't fall through to `ToolApprovalRequested` (the other member of the `ToolApproval`
+    union), because `extra='forbid'` rejects the unexpected key there.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        VercelAIAdapter.build_run_input(_approval_request_body(approved))
+
+    # `UIMessagePart` is an undiscriminated union, so every member that fails to match reports its
+    # own errors; only the ones located on `approved` itself say why the approval was rejected.
+    errors = {error['type'] for error in exc_info.value.errors() if error['loc'][-1] == 'approved'}
+    assert errors == snapshot({'bool_type', 'extra_forbidden'})
+
+
+@pytest.mark.parametrize('approved,expected', [(True, True), (False, False)])
+def test_tool_approval_accepts_literal_bools(approved: bool, expected: bool):
+    """Literal JSON `true`/`false` still round-trip into the approval a spec-conforming client meant."""
+    agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
+
+    @agent.tool_plain(requires_approval=True)
+    def delete_file(path: str) -> str:
+        return f'Deleted {path}'  # pragma: no cover
+
+    run_input = VercelAIAdapter.build_run_input(_approval_request_body(approved))
+    adapter = VercelAIAdapter(agent, run_input, sdk_version=6)
+
+    assert adapter.deferred_tool_results == snapshot(DeferredToolResults(approvals={'delete_1': expected}))
+
+
 async def test_tool_approval_ignores_output_denied_parts():
     """Test that output-denied parts are not yielded by iter_tool_approval_responses.
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3557,7 +3557,7 @@ async def test_tool_approval_denial_with_reason():
     assert approvals['delete_3'] is True
 
 
-def _approval_request_body(approved: Any) -> bytes:
+def _approval_request_body(approved: object) -> bytes:
     """A client request resolving one pending approval, as raw JSON off the wire."""
     return json.dumps(
         {
@@ -3584,7 +3584,7 @@ def _approval_request_body(approved: Any) -> bytes:
 
 
 @pytest.mark.parametrize('approved', [1, 0, 1.0, 'true', 'false', 'yes'])
-def test_tool_approval_rejects_coercible_approved(approved: Any):
+def test_tool_approval_rejects_coercible_approved(approved: object):
     """A non-boolean `approved` is rejected at the client->server boundary, never coerced.
 
     `ToolApprovalResponded.approved` is a `StrictBool`, so lax-mode coercion can't turn
@@ -3602,8 +3602,8 @@ def test_tool_approval_rejects_coercible_approved(approved: Any):
     assert errors == snapshot({'bool_type', 'extra_forbidden'})
 
 
-@pytest.mark.parametrize('approved,expected', [(True, True), (False, False)])
-def test_tool_approval_accepts_literal_bools(approved: bool, expected: bool):
+@pytest.mark.parametrize('approved', [True, False])
+def test_tool_approval_accepts_literal_bools(approved: bool):
     """Literal JSON `true`/`false` still round-trip into the approval a spec-conforming client meant."""
     agent = Agent(TestModel(), output_type=[str, DeferredToolRequests])
 
@@ -3614,7 +3614,7 @@ def test_tool_approval_accepts_literal_bools(approved: bool, expected: bool):
     run_input = VercelAIAdapter.build_run_input(_approval_request_body(approved))
     adapter = VercelAIAdapter(agent, run_input, sdk_version=6)
 
-    assert adapter.deferred_tool_results == snapshot(DeferredToolResults(approvals={'delete_1': expected}))
+    assert adapter.deferred_tool_results == snapshot(DeferredToolResults(approvals={'delete_1': approved}))
 
 
 async def test_tool_approval_ignores_output_denied_parts():


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David validated the issue and greenlit the direction; he has not reviewed the code line-by-line.

`ToolApprovalResponded.approved` was a plain `bool`, so Pydantic's lax mode coerced `{"approved": 1}` / `"true"` / `1.0` / `"yes"` into an approval at the client→server trust boundary that gates `requires_approval=True` tools. It's now a `StrictBool`, so a non-boolean value fails request validation instead of executing the call.

This is the Vercel leg of the deny-by-default hardening #6858 proposes for AG-UI — that PR is approved but **not yet merged**, so `StrictBool` does not exist anywhere in the codebase today.

**Deny vs. reject.** #6858 degrades a malformed AG-UI payload to a per-entry denial and lets the run continue; here a malformed `approved` rejects the whole request (`ValidationError` → 422, via `UIAdapter.dispatch_request`). That difference follows from where each protocol puts the decision: AG-UI's `ResumeEntry.payload` is an untyped dict with no schema to fail against, so it needs a payload model plus a runtime branch; Vercel's `approved` is a typed field of the request body, validated at parse time before any per-approval deny path exists. Both are fail-closed — this is how "deny by default" spells itself on a typed request schema, and it's already how every other malformed field in this adapter behaves.

**Scope.** Only `approved` was reproduced as defective. The issue also asked about the denial `reason` path and the rest of the model — checked and left alone: Pydantic v2 doesn't coerce int/float/bool into `str`, so `id` and `reason` already reject non-strings (`string_type`). Nothing else hardened.

<details><summary>Verification against <code>main</code>, before and after</summary>

```python
from pydantic_ai.ui.vercel_ai.request_types import ToolApprovalResponded

for raw in [1, 'true', 1.0, 'yes', 0, 'false']:
    m = ToolApprovalResponded.model_validate({'id': 'a1', 'approved': raw})
    print(f'approved={raw!r:<8} -> {m.approved!r}')
```

Before — `1`, `'true'`, `1.0`, `'yes'` all validate to `True`, and `VercelAIAdapter.deferred_tool_results` sets `approvals[tool_call_id] = True`. After — all six raise `ValidationError` (`bool_type`); literal `true`/`false` are unaffected.

No spec-conforming client is affected, and the AI SDK is more than type-level evidence here — its own reference server-side validator already validates this field with a non-coercing `z.boolean()` ([`validate-ui-messages.ts` @ `ai@6.0.57`](https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/ui/validate-ui-messages.ts)), so `{"approved": 1}` fails there too. The lax `bool` was the divergence; `StrictBool` is the conformant posture. The message type declares the field a plain boolean and declares `approved?: never` on the sibling `approval-requested` arm — [`ui-messages.ts` @ `ai@6.0.57`](https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/ui/ui-messages.ts).

That second declaration is also why the union can't route around the fix: `{'id': 'a1', 'approved': 1}` doesn't fall through to `ToolApprovalRequested`, because `extra='forbid'` rejects the unexpected key there. Both tests pin this.

</details>

**Tests** (`tests/test_vercel_ai.py`), both driving raw JSON through `VercelAIAdapter.build_run_input` — the actual client→server boundary:

- `test_tool_approval_rejects_coercible_approved` — `1`, `0`, `1.0`, `"true"`, `"false"`, `"yes"` fail validation
- `test_tool_approval_accepts_literal_bools` — literal `true`/`false` still produce the approval/denial the client meant

**Breaking change?** No, per the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md): this narrows an accepted input shape, but only for code relying on undocumented lax coercion. Spec-conforming clients — AI SDK UI's `useChat.addToolApprovalResponse` and the reference Next.js backend — always send a real boolean.

- Closes #6922

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
