### PR TITLE
Route issue attention to its first maintainer in the triage channel

### DIFF
--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -520,7 +520,14 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             for label in labels.intersection(_STAGE_LABELS):
                 _remove_label(client, repo, number, label)
             _add_labels(client, repo, number, [_ACTION_LABEL])
-            recipients = _ensure_recipients(client, repo, current, _maintainer_assignees(client, repo, current))
+            expected = {
+                **current,
+                'labels': [
+                    *(label for label in current.get('labels', []) if str(label['name']) not in _STAGE_LABELS),
+                    {'name': _ACTION_LABEL},
+                ],
+            }
+            recipients = _ensure_recipients(client, repo, expected, _maintainer_assignees(client, repo, current))
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
         except (urllib.error.HTTPError, RuntimeError) as exc:
@@ -670,7 +677,7 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     replace_bot_fallback = (
         _FALLBACK_OWNER.casefold() in {login.casefold() for login in maintainers}
         and action_transition is not None
-        and _latest_assignment_was_by_attention_bot(timeline, _FALLBACK_OWNER, action_transition[0])
+        and _latest_assignment_was_by_attention_bot(events, _FALLBACK_OWNER, action_transition[0])
     )
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -29,8 +29,11 @@ _CANDIDATE_LIMIT = 10
 _RECENT_CANDIDATE_LIMIT = _CANDIDATE_LIMIT // 2
 _BACKLOG_CANDIDATE_LIMIT = _CANDIDATE_LIMIT - _RECENT_CANDIDATE_LIMIT
 _RECONCILE_LIMIT = 25
+_ACTIVE_OPEN_LIMIT = 20
+_CLOSED_CLEANUP_LIMIT = _RECONCILE_LIMIT - _ACTIVE_OPEN_LIMIT
 _EVENT_PAGE_LIMIT = 10
 _COMMENT_PAGE_LIMIT = 10
+_DISCUSSION_PARTICIPANT_LIMIT = 50
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
@@ -59,6 +62,8 @@ class Notice(TypedDict):
 
     number: int
     kind: Literal['reminder', 'escalation']
+    expected_stage: Literal[0, 1, 2]
+    transition_id: int | str
     title: str
     recipients: list[str]
 
@@ -67,7 +72,9 @@ class NoticeRef(TypedDict):
     """The item and state that a delivered channel notice described."""
 
     number: int
-    expected_stage: Literal[0, 1]
+    expected_stage: Literal[0, 1, 2]
+    transition_id: int | str
+    recipients: list[str]
 
 
 class GitHubClient:
@@ -431,13 +438,18 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
     if 'pull_request' in item:
         return None
 
+    permissions: dict[str, object] = {}
+
     def maintainer(entry: Mapping[str, Any]) -> str | None:
         login = _login(entry)
-        if (
-            login
-            and entry.get('author_association') in _ACK_ASSOCIATIONS
-            and _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS
-        ):
+        if not login:
+            return None
+        key = login.casefold()
+        if key not in permissions:
+            if len(permissions) == _DISCUSSION_PARTICIPANT_LIMIT:
+                raise RuntimeError('Issue discussion exceeds the participant safety limit')
+            permissions[key] = _collaborator_permission(client, repo, login)
+        if login and permissions[key] in _MAINTAINER_PERMISSIONS:
             return login
         return None
 
@@ -456,15 +468,25 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
 def _ensure_recipients(
     client: GitHubClient, repo: str, item: Mapping[str, Any], maintainers: Sequence[str]
 ) -> list[str]:
-    if maintainers:
-        return list(maintainers)
     number = int(item['number'])
-    owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
+    owner = _first_maintainer_in_discussion(client, repo, item)
+    if owner and owner.casefold() in {login.casefold() for login in maintainers}:
+        return [next(login for login in maintainers if login.casefold() == owner.casefold())]
+    if owner is None and maintainers:
+        return list(maintainers)
+
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if current.get('state') != 'open' or _ACTION_LABEL not in _labels(current):
         raise RuntimeError('Attention state changed during owner selection')
+    if current.get('updated_at') != item.get('updated_at'):
+        owner = _first_maintainer_in_discussion(client, repo, current)
     if current_maintainers := _maintainer_assignees(client, repo, current):
-        return current_maintainers
+        if owner is None:
+            return current_maintainers
+        if owner.casefold() in {login.casefold() for login in current_maintainers}:
+            return [next(login for login in current_maintainers if login.casefold() == owner.casefold())]
+
+    owner = owner or _FALLBACK_OWNER
     assigned = cast(
         dict[str, Any],
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
@@ -472,7 +494,7 @@ def _ensure_recipients(
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     if owner.casefold() not in {login.casefold() for login in assigned_maintainers}:
         raise RuntimeError(f'GitHub did not assign @{owner}')
-    return assigned_maintainers
+    return [next(login for login in assigned_maintainers if login.casefold() == owner.casefold())]
 
 
 def _remove_label(client: GitHubClient, repo: str, number: int, label: str) -> None:
@@ -579,8 +601,8 @@ def _actor(event: Mapping[str, Any]) -> str:
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
 
 
-# `mentioned` and `subscribed` fire as a side effect of the bot's own reminder
-# comment mentioning the recipient, so they must never count as acknowledgement.
+# `mentioned` and `subscribed` can be generated as activity side effects, so
+# they must never count as acknowledgement.
 _NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
 _ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 
@@ -602,19 +624,26 @@ def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipi
 
 
 def _complete(client: GitHubClient, repo: str, number: int, labels: set[str]) -> None:
-    _remove_label(client, repo, number, _ACTION_LABEL)
     for label in labels.intersection(_STAGE_LABELS):
         _remove_label(client, repo, number, label)
+    _remove_label(client, repo, number, _ACTION_LABEL)
 
 
 def _notice(
     item: Mapping[str, Any],
     kind: Literal['reminder', 'escalation'],
+    stage: Literal[0, 1, 2],
+    transition: tuple[dt.datetime, dict[str, Any]],
     recipients: Sequence[str],
 ) -> Notice:
+    transition_id = transition[1].get('id')
+    if not isinstance(transition_id, (int, str)) or isinstance(transition_id, bool):
+        raise RuntimeError('Could not build a durable attention notice')
     return Notice(
         number=int(item['number']),
         kind=kind,
+        expected_stage=stage,
+        transition_id=transition_id,
         title=str(item.get('title') or '')[:300],
         recipients=list(recipients),
     )
@@ -644,6 +673,9 @@ def _reconcile_item(
     if _actor(transition_event) != 'github-actions[bot]':
         _complete(client, repo, number, labels)
         return f'#{number}: removed a foreign attention transition', None
+    if _closed_since(timeline, transition_at):
+        _complete(client, repo, number, labels)
+        return f'#{number}: completed after the item was closed', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
@@ -654,17 +686,27 @@ def _reconcile_item(
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
-    # Stage 2 is only written after Slack accepts the escalation. If cleanup
-    # was interrupted, finish it without posting the channel notice again.
+    # Stage 2 is the existing durable "terminal Slack delivery pending" state.
+    # Keeping that meaning makes the channel cutover safe for in-flight items.
     if current_stage == 2:
-        _remove_label(client, repo, number, _ACTION_LABEL)
-        return f'#{number}: completed delivered channel escalation', None
+        recipients = _ensure_recipients(client, repo, current, maintainers)
+        return f'#{number}: queued channel escalation', _notice(
+            current, 'escalation', current_stage, transition, recipients
+        )
     recipients = _ensure_recipients(client, repo, current, maintainers)
+    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+    if _closed_since(timeline, transition_at) or _acknowledged(timeline, transition_at, recipients):
+        _complete(client, repo, number, labels)
+        return f'#{number}: maintainer acknowledged the request', None
     if now - transition_at < _SLA:
         return None
     if current_stage == 0:
-        return f'#{number}: queued channel reminder', _notice(current, 'reminder', recipients)
-    return f'#{number}: queued channel escalation', _notice(current, 'escalation', recipients)
+        return f'#{number}: queued channel reminder', _notice(
+            current, 'reminder', current_stage, transition, recipients
+        )
+    return f'#{number}: queued channel escalation', _notice(
+        current, 'escalation', current_stage, transition, recipients
+    )
 
 
 def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str | None:
@@ -702,15 +744,22 @@ def reconcile(
     by healthy items always reach the Slack delivery job.
     """
     ensure_labels(client, repo)
-    encoded = urllib.parse.quote(_ACTION_LABEL, safe='')
-    items = cast(
-        list[dict[str, Any]],
-        client.get(
-            # state=all so a closed item still completes its lifecycle (labels
-            # removed) instead of leaving a dormant clock that a reopen wakes.
-            f'/repos/{repo}/issues?state=all&labels={encoded}&sort=updated&direction=asc&per_page={_RECONCILE_LIMIT}'
-        ),
+    slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
+    closed = _rotated_search(
+        client,
+        f'repo:{repo} is:closed label:"{_ACTION_LABEL}"',
+        order='asc',
+        limit=_CLOSED_CLEANUP_LIMIT,
+        slot=slot,
     )
+    active = _rotated_search(
+        client,
+        f'repo:{repo} is:open label:"{_ACTION_LABEL}"',
+        order='asc',
+        limit=_ACTIVE_OPEN_LIMIT,
+        slot=slot,
+    )
+    items = [*closed, *active]
     lines: list[str] = []
     failures: list[str] = []
     for item in items:
@@ -725,7 +774,7 @@ def reconcile(
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')
-    if len(items) == _RECONCILE_LIMIT:
+    if len(closed) == _CLOSED_CLEANUP_LIMIT or len(active) == _ACTIVE_OPEN_LIMIT:
         lines.append('additional attention items remain for a later rotated batch')
     encoded_escalated = urllib.parse.quote(_ESCALATED_LABEL, safe='')
     dormant = cast(
@@ -765,7 +814,7 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
     if output_path := os.environ.get('GITHUB_OUTPUT'):
         reasons = {
             'reminder': 'no maintainer has acted for three days',
-            'escalation': 'the channel reminder has had no maintainer response for three more days',
+            'escalation': 'the previous reminder has had no maintainer response for three more days',
         }
         details: list[str] = []
         for notice in notices:
@@ -783,15 +832,17 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
                     *details,
                     '',
                     '*Expected action:* Open each item and make its next maintainer decision there. Reply, review, '
-                    'merge, close, or request changes as appropriate. Do not remove the attention labels; the '
-                    'monitor clears them after maintainer activity.',
+                    'merge, close, or request changes as appropriate. If no work is needed, say so briefly. Do not '
+                    'remove the attention labels; the monitor clears them after maintainer activity.',
                 ]
             )
         }
         refs = [
             NoticeRef(
                 number=notice['number'],
-                expected_stage=0 if notice['kind'] == 'reminder' else 1,
+                expected_stage=notice['expected_stage'],
+                transition_id=notice['transition_id'],
+                recipients=notice['recipients'],
             )
             for notice in notices
         ]
@@ -799,6 +850,9 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
             output.write(f'has_notices={str(bool(notices)).lower()}\n')
             output.write(f'notice_items={json.dumps(refs, separators=(",", ":"))}\n')
             output.write(f'slack_payload={json.dumps(payload, separators=(",", ":"))}\n')
+
+
+_LOGIN_PATTERN = re.compile(r'(?=.{1,39}\Z)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?')
 
 
 def _notice_refs(loaded: object) -> list[NoticeRef]:
@@ -813,20 +867,38 @@ def _notice_refs(loaded: object) -> list[NoticeRef]:
         if not isinstance(value, Mapping):
             raise ValueError('Notice has an invalid shape')
         notice = cast(Mapping[str, object], value)
-        if set(notice) != {'number', 'expected_stage'}:
+        if set(notice) != {'number', 'expected_stage', 'transition_id', 'recipients'}:
             raise ValueError('Notice has an invalid shape')
         number = notice['number']
         stage = notice['expected_stage']
+        transition_id = notice['transition_id']
+        recipients = notice['recipients']
+        recipient_values = cast(list[object], recipients) if isinstance(recipients, list) else []
         if (
             not isinstance(number, int)
             or isinstance(number, bool)
             or number < 1
             or not isinstance(stage, int)
             or isinstance(stage, bool)
-            or stage not in {0, 1}
+            or stage not in {0, 1, 2}
+            or not isinstance(transition_id, (int, str))
+            or isinstance(transition_id, bool)
+            or (isinstance(transition_id, int) and transition_id < 1)
+            or (isinstance(transition_id, str) and not 1 <= len(transition_id) <= 100)
+            or not isinstance(recipients, list)
+            or not 1 <= len(recipient_values) <= 10
+            or any(not isinstance(login, str) or not _LOGIN_PATTERN.fullmatch(login) for login in recipient_values)
+            or len({cast(str, login).casefold() for login in recipient_values}) != len(recipient_values)
         ):
             raise ValueError('Notice has invalid values')
-        notices.append(NoticeRef(number=number, expected_stage=cast(Literal[0, 1], stage)))
+        notices.append(
+            NoticeRef(
+                number=number,
+                expected_stage=cast(Literal[0, 1, 2], stage),
+                transition_id=transition_id,
+                recipients=cast(list[str], recipient_values),
+            )
+        )
     if len(notices) > _RECONCILE_LIMIT or len({notice['number'] for notice in notices}) != len(notices):
         raise ValueError('Notices must be unique and within the batch limit')
     return notices
@@ -847,19 +919,28 @@ def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str 
     if current.get('state') != 'open' or _ACTION_LABEL not in labels or stage != notice['expected_stage']:
         return None
     maintainers = _maintainer_assignees(client, repo, current)
+    if not {login.casefold() for login in notice['recipients']} <= {login.casefold() for login in maintainers}:
+        return None
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
     transition = _transition(events, stage)
-    if transition is None or _actor(transition[1]) != 'github-actions[bot]':
+    if (
+        transition is None
+        or transition[1].get('id') != notice['transition_id']
+        or _actor(transition[1]) != 'github-actions[bot]'
+    ):
         return None
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], maintainers):
+    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer activity completed the delivered notice'
+    if stage == 2:
+        _remove_label(client, repo, number, _ACTION_LABEL)
+        return f'#{number}: recorded channel escalation'
     next_stage: Literal[1, 2] = 1 if stage == 0 else 2
     _advance_stage(client, repo, number, labels, next_stage)
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
     completed_labels = labels | {_STAGE_LABELS[next_stage - 1]}
-    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], maintainers):
+    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
         _complete(client, repo, number, completed_labels)
         return f'#{number}: maintainer activity completed the delivered notice'
     if stage == 1:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -698,9 +698,11 @@ def _notice_if_current(
     return _notice(current, kind, stage, current_transition, recipients)
 
 
-def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int) -> None:
+def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int, *, new_delivery: bool = False) -> None:
     """Finish a terminal delivery while preserving its dormant marker."""
     _add_labels(client, repo, number, [_ESCALATED_LABEL])
+    if new_delivery:
+        _add_labels(client, repo, number, [_DELIVERED_LABEL])
     _remove_label(client, repo, number, _ACTION_LABEL)
     _remove_label(client, repo, number, _PINGED_LABEL)
     _remove_label(client, repo, number, _DELIVERED_LABEL)
@@ -1096,8 +1098,7 @@ def _finalize_notice(
     else:
         # Record delivery before terminal cleanup so a later GitHub failure
         # cannot make reconciliation post the escalation again.
-        _add_labels(client, repo, number, [_DELIVERED_LABEL])
-        _finish_delivered_escalation(client, repo, number)
+        _finish_delivered_escalation(client, repo, number, new_delivery=True)
 
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
     completed_labels = labels | ({_PINGED_LABEL} if stage == 0 else {_ESCALATED_LABEL, _DELIVERED_LABEL})

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -13,7 +13,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 
 # Stdlib-only imports: production invokes this script with the runner's bare
@@ -27,10 +27,12 @@ _SLA = dt.timedelta(days=3)
 _CANDIDATE_LIMIT = 10
 _RECONCILE_LIMIT = 25
 _EVENT_PAGE_LIMIT = 10
+_DISCUSSION_PAGE_LIMIT = 10
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
 _MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
+_ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 _ACTION_LABEL = 'needs-maintainer-action'
 _PINGED_LABEL = 'attention-pinged'
 _ESCALATED_LABEL = 'attention-escalated'
@@ -107,6 +109,16 @@ class GitHubClient:
             page_path = f'{parsed.path}?{urllib.parse.urlencode(query, doseq=True)}'
             pages.extend(cast(list[dict[str, Any]], self.get(page_path)))
         return pages
+
+    def pages(self, path: str, *, count: int = 1) -> Iterator[list[dict[str, Any]]]:
+        """Yield up to `count` pages from the start of a GitHub collection."""
+        separator = '&' if '?' in path else '?'
+        page_path = f'{path}{separator}per_page=100&page=1'
+        for _ in range(count):
+            values, links = self._request('GET', page_path)
+            yield cast(list[dict[str, Any]], values)
+            if not (page_path := _link_path(links, 'next')):
+                return
 
 
 def _parse_time(value: str) -> dt.datetime:
@@ -349,29 +361,45 @@ def _add_labels(client: GitHubClient, repo: str, number: int, labels: Sequence[s
     client.post(f'/repos/{repo}/issues/{number}/labels', {'labels': list(labels)})
 
 
+def _collaborator_permission(client: GitHubClient, repo: str, login: str) -> object:
+    encoded = urllib.parse.quote(login, safe='')
+    return cast(Mapping[str, object], client.get(f'/repos/{repo}/collaborators/{encoded}/permission')).get('permission')
+
+
 def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[str]:
     maintainers: list[str] = []
     for assignee in item.get('assignees', []):
         login = str(assignee['login'])
-        encoded = urllib.parse.quote(login, safe='')
-        permission = cast(Mapping[str, object], client.get(f'/repos/{repo}/collaborators/{encoded}/permission')).get(
-            'permission'
-        )
-        if permission in _MAINTAINER_PERMISSIONS:
+        if _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS:
             maintainers.append(login)
     return sorted(maintainers, key=str.casefold)
+
+
+def _first_maintainer_in_discussion(client: GitHubClient, repo: str, number: int) -> str | None:
+    for page in client.pages(f'/repos/{repo}/issues/{number}/timeline', count=_DISCUSSION_PAGE_LIMIT):
+        for event in page:
+            if (
+                event.get('event') not in {'commented', 'reviewed'}
+                or event.get('author_association') not in _ACK_ASSOCIATIONS
+            ):
+                continue
+            login = _login(event)
+            if login and _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS:
+                return login
+    return None
 
 
 def _ensure_recipients(client: GitHubClient, repo: str, number: int, maintainers: Sequence[str]) -> list[str]:
     if maintainers:
         return list(maintainers)
+    owner = _first_maintainer_in_discussion(client, repo, number) or _FALLBACK_OWNER
     assigned = cast(
         dict[str, Any],
-        client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [_FALLBACK_OWNER]}),
+        client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
-    if _FALLBACK_OWNER.casefold() not in {str(value['login']).casefold() for value in assigned.get('assignees', [])}:
-        raise RuntimeError(f'GitHub did not assign @{_FALLBACK_OWNER}')
-    return [_FALLBACK_OWNER]
+    if owner.casefold() not in {str(value['login']).casefold() for value in assigned.get('assignees', [])}:
+        raise RuntimeError(f'GitHub did not assign @{owner}')
+    return [owner]
 
 
 def _remove_label(client: GitHubClient, repo: str, number: int, label: str) -> None:
@@ -478,7 +506,6 @@ def _actor(event: Mapping[str, Any]) -> str:
 # `mentioned` and `subscribed` fire as a side effect of the bot's own reminder
 # comment mentioning the recipient, so they must never count as acknowledgement.
 _NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
-_ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 
 
 def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipients: Sequence[str]) -> bool:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -24,7 +24,6 @@ from typing import Any, Literal, TypedDict, cast  # noqa: TID251
 
 _API = 'https://api.github.com'
 _SLA = dt.timedelta(days=3)
-_BOT_ASSIGNMENT_WINDOW = dt.timedelta(minutes=1)
 _CANDIDATE_LIMIT = 10
 _RECONCILE_LIMIT = 25
 _EVENT_PAGE_LIMIT = 10
@@ -92,8 +91,8 @@ class GitHubClient:
     def post(self, path: str, payload: Mapping[str, object]) -> Any:
         return self.request('POST', path, payload)
 
-    def delete(self, path: str, payload: Mapping[str, object] | None = None) -> Any:
-        return self.request('DELETE', path, payload)
+    def delete(self, path: str) -> Any:
+        return self.request('DELETE', path)
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         """Return up to `count` newest pages for an ascending GitHub collection."""
@@ -410,14 +409,11 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
     return None
 
 
-def _remove_assignees(client: GitHubClient, repo: str, number: int, assignees: Sequence[str]) -> None:
-    client.delete(f'/repos/{repo}/issues/{number}/assignees', {'assignees': list(assignees)})
-
-
 def _validate_attention_state(previous: Mapping[str, Any], current: Mapping[str, Any]) -> None:
     previous_labels = _labels(previous)
     if _ACTION_LABEL in previous_labels and (
         current.get('state') != 'open'
+        or current.get('updated_at') != previous.get('updated_at')
         or _ACTION_LABEL not in (current_labels := _labels(current))
         or _stage(current_labels) != _stage(previous_labels)
     ):
@@ -429,38 +425,20 @@ def _ensure_recipients(
     repo: str,
     item: Mapping[str, Any],
     maintainers: Sequence[str],
-    *,
-    replace_bot_fallback: bool = False,
 ) -> list[str]:
-    fallback_login = _FALLBACK_OWNER.casefold()
     if maintainers:
-        existing = [login for login in maintainers if login.casefold() != fallback_login]
-        if not replace_bot_fallback:
-            return list(maintainers)
-        if existing:
-            number = int(item['number'])
-            current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-            _validate_attention_state(item, current)
-            current_maintainers = _maintainer_assignees(client, repo, current)
-            existing = [login for login in current_maintainers if login.casefold() != fallback_login]
-            if existing:
-                if fallback_login in {login.casefold() for login in current_maintainers}:
-                    _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
-                return existing
+        number = int(item['number'])
+        current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+        _validate_attention_state(item, current)
+        if current_maintainers := _maintainer_assignees(client, repo, current):
+            return current_maintainers
 
     owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
     number = int(item['number'])
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     _validate_attention_state(item, current)
     current_maintainers = _maintainer_assignees(client, repo, current)
-    existing = [login for login in current_maintainers if login.casefold() != fallback_login]
-    if existing:
-        if replace_bot_fallback:
-            _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
-        return existing
-    if current_maintainers and not replace_bot_fallback:
-        return current_maintainers
-    if owner.casefold() == fallback_login and current_maintainers:
+    if current_maintainers:
         return current_maintainers
 
     assigned = cast(
@@ -471,9 +449,6 @@ def _ensure_recipients(
     owner_login = owner.casefold()
     if owner_login not in {login.casefold() for login in assigned_maintainers}:
         raise RuntimeError(f'GitHub did not assign @{owner}')
-    if replace_bot_fallback and fallback_login != owner_login:
-        _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
-        assigned_maintainers = [login for login in assigned_maintainers if login.casefold() != fallback_login]
     return assigned_maintainers
 
 
@@ -520,14 +495,14 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             for label in labels.intersection(_STAGE_LABELS):
                 _remove_label(client, repo, number, label)
             _add_labels(client, repo, number, [_ACTION_LABEL])
-            expected = {
-                **current,
-                'labels': [
-                    *(label for label in current.get('labels', []) if str(label['name']) not in _STAGE_LABELS),
-                    {'name': _ACTION_LABEL},
-                ],
-            }
-            recipients = _ensure_recipients(client, repo, expected, _maintainer_assignees(client, repo, current))
+            expected = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+            if (
+                expected.get('state') != 'open'
+                or _ACTION_LABEL not in _labels(expected)
+                or _stage(_labels(expected)) != 0
+            ):
+                raise RuntimeError('Attention state changed while applying the request')
+            recipients = _ensure_recipients(client, repo, expected, _maintainer_assignees(client, repo, expected))
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
         except (urllib.error.HTTPError, RuntimeError) as exc:
@@ -583,29 +558,6 @@ def _transition(
 def _actor(event: Mapping[str, Any]) -> str:
     value = event.get('actor') or event.get('user')
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
-
-
-def _latest_assignment_was_by_attention_bot(
-    timeline: Sequence[dict[str, Any]], login: str, transition_at: dt.datetime
-) -> bool:
-    assignments = [
-        (time, event)
-        for event in timeline
-        if event.get('event') == 'assigned'
-        and isinstance(event.get('assignee'), Mapping)
-        and str(cast(Mapping[str, object], event['assignee']).get('login') or '').casefold() == login.casefold()
-        and (time := _event_time(event)) is not None
-    ]
-    latest = max(assignments, key=lambda value: value[0], default=None)
-    if latest is None:
-        return False
-    assigned_at, event = latest
-    assigner = event.get('assigner')
-    return (
-        transition_at <= assigned_at <= transition_at + _BOT_ASSIGNMENT_WINDOW
-        and isinstance(assigner, Mapping)
-        and str(cast(Mapping[str, object], assigner).get('login') or '') == 'github-actions[bot]'
-    )
 
 
 # `assigned`, `mentioned`, and `subscribed` fire as side effects of this
@@ -673,12 +625,6 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
         if label != current_stage_label:
             _remove_label(client, repo, number, label)
     maintainers = _maintainer_assignees(client, repo, current)
-    action_transition = _transition(events, 0)
-    replace_bot_fallback = (
-        _FALLBACK_OWNER.casefold() in {login.casefold() for login in maintainers}
-        and action_transition is not None
-        and _latest_assignment_was_by_attention_bot(events, _FALLBACK_OWNER, action_transition[0])
-    )
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
@@ -688,15 +634,7 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     # succeeding, so the fallback assignment happens only below this point.
     if current_stage == 2:
         return f'#{number}: queued private Slack escalation', True
-    recipients = _ensure_recipients(
-        client,
-        repo,
-        current,
-        maintainers,
-        replace_bot_fallback=replace_bot_fallback,
-    )
-    latest = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-    _validate_attention_state(current, latest)
+    recipients = _ensure_recipients(client, repo, current, maintainers)
     if current_stage == 1:
         current_body = _reminder(recipients)
         if not _fixed_comment_exists(timeline, current_body, transition_at):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -586,10 +586,7 @@ def _event_time(event: Mapping[str, Any]) -> dt.datetime | None:
     return _parse_time(str(value)) if value else None
 
 
-def _transition(
-    timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]
-) -> tuple[dt.datetime, dict[str, Any]] | None:
-    label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
+def _label_transition(timeline: Sequence[dict[str, Any]], label: str) -> tuple[dt.datetime, dict[str, Any]] | None:
     transitions = [
         (time, index, event)
         for index, event in enumerate(timeline)
@@ -600,6 +597,12 @@ def _transition(
     ]
     latest = max(transitions, key=lambda value: (value[0], value[1]), default=None)
     return (latest[0], latest[2]) if latest is not None else None
+
+
+def _transition(
+    timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]
+) -> tuple[dt.datetime, dict[str, Any]] | None:
+    return _label_transition(timeline, _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1])
 
 
 def _actor(event: Mapping[str, Any]) -> str:
@@ -678,7 +681,7 @@ def _notice_if_current(
         current.get('state') != 'open'
         or _ACTION_LABEL not in labels
         or _stage(labels) != stage
-        or not {login.casefold() for login in recipients} <= {login.casefold() for login in maintainers}
+        or {login.casefold() for login in recipients} != {login.casefold() for login in maintainers}
     ):
         return None
     if (
@@ -701,6 +704,35 @@ def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int) -
     _remove_label(client, repo, number, _ACTION_LABEL)
     _remove_label(client, repo, number, _PINGED_LABEL)
     _remove_label(client, repo, number, _DELIVERED_LABEL)
+
+
+def _valid_delivery_receipt(
+    events: Sequence[dict[str, Any]],
+    transition: tuple[dt.datetime, dict[str, Any]],
+) -> bool:
+    receipt = _label_transition(events, _DELIVERED_LABEL)
+    if receipt is None or _actor(receipt[1]) != 'github-actions[bot]':
+        return False
+    indexes = {id(event): index for index, event in enumerate(events)}
+    return (receipt[0], indexes[id(receipt[1])]) > (transition[0], indexes[id(transition[1])])
+
+
+def _finish_delivery_receipt(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    labels: set[str],
+    events: Sequence[dict[str, Any]],
+    transition: tuple[dt.datetime, dict[str, Any]],
+) -> bool:
+    if _DELIVERED_LABEL not in labels:
+        return False
+    if _valid_delivery_receipt(events, transition):
+        _finish_delivered_escalation(client, repo, number)
+        return True
+    _remove_label(client, repo, number, _DELIVERED_LABEL)
+    labels.remove(_DELIVERED_LABEL)
+    return False
 
 
 def _reconcile_item(
@@ -734,10 +766,7 @@ def _reconcile_item(
     if _closed_since(timeline, transition_at):
         _complete(client, repo, number, labels)
         return f'#{number}: completed after the item was closed', None
-    if _DELIVERED_LABEL in labels:
-        # The explicit receipt is written only after channel delivery. Removing
-        # action first makes a retry safe: cleanup cannot post it again.
-        _finish_delivered_escalation(client, repo, number)
+    if _finish_delivery_receipt(client, repo, number, labels, events, transition):
         return f'#{number}: finished delivered channel escalation', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
@@ -849,6 +878,7 @@ def reconcile(
         slot=slot,
     )
     items = [*closed, *active]
+    processed = {int(item['number']) for item in items}
     lines: list[str] = []
     failures: list[str] = []
     for item in items:
@@ -879,7 +909,7 @@ def reconcile(
     )
     for item in dormant:
         number = int(item['number'])
-        if _ACTION_LABEL in _labels(item):
+        if number in processed or _ACTION_LABEL in _labels(item):
             continue
         try:
             if line := _sweep_escalated_item(client, repo, number):
@@ -1031,7 +1061,7 @@ def _finalize_notice(
     if current.get('state') != 'open' or _ACTION_LABEL not in labels or stage != notice['expected_stage']:
         return None
     maintainers = _maintainer_assignees(client, repo, current)
-    if not {login.casefold() for login in notice['recipients']} <= {login.casefold() for login in maintainers}:
+    if {login.casefold() for login in notice['recipients']} != {login.casefold() for login in maintainers}:
         return None
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
     transition = _transition(events, stage)

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -53,6 +53,9 @@ class Decision(TypedDict):
     confidence: Literal['high', 'medium', 'low']
 
 
+_Transition = tuple[dt.datetime, dict[str, Any]]
+
+
 class GitHubClient:
     """Small GitHub REST client with bounded response parsing."""
 
@@ -427,13 +430,14 @@ def _ensure_recipients(
     repo: str,
     item: Mapping[str, Any],
     maintainers: Sequence[str],
-    transition: tuple[dt.datetime, dict[str, Any]],
+    transition: _Transition,
 ) -> list[str]:
     if maintainers:
         number = int(item['number'])
         current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
         _validate_attention_state(item, current)
         if current_maintainers := _maintainer_assignees(client, repo, current):
+            _validate_attention_transition(client, repo, item, transition)
             return current_maintainers
 
     owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
@@ -442,6 +446,7 @@ def _ensure_recipients(
     _validate_attention_state(item, current)
     current_maintainers = _maintainer_assignees(client, repo, current)
     if current_maintainers:
+        _validate_attention_transition(client, repo, item, transition)
         return current_maintainers
 
     assigned = cast(
@@ -449,7 +454,7 @@ def _ensure_recipients(
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
     _validate_attention_state(item, assigned, check_updated_at=False)
-    _validate_attention_transition(client, repo, item, transition)
+    _validate_attention_transition(client, repo, item, transition, check_updated_at=False)
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     owner_login = owner.casefold()
     if owner_login not in {login.casefold() for login in assigned_maintainers}:
@@ -555,9 +560,7 @@ def _event_time(event: Mapping[str, Any]) -> dt.datetime | None:
     return _parse_time(str(value)) if value else None
 
 
-def _transition(
-    timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]
-) -> tuple[dt.datetime, dict[str, Any]] | None:
+def _transition(timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]) -> _Transition | None:
     label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
     transitions = [
         (time, index, event)
@@ -575,7 +578,9 @@ def _validate_attention_transition(
     client: GitHubClient,
     repo: str,
     item: Mapping[str, Any],
-    expected: tuple[dt.datetime, dict[str, Any]],
+    expected: _Transition,
+    *,
+    check_updated_at: bool = True,
 ) -> None:
     number = int(item['number'])
     stage = _stage(_labels(item))
@@ -586,6 +591,8 @@ def _validate_attention_transition(
         current[1].get('id') != expected_id if expected_id is not None else current[0] != expected[0]
     ):
         raise RuntimeError('Attention transition changed during owner selection')
+    latest = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    _validate_attention_state(item, latest, check_updated_at=check_updated_at)
 
 
 def _actor(event: Mapping[str, Any]) -> str:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -40,11 +40,14 @@ _FALLBACK_OWNER = 'adtyavrdhn'
 _ACTION_LABEL = 'needs-maintainer-action'
 _PINGED_LABEL = 'attention-pinged'
 _ESCALATED_LABEL = 'attention-escalated'
+_DELIVERED_LABEL = 'attention-delivered'
 _STAGE_LABELS = (_PINGED_LABEL, _ESCALATED_LABEL)
+_LIFECYCLE_LABELS = (*_STAGE_LABELS, _DELIVERED_LABEL)
 _LABELS = {
     _ACTION_LABEL: ('d4c5f9', 'The next meaningful action must come from a maintainer'),
     _PINGED_LABEL: ('fbca04', 'The assigned maintainer has received one reminder'),
     _ESCALATED_LABEL: ('d93f0b', 'The maintainer attention request has been escalated after one reminder'),
+    _DELIVERED_LABEL: ('ededed', 'A delivered channel escalation is waiting for GitHub state cleanup'),
 }
 
 
@@ -81,6 +84,7 @@ class GitHubClient:
 
     def __init__(self, token: str) -> None:
         self._token = token
+        self._maintainers: dict[str, dict[str, str]] = {}
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -144,6 +148,24 @@ class GitHubClient:
             if not (page_path := _link_path(links, 'next')):
                 return
         raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
+
+    def maintainer_logins(self, repo: str) -> Mapping[str, str]:
+        if repo not in self._maintainers:
+            maintainers: dict[str, str] = {}
+            for page in self.pages(
+                f'/repos/{repo}/collaborators?affiliation=all',
+                count=_COLLABORATOR_PAGE_LIMIT,
+            ):
+                for collaborator in page:
+                    permissions = collaborator.get('permissions')
+                    if (
+                        isinstance(permissions, Mapping)
+                        and cast(Mapping[str, object], permissions).get('push') is True
+                        and (login := str(collaborator.get('login') or ''))
+                    ):
+                        maintainers[login.casefold()] = login
+            self._maintainers[repo] = maintainers
+        return self._maintainers[repo]
 
 
 def _parse_time(value: str) -> dt.datetime:
@@ -418,46 +440,27 @@ def _add_labels(client: GitHubClient, repo: str, number: int, labels: Sequence[s
     client.post(f'/repos/{repo}/issues/{number}/labels', {'labels': list(labels)})
 
 
-def _maintainer_roster(client: GitHubClient, repo: str) -> dict[str, str]:
-    """Load current write-capable collaborators once per command."""
-    maintainers: dict[str, str] = {}
-    for page in client.pages(
-        f'/repos/{repo}/collaborators?affiliation=all',
-        count=_COLLABORATOR_PAGE_LIMIT,
-    ):
-        for collaborator in page:
-            permissions = collaborator.get('permissions')
-            if isinstance(permissions, Mapping) and cast(Mapping[str, object], permissions).get('push') is True:
-                login = str(collaborator.get('login') or '')
-                if login:
-                    maintainers[login.casefold()] = login
-    return maintainers
-
-
-def _maintainer_assignees(maintainer_roster: Mapping[str, str], item: Mapping[str, Any]) -> list[str]:
+def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[str]:
+    maintainers = client.maintainer_logins(repo)
     return sorted(
         (
-            maintainer_roster[login.casefold()]
+            maintainers[login.casefold()]
             for assignee in item.get('assignees', [])
-            if (login := str(assignee['login'])) and login.casefold() in maintainer_roster
+            if (login := str(assignee['login'])) and login.casefold() in maintainers
         ),
         key=str.casefold,
     )
 
 
-def _first_maintainer_in_discussion(
-    client: GitHubClient,
-    repo: str,
-    item: Mapping[str, Any],
-    maintainer_roster: Mapping[str, str],
-) -> str | None:
+def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
     """Return the first current maintainer who authored or discussed an issue."""
     if 'pull_request' in item:
         return None
+    maintainers = client.maintainer_logins(repo)
 
     def maintainer(entry: Mapping[str, Any]) -> str | None:
         login = _login(entry)
-        return maintainer_roster.get(login.casefold()) if login else None
+        return maintainers.get(login.casefold()) if login else None
 
     if author := maintainer(item):
         return author
@@ -475,17 +478,16 @@ def _ensure_recipients(
     client: GitHubClient,
     repo: str,
     item: Mapping[str, Any],
-    maintainer_roster: Mapping[str, str],
 ) -> list[str]:
     number = int(item['number'])
-    owner = _first_maintainer_in_discussion(client, repo, item, maintainer_roster)
+    owner = _first_maintainer_in_discussion(client, repo, item)
 
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if current.get('state') != 'open' or _ACTION_LABEL not in _labels(current):
         raise RuntimeError('Attention state changed during owner selection')
     if current.get('updated_at') != item.get('updated_at'):
-        owner = _first_maintainer_in_discussion(client, repo, current, maintainer_roster)
-    current_maintainers = _maintainer_assignees(maintainer_roster, current)
+        owner = _first_maintainer_in_discussion(client, repo, current)
+    current_maintainers = _maintainer_assignees(client, repo, current)
     if current_maintainers:
         if owner is None:
             return current_maintainers
@@ -499,7 +501,7 @@ def _ensure_recipients(
     assigned = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if assigned.get('state') != 'open' or _ACTION_LABEL not in _labels(assigned):
         raise RuntimeError('Attention state changed during owner assignment')
-    assigned_maintainers = _maintainer_assignees(maintainer_roster, assigned)
+    assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     if [login.casefold() for login in assigned_maintainers] != [owner.casefold()]:
         raise RuntimeError(f'GitHub did not assign @{owner}')
     return assigned_maintainers
@@ -525,7 +527,6 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
     if {decision['item_number'] for decision in decisions} != candidates.keys():
         raise ValueError('Agent output must classify every snapshot candidate exactly once')
     ensure_labels(client, repo)
-    maintainer_roster = _maintainer_roster(client, repo)
     lines: list[str] = []
     failures: list[str] = []
     for decision in decisions:
@@ -546,18 +547,13 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             if decision['next_actor'] != 'maintainer':
                 lines.append(f'#{number}: did not request maintainer attention')
                 continue
-            for label in labels.intersection(_STAGE_LABELS):
+            for label in labels.intersection(_LIFECYCLE_LABELS):
                 _remove_label(client, repo, number, label)
             _add_labels(client, repo, number, [_ACTION_LABEL])
             attention_item = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
             if attention_item.get('state') != 'open' or _ACTION_LABEL not in _labels(attention_item):
                 raise RuntimeError('Attention state changed while applying the request')
-            recipients = _ensure_recipients(
-                client,
-                repo,
-                attention_item,
-                maintainer_roster,
-            )
+            recipients = _ensure_recipients(client, repo, attention_item)
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
         except (urllib.error.HTTPError, RuntimeError) as exc:
@@ -634,9 +630,16 @@ def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipi
 
 
 def _complete(client: GitHubClient, repo: str, number: int, labels: set[str]) -> None:
-    for label in labels.intersection(_STAGE_LABELS):
+    for label in labels.intersection(_LIFECYCLE_LABELS):
         _remove_label(client, repo, number, label)
     _remove_label(client, repo, number, _ACTION_LABEL)
+
+
+def _transition_id(transition: tuple[dt.datetime, dict[str, Any]]) -> int | str:
+    transition_id = transition[1].get('id')
+    if not isinstance(transition_id, (int, str)) or isinstance(transition_id, bool):
+        raise RuntimeError('Could not build a durable attention notice')
+    return transition_id
 
 
 def _notice(
@@ -646,14 +649,11 @@ def _notice(
     transition: tuple[dt.datetime, dict[str, Any]],
     recipients: Sequence[str],
 ) -> Notice:
-    transition_id = transition[1].get('id')
-    if not isinstance(transition_id, (int, str)) or isinstance(transition_id, bool):
-        raise RuntimeError('Could not build a durable attention notice')
     return Notice(
         number=int(item['number']),
         kind=kind,
         expected_stage=stage,
-        transition_id=transition_id,
+        transition_id=_transition_id(transition),
         title=str(item.get('title') or '')[:300],
         recipients=list(recipients),
     )
@@ -665,16 +665,15 @@ def _notice_if_current(
     number: int,
     kind: Literal['reminder', 'escalation'],
     stage: Literal[0, 1, 2],
-    transition: tuple[dt.datetime, dict[str, Any]],
+    transition_id: int | str,
     recipients: Sequence[str],
-    maintainer_roster: Mapping[str, str],
 ) -> Notice | None:
     """Build a notice only if its transition and owners are still live."""
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
     current_transition = _transition(events, stage)
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     labels = _labels(current)
-    maintainers = _maintainer_assignees(maintainer_roster, current)
+    maintainers = _maintainer_assignees(client, repo, current)
     if (
         current.get('state') != 'open'
         or _ACTION_LABEL not in labels
@@ -684,24 +683,30 @@ def _notice_if_current(
         return None
     if (
         current_transition is None
-        or current_transition[1].get('id') != transition[1].get('id')
+        or current_transition[1].get('id') != transition_id
         or _actor(current_transition[1]) != 'github-actions[bot]'
     ):
+        return None
+    acknowledged_transition = _transition(events, 1) if stage == 2 else current_transition
+    acknowledged_since = acknowledged_transition[0] if acknowledged_transition is not None else current_transition[0]
+    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+    if _closed_since(timeline, current_transition[0]) or _acknowledged(timeline, acknowledged_since, recipients):
         return None
     return _notice(current, kind, stage, current_transition, recipients)
 
 
 def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int) -> None:
     """Finish a terminal delivery while preserving its dormant marker."""
+    _add_labels(client, repo, number, [_ESCALATED_LABEL])
     _remove_label(client, repo, number, _ACTION_LABEL)
     _remove_label(client, repo, number, _PINGED_LABEL)
+    _remove_label(client, repo, number, _DELIVERED_LABEL)
 
 
 def _reconcile_item(
     client: GitHubClient,
     repo: str,
     number: int,
-    maintainer_roster: Mapping[str, str],
     *,
     now: dt.datetime,
 ) -> tuple[str, Notice | None] | None:
@@ -729,23 +734,22 @@ def _reconcile_item(
     if _closed_since(timeline, transition_at):
         _complete(client, repo, number, labels)
         return f'#{number}: completed after the item was closed', None
-    if set(_STAGE_LABELS) <= labels:
-        # Both existing stage labels are the short-lived receipt written only
-        # after a terminal channel delivery. Removing action first makes a
-        # retry safe: a failed cleanup cannot post the escalation again.
+    if _DELIVERED_LABEL in labels:
+        # The explicit receipt is written only after channel delivery. Removing
+        # action first makes a retry safe: cleanup cannot post it again.
         _finish_delivered_escalation(client, repo, number)
         return f'#{number}: finished delivered channel escalation', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
             _remove_label(client, repo, number, label)
-    maintainers = _maintainer_assignees(maintainer_roster, current)
+    maintainers = _maintainer_assignees(client, repo, current)
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
-    recipients = _ensure_recipients(client, repo, current, maintainer_roster)
+    recipients = _ensure_recipients(client, repo, current)
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
     if _closed_since(timeline, transition_at) or _acknowledged(timeline, acknowledged_since, recipients):
         _complete(client, repo, number, labels)
@@ -759,9 +763,8 @@ def _reconcile_item(
             number,
             'escalation',
             current_stage,
-            transition,
+            _transition_id(transition),
             recipients,
-            maintainer_roster,
         )
         return (f'#{number}: queued channel escalation', notice) if notice is not None else None
     if now - transition_at < _SLA:
@@ -773,9 +776,8 @@ def _reconcile_item(
             number,
             'reminder',
             current_stage,
-            transition,
+            _transition_id(transition),
             recipients,
-            maintainer_roster,
         )
         return (f'#{number}: queued channel reminder', notice) if notice is not None else None
     notice = _notice_if_current(
@@ -784,9 +786,8 @@ def _reconcile_item(
         number,
         'escalation',
         current_stage,
-        transition,
+        _transition_id(transition),
         recipients,
-        maintainer_roster,
     )
     return (f'#{number}: queued channel escalation', notice) if notice is not None else None
 
@@ -797,6 +798,9 @@ def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str |
     labels = _labels(current)
     if _ACTION_LABEL in labels or _ESCALATED_LABEL not in labels:
         return None
+    if _DELIVERED_LABEL in labels:
+        _remove_label(client, repo, number, _DELIVERED_LABEL)
+        labels.remove(_DELIVERED_LABEL)
     if _PINGED_LABEL in labels:
         _remove_label(client, repo, number, _PINGED_LABEL)
         labels.remove(_PINGED_LABEL)
@@ -829,7 +833,6 @@ def reconcile(
     by healthy items always reach the Slack delivery job.
     """
     ensure_labels(client, repo)
-    maintainer_roster = _maintainer_roster(client, repo)
     slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
     closed = _rotated_search(
         client,
@@ -851,7 +854,7 @@ def reconcile(
     for item in items:
         number = int(item['number'])
         try:
-            if result := _reconcile_item(client, repo, number, maintainer_roster, now=now):
+            if result := _reconcile_item(client, repo, number, now=now):
                 line, notice = result
                 lines.append(line)
                 if notice is not None and notices is not None:
@@ -990,6 +993,25 @@ def _notice_refs(loaded: object) -> list[NoticeRef]:
     return notices
 
 
+def prepare_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[Notice]:
+    """Revalidate notices immediately before their channel delivery."""
+    prepared: list[Notice] = []
+    for notice in notices:
+        stage = notice['expected_stage']
+        kind: Literal['reminder', 'escalation'] = 'reminder' if stage == 0 else 'escalation'
+        if live := _notice_if_current(
+            client,
+            repo,
+            notice['number'],
+            kind,
+            stage,
+            notice['transition_id'],
+            notice['recipients'],
+        ):
+            prepared.append(live)
+    return prepared
+
+
 def _closed_since(timeline: Sequence[dict[str, Any]], since: dt.datetime) -> bool:
     return any(
         event.get('event') == 'closed' and (event_time := _event_time(event)) is not None and event_time >= since
@@ -1001,7 +1023,6 @@ def _finalize_notice(
     client: GitHubClient,
     repo: str,
     notice: NoticeRef,
-    maintainer_roster: Mapping[str, str],
 ) -> str | None:
     number = notice['number']
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
@@ -1009,7 +1030,7 @@ def _finalize_notice(
     stage = _stage(labels)
     if current.get('state') != 'open' or _ACTION_LABEL not in labels or stage != notice['expected_stage']:
         return None
-    maintainers = _maintainer_assignees(maintainer_roster, current)
+    maintainers = _maintainer_assignees(client, repo, current)
     if not {login.casefold() for login in notice['recipients']} <= {login.casefold() for login in maintainers}:
         return None
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
@@ -1033,9 +1054,8 @@ def _finalize_notice(
             number,
             kind,
             stage,
-            transition,
+            _transition_id(transition),
             notice['recipients'],
-            maintainer_roster,
         )
         is None
     ):
@@ -1044,15 +1064,13 @@ def _finalize_notice(
     if stage == 0:
         _advance_stage(client, repo, number, labels, 1)
     else:
-        # Both stage labels are a retry-safe receipt that Slack delivered the
-        # terminal escalation. Reconciliation completes this cleanup without
-        # posting again if a later GitHub write fails.
-        receipt_label = _ESCALATED_LABEL if stage == 1 else _PINGED_LABEL
-        _add_labels(client, repo, number, [receipt_label])
+        # Record delivery before terminal cleanup so a later GitHub failure
+        # cannot make reconciliation post the escalation again.
+        _add_labels(client, repo, number, [_DELIVERED_LABEL])
         _finish_delivered_escalation(client, repo, number)
 
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    completed_labels = labels | ({_PINGED_LABEL} if stage == 0 else set(_STAGE_LABELS))
+    completed_labels = labels | ({_PINGED_LABEL} if stage == 0 else {_ESCALATED_LABEL, _DELIVERED_LABEL})
     if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
         _complete(client, repo, number, completed_labels)
         return f'#{number}: maintainer activity completed the delivered notice'
@@ -1061,13 +1079,12 @@ def _finalize_notice(
 
 def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[str]:
     """Advance attention state only after the channel delivery succeeds."""
-    maintainer_roster = _maintainer_roster(client, repo)
     lines: list[str] = []
     failures: list[str] = []
     for notice in notices:
         number = notice['number']
         try:
-            if line := _finalize_notice(client, repo, notice, maintainer_roster):
+            if line := _finalize_notice(client, repo, notice):
                 lines.append(line)
         except (urllib.error.HTTPError, RuntimeError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
@@ -1089,7 +1106,7 @@ def _write_summary(lines: Sequence[str]) -> None:
 def main() -> int:
     """Build a snapshot, apply decisions, or reconcile reminders."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('mode', choices=['snapshot', 'apply', 'reconcile', 'finalize'])
+    parser.add_argument('mode', choices=['snapshot', 'apply', 'reconcile', 'prepare', 'finalize'])
     parser.add_argument('--snapshot-path', default='attention-candidates.json')
     parser.add_argument('--agent-output', default=os.environ.get('GH_AW_AGENT_OUTPUT'))
     args = parser.parse_args()
@@ -1111,6 +1128,13 @@ def main() -> int:
         notices: list[Notice] = []
         lines, failures = reconcile(client, repo, now=now, notices=notices)
         _write_notices(repo, notices)
+    elif args.mode == 'prepare':
+        source = os.environ.get('ATTENTION_NOTICES')
+        if source is None:
+            parser.error('ATTENTION_NOTICES is required')
+        notices = prepare_notices(client, repo, _notice_refs(json.loads(source)))
+        _write_notices(repo, notices)
+        lines = [f'prepared {len(notices)} current attention notice(s)']
     else:
         source = os.environ.get('ATTENTION_NOTICES')
         if source is None:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -33,11 +33,10 @@ _ACTIVE_OPEN_LIMIT = 20
 _CLOSED_CLEANUP_LIMIT = _RECONCILE_LIMIT - _ACTIVE_OPEN_LIMIT
 _EVENT_PAGE_LIMIT = 10
 _COMMENT_PAGE_LIMIT = 10
-_DISCUSSION_PARTICIPANT_LIMIT = 50
+_COLLABORATOR_PAGE_LIMIT = 10
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
-_MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
 _ACTION_LABEL = 'needs-maintainer-action'
 _PINGED_LABEL = 'attention-pinged'
 _ESCALATED_LABEL = 'attention-escalated'
@@ -114,8 +113,8 @@ class GitHubClient:
     def post(self, path: str, payload: Mapping[str, object]) -> Any:
         return self.request('POST', path, payload)
 
-    def delete(self, path: str) -> Any:
-        return self.request('DELETE', path)
+    def delete(self, path: str, payload: Mapping[str, object] | None = None) -> Any:
+        return self.request('DELETE', path, payload)
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         """Return up to `count` newest pages for an ascending GitHub collection."""
@@ -419,39 +418,46 @@ def _add_labels(client: GitHubClient, repo: str, number: int, labels: Sequence[s
     client.post(f'/repos/{repo}/issues/{number}/labels', {'labels': list(labels)})
 
 
-def _collaborator_permission(client: GitHubClient, repo: str, login: str) -> object:
-    encoded = urllib.parse.quote(login, safe='')
-    return cast(Mapping[str, object], client.get(f'/repos/{repo}/collaborators/{encoded}/permission')).get('permission')
+def _maintainer_roster(client: GitHubClient, repo: str) -> dict[str, str]:
+    """Load current write-capable collaborators once per command."""
+    maintainers: dict[str, str] = {}
+    for page in client.pages(
+        f'/repos/{repo}/collaborators?affiliation=all',
+        count=_COLLABORATOR_PAGE_LIMIT,
+    ):
+        for collaborator in page:
+            permissions = collaborator.get('permissions')
+            if isinstance(permissions, Mapping) and cast(Mapping[str, object], permissions).get('push') is True:
+                login = str(collaborator.get('login') or '')
+                if login:
+                    maintainers[login.casefold()] = login
+    return maintainers
 
 
-def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[str]:
-    maintainers: list[str] = []
-    for assignee in item.get('assignees', []):
-        login = str(assignee['login'])
-        if _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS:
-            maintainers.append(login)
-    return sorted(maintainers, key=str.casefold)
+def _maintainer_assignees(maintainer_roster: Mapping[str, str], item: Mapping[str, Any]) -> list[str]:
+    return sorted(
+        (
+            maintainer_roster[login.casefold()]
+            for assignee in item.get('assignees', [])
+            if (login := str(assignee['login'])) and login.casefold() in maintainer_roster
+        ),
+        key=str.casefold,
+    )
 
 
-def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
+def _first_maintainer_in_discussion(
+    client: GitHubClient,
+    repo: str,
+    item: Mapping[str, Any],
+    maintainer_roster: Mapping[str, str],
+) -> str | None:
     """Return the first current maintainer who authored or discussed an issue."""
     if 'pull_request' in item:
         return None
 
-    permissions: dict[str, object] = {}
-
     def maintainer(entry: Mapping[str, Any]) -> str | None:
         login = _login(entry)
-        if not login:
-            return None
-        key = login.casefold()
-        if key not in permissions:
-            if len(permissions) == _DISCUSSION_PARTICIPANT_LIMIT:
-                raise RuntimeError('Issue discussion exceeds the participant safety limit')
-            permissions[key] = _collaborator_permission(client, repo, login)
-        if login and permissions[key] in _MAINTAINER_PERMISSIONS:
-            return login
-        return None
+        return maintainer_roster.get(login.casefold()) if login else None
 
     if author := maintainer(item):
         return author
@@ -466,35 +472,37 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
 
 
 def _ensure_recipients(
-    client: GitHubClient, repo: str, item: Mapping[str, Any], maintainers: Sequence[str]
+    client: GitHubClient,
+    repo: str,
+    item: Mapping[str, Any],
+    maintainer_roster: Mapping[str, str],
 ) -> list[str]:
     number = int(item['number'])
-    owner = _first_maintainer_in_discussion(client, repo, item)
-    if owner and owner.casefold() in {login.casefold() for login in maintainers}:
-        return [next(login for login in maintainers if login.casefold() == owner.casefold())]
-    if owner is None and maintainers:
-        return list(maintainers)
+    owner = _first_maintainer_in_discussion(client, repo, item, maintainer_roster)
 
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if current.get('state') != 'open' or _ACTION_LABEL not in _labels(current):
         raise RuntimeError('Attention state changed during owner selection')
     if current.get('updated_at') != item.get('updated_at'):
-        owner = _first_maintainer_in_discussion(client, repo, current)
-    if current_maintainers := _maintainer_assignees(client, repo, current):
+        owner = _first_maintainer_in_discussion(client, repo, current, maintainer_roster)
+    current_maintainers = _maintainer_assignees(maintainer_roster, current)
+    if current_maintainers:
         if owner is None:
             return current_maintainers
-        if owner.casefold() in {login.casefold() for login in current_maintainers}:
-            return [next(login for login in current_maintainers if login.casefold() == owner.casefold())]
 
     owner = owner or _FALLBACK_OWNER
-    assigned = cast(
-        dict[str, Any],
-        client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
-    )
-    assigned_maintainers = _maintainer_assignees(client, repo, assigned)
-    if owner.casefold() not in {login.casefold() for login in assigned_maintainers}:
+    if owner.casefold() not in {login.casefold() for login in current_maintainers}:
+        client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]})
+    if other_owners := [login for login in current_maintainers if login.casefold() != owner.casefold()]:
+        client.delete(f'/repos/{repo}/issues/{number}/assignees', {'assignees': other_owners})
+
+    assigned = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    if assigned.get('state') != 'open' or _ACTION_LABEL not in _labels(assigned):
+        raise RuntimeError('Attention state changed during owner assignment')
+    assigned_maintainers = _maintainer_assignees(maintainer_roster, assigned)
+    if [login.casefold() for login in assigned_maintainers] != [owner.casefold()]:
         raise RuntimeError(f'GitHub did not assign @{owner}')
-    return [next(login for login in assigned_maintainers if login.casefold() == owner.casefold())]
+    return assigned_maintainers
 
 
 def _remove_label(client: GitHubClient, repo: str, number: int, label: str) -> None:
@@ -517,6 +525,7 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
     if {decision['item_number'] for decision in decisions} != candidates.keys():
         raise ValueError('Agent output must classify every snapshot candidate exactly once')
     ensure_labels(client, repo)
+    maintainer_roster = _maintainer_roster(client, repo)
     lines: list[str] = []
     failures: list[str] = []
     for decision in decisions:
@@ -547,7 +556,7 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
                 client,
                 repo,
                 attention_item,
-                _maintainer_assignees(client, repo, attention_item),
+                maintainer_roster,
             )
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
@@ -586,14 +595,15 @@ def _transition(
 ) -> tuple[dt.datetime, dict[str, Any]] | None:
     label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
     transitions = [
-        (time, event)
-        for event in timeline
+        (time, index, event)
+        for index, event in enumerate(timeline)
         if event.get('event') == 'labeled'
         and isinstance(event.get('label'), Mapping)
         and cast(Mapping[str, object], event['label']).get('name') == label
         and (time := _event_time(event)) is not None
     ]
-    return max(transitions, key=lambda value: value[0], default=None)
+    latest = max(transitions, key=lambda value: (value[0], value[1]), default=None)
+    return (latest[0], latest[2]) if latest is not None else None
 
 
 def _actor(event: Mapping[str, Any]) -> str:
@@ -649,8 +659,51 @@ def _notice(
     )
 
 
+def _notice_if_current(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    kind: Literal['reminder', 'escalation'],
+    stage: Literal[0, 1, 2],
+    transition: tuple[dt.datetime, dict[str, Any]],
+    recipients: Sequence[str],
+    maintainer_roster: Mapping[str, str],
+) -> Notice | None:
+    """Build a notice only if its transition and owners are still live."""
+    events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
+    current_transition = _transition(events, stage)
+    current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    labels = _labels(current)
+    maintainers = _maintainer_assignees(maintainer_roster, current)
+    if (
+        current.get('state') != 'open'
+        or _ACTION_LABEL not in labels
+        or _stage(labels) != stage
+        or not {login.casefold() for login in recipients} <= {login.casefold() for login in maintainers}
+    ):
+        return None
+    if (
+        current_transition is None
+        or current_transition[1].get('id') != transition[1].get('id')
+        or _actor(current_transition[1]) != 'github-actions[bot]'
+    ):
+        return None
+    return _notice(current, kind, stage, current_transition, recipients)
+
+
+def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int) -> None:
+    """Finish a terminal delivery while preserving its dormant marker."""
+    _remove_label(client, repo, number, _ACTION_LABEL)
+    _remove_label(client, repo, number, _PINGED_LABEL)
+
+
 def _reconcile_item(
-    client: GitHubClient, repo: str, number: int, *, now: dt.datetime
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    maintainer_roster: Mapping[str, str],
+    *,
+    now: dt.datetime,
 ) -> tuple[str, Notice | None] | None:
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     labels = _labels(current)
@@ -676,37 +729,66 @@ def _reconcile_item(
     if _closed_since(timeline, transition_at):
         _complete(client, repo, number, labels)
         return f'#{number}: completed after the item was closed', None
+    if set(_STAGE_LABELS) <= labels:
+        # Both existing stage labels are the short-lived receipt written only
+        # after a terminal channel delivery. Removing action first makes a
+        # retry safe: a failed cleanup cannot post the escalation again.
+        _finish_delivered_escalation(client, repo, number)
+        return f'#{number}: finished delivered channel escalation', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
             _remove_label(client, repo, number, label)
-    maintainers = _maintainer_assignees(client, repo, current)
+    maintainers = _maintainer_assignees(maintainer_roster, current)
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
+    recipients = _ensure_recipients(client, repo, current, maintainer_roster)
+    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+    if _closed_since(timeline, transition_at) or _acknowledged(timeline, acknowledged_since, recipients):
+        _complete(client, repo, number, labels)
+        return f'#{number}: maintainer acknowledged the request', None
     # Stage 2 is the existing durable "terminal Slack delivery pending" state.
     # Keeping that meaning makes the channel cutover safe for in-flight items.
     if current_stage == 2:
-        recipients = _ensure_recipients(client, repo, current, maintainers)
-        return f'#{number}: queued channel escalation', _notice(
-            current, 'escalation', current_stage, transition, recipients
+        notice = _notice_if_current(
+            client,
+            repo,
+            number,
+            'escalation',
+            current_stage,
+            transition,
+            recipients,
+            maintainer_roster,
         )
-    recipients = _ensure_recipients(client, repo, current, maintainers)
-    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _closed_since(timeline, transition_at) or _acknowledged(timeline, transition_at, recipients):
-        _complete(client, repo, number, labels)
-        return f'#{number}: maintainer acknowledged the request', None
+        return (f'#{number}: queued channel escalation', notice) if notice is not None else None
     if now - transition_at < _SLA:
         return None
     if current_stage == 0:
-        return f'#{number}: queued channel reminder', _notice(
-            current, 'reminder', current_stage, transition, recipients
+        notice = _notice_if_current(
+            client,
+            repo,
+            number,
+            'reminder',
+            current_stage,
+            transition,
+            recipients,
+            maintainer_roster,
         )
-    return f'#{number}: queued channel escalation', _notice(
-        current, 'escalation', current_stage, transition, recipients
+        return (f'#{number}: queued channel reminder', notice) if notice is not None else None
+    notice = _notice_if_current(
+        client,
+        repo,
+        number,
+        'escalation',
+        current_stage,
+        transition,
+        recipients,
+        maintainer_roster,
     )
+    return (f'#{number}: queued channel escalation', notice) if notice is not None else None
 
 
 def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str | None:
@@ -715,6 +797,9 @@ def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str |
     labels = _labels(current)
     if _ACTION_LABEL in labels or _ESCALATED_LABEL not in labels:
         return None
+    if _PINGED_LABEL in labels:
+        _remove_label(client, repo, number, _PINGED_LABEL)
+        labels.remove(_PINGED_LABEL)
     if current.get('state') != 'open':
         _complete(client, repo, number, labels)
         return f'#{number}: cleared escalation marker after the item was closed'
@@ -744,6 +829,7 @@ def reconcile(
     by healthy items always reach the Slack delivery job.
     """
     ensure_labels(client, repo)
+    maintainer_roster = _maintainer_roster(client, repo)
     slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
     closed = _rotated_search(
         client,
@@ -765,7 +851,7 @@ def reconcile(
     for item in items:
         number = int(item['number'])
         try:
-            if result := _reconcile_item(client, repo, number, now=now):
+            if result := _reconcile_item(client, repo, number, maintainer_roster, now=now):
                 line, notice = result
                 lines.append(line)
                 if notice is not None and notices is not None:
@@ -911,14 +997,19 @@ def _closed_since(timeline: Sequence[dict[str, Any]], since: dt.datetime) -> boo
     )
 
 
-def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str | None:
+def _finalize_notice(
+    client: GitHubClient,
+    repo: str,
+    notice: NoticeRef,
+    maintainer_roster: Mapping[str, str],
+) -> str | None:
     number = notice['number']
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     labels = _labels(current)
     stage = _stage(labels)
     if current.get('state') != 'open' or _ACTION_LABEL not in labels or stage != notice['expected_stage']:
         return None
-    maintainers = _maintainer_assignees(client, repo, current)
+    maintainers = _maintainer_assignees(maintainer_roster, current)
     if not {login.casefold() for login in notice['recipients']} <= {login.casefold() for login in maintainers}:
         return None
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
@@ -933,30 +1024,50 @@ def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str 
     if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer activity completed the delivered notice'
-    if stage == 2:
-        _remove_label(client, repo, number, _ACTION_LABEL)
-        return f'#{number}: recorded channel escalation'
-    next_stage: Literal[1, 2] = 1 if stage == 0 else 2
-    _advance_stage(client, repo, number, labels, next_stage)
+
+    kind: Literal['reminder', 'escalation'] = 'reminder' if stage == 0 else 'escalation'
+    if (
+        _notice_if_current(
+            client,
+            repo,
+            number,
+            kind,
+            stage,
+            transition,
+            notice['recipients'],
+            maintainer_roster,
+        )
+        is None
+    ):
+        return None
+
+    if stage == 0:
+        _advance_stage(client, repo, number, labels, 1)
+    else:
+        # Both stage labels are a retry-safe receipt that Slack delivered the
+        # terminal escalation. Reconciliation completes this cleanup without
+        # posting again if a later GitHub write fails.
+        receipt_label = _ESCALATED_LABEL if stage == 1 else _PINGED_LABEL
+        _add_labels(client, repo, number, [receipt_label])
+        _finish_delivered_escalation(client, repo, number)
+
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    completed_labels = labels | {_STAGE_LABELS[next_stage - 1]}
+    completed_labels = labels | ({_PINGED_LABEL} if stage == 0 else set(_STAGE_LABELS))
     if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
         _complete(client, repo, number, completed_labels)
         return f'#{number}: maintainer activity completed the delivered notice'
-    if stage == 1:
-        _remove_label(client, repo, number, _ACTION_LABEL)
-    kind = 'reminder' if stage == 0 else 'escalation'
     return f'#{number}: recorded channel {kind}'
 
 
 def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[str]:
     """Advance attention state only after the channel delivery succeeds."""
+    maintainer_roster = _maintainer_roster(client, repo)
     lines: list[str] = []
     failures: list[str] = []
     for notice in notices:
         number = notice['number']
         try:
-            if line := _finalize_notice(client, repo, notice):
+            if line := _finalize_notice(client, repo, notice, maintainer_roster):
                 lines.append(line)
         except (urllib.error.HTTPError, RuntimeError) as exc:
             if isinstance(exc, urllib.error.HTTPError):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -25,6 +25,8 @@ from typing import Any, Literal, TypedDict, cast  # noqa: TID251
 _API = 'https://api.github.com'
 _SLA = dt.timedelta(days=3)
 _CANDIDATE_LIMIT = 10
+_RECENT_CANDIDATE_LIMIT = 5
+_BACKLOG_CANDIDATE_LIMIT = _CANDIDATE_LIMIT - _RECENT_CANDIDATE_LIMIT
 _RECONCILE_LIMIT = 25
 _EVENT_PAGE_LIMIT = 10
 _COMMENT_PAGE_LIMIT = 10
@@ -35,13 +37,16 @@ _FALLBACK_OWNER = 'adtyavrdhn'
 _MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
 _ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 _ACTION_LABEL = 'needs-maintainer-action'
+_NOTIFIED_LABEL = 'attention-notified'
 _PINGED_LABEL = 'attention-pinged'
 _ESCALATED_LABEL = 'attention-escalated'
 _STAGE_LABELS = (_PINGED_LABEL, _ESCALATED_LABEL)
+_LIFECYCLE_LABELS = (_NOTIFIED_LABEL, *_STAGE_LABELS)
 _LABELS = {
     _ACTION_LABEL: ('d4c5f9', 'The next meaningful action must come from a maintainer'),
-    _PINGED_LABEL: ('fbca04', 'The assigned maintainer has received one reminder'),
-    _ESCALATED_LABEL: ('d93f0b', 'The maintainer attention request has been escalated after one reminder'),
+    _NOTIFIED_LABEL: ('c5def5', 'The triage channel received the initial maintainer attention notice'),
+    _PINGED_LABEL: ('fbca04', 'The triage channel received one maintainer attention reminder'),
+    _ESCALATED_LABEL: ('d93f0b', 'The triage channel received the terminal maintainer escalation'),
 }
 
 
@@ -51,6 +56,27 @@ class Decision(TypedDict):
     item_number: int
     next_actor: Literal['maintainer', 'contributor', 'automation', 'none', 'uncertain']
     confidence: Literal['high', 'medium', 'low']
+
+
+class Notice(TypedDict):
+    """A fixed host-built notification for the private triage channel."""
+
+    number: int
+    kind: Literal['initial', 'reminder', 'escalation']
+    expected_stage: Literal[0, 1, 2]
+    transition_id: int | str
+    title: str
+    recipients: list[str]
+
+
+class NoticeRef(TypedDict):
+    """The bounded state reference carried from Slack delivery to finalization."""
+
+    number: int
+    kind: Literal['initial', 'reminder', 'escalation']
+    expected_stage: Literal[0, 1, 2]
+    transition_id: int | str
+    recipients: list[str]
 
 
 _Transition = tuple[dt.datetime, dict[str, Any]]
@@ -238,14 +264,24 @@ def _candidate_page(client: GitHubClient, repo: str, *, now: dt.datetime) -> lis
     total = min(int(first.get('total_count') or 0), 1_000)
     if not total:
         return []
-    pages = math.ceil(total / _CANDIDATE_LIMIT)
+    recent = cast(
+        dict[str, Any],
+        client.get(f'/search/issues?q={query}&sort=updated&order=desc&per_page={_RECENT_CANDIDATE_LIMIT}&page=1'),
+    )
+    pages = math.ceil(total / _BACKLOG_CANDIDATE_LIMIT)
     slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
     page = slot % pages + 1
-    result = cast(
+    backlog = cast(
         dict[str, Any],
-        client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page={_CANDIDATE_LIMIT}&page={page}'),
+        client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page={_BACKLOG_CANDIDATE_LIMIT}&page={page}'),
     )
-    return cast(list[dict[str, Any]], result.get('items') or [])
+    candidates: dict[int, dict[str, Any]] = {}
+    for item in [
+        *cast(list[dict[str, Any]], recent.get('items') or []),
+        *cast(list[dict[str, Any]], backlog.get('items') or []),
+    ]:
+        candidates.setdefault(int(item['number']), item)
+    return list(candidates.values())[:_CANDIDATE_LIMIT]
 
 
 def build_snapshot(client: GitHubClient, repo: str, *, now: dt.datetime) -> dict[str, object]:
@@ -502,7 +538,7 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             if decision['next_actor'] != 'maintainer':
                 lines.append(f'#{number}: did not request maintainer attention')
                 continue
-            for label in labels.intersection(_STAGE_LABELS):
+            for label in labels.intersection(_LIFECYCLE_LABELS):
                 _remove_label(client, repo, number, label)
             _add_labels(client, repo, number, [_ACTION_LABEL])
             expected = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
@@ -550,11 +586,6 @@ def _advance_stage(client: GitHubClient, repo: str, number: int, labels: set[str
             _remove_label(client, repo, number, label)
 
 
-def _reminder(recipients: Sequence[str]) -> str:
-    mentions = ' '.join(f'@{login}' for login in recipients)
-    return f'{mentions} this still needs a maintainer decision. Could you take a look?'
-
-
 def _event_time(event: Mapping[str, Any]) -> dt.datetime | None:
     value = event.get('created_at') or event.get('submitted_at')
     return _parse_time(str(value)) if value else None
@@ -600,8 +631,8 @@ def _actor(event: Mapping[str, Any]) -> str:
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
 
 
-# `mentioned` and `subscribed` fire as side effects of the bot's own reminder
-# comment mentioning the recipient, so they must never count as acknowledgement.
+# `mentioned` and `subscribed` can fire as side effects of GitHub activity and
+# must never count as acknowledgement.
 _NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
 
 
@@ -621,24 +652,35 @@ def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipi
     )
 
 
-def _fixed_comment_exists(timeline: Sequence[dict[str, Any]], body: str, since: dt.datetime) -> bool:
-    return any(
-        _actor(event) == 'github-actions[bot]'
-        and event.get('event') == 'commented'
-        and event.get('body') == body
-        and (event_time := _event_time(event)) is not None
-        and event_time >= since
-        for event in timeline
-    )
-
-
 def _complete(client: GitHubClient, repo: str, number: int, labels: set[str]) -> None:
     _remove_label(client, repo, number, _ACTION_LABEL)
-    for label in labels.intersection(_STAGE_LABELS):
+    for label in labels.intersection(_LIFECYCLE_LABELS):
         _remove_label(client, repo, number, label)
 
 
-def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.datetime) -> tuple[str, bool] | None:
+def _notice(
+    item: Mapping[str, Any],
+    kind: Literal['initial', 'reminder', 'escalation'],
+    stage: Literal[0, 1, 2],
+    transition: _Transition,
+    recipients: Sequence[str],
+) -> Notice:
+    transition_id = transition[1].get('id')
+    if not isinstance(transition_id, (int, str)) or isinstance(transition_id, bool) or not recipients:
+        raise RuntimeError('Could not build a durable attention notice')
+    return Notice(
+        number=int(item['number']),
+        kind=kind,
+        expected_stage=stage,
+        transition_id=transition_id,
+        title=str(item.get('title') or '')[:300],
+        recipients=list(recipients),
+    )
+
+
+def _reconcile_item(
+    client: GitHubClient, repo: str, number: int, *, now: dt.datetime
+) -> tuple[str, Notice | None] | None:
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     labels = _labels(current)
     if current.get('state') != 'open':
@@ -646,7 +688,7 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
         # labels so a later reopen can't wake an ancient SLA clock.
         if _ACTION_LABEL in labels:
             _complete(client, repo, number, labels)
-            return f'#{number}: completed after the item was closed', False
+            return f'#{number}: completed after the item was closed', None
         return None
     if _ACTION_LABEL not in labels:
         return None
@@ -659,7 +701,7 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     transition_at, transition_event = transition
     if _actor(transition_event) != 'github-actions[bot]':
         _complete(client, repo, number, labels)
-        return f'#{number}: removed a foreign attention transition', False
+        return f'#{number}: removed a foreign attention transition', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
@@ -669,31 +711,30 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
         _complete(client, repo, number, labels)
-        return f'#{number}: maintainer acknowledged the request', False
-    # Queueing the Slack escalation must never depend on a GitHub write
-    # succeeding, so the fallback assignment happens only below this point.
-    if current_stage == 2:
-        return f'#{number}: queued private Slack escalation', True
+        return f'#{number}: maintainer acknowledged the request', None
     recipients = _ensure_recipients(client, repo, current, maintainers, transition)
-    if current_stage == 1:
-        current_body = _reminder(recipients)
-        if not _fixed_comment_exists(timeline, current_body, transition_at):
-            _remove_label(client, repo, number, _PINGED_LABEL)
-            _add_labels(client, repo, number, [_PINGED_LABEL])
-            client.post(f'/repos/{repo}/issues/{number}/comments', {'body': current_body})
-            return f'#{number}: restored maintainer reminder', False
+    if current_stage == 2:
+        return (
+            f'#{number}: queued terminal triage channel escalation',
+            _notice(current, 'escalation', 2, transition, recipients),
+        )
+    if _NOTIFIED_LABEL not in labels:
+        kind: Literal['initial', 'reminder'] = 'initial' if current_stage == 0 else 'reminder'
+        return (
+            f'#{number}: queued {kind} triage channel notice',
+            _notice(current, kind, current_stage, transition, recipients),
+        )
     if now - transition_at < _SLA:
         return None
     if current_stage == 0:
-        _advance_stage(client, repo, number, labels, 1)
-        client.post(f'/repos/{repo}/issues/{number}/comments', {'body': _reminder(recipients)})
-        return f'#{number}: reminded assigned maintainer', False
-    _advance_stage(client, repo, number, labels, 2)
-    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _acknowledged(timeline, transition_at, recipients):
-        _complete(client, repo, number, labels | {_ESCALATED_LABEL})
-        return f'#{number}: maintainer acknowledged the request', False
-    return f'#{number}: queued private Slack escalation', True
+        return (
+            f'#{number}: queued triage channel reminder',
+            _notice(current, 'reminder', 0, transition, recipients),
+        )
+    return (
+        f'#{number}: queued terminal triage channel escalation',
+        _notice(current, 'escalation', 1, transition, recipients),
+    )
 
 
 def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str | None:
@@ -723,12 +764,12 @@ def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str |
 
 
 def reconcile(
-    client: GitHubClient, repo: str, *, now: dt.datetime, escalations: list[int] | None = None
+    client: GitHubClient, repo: str, *, now: dt.datetime, notices: list[Notice] | None = None
 ) -> tuple[list[str], list[str]]:
     """Advance a bounded batch of active attention requests.
 
-    Per-item failures are returned rather than raised so that escalations
-    queued by healthy items always reach the Slack delivery job.
+    Per-item failures are returned rather than raised so that notices queued
+    by healthy items always reach the triage channel delivery job.
     """
     ensure_labels(client, repo)
     encoded = urllib.parse.quote(_ACTION_LABEL, safe='')
@@ -746,10 +787,10 @@ def reconcile(
         number = int(item['number'])
         try:
             if result := _reconcile_item(client, repo, number, now=now):
-                line, should_escalate = result
+                line, notice = result
                 lines.append(line)
-                if should_escalate and escalations is not None:
-                    escalations.append(number)
+                if notice is not None and notices is not None:
+                    notices.append(notice)
         except (urllib.error.HTTPError, RuntimeError, ValueError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
@@ -780,45 +821,168 @@ def reconcile(
     return lines, failures
 
 
-def _write_escalations(repo: str, numbers: Sequence[int]) -> None:
-    unique_numbers = sorted(set(numbers))
+def _slack_escape(value: str) -> str:
+    return value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+
+def _notice_ref(notice: Notice) -> NoticeRef:
+    return NoticeRef(
+        number=notice['number'],
+        kind=notice['kind'],
+        expected_stage=notice['expected_stage'],
+        transition_id=notice['transition_id'],
+        recipients=notice['recipients'],
+    )
+
+
+def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
     if output_path := os.environ.get('GITHUB_OUTPUT'):
-        links = ', '.join(f'<https://github.com/{repo}/issues/{number}|#{number}>' for number in unique_numbers)
-        payload = {'text': f':warning: Maintainer attention needs your view: {links}'}
+        details: list[str] = []
+        for notice in notices:
+            owners = ', '.join(f'@{_slack_escape(login)}' for login in notice['recipients'])
+            title = _slack_escape(notice['title']) or '(untitled)'
+            details.append(
+                f'• *{notice["kind"].title()}*: '
+                f'<https://github.com/{repo}/issues/{notice["number"]}|#{notice["number"]} {title}> — {owners}'
+            )
+        payload = {
+            'text': '\n'.join(
+                [
+                    '<!channel> *Maintainer attention requested*',
+                    *details,
+                    '',
+                    '*Why:* The triage agent reviewed each item and its recent activity and found with high '
+                    'confidence that a maintainer owns the next step.',
+                    '*Expected action:* Open the item and make the next project decision: reply, review, merge or '
+                    'close it, or ask for changes. If no work is needed, leave a brief comment. Do not remove the '
+                    'attention labels; the monitor clears them after maintainer activity.',
+                ]
+            )
+        }
+        refs = [_notice_ref(notice) for notice in notices]
         with Path(output_path).open('a', encoding='utf-8') as output:
-            output.write(f'has_escalations={str(bool(unique_numbers)).lower()}\n')
-            output.write(f'escalation_items={json.dumps(unique_numbers, separators=(",", ":"))}\n')
+            output.write(f'has_notices={str(bool(notices)).lower()}\n')
+            output.write(f'notice_items={json.dumps(refs, separators=(",", ":"))}\n')
             output.write(f'slack_payload={json.dumps(payload, separators=(",", ":"))}\n')
 
 
-def _escalation_numbers(loaded: object) -> list[int]:
+_LOGIN_PATTERN = re.compile(r'(?=.{1,39}\Z)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?')
+_NOTICE_STAGES: dict[str, frozenset[int]] = {
+    'initial': frozenset({0}),
+    'reminder': frozenset({0, 1}),
+    'escalation': frozenset({1, 2}),
+}
+
+
+def _notice_refs(loaded: object) -> list[NoticeRef]:
     if not isinstance(loaded, Mapping):
-        raise ValueError('Escalations must contain only an items list')
+        raise ValueError('Notices must contain only an items list')
     data = cast(Mapping[str, object], loaded)
     if set(data) != {'items'} or not isinstance(data['items'], list):
-        raise ValueError('Escalations must contain only an items list')
-    numbers = cast(list[object], data['items'])
-    if (
-        len(numbers) > _RECONCILE_LIMIT
-        or any(not isinstance(number, int) or isinstance(number, bool) or number < 1 for number in numbers)
-        or len(numbers) != len(set(numbers))
-    ):
-        raise ValueError('Escalations must contain unique positive item numbers within the batch limit')
-    return cast(list[int], numbers)
+        raise ValueError('Notices must contain only an items list')
+    values = cast(list[object], data['items'])
+    if len(values) > _RECONCILE_LIMIT:
+        raise ValueError('Notices exceed the batch limit')
+    notices: list[NoticeRef] = []
+    for value in values:
+        if not isinstance(value, Mapping) or set(cast(Mapping[object, object], value)) != {
+            'number',
+            'kind',
+            'expected_stage',
+            'transition_id',
+            'recipients',
+        }:
+            raise ValueError('Each notice must contain the complete bounded state reference')
+        notice = cast(Mapping[str, object], value)
+        number = notice['number']
+        kind = notice['kind']
+        stage = notice['expected_stage']
+        transition_id = notice['transition_id']
+        recipients = notice['recipients']
+        if not isinstance(recipients, list):
+            raise ValueError('Notice contains an invalid state reference')
+        recipient_values = cast(list[object], recipients)
+        if (
+            not isinstance(number, int)
+            or isinstance(number, bool)
+            or number < 1
+            or not isinstance(kind, str)
+            or kind not in _NOTICE_STAGES
+            or not isinstance(stage, int)
+            or isinstance(stage, bool)
+            or stage not in _NOTICE_STAGES[kind]
+            or not isinstance(transition_id, (int, str))
+            or isinstance(transition_id, bool)
+            or transition_id == ''
+            or (isinstance(transition_id, str) and len(transition_id) > 100)
+            or not 1 <= len(recipient_values) <= 10
+            or any(not isinstance(login, str) or _LOGIN_PATTERN.fullmatch(login) is None for login in recipient_values)
+        ):
+            raise ValueError('Notice contains an invalid state reference')
+        recipient_logins = cast(list[str], recipient_values)
+        if len({login.casefold() for login in recipient_logins}) != len(recipient_logins):
+            raise ValueError('Notice recipients must be unique')
+        notices.append(
+            NoticeRef(
+                number=number,
+                kind=cast(Literal['initial', 'reminder', 'escalation'], kind),
+                expected_stage=cast(Literal[0, 1, 2], stage),
+                transition_id=transition_id,
+                recipients=recipient_logins,
+            )
+        )
+    numbers = [notice['number'] for notice in notices]
+    if len(numbers) != len(set(numbers)):
+        raise ValueError('Notices must contain unique item numbers')
+    return notices
 
 
-def finalize_escalations(client: GitHubClient, repo: str, numbers: Sequence[int]) -> list[str]:
-    """Clear active state only after the private Slack delivery succeeds."""
+def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[str]:
+    """Advance attention state only after the triage channel delivery succeeds."""
     lines: list[str] = []
     failures: list[str] = []
-    for number in numbers:
+    for notice in notices:
+        number = notice['number']
         try:
             current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
             labels = _labels(current)
-            if {_ACTION_LABEL, _ESCALATED_LABEL} <= labels:
+            if current.get('state') != 'open':
+                if _ACTION_LABEL in labels:
+                    _complete(client, repo, number, labels)
+                continue
+            if _ACTION_LABEL not in labels or _stage(labels) != notice['expected_stage']:
+                continue
+            events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
+            transition = _transition(events, notice['expected_stage'])
+            if transition is None or transition[1].get('id') != notice['transition_id']:
+                continue
+            maintainers = _maintainer_assignees(client, repo, current)
+            if not maintainers or {login.casefold() for login in maintainers} != {
+                login.casefold() for login in notice['recipients']
+            }:
+                continue
+            timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+            reminder_transition = _transition(events, 1) if notice['expected_stage'] == 2 else None
+            acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition[0]
+            if _acknowledged(timeline, acknowledged_since, maintainers):
+                _complete(client, repo, number, labels)
+                lines.append(f'#{number}: maintainer acknowledged the delivered notice')
+                continue
+            if notice['kind'] == 'initial':
+                _add_labels(client, repo, number, [_NOTIFIED_LABEL])
+                lines.append(f'#{number}: recorded initial triage channel notice')
+            elif notice['kind'] == 'reminder':
+                _add_labels(client, repo, number, [_NOTIFIED_LABEL])
+                if notice['expected_stage'] == 0:
+                    _advance_stage(client, repo, number, labels | {_NOTIFIED_LABEL}, 1)
+                lines.append(f'#{number}: recorded triage channel reminder')
+            else:
+                if notice['expected_stage'] == 1:
+                    _advance_stage(client, repo, number, labels, 2)
                 _remove_label(client, repo, number, _ACTION_LABEL)
-                lines.append(f'#{number}: delivered private Slack escalation')
-        except (urllib.error.HTTPError, RuntimeError) as exc:
+                _remove_label(client, repo, number, _NOTIFIED_LABEL)
+                lines.append(f'#{number}: recorded terminal triage channel escalation')
+        except (urllib.error.HTTPError, RuntimeError, ValueError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')
@@ -857,14 +1021,14 @@ def main() -> int:
             parser.error('--agent-output is required')
         lines = apply_decisions(client, repo, args.agent_output, args.snapshot_path)
     elif args.mode == 'reconcile':
-        escalations: list[int] = []
-        lines, failures = reconcile(client, repo, now=now, escalations=escalations)
-        _write_escalations(repo, escalations)
+        notices: list[Notice] = []
+        lines, failures = reconcile(client, repo, now=now, notices=notices)
+        _write_notices(repo, notices)
     else:
-        source = os.environ.get('ATTENTION_ESCALATIONS')
+        source = os.environ.get('ATTENTION_NOTICES')
         if source is None:
-            parser.error('ATTENTION_ESCALATIONS is required')
-        lines = finalize_escalations(client, repo, _escalation_numbers(json.loads(source)))
+            parser.error('ATTENTION_NOTICES is required')
+        lines = finalize_notices(client, repo, _notice_refs(json.loads(source)))
     _write_summary(lines + [f'failed: {failure}' for failure in failures])
     for line in lines:
         print(line)

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -427,6 +427,7 @@ def _ensure_recipients(
     repo: str,
     item: Mapping[str, Any],
     maintainers: Sequence[str],
+    transition: tuple[dt.datetime, dict[str, Any]],
 ) -> list[str]:
     if maintainers:
         number = int(item['number'])
@@ -448,6 +449,7 @@ def _ensure_recipients(
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
     _validate_attention_state(item, assigned, check_updated_at=False)
+    _validate_attention_transition(client, repo, item, transition)
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     owner_login = owner.casefold()
     if owner_login not in {login.casefold() for login in assigned_maintainers}:
@@ -505,7 +507,17 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
                 or _stage(_labels(expected)) != 0
             ):
                 raise RuntimeError('Attention state changed while applying the request')
-            recipients = _ensure_recipients(client, repo, expected, _maintainer_assignees(client, repo, expected))
+            events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
+            transition = _transition(events, 0)
+            if transition is None or _actor(transition[1]) != 'github-actions[bot]':
+                raise RuntimeError('Could not verify the new attention transition')
+            recipients = _ensure_recipients(
+                client,
+                repo,
+                expected,
+                _maintainer_assignees(client, repo, expected),
+                transition,
+            )
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
         except (urllib.error.HTTPError, RuntimeError) as exc:
@@ -556,6 +568,23 @@ def _transition(
         and (time := _event_time(event)) is not None
     ]
     return max(transitions, key=lambda value: value[0], default=None)
+
+
+def _validate_attention_transition(
+    client: GitHubClient,
+    repo: str,
+    item: Mapping[str, Any],
+    expected: tuple[dt.datetime, dict[str, Any]],
+) -> None:
+    number = int(item['number'])
+    stage = _stage(_labels(item))
+    events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
+    current = _transition(events, stage)
+    expected_id = expected[1].get('id')
+    if current is None or (
+        current[1].get('id') != expected_id if expected_id is not None else current[0] != expected[0]
+    ):
+        raise RuntimeError('Attention transition changed during owner selection')
 
 
 def _actor(event: Mapping[str, Any]) -> str:
@@ -637,7 +666,7 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     # succeeding, so the fallback assignment happens only below this point.
     if current_stage == 2:
         return f'#{number}: queued private Slack escalation', True
-    recipients = _ensure_recipients(client, repo, current, maintainers)
+    recipients = _ensure_recipients(client, repo, current, maintainers, transition)
     if current_stage == 1:
         current_body = _reminder(recipients)
         if not _fixed_comment_exists(timeline, current_body, transition_at):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -600,9 +600,9 @@ def _actor(event: Mapping[str, Any]) -> str:
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
 
 
-# `assigned`, `mentioned`, and `subscribed` fire as side effects of this
-# workflow's own actions, so they must never count as acknowledgement.
-_NON_ACK_EVENTS = frozenset({'assigned', 'mentioned', 'subscribed'})
+# `mentioned` and `subscribed` fire as side effects of the bot's own reminder
+# comment mentioning the recipient, so they must never count as acknowledgement.
+_NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
 
 
 def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipients: Sequence[str]) -> bool:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -454,7 +454,7 @@ def _ensure_recipients(
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
     _validate_attention_state(item, assigned, check_updated_at=False)
-    _validate_attention_transition(client, repo, item, transition, check_updated_at=False)
+    _validate_attention_transition(client, repo, assigned, transition)
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     owner_login = owner.casefold()
     if owner_login not in {login.casefold() for login in assigned_maintainers}:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -24,9 +24,12 @@ from typing import Any, Literal, TypedDict, cast  # noqa: TID251
 
 _API = 'https://api.github.com'
 _SLA = dt.timedelta(days=3)
+_BOT_ASSIGNMENT_WINDOW = dt.timedelta(minutes=1)
 _CANDIDATE_LIMIT = 10
 _RECONCILE_LIMIT = 25
 _EVENT_PAGE_LIMIT = 10
+_COMMENT_PAGE_LIMIT = 10
+_COLLABORATOR_PAGE_LIMIT = 2
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
@@ -56,6 +59,7 @@ class GitHubClient:
 
     def __init__(self, token: str) -> None:
         self._token = token
+        self._maintainers: dict[str, frozenset[str]] = {}
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -119,6 +123,17 @@ class GitHubClient:
             if not (page_path := _link_path(links, 'next')):
                 return
         raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
+
+    def maintainer_logins(self, repo: str) -> frozenset[str]:
+        if repo not in self._maintainers:
+            maintainers: set[str] = set()
+            for page in self.pages(
+                f'/repos/{repo}/collaborators?permission=push',
+                count=_COLLABORATOR_PAGE_LIMIT,
+            ):
+                maintainers.update(login.casefold() for value in page if (login := str(value.get('login') or '')))
+            self._maintainers[repo] = frozenset(maintainers)
+        return self._maintainers[repo]
 
 
 def _parse_time(value: str) -> dt.datetime:
@@ -379,30 +394,34 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
     if 'pull_request' in item:
         return None
 
-    permissions: dict[str, bool] = {}
-
-    def is_maintainer(login: str) -> bool:
-        normalized = login.casefold()
-        if normalized not in permissions:
-            permissions[normalized] = _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS
-        return permissions[normalized]
+    maintainers = client.maintainer_logins(repo)
 
     author = _login(item)
-    if author and is_maintainer(author):
+    if author and author.casefold() in maintainers:
         return author
 
     number = int(item['number'])
-    comment_pages = _last_page(int(item.get('comments') or 0), 100)
+    comment_pages = min(_last_page(int(item.get('comments') or 0), 100), _COMMENT_PAGE_LIMIT)
     for page in client.pages(f'/repos/{repo}/issues/{number}/comments', count=comment_pages):
         for comment in page:
             login = _login(comment)
-            if login and is_maintainer(login):
+            if login and login.casefold() in maintainers:
                 return login
     return None
 
 
 def _remove_assignees(client: GitHubClient, repo: str, number: int, assignees: Sequence[str]) -> None:
     client.delete(f'/repos/{repo}/issues/{number}/assignees', {'assignees': list(assignees)})
+
+
+def _validate_attention_state(previous: Mapping[str, Any], current: Mapping[str, Any]) -> None:
+    previous_labels = _labels(previous)
+    if _ACTION_LABEL in previous_labels and (
+        current.get('state') != 'open'
+        or _ACTION_LABEL not in (current_labels := _labels(current))
+        or _stage(current_labels) != _stage(previous_labels)
+    ):
+        raise RuntimeError('Attention state changed during owner selection')
 
 
 def _ensure_recipients(
@@ -413,35 +432,49 @@ def _ensure_recipients(
     *,
     replace_bot_fallback: bool = False,
 ) -> list[str]:
-    if maintainers and not replace_bot_fallback:
-        return list(maintainers)
+    fallback_login = _FALLBACK_OWNER.casefold()
+    if maintainers:
+        existing = [login for login in maintainers if login.casefold() != fallback_login]
+        if not replace_bot_fallback:
+            return list(maintainers)
+        if existing:
+            number = int(item['number'])
+            current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+            _validate_attention_state(item, current)
+            current_maintainers = _maintainer_assignees(client, repo, current)
+            existing = [login for login in current_maintainers if login.casefold() != fallback_login]
+            if existing:
+                if fallback_login in {login.casefold() for login in current_maintainers}:
+                    _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
+                return existing
+
     owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
     number = int(item['number'])
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    _validate_attention_state(item, current)
     current_maintainers = _maintainer_assignees(client, repo, current)
-    if current_maintainers and not (
-        replace_bot_fallback and [login.casefold() for login in current_maintainers] == [_FALLBACK_OWNER.casefold()]
-    ):
+    existing = [login for login in current_maintainers if login.casefold() != fallback_login]
+    if existing:
+        if replace_bot_fallback:
+            _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
+        return existing
+    if current_maintainers and not replace_bot_fallback:
         return current_maintainers
+    if owner.casefold() == fallback_login and current_maintainers:
+        return current_maintainers
+
     assigned = cast(
         dict[str, Any],
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     owner_login = owner.casefold()
-    fallback_login = _FALLBACK_OWNER.casefold()
-    selected = {owner_login}
-    if replace_bot_fallback:
-        selected.add(fallback_login)
-    existing = [login for login in assigned_maintainers if login.casefold() not in selected]
-    if existing:
-        _remove_assignees(client, repo, number, [owner, *([_FALLBACK_OWNER] if replace_bot_fallback else [])])
-        return existing
     if owner_login not in {login.casefold() for login in assigned_maintainers}:
         raise RuntimeError(f'GitHub did not assign @{owner}')
     if replace_bot_fallback and fallback_login != owner_login:
         _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
-    return [owner]
+        assigned_maintainers = [login for login in assigned_maintainers if login.casefold() != fallback_login]
+    return assigned_maintainers
 
 
 def _remove_label(client: GitHubClient, repo: str, number: int, label: str) -> None:
@@ -545,7 +578,9 @@ def _actor(event: Mapping[str, Any]) -> str:
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
 
 
-def _latest_assignment_was_by_bot(timeline: Sequence[dict[str, Any]], login: str) -> bool:
+def _latest_assignment_was_by_attention_bot(
+    timeline: Sequence[dict[str, Any]], login: str, transition_at: dt.datetime
+) -> bool:
     assignments = [
         (time, event)
         for event in timeline
@@ -555,12 +590,20 @@ def _latest_assignment_was_by_bot(timeline: Sequence[dict[str, Any]], login: str
         and (time := _event_time(event)) is not None
     ]
     latest = max(assignments, key=lambda value: value[0], default=None)
-    return latest is not None and _actor(latest[1]) == 'github-actions[bot]'
+    if latest is None:
+        return False
+    assigned_at, event = latest
+    assigner = event.get('assigner')
+    return (
+        transition_at <= assigned_at <= transition_at + _BOT_ASSIGNMENT_WINDOW
+        and isinstance(assigner, Mapping)
+        and str(cast(Mapping[str, object], assigner).get('login') or '') == 'github-actions[bot]'
+    )
 
 
-# `mentioned` and `subscribed` fire as a side effect of the bot's own reminder
-# comment mentioning the recipient, so they must never count as acknowledgement.
-_NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
+# `assigned`, `mentioned`, and `subscribed` fire as side effects of this
+# workflow's own actions, so they must never count as acknowledgement.
+_NON_ACK_EVENTS = frozenset({'assigned', 'mentioned', 'subscribed'})
 
 
 def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipients: Sequence[str]) -> bool:
@@ -623,9 +666,12 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
         if label != current_stage_label:
             _remove_label(client, repo, number, label)
     maintainers = _maintainer_assignees(client, repo, current)
-    replace_bot_fallback = [login.casefold() for login in maintainers] == [
-        _FALLBACK_OWNER.casefold()
-    ] and _latest_assignment_was_by_bot(timeline, _FALLBACK_OWNER)
+    action_transition = _transition(events, 0)
+    replace_bot_fallback = (
+        _FALLBACK_OWNER.casefold() in {login.casefold() for login in maintainers}
+        and action_transition is not None
+        and _latest_assignment_was_by_attention_bot(timeline, _FALLBACK_OWNER, action_transition[0])
+    )
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
@@ -642,6 +688,8 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
         maintainers,
         replace_bot_fallback=replace_bot_fallback,
     )
+    latest = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    _validate_attention_state(current, latest)
     if current_stage == 1:
         current_body = _reminder(recipients)
         if not _fixed_comment_exists(timeline, current_body, transition_at):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -26,28 +26,23 @@ _API = 'https://api.github.com'
 _SLA = dt.timedelta(days=3)
 _RECENT_ACTIVITY_WINDOW = dt.timedelta(days=45)
 _CANDIDATE_LIMIT = 10
-_RECENT_CANDIDATE_LIMIT = 5
+_RECENT_CANDIDATE_LIMIT = _CANDIDATE_LIMIT // 2
 _BACKLOG_CANDIDATE_LIMIT = _CANDIDATE_LIMIT - _RECENT_CANDIDATE_LIMIT
 _RECONCILE_LIMIT = 25
 _EVENT_PAGE_LIMIT = 10
 _COMMENT_PAGE_LIMIT = 10
-_COLLABORATOR_PAGE_LIMIT = 2
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
 _MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
-_ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 _ACTION_LABEL = 'needs-maintainer-action'
-_NOTIFIED_LABEL = 'attention-notified'
 _PINGED_LABEL = 'attention-pinged'
 _ESCALATED_LABEL = 'attention-escalated'
 _STAGE_LABELS = (_PINGED_LABEL, _ESCALATED_LABEL)
-_LIFECYCLE_LABELS = (_NOTIFIED_LABEL, *_STAGE_LABELS)
 _LABELS = {
     _ACTION_LABEL: ('d4c5f9', 'The next meaningful action must come from a maintainer'),
-    _NOTIFIED_LABEL: ('c5def5', 'The triage channel received the initial maintainer attention notice'),
-    _PINGED_LABEL: ('fbca04', 'The triage channel received one maintainer attention reminder'),
-    _ESCALATED_LABEL: ('d93f0b', 'The triage channel received the terminal maintainer escalation'),
+    _PINGED_LABEL: ('fbca04', 'The assigned maintainer has received one reminder'),
+    _ESCALATED_LABEL: ('d93f0b', 'The maintainer attention request has been escalated after one reminder'),
 }
 
 
@@ -60,27 +55,19 @@ class Decision(TypedDict):
 
 
 class Notice(TypedDict):
-    """A fixed host-built notification for the private triage channel."""
+    """One fixed channel notification."""
 
     number: int
-    kind: Literal['initial', 'reminder', 'escalation']
-    expected_stage: Literal[0, 1, 2]
-    transition_id: int | str
+    kind: Literal['reminder', 'escalation']
     title: str
     recipients: list[str]
 
 
 class NoticeRef(TypedDict):
-    """The bounded state reference carried from Slack delivery to finalization."""
+    """The item and state that a delivered channel notice described."""
 
     number: int
-    kind: Literal['initial', 'reminder', 'escalation']
-    expected_stage: Literal[0, 1, 2]
-    transition_id: int | str
-    recipients: list[str]
-
-
-_Transition = tuple[dt.datetime, dict[str, Any]]
+    expected_stage: Literal[0, 1]
 
 
 class GitHubClient:
@@ -88,7 +75,6 @@ class GitHubClient:
 
     def __init__(self, token: str) -> None:
         self._token = token
-        self._maintainers: dict[str, frozenset[str]] = {}
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -142,8 +128,8 @@ class GitHubClient:
             pages.extend(cast(list[dict[str, Any]], self.get(page_path)))
         return pages
 
-    def pages(self, path: str, *, count: int = 1) -> Iterator[list[dict[str, Any]]]:
-        """Yield up to `count` pages from the start of a GitHub collection."""
+    def pages(self, path: str, *, count: int) -> Iterator[list[dict[str, Any]]]:
+        """Yield an ascending collection without silently truncating it."""
         separator = '&' if '?' in path else '?'
         page_path = f'{path}{separator}per_page=100&page=1'
         for _ in range(count):
@@ -152,17 +138,6 @@ class GitHubClient:
             if not (page_path := _link_path(links, 'next')):
                 return
         raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
-
-    def maintainer_logins(self, repo: str) -> frozenset[str]:
-        if repo not in self._maintainers:
-            maintainers: set[str] = set()
-            for page in self.pages(
-                f'/repos/{repo}/collaborators?permission=push',
-                count=_COLLABORATOR_PAGE_LIMIT,
-            ):
-                maintainers.update(login.casefold() for value in page if (login := str(value.get('login') or '')))
-            self._maintainers[repo] = frozenset(maintainers)
-        return self._maintainers[repo]
 
 
 def _parse_time(value: str) -> dt.datetime:
@@ -255,48 +230,54 @@ def _candidate_context(
     ], pr_context
 
 
+def _rotated_search(
+    client: GitHubClient,
+    query: str,
+    *,
+    order: Literal['asc', 'desc'],
+    limit: int,
+    slot: int,
+) -> list[dict[str, Any]]:
+    encoded = urllib.parse.quote_plus(query)
+    first = cast(
+        dict[str, Any],
+        client.get(f'/search/issues?q={encoded}&sort=updated&order={order}&per_page=1'),
+    )
+    total = min(int(first.get('total_count') or 0), 1_000)
+    if not total:
+        return []
+    page = slot % math.ceil(total / limit) + 1
+    result = cast(
+        dict[str, Any],
+        client.get(f'/search/issues?q={encoded}&sort=updated&order={order}&per_page={limit}&page={page}'),
+    )
+    return cast(list[dict[str, Any]], result.get('items') or [])
+
+
 def _candidate_page(client: GitHubClient, repo: str, *, now: dt.datetime) -> list[dict[str, Any]]:
     before = (now - _SLA).date().isoformat()
     # An escalated item stays dormant until the reconcile sweep sees real
     # activity and removes the marker; only then may a fresh lifecycle start.
     excluded = f'-label:"{_ACTION_LABEL}" -label:"{_ESCALATED_LABEL}"'
-    raw_query = f'repo:{repo} is:open updated:<{before} {excluded}'
-    query = urllib.parse.quote_plus(raw_query)
-    first = cast(dict[str, Any], client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page=1'))
-    total = min(int(first.get('total_count') or 0), 1_000)
-    if not total:
-        return []
+    base_query = f'repo:{repo} is:open updated:<{before} {excluded}'
     slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
     recent_after = (now - _RECENT_ACTIVITY_WINDOW).date().isoformat()
-    recent_query = urllib.parse.quote_plus(f'{raw_query} updated:>={recent_after}')
-    recent_first = cast(
-        dict[str, Any],
-        client.get(f'/search/issues?q={recent_query}&sort=updated&order=desc&per_page=1'),
+    recent = _rotated_search(
+        client,
+        f'{base_query} updated:>={recent_after}',
+        order='desc',
+        limit=_RECENT_CANDIDATE_LIMIT,
+        slot=slot,
     )
-    recent_total = min(int(recent_first.get('total_count') or 0), 1_000)
-    recent_items: list[dict[str, Any]] = []
-    if recent_total:
-        recent_pages = math.ceil(recent_total / _RECENT_CANDIDATE_LIMIT)
-        recent_page = slot % recent_pages + 1
-        recent = cast(
-            dict[str, Any],
-            client.get(
-                f'/search/issues?q={recent_query}&sort=updated&order=desc'
-                f'&per_page={_RECENT_CANDIDATE_LIMIT}&page={recent_page}'
-            ),
-        )
-        recent_items = cast(list[dict[str, Any]], recent.get('items') or [])
-    pages = math.ceil(total / _BACKLOG_CANDIDATE_LIMIT)
-    page = slot % pages + 1
-    backlog = cast(
-        dict[str, Any],
-        client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page={_BACKLOG_CANDIDATE_LIMIT}&page={page}'),
+    backlog = _rotated_search(
+        client,
+        base_query,
+        order='asc',
+        limit=_BACKLOG_CANDIDATE_LIMIT,
+        slot=slot,
     )
     candidates: dict[int, dict[str, Any]] = {}
-    for item in [
-        *recent_items,
-        *cast(list[dict[str, Any]], backlog.get('items') or []),
-    ]:
+    for item in [*recent, *backlog]:
         candidates.setdefault(int(item['number']), item)
     return list(candidates.values())[:_CANDIDATE_LIMIT]
 
@@ -446,71 +427,50 @@ def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, An
 
 
 def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
+    """Return the first current maintainer who authored or discussed an issue."""
     if 'pull_request' in item:
         return None
 
-    maintainers = client.maintainer_logins(repo)
+    def maintainer(entry: Mapping[str, Any]) -> str | None:
+        login = _login(entry)
+        if (
+            login
+            and entry.get('author_association') in _ACK_ASSOCIATIONS
+            and _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS
+        ):
+            return login
+        return None
 
-    author = _login(item)
-    if author and author.casefold() in maintainers:
+    if author := maintainer(item):
         return author
-
-    number = int(item['number'])
-    comment_pages = min(_last_page(int(item.get('comments') or 0), 100), _COMMENT_PAGE_LIMIT)
-    for page in client.pages(f'/repos/{repo}/issues/{number}/comments', count=comment_pages):
-        for comment in page:
-            login = _login(comment)
-            if login and login.casefold() in maintainers:
-                return login
+    comments = int(item.get('comments') or 0)
+    if comments:
+        pages = min(_last_page(comments, 100), _COMMENT_PAGE_LIMIT)
+        for page in client.pages(f'/repos/{repo}/issues/{int(item["number"])}/comments', count=pages):
+            for comment in page:
+                if login := maintainer(comment):
+                    return login
     return None
 
 
-def _validate_attention_state(
-    previous: Mapping[str, Any], current: Mapping[str, Any], *, check_updated_at: bool = True
-) -> None:
-    previous_labels = _labels(previous)
-    if _ACTION_LABEL in previous_labels and (
-        current.get('state') != 'open'
-        or (check_updated_at and current.get('updated_at') != previous.get('updated_at'))
-        or _ACTION_LABEL not in (current_labels := _labels(current))
-        or _stage(current_labels) != _stage(previous_labels)
-    ):
-        raise RuntimeError('Attention state changed during owner selection')
-
-
 def _ensure_recipients(
-    client: GitHubClient,
-    repo: str,
-    item: Mapping[str, Any],
-    maintainers: Sequence[str],
-    transition: _Transition,
+    client: GitHubClient, repo: str, item: Mapping[str, Any], maintainers: Sequence[str]
 ) -> list[str]:
     if maintainers:
-        number = int(item['number'])
-        current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-        _validate_attention_state(item, current)
-        if current_maintainers := _maintainer_assignees(client, repo, current):
-            _validate_attention_transition(client, repo, item, transition)
-            return current_maintainers
-
-    owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
+        return list(maintainers)
     number = int(item['number'])
+    owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-    _validate_attention_state(item, current)
-    current_maintainers = _maintainer_assignees(client, repo, current)
-    if current_maintainers:
-        _validate_attention_transition(client, repo, item, transition)
+    if current.get('state') != 'open' or _ACTION_LABEL not in _labels(current):
+        raise RuntimeError('Attention state changed during owner selection')
+    if current_maintainers := _maintainer_assignees(client, repo, current):
         return current_maintainers
-
     assigned = cast(
         dict[str, Any],
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
-    _validate_attention_state(item, assigned, check_updated_at=False)
-    _validate_attention_transition(client, repo, assigned, transition)
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
-    owner_login = owner.casefold()
-    if owner_login not in {login.casefold() for login in assigned_maintainers}:
+    if owner.casefold() not in {login.casefold() for login in assigned_maintainers}:
         raise RuntimeError(f'GitHub did not assign @{owner}')
     return assigned_maintainers
 
@@ -555,26 +515,17 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             if decision['next_actor'] != 'maintainer':
                 lines.append(f'#{number}: did not request maintainer attention')
                 continue
-            for label in labels.intersection(_LIFECYCLE_LABELS):
+            for label in labels.intersection(_STAGE_LABELS):
                 _remove_label(client, repo, number, label)
             _add_labels(client, repo, number, [_ACTION_LABEL])
-            expected = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-            if (
-                expected.get('state') != 'open'
-                or _ACTION_LABEL not in _labels(expected)
-                or _stage(_labels(expected)) != 0
-            ):
+            attention_item = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+            if attention_item.get('state') != 'open' or _ACTION_LABEL not in _labels(attention_item):
                 raise RuntimeError('Attention state changed while applying the request')
-            events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
-            transition = _transition(events, 0)
-            if transition is None or _actor(transition[1]) != 'github-actions[bot]':
-                raise RuntimeError('Could not verify the new attention transition')
             recipients = _ensure_recipients(
                 client,
                 repo,
-                expected,
-                _maintainer_assignees(client, repo, expected),
-                transition,
+                attention_item,
+                _maintainer_assignees(client, repo, attention_item),
             )
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
@@ -608,43 +559,19 @@ def _event_time(event: Mapping[str, Any]) -> dt.datetime | None:
     return _parse_time(str(value)) if value else None
 
 
-def _label_transition(timeline: Sequence[dict[str, Any]], label: str) -> _Transition | None:
+def _transition(
+    timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]
+) -> tuple[dt.datetime, dict[str, Any]] | None:
+    label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
     transitions = [
-        (time, index, event)
-        for index, event in enumerate(timeline)
+        (time, event)
+        for event in timeline
         if event.get('event') == 'labeled'
         and isinstance(event.get('label'), Mapping)
         and cast(Mapping[str, object], event['label']).get('name') == label
         and (time := _event_time(event)) is not None
     ]
-    latest = max(transitions, key=lambda value: (value[0], value[1]), default=None)
-    return (latest[0], latest[2]) if latest is not None else None
-
-
-def _transition(timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]) -> _Transition | None:
-    label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
-    return _label_transition(timeline, label)
-
-
-def _validate_attention_transition(
-    client: GitHubClient,
-    repo: str,
-    item: Mapping[str, Any],
-    expected: _Transition,
-    *,
-    check_updated_at: bool = True,
-) -> None:
-    number = int(item['number'])
-    stage = _stage(_labels(item))
-    events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
-    current = _transition(events, stage)
-    expected_id = expected[1].get('id')
-    if current is None or (
-        current[1].get('id') != expected_id if expected_id is not None else current[0] != expected[0]
-    ):
-        raise RuntimeError('Attention transition changed during owner selection')
-    latest = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-    _validate_attention_state(item, latest, check_updated_at=check_updated_at)
+    return max(transitions, key=lambda value: value[0], default=None)
 
 
 def _actor(event: Mapping[str, Any]) -> str:
@@ -652,9 +579,10 @@ def _actor(event: Mapping[str, Any]) -> str:
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
 
 
-# `mentioned` and `subscribed` can fire as side effects of GitHub activity and
-# must never count as acknowledgement.
+# `mentioned` and `subscribed` fire as a side effect of the bot's own reminder
+# comment mentioning the recipient, so they must never count as acknowledgement.
 _NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
+_ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 
 
 def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipients: Sequence[str]) -> bool:
@@ -673,34 +601,20 @@ def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipi
     )
 
 
-def _closed_since(timeline: Sequence[dict[str, Any]], since: dt.datetime) -> bool:
-    return any(
-        event.get('event') == 'closed' and (event_time := _event_time(event)) is not None and event_time >= since
-        for event in timeline
-    )
-
-
 def _complete(client: GitHubClient, repo: str, number: int, labels: set[str]) -> None:
-    for label in labels.intersection(_LIFECYCLE_LABELS):
-        _remove_label(client, repo, number, label)
     _remove_label(client, repo, number, _ACTION_LABEL)
+    for label in labels.intersection(_STAGE_LABELS):
+        _remove_label(client, repo, number, label)
 
 
 def _notice(
     item: Mapping[str, Any],
-    kind: Literal['initial', 'reminder', 'escalation'],
-    stage: Literal[0, 1, 2],
-    transition: _Transition,
+    kind: Literal['reminder', 'escalation'],
     recipients: Sequence[str],
 ) -> Notice:
-    transition_id = transition[1].get('id')
-    if not isinstance(transition_id, (int, str)) or isinstance(transition_id, bool) or not recipients:
-        raise RuntimeError('Could not build a durable attention notice')
     return Notice(
         number=int(item['number']),
         kind=kind,
-        expected_stage=stage,
-        transition_id=transition_id,
         title=str(item.get('title') or '')[:300],
         recipients=list(recipients),
     )
@@ -730,9 +644,6 @@ def _reconcile_item(
     if _actor(transition_event) != 'github-actions[bot]':
         _complete(client, repo, number, labels)
         return f'#{number}: removed a foreign attention transition', None
-    if _closed_since(timeline, transition_at):
-        _complete(client, repo, number, labels)
-        return f'#{number}: completed after the item was closed', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
@@ -743,39 +654,17 @@ def _reconcile_item(
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
-    recipients = _ensure_recipients(client, repo, current, maintainers, transition)
+    # Stage 2 is only written after Slack accepts the escalation. If cleanup
+    # was interrupted, finish it without posting the channel notice again.
     if current_stage == 2:
-        return (
-            f'#{number}: queued terminal triage channel escalation',
-            _notice(current, 'escalation', 2, transition, recipients),
-        )
-    notified_transition = _label_transition(events, _NOTIFIED_LABEL)
-    if (
-        _NOTIFIED_LABEL not in labels
-        or notified_transition is None
-        or _actor(notified_transition[1]) != 'github-actions[bot]'
-    ):
-        if _NOTIFIED_LABEL in labels:
-            _remove_label(client, repo, number, _NOTIFIED_LABEL)
-        return (
-            f'#{number}: queued initial triage channel notice',
-            _notice(current, 'initial', current_stage, transition, recipients),
-        )
-    sla_started_at = max(
-        transition_at,
-        notified_transition[0],
-    )
-    if now - sla_started_at < _SLA:
+        _remove_label(client, repo, number, _ACTION_LABEL)
+        return f'#{number}: completed delivered channel escalation', None
+    recipients = _ensure_recipients(client, repo, current, maintainers)
+    if now - transition_at < _SLA:
         return None
     if current_stage == 0:
-        return (
-            f'#{number}: queued triage channel reminder',
-            _notice(current, 'reminder', 0, transition, recipients),
-        )
-    return (
-        f'#{number}: queued terminal triage channel escalation',
-        _notice(current, 'escalation', 1, transition, recipients),
-    )
+        return f'#{number}: queued channel reminder', _notice(current, 'reminder', recipients)
+    return f'#{number}: queued channel escalation', _notice(current, 'escalation', recipients)
 
 
 def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str | None:
@@ -804,47 +693,24 @@ def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str |
     return None
 
 
-def _active_items(client: GitHubClient, repo: str, *, now: dt.datetime) -> list[dict[str, Any]]:
-    """Prioritize channel-undelivered requests, then fill from the oldest active items."""
-    query = urllib.parse.quote_plus(f'repo:{repo} is:open label:"{_ACTION_LABEL}" -label:"{_NOTIFIED_LABEL}"')
-    first = cast(dict[str, Any], client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page=1'))
-    total = min(int(first.get('total_count') or 0), 1_000)
-    priority: list[dict[str, Any]] = []
-    if total:
-        pages = math.ceil(total / _RECONCILE_LIMIT)
-        slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
-        page = slot % pages + 1
-        result = cast(
-            dict[str, Any],
-            client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page={_RECONCILE_LIMIT}&page={page}'),
-        )
-        priority = cast(list[dict[str, Any]], result.get('items') or [])
-
-    encoded = urllib.parse.quote(_ACTION_LABEL, safe='')
-    fallback = cast(
-        list[dict[str, Any]],
-        client.get(
-            # state=all so a closed item still completes its lifecycle instead
-            # of leaving a dormant clock that a reopen wakes.
-            f'/repos/{repo}/issues?state=all&labels={encoded}&sort=updated&direction=asc&per_page={_RECONCILE_LIMIT}'
-        ),
-    )
-    items: dict[int, dict[str, Any]] = {}
-    for item in [*priority, *fallback]:
-        items.setdefault(int(item['number']), item)
-    return list(items.values())[:_RECONCILE_LIMIT]
-
-
 def reconcile(
     client: GitHubClient, repo: str, *, now: dt.datetime, notices: list[Notice] | None = None
 ) -> tuple[list[str], list[str]]:
     """Advance a bounded batch of active attention requests.
 
     Per-item failures are returned rather than raised so that notices queued
-    by healthy items always reach the triage channel delivery job.
+    by healthy items always reach the Slack delivery job.
     """
     ensure_labels(client, repo)
-    items = _active_items(client, repo, now=now)
+    encoded = urllib.parse.quote(_ACTION_LABEL, safe='')
+    items = cast(
+        list[dict[str, Any]],
+        client.get(
+            # state=all so a closed item still completes its lifecycle (labels
+            # removed) instead of leaving a dormant clock that a reopen wakes.
+            f'/repos/{repo}/issues?state=all&labels={encoded}&sort=updated&direction=asc&per_page={_RECONCILE_LIMIT}'
+        ),
+    )
     lines: list[str] = []
     failures: list[str] = []
     for item in items:
@@ -865,10 +731,11 @@ def reconcile(
     dormant = cast(
         list[dict[str, Any]],
         client.get(
-            # Recent-first makes renewed activity on an old escalated item
-            # visible immediately. Processed items lose the escalation label,
-            # so bursts larger than the bound drain over subsequent runs.
+            # state=all so a dormant item closed while escalated still sheds
+            # its marker instead of carrying it forever.
             f'/repos/{repo}/issues?state=all&labels={encoded_escalated}'
+            # Recent-first ensures that renewed activity on an old escalated
+            # issue cannot sit behind the oldest 25 dormant items.
             f'&sort=updated&direction=desc&per_page={_RECONCILE_LIMIT}'
         ),
     )
@@ -894,22 +761,11 @@ def _slack_escape(value: str) -> str:
     return normalized.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
 
-def _notice_ref(notice: Notice) -> NoticeRef:
-    return NoticeRef(
-        number=notice['number'],
-        kind=notice['kind'],
-        expected_stage=notice['expected_stage'],
-        transition_id=notice['transition_id'],
-        recipients=notice['recipients'],
-    )
-
-
 def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
     if output_path := os.environ.get('GITHUB_OUTPUT'):
         reasons = {
-            'initial': 'triage identified a maintainer as the next actor',
-            'reminder': 'there has been no maintainer activity for three days',
-            'escalation': 'the reminder has had no maintainer activity for three more days',
+            'reminder': 'no maintainer has acted for three days',
+            'escalation': 'the channel reminder has had no maintainer response for three more days',
         }
         details: list[str] = []
         for notice in notices:
@@ -926,25 +782,23 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
                     '<!channel> *Maintainer attention requested*',
                     *details,
                     '',
-                    '*Expected action:* Open each item and make its next maintainer decision there. A reply, review, '
-                    'merge, close, or request for changes counts. If no work is needed, say so briefly. Do not remove '
-                    'the attention labels; the monitor clears them after maintainer activity.',
+                    '*Expected action:* Open each item and make its next maintainer decision there. Reply, review, '
+                    'merge, close, or request changes as appropriate. Do not remove the attention labels; the '
+                    'monitor clears them after maintainer activity.',
                 ]
             )
         }
-        refs = [_notice_ref(notice) for notice in notices]
+        refs = [
+            NoticeRef(
+                number=notice['number'],
+                expected_stage=0 if notice['kind'] == 'reminder' else 1,
+            )
+            for notice in notices
+        ]
         with Path(output_path).open('a', encoding='utf-8') as output:
             output.write(f'has_notices={str(bool(notices)).lower()}\n')
             output.write(f'notice_items={json.dumps(refs, separators=(",", ":"))}\n')
             output.write(f'slack_payload={json.dumps(payload, separators=(",", ":"))}\n')
-
-
-_LOGIN_PATTERN = re.compile(r'(?=.{1,39}\Z)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?')
-_NOTICE_STAGES: dict[str, frozenset[int]] = {
-    'initial': frozenset({0, 1}),
-    'reminder': frozenset({0, 1}),
-    'escalation': frozenset({1, 2}),
-}
 
 
 def _notice_refs(loaded: object) -> list[NoticeRef]:
@@ -954,158 +808,68 @@ def _notice_refs(loaded: object) -> list[NoticeRef]:
     if set(data) != {'items'} or not isinstance(data['items'], list):
         raise ValueError('Notices must contain only an items list')
     values = cast(list[object], data['items'])
-    if len(values) > _RECONCILE_LIMIT:
-        raise ValueError('Notices exceed the batch limit')
     notices: list[NoticeRef] = []
     for value in values:
-        if not isinstance(value, Mapping) or set(cast(Mapping[object, object], value)) != {
-            'number',
-            'kind',
-            'expected_stage',
-            'transition_id',
-            'recipients',
-        }:
-            raise ValueError('Each notice must contain the complete bounded state reference')
+        if not isinstance(value, Mapping):
+            raise ValueError('Notice has an invalid shape')
         notice = cast(Mapping[str, object], value)
+        if set(notice) != {'number', 'expected_stage'}:
+            raise ValueError('Notice has an invalid shape')
         number = notice['number']
-        kind = notice['kind']
         stage = notice['expected_stage']
-        transition_id = notice['transition_id']
-        recipients = notice['recipients']
-        if not isinstance(recipients, list):
-            raise ValueError('Notice contains an invalid state reference')
-        recipient_values = cast(list[object], recipients)
         if (
             not isinstance(number, int)
             or isinstance(number, bool)
             or number < 1
-            or not isinstance(kind, str)
-            or kind not in _NOTICE_STAGES
             or not isinstance(stage, int)
             or isinstance(stage, bool)
-            or stage not in _NOTICE_STAGES[kind]
-            or not isinstance(transition_id, (int, str))
-            or isinstance(transition_id, bool)
-            or transition_id == ''
-            or (isinstance(transition_id, str) and len(transition_id) > 100)
-            or not 1 <= len(recipient_values) <= 10
-            or any(not isinstance(login, str) or _LOGIN_PATTERN.fullmatch(login) is None for login in recipient_values)
+            or stage not in {0, 1}
         ):
-            raise ValueError('Notice contains an invalid state reference')
-        recipient_logins = cast(list[str], recipient_values)
-        if len({login.casefold() for login in recipient_logins}) != len(recipient_logins):
-            raise ValueError('Notice recipients must be unique')
-        notices.append(
-            NoticeRef(
-                number=number,
-                kind=cast(Literal['initial', 'reminder', 'escalation'], kind),
-                expected_stage=cast(Literal[0, 1, 2], stage),
-                transition_id=transition_id,
-                recipients=recipient_logins,
-            )
-        )
-    numbers = [notice['number'] for notice in notices]
-    if len(numbers) != len(set(numbers)):
-        raise ValueError('Notices must contain unique item numbers')
+            raise ValueError('Notice has invalid values')
+        notices.append(NoticeRef(number=number, expected_stage=cast(Literal[0, 1], stage)))
+    if len(notices) > _RECONCILE_LIMIT or len({notice['number'] for notice in notices}) != len(notices):
+        raise ValueError('Notices must be unique and within the batch limit')
     return notices
 
 
-def _notice_state(
-    client: GitHubClient, repo: str, notice: NoticeRef
-) -> tuple[dict[str, Any], set[str], _Transition, list[str]] | None:
-    """Return a notice's exact live state, or `None` if it has changed."""
-    number = notice['number']
-    current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-    labels = _labels(current)
-    current_stage = _stage(labels)
-    resumed_stage = (notice['kind'] == 'reminder' and notice['expected_stage'] == 0 and current_stage == 1) or (
-        notice['kind'] == 'escalation' and notice['expected_stage'] == 1 and current_stage == 2
+def _closed_since(timeline: Sequence[dict[str, Any]], since: dt.datetime) -> bool:
+    return any(
+        event.get('event') == 'closed' and (event_time := _event_time(event)) is not None and event_time >= since
+        for event in timeline
     )
-    if (
-        current.get('state') != 'open'
-        or _ACTION_LABEL not in labels
-        or (current_stage != notice['expected_stage'] and not resumed_stage)
-    ):
-        return None
-    events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
-    transition = _transition(events, notice['expected_stage'])
-    if transition is None or transition[1].get('id') != notice['transition_id']:
-        return None
-    if resumed_stage:
-        resumed_transition = _transition(events, current_stage)
-        if (
-            resumed_transition is None
-            or _actor(resumed_transition[1]) != 'github-actions[bot]'
-            or resumed_transition[0] < transition[0]
-        ):
-            return None
-    maintainers = _maintainer_assignees(client, repo, current)
-    if not maintainers or {login.casefold() for login in maintainers} != {
-        login.casefold() for login in notice['recipients']
-    }:
-        return None
-    latest = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-    if (
-        latest.get('updated_at') != current.get('updated_at')
-        or latest.get('state') != 'open'
-        or _labels(latest) != labels
-        or {str(assignee['login']).casefold() for assignee in latest.get('assignees', [])}
-        != {str(assignee['login']).casefold() for assignee in current.get('assignees', [])}
-    ):
-        return None
-    return latest, labels, transition, maintainers
 
 
 def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str | None:
     number = notice['number']
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     labels = _labels(current)
-    if current.get('state') != 'open':
-        if _ACTION_LABEL in labels:
-            _complete(client, repo, number, labels)
+    stage = _stage(labels)
+    if current.get('state') != 'open' or _ACTION_LABEL not in labels or stage != notice['expected_stage']:
         return None
-    if _notice_state(client, repo, notice) is None:
+    maintainers = _maintainer_assignees(client, repo, current)
+    events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
+    transition = _transition(events, stage)
+    if transition is None or _actor(transition[1]) != 'github-actions[bot]':
         return None
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if (state := _notice_state(client, repo, notice)) is None:
-        return None
-    _, labels, transition, maintainers = state
-    reminder_transition = _transition(timeline, 1) if notice['expected_stage'] == 2 else None
-    acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition[0]
-    if _closed_since(timeline, transition[0]):
+    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], maintainers):
         _complete(client, repo, number, labels)
-        return f'#{number}: completed after the item was closed'
-    if _acknowledged(timeline, acknowledged_since, maintainers):
-        _complete(client, repo, number, labels)
-        return f'#{number}: maintainer acknowledged the delivered notice'
-    if notice['kind'] == 'initial':
-        _add_labels(client, repo, number, [_NOTIFIED_LABEL])
-        return f'#{number}: recorded initial triage channel notice'
-    if notice['kind'] == 'reminder':
-        _add_labels(client, repo, number, [_NOTIFIED_LABEL])
-        if _stage(labels) == 0:
-            _advance_stage(client, repo, number, labels | {_NOTIFIED_LABEL}, 1)
-        timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-        if _acknowledged(timeline, acknowledged_since, maintainers):
-            _complete(client, repo, number, labels | {_NOTIFIED_LABEL, _PINGED_LABEL})
-            return f'#{number}: maintainer acknowledged the delivered notice'
-        return f'#{number}: recorded triage channel reminder'
-    if _stage(labels) == 1:
-        _advance_stage(client, repo, number, labels, 2)
+        return f'#{number}: maintainer activity completed the delivered notice'
+    next_stage: Literal[1, 2] = 1 if stage == 0 else 2
+    _advance_stage(client, repo, number, labels, next_stage)
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _acknowledged(timeline, acknowledged_since, maintainers):
-        _complete(client, repo, number, labels | {_ESCALATED_LABEL})
-        return f'#{number}: maintainer acknowledged the delivered notice'
-    for label in labels.intersection(_STAGE_LABELS):
-        if label != _ESCALATED_LABEL:
-            _remove_label(client, repo, number, label)
-    _remove_label(client, repo, number, _NOTIFIED_LABEL)
-    _remove_label(client, repo, number, _ACTION_LABEL)
-    return f'#{number}: recorded terminal triage channel escalation'
+    completed_labels = labels | {_STAGE_LABELS[next_stage - 1]}
+    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], maintainers):
+        _complete(client, repo, number, completed_labels)
+        return f'#{number}: maintainer activity completed the delivered notice'
+    if stage == 1:
+        _remove_label(client, repo, number, _ACTION_LABEL)
+    kind = 'reminder' if stage == 0 else 'escalation'
+    return f'#{number}: recorded channel {kind}'
 
 
 def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[str]:
-    """Advance attention state only after the triage channel delivery succeeds."""
+    """Advance attention state only after the channel delivery succeeds."""
     lines: list[str] = []
     failures: list[str] = []
     for notice in notices:
@@ -1113,7 +877,7 @@ def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRe
         try:
             if line := _finalize_notice(client, repo, notice):
                 lines.append(line)
-        except (urllib.error.HTTPError, RuntimeError, ValueError) as exc:
+        except (urllib.error.HTTPError, RuntimeError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -27,7 +27,6 @@ _SLA = dt.timedelta(days=3)
 _CANDIDATE_LIMIT = 10
 _RECONCILE_LIMIT = 25
 _EVENT_PAGE_LIMIT = 10
-_DISCUSSION_PAGE_LIMIT = 10
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
@@ -89,8 +88,8 @@ class GitHubClient:
     def post(self, path: str, payload: Mapping[str, object]) -> Any:
         return self.request('POST', path, payload)
 
-    def delete(self, path: str) -> Any:
-        return self.request('DELETE', path)
+    def delete(self, path: str, payload: Mapping[str, object] | None = None) -> Any:
+        return self.request('DELETE', path, payload)
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         """Return up to `count` newest pages for an ascending GitHub collection."""
@@ -389,36 +388,59 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
         return permissions[normalized]
 
     author = _login(item)
-    if item.get('author_association') in _ACK_ASSOCIATIONS and author and is_maintainer(author):
+    if author and is_maintainer(author):
         return author
 
     number = int(item['number'])
-    for page in client.pages(f'/repos/{repo}/issues/{number}/timeline', count=_DISCUSSION_PAGE_LIMIT):
-        for event in page:
-            if event.get('event') != 'commented' or event.get('author_association') not in _ACK_ASSOCIATIONS:
-                continue
-            login = _login(event)
+    comment_pages = _last_page(int(item.get('comments') or 0), 100)
+    for page in client.pages(f'/repos/{repo}/issues/{number}/comments', count=comment_pages):
+        for comment in page:
+            login = _login(comment)
             if login and is_maintainer(login):
                 return login
     return None
 
 
+def _remove_assignees(client: GitHubClient, repo: str, number: int, assignees: Sequence[str]) -> None:
+    client.delete(f'/repos/{repo}/issues/{number}/assignees', {'assignees': list(assignees)})
+
+
 def _ensure_recipients(
-    client: GitHubClient, repo: str, item: Mapping[str, Any], maintainers: Sequence[str]
+    client: GitHubClient,
+    repo: str,
+    item: Mapping[str, Any],
+    maintainers: Sequence[str],
+    *,
+    replace_bot_fallback: bool = False,
 ) -> list[str]:
-    if maintainers:
+    if maintainers and not replace_bot_fallback:
         return list(maintainers)
     owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
     number = int(item['number'])
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-    if maintainers := _maintainer_assignees(client, repo, current):
-        return maintainers
+    current_maintainers = _maintainer_assignees(client, repo, current)
+    if current_maintainers and not (
+        replace_bot_fallback and [login.casefold() for login in current_maintainers] == [_FALLBACK_OWNER.casefold()]
+    ):
+        return current_maintainers
     assigned = cast(
         dict[str, Any],
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
-    if owner.casefold() not in {str(value['login']).casefold() for value in assigned.get('assignees', [])}:
+    assigned_maintainers = _maintainer_assignees(client, repo, assigned)
+    owner_login = owner.casefold()
+    fallback_login = _FALLBACK_OWNER.casefold()
+    selected = {owner_login}
+    if replace_bot_fallback:
+        selected.add(fallback_login)
+    existing = [login for login in assigned_maintainers if login.casefold() not in selected]
+    if existing:
+        _remove_assignees(client, repo, number, [owner, *([_FALLBACK_OWNER] if replace_bot_fallback else [])])
+        return existing
+    if owner_login not in {login.casefold() for login in assigned_maintainers}:
         raise RuntimeError(f'GitHub did not assign @{owner}')
+    if replace_bot_fallback and fallback_login != owner_login:
+        _remove_assignees(client, repo, number, [_FALLBACK_OWNER])
     return [owner]
 
 
@@ -523,6 +545,19 @@ def _actor(event: Mapping[str, Any]) -> str:
     return str(cast(Mapping[str, object], value).get('login') or '') if isinstance(value, Mapping) else ''
 
 
+def _latest_assignment_was_by_bot(timeline: Sequence[dict[str, Any]], login: str) -> bool:
+    assignments = [
+        (time, event)
+        for event in timeline
+        if event.get('event') == 'assigned'
+        and isinstance(event.get('assignee'), Mapping)
+        and str(cast(Mapping[str, object], event['assignee']).get('login') or '').casefold() == login.casefold()
+        and (time := _event_time(event)) is not None
+    ]
+    latest = max(assignments, key=lambda value: value[0], default=None)
+    return latest is not None and _actor(latest[1]) == 'github-actions[bot]'
+
+
 # `mentioned` and `subscribed` fire as a side effect of the bot's own reminder
 # comment mentioning the recipient, so they must never count as acknowledgement.
 _NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
@@ -588,6 +623,9 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
         if label != current_stage_label:
             _remove_label(client, repo, number, label)
     maintainers = _maintainer_assignees(client, repo, current)
+    replace_bot_fallback = [login.casefold() for login in maintainers] == [
+        _FALLBACK_OWNER.casefold()
+    ] and _latest_assignment_was_by_bot(timeline, _FALLBACK_OWNER)
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
     if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
@@ -597,7 +635,13 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     # succeeding, so the fallback assignment happens only below this point.
     if current_stage == 2:
         return f'#{number}: queued private Slack escalation', True
-    recipients = _ensure_recipients(client, repo, current, maintainers)
+    recipients = _ensure_recipients(
+        client,
+        repo,
+        current,
+        maintainers,
+        replace_bot_fallback=replace_bot_fallback,
+    )
     if current_stage == 1:
         current_body = _reminder(recipients)
         if not _fixed_comment_exists(timeline, current_body, transition_at):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -24,6 +24,7 @@ from typing import Any, Literal, TypedDict, cast  # noqa: TID251
 
 _API = 'https://api.github.com'
 _SLA = dt.timedelta(days=3)
+_RECENT_ACTIVITY_WINDOW = dt.timedelta(days=45)
 _CANDIDATE_LIMIT = 10
 _RECENT_CANDIDATE_LIMIT = 5
 _BACKLOG_CANDIDATE_LIMIT = _CANDIDATE_LIMIT - _RECENT_CANDIDATE_LIMIT
@@ -259,17 +260,33 @@ def _candidate_page(client: GitHubClient, repo: str, *, now: dt.datetime) -> lis
     # An escalated item stays dormant until the reconcile sweep sees real
     # activity and removes the marker; only then may a fresh lifecycle start.
     excluded = f'-label:"{_ACTION_LABEL}" -label:"{_ESCALATED_LABEL}"'
-    query = urllib.parse.quote_plus(f'repo:{repo} is:open updated:<{before} {excluded}')
+    raw_query = f'repo:{repo} is:open updated:<{before} {excluded}'
+    query = urllib.parse.quote_plus(raw_query)
     first = cast(dict[str, Any], client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page=1'))
     total = min(int(first.get('total_count') or 0), 1_000)
     if not total:
         return []
-    recent = cast(
-        dict[str, Any],
-        client.get(f'/search/issues?q={query}&sort=updated&order=desc&per_page={_RECENT_CANDIDATE_LIMIT}&page=1'),
-    )
-    pages = math.ceil(total / _BACKLOG_CANDIDATE_LIMIT)
     slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
+    recent_after = (now - _RECENT_ACTIVITY_WINDOW).date().isoformat()
+    recent_query = urllib.parse.quote_plus(f'{raw_query} updated:>={recent_after}')
+    recent_first = cast(
+        dict[str, Any],
+        client.get(f'/search/issues?q={recent_query}&sort=updated&order=desc&per_page=1'),
+    )
+    recent_total = min(int(recent_first.get('total_count') or 0), 1_000)
+    recent_items: list[dict[str, Any]] = []
+    if recent_total:
+        recent_pages = math.ceil(recent_total / _RECENT_CANDIDATE_LIMIT)
+        recent_page = slot % recent_pages + 1
+        recent = cast(
+            dict[str, Any],
+            client.get(
+                f'/search/issues?q={recent_query}&sort=updated&order=desc'
+                f'&per_page={_RECENT_CANDIDATE_LIMIT}&page={recent_page}'
+            ),
+        )
+        recent_items = cast(list[dict[str, Any]], recent.get('items') or [])
+    pages = math.ceil(total / _BACKLOG_CANDIDATE_LIMIT)
     page = slot % pages + 1
     backlog = cast(
         dict[str, Any],
@@ -277,7 +294,7 @@ def _candidate_page(client: GitHubClient, repo: str, *, now: dt.datetime) -> lis
     )
     candidates: dict[int, dict[str, Any]] = {}
     for item in [
-        *cast(list[dict[str, Any]], recent.get('items') or []),
+        *recent_items,
         *cast(list[dict[str, Any]], backlog.get('items') or []),
     ]:
         candidates.setdefault(int(item['number']), item)
@@ -591,8 +608,7 @@ def _event_time(event: Mapping[str, Any]) -> dt.datetime | None:
     return _parse_time(str(value)) if value else None
 
 
-def _transition(timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]) -> _Transition | None:
-    label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
+def _label_transition(timeline: Sequence[dict[str, Any]], label: str) -> _Transition | None:
     transitions = [
         (time, index, event)
         for index, event in enumerate(timeline)
@@ -603,6 +619,11 @@ def _transition(timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]) -> 
     ]
     latest = max(transitions, key=lambda value: (value[0], value[1]), default=None)
     return (latest[0], latest[2]) if latest is not None else None
+
+
+def _transition(timeline: Sequence[dict[str, Any]], stage: Literal[0, 1, 2]) -> _Transition | None:
+    label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
+    return _label_transition(timeline, label)
 
 
 def _validate_attention_transition(
@@ -653,9 +674,9 @@ def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipi
 
 
 def _complete(client: GitHubClient, repo: str, number: int, labels: set[str]) -> None:
-    _remove_label(client, repo, number, _ACTION_LABEL)
     for label in labels.intersection(_LIFECYCLE_LABELS):
         _remove_label(client, repo, number, label)
+    _remove_label(client, repo, number, _ACTION_LABEL)
 
 
 def _notice(
@@ -702,6 +723,14 @@ def _reconcile_item(
     if _actor(transition_event) != 'github-actions[bot]':
         _complete(client, repo, number, labels)
         return f'#{number}: removed a foreign attention transition', None
+    if any(
+        event.get('event') == 'closed'
+        and (event_time := _event_time(event)) is not None
+        and event_time >= transition_at
+        for event in timeline
+    ):
+        _complete(client, repo, number, labels)
+        return f'#{number}: completed after the item was closed', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
@@ -724,7 +753,12 @@ def _reconcile_item(
             f'#{number}: queued {kind} triage channel notice',
             _notice(current, kind, current_stage, transition, recipients),
         )
-    if now - transition_at < _SLA:
+    notified_transition = _label_transition(events, _NOTIFIED_LABEL)
+    sla_started_at = max(
+        transition_at,
+        notified_transition[0] if notified_transition is not None else transition_at,
+    )
+    if now - sla_started_at < _SLA:
         return None
     if current_stage == 0:
         return (
@@ -755,12 +789,43 @@ def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str |
     if any(
         _actor(event) != 'github-actions[bot]'
         and (event_time := _event_time(event)) is not None
-        and event_time > transition[0]
+        and event_time >= transition[0]
         for event in timeline
     ):
         _remove_label(client, repo, number, _ESCALATED_LABEL)
         return f'#{number}: restored attention eligibility after new activity'
     return None
+
+
+def _active_items(client: GitHubClient, repo: str, *, now: dt.datetime) -> list[dict[str, Any]]:
+    """Prioritize channel-undelivered requests, then fill from the oldest active items."""
+    query = urllib.parse.quote_plus(f'repo:{repo} is:open label:"{_ACTION_LABEL}" -label:"{_NOTIFIED_LABEL}"')
+    first = cast(dict[str, Any], client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page=1'))
+    total = min(int(first.get('total_count') or 0), 1_000)
+    priority: list[dict[str, Any]] = []
+    if total:
+        pages = math.ceil(total / _RECONCILE_LIMIT)
+        slot = int(now.timestamp()) // int(_SLA.total_seconds() / 12)
+        page = slot % pages + 1
+        result = cast(
+            dict[str, Any],
+            client.get(f'/search/issues?q={query}&sort=updated&order=asc&per_page={_RECONCILE_LIMIT}&page={page}'),
+        )
+        priority = cast(list[dict[str, Any]], result.get('items') or [])
+
+    encoded = urllib.parse.quote(_ACTION_LABEL, safe='')
+    fallback = cast(
+        list[dict[str, Any]],
+        client.get(
+            # state=all so a closed item still completes its lifecycle instead
+            # of leaving a dormant clock that a reopen wakes.
+            f'/repos/{repo}/issues?state=all&labels={encoded}&sort=updated&direction=asc&per_page={_RECONCILE_LIMIT}'
+        ),
+    )
+    items: dict[int, dict[str, Any]] = {}
+    for item in [*priority, *fallback]:
+        items.setdefault(int(item['number']), item)
+    return list(items.values())[:_RECONCILE_LIMIT]
 
 
 def reconcile(
@@ -772,15 +837,7 @@ def reconcile(
     by healthy items always reach the triage channel delivery job.
     """
     ensure_labels(client, repo)
-    encoded = urllib.parse.quote(_ACTION_LABEL, safe='')
-    items = cast(
-        list[dict[str, Any]],
-        client.get(
-            # state=all so a closed item still completes its lifecycle (labels
-            # removed) instead of leaving a dormant clock that a reopen wakes.
-            f'/repos/{repo}/issues?state=all&labels={encoded}&sort=updated&direction=asc&per_page={_RECONCILE_LIMIT}'
-        ),
-    )
+    items = _active_items(client, repo, now=now)
     lines: list[str] = []
     failures: list[str] = []
     for item in items:
@@ -801,10 +858,11 @@ def reconcile(
     dormant = cast(
         list[dict[str, Any]],
         client.get(
-            # state=all so a dormant item closed while escalated still sheds
-            # its marker instead of carrying it forever.
+            # Recent-first makes renewed activity on an old escalated item
+            # visible immediately. Processed items lose the escalation label,
+            # so bursts larger than the bound drain over subsequent runs.
             f'/repos/{repo}/issues?state=all&labels={encoded_escalated}'
-            f'&sort=updated&direction=asc&per_page={_RECONCILE_LIMIT}'
+            f'&sort=updated&direction=desc&per_page={_RECONCILE_LIMIT}'
         ),
     )
     for item in dormant:
@@ -837,13 +895,19 @@ def _notice_ref(notice: Notice) -> NoticeRef:
 
 def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
     if output_path := os.environ.get('GITHUB_OUTPUT'):
+        reasons = {
+            'initial': 'triage identified a maintainer as the next actor',
+            'reminder': 'there has been no maintainer activity for three days',
+            'escalation': 'the reminder has had no maintainer activity for three more days',
+        }
         details: list[str] = []
         for notice in notices:
             owners = ', '.join(f'@{_slack_escape(login)}' for login in notice['recipients'])
             title = _slack_escape(notice['title']) or '(untitled)'
             details.append(
                 f'• *{notice["kind"].title()}*: '
-                f'<https://github.com/{repo}/issues/{notice["number"]}|#{notice["number"]} {title}> — {owners}'
+                f'<https://github.com/{repo}/issues/{notice["number"]}|#{notice["number"]} {title}> — '
+                f'owner {owners}; why: {reasons[notice["kind"]]}'
             )
         payload = {
             'text': '\n'.join(
@@ -851,11 +915,9 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
                     '<!channel> *Maintainer attention requested*',
                     *details,
                     '',
-                    '*Why:* The triage agent reviewed each item and its recent activity and found with high '
-                    'confidence that a maintainer owns the next step.',
-                    '*Expected action:* Open the item and make the next project decision: reply, review, merge or '
-                    'close it, or ask for changes. If no work is needed, leave a brief comment. Do not remove the '
-                    'attention labels; the monitor clears them after maintainer activity.',
+                    '*Expected action:* Open each item and make its next maintainer decision there. A reply, review, '
+                    'merge, close, or request for changes counts. If no work is needed, say so briefly. Do not remove '
+                    'the attention labels; the monitor clears them after maintainer activity.',
                 ]
             )
         }
@@ -937,6 +999,78 @@ def _notice_refs(loaded: object) -> list[NoticeRef]:
     return notices
 
 
+def _notice_state(
+    client: GitHubClient, repo: str, notice: NoticeRef
+) -> tuple[dict[str, Any], set[str], _Transition, list[str]] | None:
+    """Return a notice's exact live state, or `None` if it has changed."""
+    number = notice['number']
+    current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    labels = _labels(current)
+    if current.get('state') != 'open' or _ACTION_LABEL not in labels or _stage(labels) != notice['expected_stage']:
+        return None
+    events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
+    transition = _transition(events, notice['expected_stage'])
+    if transition is None or transition[1].get('id') != notice['transition_id']:
+        return None
+    maintainers = _maintainer_assignees(client, repo, current)
+    if not maintainers or {login.casefold() for login in maintainers} != {
+        login.casefold() for login in notice['recipients']
+    }:
+        return None
+    latest = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    if (
+        latest.get('updated_at') != current.get('updated_at')
+        or latest.get('state') != 'open'
+        or _labels(latest) != labels
+        or {str(assignee['login']).casefold() for assignee in latest.get('assignees', [])}
+        != {str(assignee['login']).casefold() for assignee in current.get('assignees', [])}
+    ):
+        return None
+    return latest, labels, transition, maintainers
+
+
+def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str | None:
+    number = notice['number']
+    current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    labels = _labels(current)
+    if current.get('state') != 'open':
+        if _ACTION_LABEL in labels:
+            _complete(client, repo, number, labels)
+        return None
+    if _notice_state(client, repo, notice) is None:
+        return None
+    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+    if (state := _notice_state(client, repo, notice)) is None:
+        return None
+    _, labels, transition, maintainers = state
+    reminder_transition = _transition(timeline, 1) if notice['expected_stage'] == 2 else None
+    acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition[0]
+    if _acknowledged(timeline, acknowledged_since, maintainers):
+        _complete(client, repo, number, labels)
+        return f'#{number}: maintainer acknowledged the delivered notice'
+    if notice['kind'] == 'initial':
+        _add_labels(client, repo, number, [_NOTIFIED_LABEL])
+        return f'#{number}: recorded initial triage channel notice'
+    if notice['kind'] == 'reminder':
+        _add_labels(client, repo, number, [_NOTIFIED_LABEL])
+        if notice['expected_stage'] == 0:
+            _advance_stage(client, repo, number, labels | {_NOTIFIED_LABEL}, 1)
+            timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+            if _acknowledged(timeline, acknowledged_since, maintainers):
+                _complete(client, repo, number, labels | {_NOTIFIED_LABEL, _PINGED_LABEL})
+                return f'#{number}: maintainer acknowledged the delivered notice'
+        return f'#{number}: recorded triage channel reminder'
+    if notice['expected_stage'] == 1:
+        _advance_stage(client, repo, number, labels, 2)
+        timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+        if _acknowledged(timeline, acknowledged_since, maintainers):
+            _complete(client, repo, number, labels | {_ESCALATED_LABEL})
+            return f'#{number}: maintainer acknowledged the delivered notice'
+    _remove_label(client, repo, number, _NOTIFIED_LABEL)
+    _remove_label(client, repo, number, _ACTION_LABEL)
+    return f'#{number}: recorded terminal triage channel escalation'
+
+
 def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[str]:
     """Advance attention state only after the triage channel delivery succeeds."""
     lines: list[str] = []
@@ -944,44 +1078,8 @@ def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRe
     for notice in notices:
         number = notice['number']
         try:
-            current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
-            labels = _labels(current)
-            if current.get('state') != 'open':
-                if _ACTION_LABEL in labels:
-                    _complete(client, repo, number, labels)
-                continue
-            if _ACTION_LABEL not in labels or _stage(labels) != notice['expected_stage']:
-                continue
-            events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
-            transition = _transition(events, notice['expected_stage'])
-            if transition is None or transition[1].get('id') != notice['transition_id']:
-                continue
-            maintainers = _maintainer_assignees(client, repo, current)
-            if not maintainers or {login.casefold() for login in maintainers} != {
-                login.casefold() for login in notice['recipients']
-            }:
-                continue
-            timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-            reminder_transition = _transition(events, 1) if notice['expected_stage'] == 2 else None
-            acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition[0]
-            if _acknowledged(timeline, acknowledged_since, maintainers):
-                _complete(client, repo, number, labels)
-                lines.append(f'#{number}: maintainer acknowledged the delivered notice')
-                continue
-            if notice['kind'] == 'initial':
-                _add_labels(client, repo, number, [_NOTIFIED_LABEL])
-                lines.append(f'#{number}: recorded initial triage channel notice')
-            elif notice['kind'] == 'reminder':
-                _add_labels(client, repo, number, [_NOTIFIED_LABEL])
-                if notice['expected_stage'] == 0:
-                    _advance_stage(client, repo, number, labels | {_NOTIFIED_LABEL}, 1)
-                lines.append(f'#{number}: recorded triage channel reminder')
-            else:
-                if notice['expected_stage'] == 1:
-                    _advance_stage(client, repo, number, labels, 2)
-                _remove_label(client, repo, number, _ACTION_LABEL)
-                _remove_label(client, repo, number, _NOTIFIED_LABEL)
-                lines.append(f'#{number}: recorded terminal triage channel escalation')
+            if line := _finalize_notice(client, repo, notice):
+                lines.append(line)
         except (urllib.error.HTTPError, RuntimeError, ValueError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -700,9 +700,8 @@ def _notice_if_current(
 
 def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int, *, new_delivery: bool = False) -> None:
     """Finish a terminal delivery while preserving its dormant marker."""
-    _add_labels(client, repo, number, [_ESCALATED_LABEL])
-    if new_delivery:
-        _add_labels(client, repo, number, [_DELIVERED_LABEL])
+    labels = [_ESCALATED_LABEL, _DELIVERED_LABEL] if new_delivery else [_ESCALATED_LABEL]
+    _add_labels(client, repo, number, labels)
     _remove_label(client, repo, number, _ACTION_LABEL)
     _remove_label(client, repo, number, _PINGED_LABEL)
     _remove_label(client, repo, number, _DELIVERED_LABEL)

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -119,6 +119,7 @@ class GitHubClient:
             yield cast(list[dict[str, Any]], values)
             if not (page_path := _link_path(links, 'next')):
                 return
+        raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
 
 
 def _parse_time(value: str) -> dt.datetime:
@@ -375,24 +376,43 @@ def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, An
     return sorted(maintainers, key=str.casefold)
 
 
-def _first_maintainer_in_discussion(client: GitHubClient, repo: str, number: int) -> str | None:
+def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
+    if 'pull_request' in item:
+        return None
+
+    permissions: dict[str, bool] = {}
+
+    def is_maintainer(login: str) -> bool:
+        normalized = login.casefold()
+        if normalized not in permissions:
+            permissions[normalized] = _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS
+        return permissions[normalized]
+
+    author = _login(item)
+    if item.get('author_association') in _ACK_ASSOCIATIONS and author and is_maintainer(author):
+        return author
+
+    number = int(item['number'])
     for page in client.pages(f'/repos/{repo}/issues/{number}/timeline', count=_DISCUSSION_PAGE_LIMIT):
         for event in page:
-            if (
-                event.get('event') not in {'commented', 'reviewed'}
-                or event.get('author_association') not in _ACK_ASSOCIATIONS
-            ):
+            if event.get('event') != 'commented' or event.get('author_association') not in _ACK_ASSOCIATIONS:
                 continue
             login = _login(event)
-            if login and _collaborator_permission(client, repo, login) in _MAINTAINER_PERMISSIONS:
+            if login and is_maintainer(login):
                 return login
     return None
 
 
-def _ensure_recipients(client: GitHubClient, repo: str, number: int, maintainers: Sequence[str]) -> list[str]:
+def _ensure_recipients(
+    client: GitHubClient, repo: str, item: Mapping[str, Any], maintainers: Sequence[str]
+) -> list[str]:
     if maintainers:
         return list(maintainers)
-    owner = _first_maintainer_in_discussion(client, repo, number) or _FALLBACK_OWNER
+    owner = _first_maintainer_in_discussion(client, repo, item) or _FALLBACK_OWNER
+    number = int(item['number'])
+    current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
+    if maintainers := _maintainer_assignees(client, repo, current):
+        return maintainers
     assigned = cast(
         dict[str, Any],
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
@@ -445,7 +465,7 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             for label in labels.intersection(_STAGE_LABELS):
                 _remove_label(client, repo, number, label)
             _add_labels(client, repo, number, [_ACTION_LABEL])
-            recipients = _ensure_recipients(client, repo, number, _maintainer_assignees(client, repo, current))
+            recipients = _ensure_recipients(client, repo, current, _maintainer_assignees(client, repo, current))
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
         except (urllib.error.HTTPError, RuntimeError) as exc:
@@ -577,7 +597,7 @@ def _reconcile_item(client: GitHubClient, repo: str, number: int, *, now: dt.dat
     # succeeding, so the fallback assignment happens only below this point.
     if current_stage == 2:
         return f'#{number}: queued private Slack escalation', True
-    recipients = _ensure_recipients(client, repo, number, maintainers)
+    recipients = _ensure_recipients(client, repo, current, maintainers)
     if current_stage == 1:
         current_body = _reminder(recipients)
         if not _fixed_comment_exists(timeline, current_body, transition_at):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -560,14 +560,15 @@ def _transition(
 ) -> tuple[dt.datetime, dict[str, Any]] | None:
     label = _ACTION_LABEL if stage == 0 else _STAGE_LABELS[stage - 1]
     transitions = [
-        (time, event)
-        for event in timeline
+        (time, index, event)
+        for index, event in enumerate(timeline)
         if event.get('event') == 'labeled'
         and isinstance(event.get('label'), Mapping)
         and cast(Mapping[str, object], event['label']).get('name') == label
         and (time := _event_time(event)) is not None
     ]
-    return max(transitions, key=lambda value: value[0], default=None)
+    latest = max(transitions, key=lambda value: (value[0], value[1]), default=None)
+    return (latest[0], latest[2]) if latest is not None else None
 
 
 def _validate_attention_transition(

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -409,11 +409,13 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
     return None
 
 
-def _validate_attention_state(previous: Mapping[str, Any], current: Mapping[str, Any]) -> None:
+def _validate_attention_state(
+    previous: Mapping[str, Any], current: Mapping[str, Any], *, check_updated_at: bool = True
+) -> None:
     previous_labels = _labels(previous)
     if _ACTION_LABEL in previous_labels and (
         current.get('state') != 'open'
-        or current.get('updated_at') != previous.get('updated_at')
+        or (check_updated_at and current.get('updated_at') != previous.get('updated_at'))
         or _ACTION_LABEL not in (current_labels := _labels(current))
         or _stage(current_labels) != _stage(previous_labels)
     ):
@@ -445,6 +447,7 @@ def _ensure_recipients(
         dict[str, Any],
         client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]}),
     )
+    _validate_attention_state(item, assigned, check_updated_at=False)
     assigned_maintainers = _maintainer_assignees(client, repo, assigned)
     owner_login = owner.casefold()
     if owner_login not in {login.casefold() for login in assigned_maintainers}:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -673,6 +673,13 @@ def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipi
     )
 
 
+def _closed_since(timeline: Sequence[dict[str, Any]], since: dt.datetime) -> bool:
+    return any(
+        event.get('event') == 'closed' and (event_time := _event_time(event)) is not None and event_time >= since
+        for event in timeline
+    )
+
+
 def _complete(client: GitHubClient, repo: str, number: int, labels: set[str]) -> None:
     for label in labels.intersection(_LIFECYCLE_LABELS):
         _remove_label(client, repo, number, label)
@@ -723,12 +730,7 @@ def _reconcile_item(
     if _actor(transition_event) != 'github-actions[bot]':
         _complete(client, repo, number, labels)
         return f'#{number}: removed a foreign attention transition', None
-    if any(
-        event.get('event') == 'closed'
-        and (event_time := _event_time(event)) is not None
-        and event_time >= transition_at
-        for event in timeline
-    ):
+    if _closed_since(timeline, transition_at):
         _complete(client, repo, number, labels)
         return f'#{number}: completed after the item was closed', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
@@ -747,16 +749,21 @@ def _reconcile_item(
             f'#{number}: queued terminal triage channel escalation',
             _notice(current, 'escalation', 2, transition, recipients),
         )
-    if _NOTIFIED_LABEL not in labels:
-        kind: Literal['initial', 'reminder'] = 'initial' if current_stage == 0 else 'reminder'
-        return (
-            f'#{number}: queued {kind} triage channel notice',
-            _notice(current, kind, current_stage, transition, recipients),
-        )
     notified_transition = _label_transition(events, _NOTIFIED_LABEL)
+    if (
+        _NOTIFIED_LABEL not in labels
+        or notified_transition is None
+        or _actor(notified_transition[1]) != 'github-actions[bot]'
+    ):
+        if _NOTIFIED_LABEL in labels:
+            _remove_label(client, repo, number, _NOTIFIED_LABEL)
+        return (
+            f'#{number}: queued initial triage channel notice',
+            _notice(current, 'initial', current_stage, transition, recipients),
+        )
     sla_started_at = max(
         transition_at,
-        notified_transition[0] if notified_transition is not None else transition_at,
+        notified_transition[0],
     )
     if now - sla_started_at < _SLA:
         return None
@@ -880,7 +887,11 @@ def reconcile(
 
 
 def _slack_escape(value: str) -> str:
-    return value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+    normalized = ' '.join(value.split())
+    for character in '*_~`|\\':
+        normalized = normalized.replace(character, '')
+    normalized = ' '.join(normalized.split())
+    return normalized.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
 
 def _notice_ref(notice: Notice) -> NoticeRef:
@@ -930,7 +941,7 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
 
 _LOGIN_PATTERN = re.compile(r'(?=.{1,39}\Z)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?')
 _NOTICE_STAGES: dict[str, frozenset[int]] = {
-    'initial': frozenset({0}),
+    'initial': frozenset({0, 1}),
     'reminder': frozenset({0, 1}),
     'escalation': frozenset({1, 2}),
 }
@@ -1006,12 +1017,28 @@ def _notice_state(
     number = notice['number']
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     labels = _labels(current)
-    if current.get('state') != 'open' or _ACTION_LABEL not in labels or _stage(labels) != notice['expected_stage']:
+    current_stage = _stage(labels)
+    resumed_stage = (notice['kind'] == 'reminder' and notice['expected_stage'] == 0 and current_stage == 1) or (
+        notice['kind'] == 'escalation' and notice['expected_stage'] == 1 and current_stage == 2
+    )
+    if (
+        current.get('state') != 'open'
+        or _ACTION_LABEL not in labels
+        or (current_stage != notice['expected_stage'] and not resumed_stage)
+    ):
         return None
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
     transition = _transition(events, notice['expected_stage'])
     if transition is None or transition[1].get('id') != notice['transition_id']:
         return None
+    if resumed_stage:
+        resumed_transition = _transition(events, current_stage)
+        if (
+            resumed_transition is None
+            or _actor(resumed_transition[1]) != 'github-actions[bot]'
+            or resumed_transition[0] < transition[0]
+        ):
+            return None
     maintainers = _maintainer_assignees(client, repo, current)
     if not maintainers or {login.casefold() for login in maintainers} != {
         login.casefold() for login in notice['recipients']
@@ -1045,6 +1072,9 @@ def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str 
     _, labels, transition, maintainers = state
     reminder_transition = _transition(timeline, 1) if notice['expected_stage'] == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition[0]
+    if _closed_since(timeline, transition[0]):
+        _complete(client, repo, number, labels)
+        return f'#{number}: completed after the item was closed'
     if _acknowledged(timeline, acknowledged_since, maintainers):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the delivered notice'
@@ -1053,19 +1083,22 @@ def _finalize_notice(client: GitHubClient, repo: str, notice: NoticeRef) -> str 
         return f'#{number}: recorded initial triage channel notice'
     if notice['kind'] == 'reminder':
         _add_labels(client, repo, number, [_NOTIFIED_LABEL])
-        if notice['expected_stage'] == 0:
+        if _stage(labels) == 0:
             _advance_stage(client, repo, number, labels | {_NOTIFIED_LABEL}, 1)
-            timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-            if _acknowledged(timeline, acknowledged_since, maintainers):
-                _complete(client, repo, number, labels | {_NOTIFIED_LABEL, _PINGED_LABEL})
-                return f'#{number}: maintainer acknowledged the delivered notice'
-        return f'#{number}: recorded triage channel reminder'
-    if notice['expected_stage'] == 1:
-        _advance_stage(client, repo, number, labels, 2)
         timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
         if _acknowledged(timeline, acknowledged_since, maintainers):
-            _complete(client, repo, number, labels | {_ESCALATED_LABEL})
+            _complete(client, repo, number, labels | {_NOTIFIED_LABEL, _PINGED_LABEL})
             return f'#{number}: maintainer acknowledged the delivered notice'
+        return f'#{number}: recorded triage channel reminder'
+    if _stage(labels) == 1:
+        _advance_stage(client, repo, number, labels, 2)
+    timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
+    if _acknowledged(timeline, acknowledged_since, maintainers):
+        _complete(client, repo, number, labels | {_ESCALATED_LABEL})
+        return f'#{number}: maintainer acknowledged the delivered notice'
+    for label in labels.intersection(_STAGE_LABELS):
+        if label != _ESCALATED_LABEL:
+            _remove_label(client, repo, number, label)
     _remove_label(client, repo, number, _NOTIFIED_LABEL)
     _remove_label(client, repo, number, _ACTION_LABEL)
     return f'#{number}: recorded terminal triage channel escalation'

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -155,15 +155,23 @@ class FakeClient:
         labels = {label['name'] for label in self.items[number]['labels']}
         stage = monitor._stage(labels)
         label = monitor._ACTION_LABEL if stage == 0 else monitor._STAGE_LABELS[stage - 1]
-        events = [
-            {
-                'id': f'default-stage-{stage}',
-                'event': 'labeled',
-                'created_at': OLD,
-                'actor': {'login': 'github-actions[bot]'},
-                'label': {'name': label},
-            }
-        ]
+        stage_event = {
+            'id': f'default-stage-{stage}',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': label},
+        }
+        notified_event = {
+            'id': 'default-notified',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._NOTIFIED_LABEL},
+        }
+        events = [stage_event]
+        if monitor._NOTIFIED_LABEL in labels:
+            events = [stage_event, notified_event] if stage == 0 else [notified_event, stage_event]
         return events
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
@@ -1315,6 +1323,53 @@ def test_finalize_clears_delivered_state_if_item_closed_during_delivery():
     )
 
 
+@pytest.mark.parametrize(
+    ('labels', 'kind', 'stage', 'transition_label', 'transition_id'),
+    [
+        (
+            [monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL],
+            'reminder',
+            0,
+            monitor._ACTION_LABEL,
+            'action-transition',
+        ),
+        (
+            [monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL],
+            'escalation',
+            1,
+            monitor._PINGED_LABEL,
+            'reminder-transition',
+        ),
+    ],
+)
+def test_finalize_retires_a_lifecycle_closed_and_reopened_during_channel_delivery(
+    labels: list[str],
+    kind: str,
+    stage: int,
+    transition_label: str,
+    transition_id: str,
+):
+    client = FakeClient({7: item(7, labels=labels, assignees=[monitor._FALLBACK_OWNER])})
+    client.timelines[7] = [
+        {
+            'id': transition_id,
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': transition_label},
+        },
+        {'event': 'closed', 'created_at': '2026-07-18T00:00:00Z', 'actor': {'login': 'contributor'}},
+        {'event': 'reopened', 'created_at': '2026-07-18T00:01:00Z', 'actor': {'login': 'contributor'}},
+    ]
+
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, kind, stage, transition_id=transition_id)]}),
+    ) == ['#7: completed after the item was closed']
+    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
 def test_finalize_skips_items_whose_state_was_already_cleared():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL]), 8: item(8)})
 
@@ -1467,6 +1522,40 @@ def test_finalize_catches_acknowledgement_during_terminal_escalation():
     )
 
 
+def test_finalize_resumes_a_partially_recorded_terminal_escalation():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
+    client.timelines[7] = [
+        {
+            'id': 'reminder-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._PINGED_LABEL},
+        }
+    ]
+    notice = monitor._notice_refs({'items': [notice_ref(7, 'escalation', 1, transition_id='reminder-transition')]})
+    client.fail_delete_labels.add(monitor._PINGED_LABEL)
+
+    with pytest.raises(RuntimeError, match=r'#7: HTTPError'):
+        monitor.finalize_notices(client, 'r', notice)
+    assert {monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._ESCALATED_LABEL}.issubset(
+        {label['name'] for label in client.items[7]['labels']}
+    )
+
+    client.fail_delete_labels.clear()
+    assert monitor.finalize_notices(client, 'r', notice) == ['#7: recorded terminal triage channel escalation']
+    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
+    assert monitor._ESCALATED_LABEL in {label['name'] for label in client.items[7]['labels']}
+
+
 @pytest.mark.parametrize(
     'contents',
     [
@@ -1478,7 +1567,7 @@ def test_finalize_catches_acknowledgement_during_terminal_escalation():
         {'items': [notice_ref(0, 'initial', 0)]},
         {'items': [notice_ref(7, 'initial', 0), notice_ref(7, 'initial', 0)]},
         {'items': [notice_ref(number, 'initial', 0) for number in range(1, monitor._RECONCILE_LIMIT + 2)]},
-        {'items': [notice_ref(7, 'initial', 1)]},
+        {'items': [notice_ref(7, 'initial', 2)]},
         {'items': [notice_ref(7, 'unknown', 0)]},
         {'items': [{**notice_ref(7, 'initial', 0), 'kind': []}]},
         {'items': [{**notice_ref(7, 'initial', 0), 'transition_id': 'x' * 101}]},
@@ -1515,7 +1604,7 @@ def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, mo
                 'kind': 'initial',
                 'expected_stage': 0,
                 'transition_id': 'event-7',
-                'title': 'Handle <unsafe> & important',
+                'title': 'Handle <unsafe>\n*fake owner* | <!channel> & important',
                 'recipients': ['DouweM'],
             }
         ],
@@ -1528,7 +1617,9 @@ def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, mo
     ]
     text = json.loads(values['slack_payload'])['text']
     assert text.startswith('<!channel> *Maintainer attention requested*')
-    assert '#7 Handle &lt;unsafe&gt; &amp; important' in text
+    assert '#7 Handle &lt;unsafe&gt; fake owner &lt;!channel&gt; &amp; important' in text
+    assert text.count('<!channel>') == 1
+    assert '\n*fake owner*' not in text
     assert '— owner @DouweM; why: triage identified a maintainer as the next actor' in text
     assert '*Expected action:*' in text
     assert 'Do not remove the attention labels' in text
@@ -1557,10 +1648,46 @@ def test_recent_activity_delays_the_next_reminder():
             'created_at': '2026-07-19T00:00:00Z',
             'actor': {'login': 'github-actions[bot]'},
             'label': {'name': monitor._ACTION_LABEL},
-        }
+        },
+        {
+            'event': 'labeled',
+            'created_at': '2026-07-19T00:00:00Z',
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._NOTIFIED_LABEL},
+        },
     ]
 
     assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW) == ([], [])
+
+
+@pytest.mark.parametrize('actor', ['outside-collaborator', ''])
+def test_foreign_or_unverifiable_notified_label_cannot_suppress_initial_channel_notice(actor: str):
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        }
+    ]
+    if actor:
+        client.timelines[7].append(
+            {
+                'event': 'labeled',
+                'created_at': '2026-07-19T00:00:00Z',
+                'actor': {'login': actor},
+                'label': {'name': monitor._NOTIFIED_LABEL},
+            }
+        )
+
+    notices: list[monitor.Notice] = []
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: queued initial triage channel notice'],
+        [],
+    )
+    assert notices[0]['kind'] == 'initial'
+    assert any(call[0] == 'DELETE' and monitor._NOTIFIED_LABEL in call[1] for call in client.calls)
 
 
 def test_initial_channel_delivery_starts_a_fresh_reminder_sla():
@@ -1774,10 +1901,10 @@ def test_reconcile_migrates_legacy_pinged_state_to_channel_notice():
 
     notices: list[monitor.Notice] = []
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued reminder triage channel notice'],
+        ['#7: queued initial triage channel notice'],
         [],
     )
-    assert notices[0]['kind'] == 'reminder'
+    assert notices[0]['kind'] == 'initial'
     assert notices[0]['expected_stage'] == 1
     assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
 
@@ -1802,7 +1929,7 @@ def test_legacy_notice_uses_the_current_maintainer_assignment():
 
     notices: list[monitor.Notice] = []
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued reminder triage channel notice'],
+        ['#7: queued initial triage channel notice'],
         [],
     )
     assert notices[0]['recipients'] == ['bob']
@@ -1958,6 +2085,12 @@ def test_bot_triggered_mention_event_is_not_an_acknowledgement():
 def test_latest_stage_transition_restarts_the_sla_clock():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
     client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._NOTIFIED_LABEL},
+        },
         {
             'event': 'labeled',
             'created_at': OLD,

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -42,6 +42,13 @@ def item(
     }
 
 
+def label_event(
+    label: str, *, actor: str = 'github-actions[bot]', created_at: str = OLD, event_id: str | None = None
+) -> dict[str, Any]:
+    event = {'event': 'labeled', 'created_at': created_at, 'actor': {'login': actor}, 'label': {'name': label}}
+    return {**event, 'id': event_id} if event_id else event
+
+
 class FakeClient:
     def __init__(self, items: dict[int, dict[str, Any]] | None = None) -> None:
         self.items = items or {}
@@ -139,15 +146,7 @@ class FakeClient:
         labels = {label['name'] for label in self.items[number]['labels']}
         stage = monitor._stage(labels)
         label = monitor._ACTION_LABEL if stage == 0 else monitor._STAGE_LABELS[stage - 1]
-        events = [
-            {
-                'id': f'default-stage-{stage}',
-                'event': 'labeled',
-                'created_at': OLD,
-                'actor': {'login': 'github-actions[bot]'},
-                'label': {'name': label},
-            }
-        ]
+        events = [label_event(label, event_id=f'default-stage-{stage}')]
         return events
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
@@ -611,8 +610,11 @@ def test_reconcile_queues_channel_reminder_for_assigned_maintainers():
             'recipients': ['alice', 'bob'],
         }
     ]
-    assert not any(call[1].endswith('/comments') for call in client.calls)
     assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+    assert monitor.finalize_notices(
+        client, 'pydantic/pydantic-ai', monitor._notice_refs({'items': [notice_ref(7, 0, recipients=['alice', 'bob'])]})
+    ) == ['#7: recorded channel reminder']
+    assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
 
 
 def test_reconcile_routes_existing_action_to_first_maintainer_participant():
@@ -664,9 +666,9 @@ def test_reconcile_queues_channel_escalation_without_advancing_before_delivery()
         [],
     )
     assert notices[0]['kind'] == 'escalation'
-    assert not any(call[1].endswith('/comments') for call in client.calls)
-    assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
     assert monitor._ESCALATED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+    assert monitor.finalize_notices(client, 'pydantic/pydantic-ai', [notices[0]]) == ['#7: recorded channel escalation']
+    assert monitor._ESCALATED_LABEL in {label['name'] for label in client.items[7]['labels']}
 
 
 def test_reconcile_retries_preexisting_pending_escalation():
@@ -678,43 +680,43 @@ def test_reconcile_retries_preexisting_pending_escalation():
         [],
     )
     assert notices[0]['expected_stage'] == 2
-    assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
-    assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
+    assert monitor.finalize_notices(client, 'r', [notices[0]]) == ['#7: recorded channel escalation']
+    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
 def test_reconcile_finishes_a_delivered_escalation_receipt_without_reposting():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._DELIVERED_LABEL])})
-    notices: list[monitor.Notice] = []
-
-    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+    client.timelines[7] = [
+        label_event(monitor._PINGED_LABEL),
+        label_event(monitor._DELIVERED_LABEL),
+    ]
+    assert monitor.reconcile(client, 'r', now=NOW) == (
         ['#7: finished delivered channel escalation'],
         [],
     )
-    assert notices == []
     assert {label['name'] for label in client.items[7]['labels']} == {monitor._ESCALATED_LABEL}
+
+
+def test_reconcile_ignores_a_foreign_delivery_receipt():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._DELIVERED_LABEL])})
+    client.timelines[7] = [
+        label_event(monitor._ACTION_LABEL),
+        label_event(monitor._DELIVERED_LABEL, actor='maintainer'),
+    ]
+    assert monitor.reconcile(client, 'r', now=NOW)[0] == ['#7: queued channel reminder']
 
 
 def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])})
     client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._PINGED_LABEL},
-        },
+        label_event(monitor._PINGED_LABEL),
         {
             'event': 'commented',
             'created_at': '2026-07-18T00:00:00Z',
             'actor': {'login': monitor._FALLBACK_OWNER},
             'body': 'I will handle this.',
         },
-        {
-            'event': 'labeled',
-            'created_at': '2026-07-19T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ESCALATED_LABEL},
-        },
+        label_event(monitor._ESCALATED_LABEL, created_at='2026-07-19T00:00:00Z'),
     ]
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
@@ -751,50 +753,6 @@ def test_terminal_stage_rechecks_acknowledgement_after_owner_selection():
     assert notices == []
 
 
-def test_finalize_advances_reminder_only_after_channel_delivery():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-
-    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 0)]})) == [
-        '#7: recorded channel reminder'
-    ]
-    assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
-    assert monitor._ACTION_LABEL in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_records_escalation_then_clears_active_state():
-    client = FakeClient(
-        {7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=[monitor._FALLBACK_OWNER])}
-    )
-
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 1)]}),
-    ) == ['#7: recorded channel escalation']
-    labels = {label['name'] for label in client.items[7]['labels']}
-    assert monitor._ACTION_LABEL not in labels
-    assert monitor._ESCALATED_LABEL in labels
-
-
-def test_finalize_delivers_a_preexisting_stage_two_escalation():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL],
-                assignees=[monitor._FALLBACK_OWNER],
-            )
-        }
-    )
-
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 2)]}),
-    ) == ['#7: recorded channel escalation']
-    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
-
-
 def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
     client = FakeClient(
         {7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=[monitor._FALLBACK_OWNER])}
@@ -810,6 +768,10 @@ def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
         monitor._DELIVERED_LABEL,
     }
     client.fail_delete_labels.clear()
+    client.timelines[7] = [
+        label_event(monitor._ESCALATED_LABEL),
+        label_event(monitor._DELIVERED_LABEL),
+    ]
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
@@ -819,33 +781,19 @@ def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
     assert notices == []
 
 
-def test_finalize_skips_notice_when_stage_changed_during_delivery():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=['alice'])})
-    client.permissions = {'alice': 'write'}
-
-    assert (
-        monitor.finalize_notices(
-            client,
-            'r',
-            monitor._notice_refs({'items': [notice_ref(7, 0)]}),
-        )
-        == []
-    )
-    assert monitor._ESCALATED_LABEL not in {label['name'] for label in client.items[7]['labels']}
-
-
 @pytest.mark.parametrize(
-    'ref',
+    ('labels', 'ref'),
     [
-        notice_ref(7, 0, transition_id='replacement-transition'),
-        notice_ref(7, 0, recipients=['different-owner']),
+        ([monitor._ACTION_LABEL, monitor._PINGED_LABEL], notice_ref(7, 0)),
+        ([monitor._ACTION_LABEL], notice_ref(7, 0, transition_id='replacement-transition')),
+        ([monitor._ACTION_LABEL], notice_ref(7, 0, recipients=['different-owner'])),
     ],
 )
-def test_finalize_skips_notice_when_transition_or_owner_changed(ref: dict[str, object]):
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+def test_finalize_skips_a_stale_notice(labels: list[str], ref: dict[str, object]):
+    client = FakeClient({7: item(7, labels=labels, assignees=[monitor._FALLBACK_OWNER])})
 
     assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [ref]})) == []
-    assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+    assert {label['name'] for label in client.items[7]['labels']} == set(labels)
 
 
 def test_prepare_notices_filters_stale_owners_immediately_before_delivery():
@@ -853,6 +801,10 @@ def test_prepare_notices_filters_stale_owners_immediately_before_delivery():
     refs = monitor._notice_refs({'items': [notice_ref(7, 0)]})
 
     assert [notice['number'] for notice in monitor.prepare_notices(client, 'r', refs)] == [7]
+
+    client.permissions['bob'] = 'write'
+    client.items[7]['assignees'].append({'login': 'bob'})
+    assert monitor.prepare_notices(client, 'r', refs) == []
 
     client.items[7]['assignees'] = []
     assert monitor.prepare_notices(client, 'r', refs) == []
@@ -1040,8 +992,6 @@ def test_collaborator_comment_by_non_recipient_completes_the_request():
 
 
 def test_closed_item_completes_and_strips_lifecycle_labels():
-    # Closing an item is the ultimate resolution: the action and stage labels
-    # are removed so a later reopen can't wake an ancient SLA clock.
     closed = item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])
     closed['state'] = 'closed'
     client = FakeClient({7: closed})
@@ -1049,7 +999,6 @@ def test_closed_item_completes_and_strips_lifecycle_labels():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: completed after the item was closed'], [])
     assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
     assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
-    # No channel notice is produced for a closed item.
     assert not any(call[1].endswith('/comments') for call in client.calls)
 
 

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -133,27 +133,21 @@ class FakeClient:
         self.calls.append(('LAST', path, None))
         number = int(path.split('/issues/')[1].split('/')[0])
         if number in self.timelines:
-            return self.timelines[number]
+            return [
+                {**event, 'id': event.get('id', f'event-{index}')} for index, event in enumerate(self.timelines[number])
+            ]
         labels = {label['name'] for label in self.items[number]['labels']}
         stage = monitor._stage(labels)
         label = monitor._ACTION_LABEL if stage == 0 else monitor._STAGE_LABELS[stage - 1]
         events = [
             {
+                'id': f'default-stage-{stage}',
                 'event': 'labeled',
                 'created_at': OLD,
                 'actor': {'login': 'github-actions[bot]'},
                 'label': {'name': label},
             }
         ]
-        if stage == 1 and path.endswith('/timeline'):
-            events.append(
-                {
-                    'event': 'commented',
-                    'created_at': OLD,
-                    'actor': {'login': 'github-actions[bot]'},
-                    'body': monitor._reminder([monitor._FALLBACK_OWNER]),
-                }
-            )
         return events
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
@@ -236,6 +230,23 @@ def write_output(
         ),
         encoding='utf-8',
     )
+
+
+def notice_ref(
+    number: int,
+    kind: str,
+    stage: int,
+    *,
+    transition_id: int | str | None = None,
+    recipients: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        'number': number,
+        'kind': kind,
+        'expected_stage': stage,
+        'transition_id': transition_id or f'default-stage-{stage}',
+        'recipients': recipients or [monitor._FALLBACK_OWNER],
+    }
 
 
 def test_last_page_uses_the_page_containing_the_newest_activity():
@@ -353,6 +364,28 @@ def test_candidate_search_excludes_active_and_escalated_labels():
     query = client.calls[0][1]
     assert urllib.parse.quote_plus(f'-label:"{monitor._ACTION_LABEL}"') in query
     assert urllib.parse.quote_plus(f'-label:"{monitor._ESCALATED_LABEL}"') in query
+
+
+def test_candidate_search_combines_recent_activity_with_rotating_backlog():
+    class SearchClient:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def get(self, path: str) -> object:
+            self.calls.append(path)
+            if 'per_page=1' in path:
+                return {'total_count': 100}
+            if 'order=desc' in path:
+                return {'items': [item(number) for number in range(96, 101)]}
+            return {'items': [item(number) for number in range(1, 6)]}
+
+    client = SearchClient()
+
+    candidates = monitor._candidate_page(client, 'pydantic/pydantic-ai', now=NOW)  # type: ignore[arg-type]
+
+    assert [candidate['number'] for candidate in candidates] == [*range(96, 101), *range(1, 6)]
+    assert any('order=desc&per_page=5&page=1' in call for call in client.calls)
+    assert any('order=asc&per_page=5&page=' in call for call in client.calls)
 
 
 def test_snapshot_recheck_skips_items_closed_after_search():
@@ -783,15 +816,26 @@ def test_apply_skips_closed_or_already_actioned_items(tmp_path: Path):
         assert not any(call[0] == 'POST' and '/issues/7/' in call[1] for call in client.calls)
 
 
-def test_reconcile_reminds_assigned_maintainers():
+def test_reconcile_queues_initial_channel_notice_for_assigned_maintainers():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['bob', 'alice'])})
     client.permissions = {'alice': 'admin', 'bob': 'write'}
+    notices: list[monitor.Notice] = []
 
-    assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW) == (['#7: reminded assigned maintainer'], [])
-
-    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
-    assert comment[2] == {'body': '@alice @bob this still needs a maintainer decision. Could you take a look?'}
-    assert any(call[0] == 'POST' and call[2] == {'labels': [monitor._PINGED_LABEL]} for call in client.calls)
+    assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW, notices=notices) == (
+        ['#7: queued initial triage channel notice'],
+        [],
+    )
+    assert notices == [
+        {
+            'number': 7,
+            'kind': 'initial',
+            'expected_stage': 0,
+            'transition_id': 'default-stage-0',
+            'title': 'Item 7',
+            'recipients': ['alice', 'bob'],
+        }
+    ]
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
 
 
 def test_reconcile_revalidates_attention_state_before_reminding_assignee():
@@ -877,10 +921,14 @@ def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
         },
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    notices: list[monitor.Notice] = []
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: queued initial triage channel notice'],
+        [],
+    )
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
-    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
-    assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
+    assert notices[0]['recipients'] == ['DouweM']
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
 
 
 def test_reconcile_stops_if_item_closes_during_assignment_request():
@@ -1063,28 +1111,38 @@ def test_reconcile_stops_if_attention_lifecycle_restarts_during_owner_selection(
     assert not any(call[0] == 'POST' and call[1].endswith(('/assignees', '/comments')) for call in client.calls)
 
 
-def test_reconcile_queues_private_escalation_without_public_comment():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
-    escalations: list[int] = []
+def test_reconcile_queues_channel_escalation_without_public_comment():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
+    notices: list[monitor.Notice] = []
 
-    assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW, escalations=escalations) == (
-        ['#7: queued private Slack escalation'],
+    assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW, notices=notices) == (
+        ['#7: queued terminal triage channel escalation'],
         [],
     )
-    assert escalations == [7]
+    assert notices == [
+        {
+            'number': 7,
+            'kind': 'escalation',
+            'expected_stage': 1,
+            'transition_id': 'default-stage-1',
+            'title': 'Item 7',
+            'recipients': [monitor._FALLBACK_OWNER],
+        }
+    ]
     assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
     assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
 
-def test_reconcile_retries_private_escalation_until_delivery():
+def test_reconcile_retries_channel_escalation_until_delivery():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._ESCALATED_LABEL])})
-    escalations: list[int] = []
+    notices: list[monitor.Notice] = []
 
-    assert monitor.reconcile(client, 'r', now=NOW, escalations=escalations) == (
-        ['#7: queued private Slack escalation'],
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: queued terminal triage channel escalation'],
         [],
     )
-    assert escalations == [7]
+    assert notices[0]['kind'] == 'escalation'
+    assert notices[0]['expected_stage'] == 2
     assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
     assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
@@ -1116,31 +1174,20 @@ def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
 
 
 def test_reconcile_rechecks_acknowledgement_before_queueing_slack():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
     event = {
+        'id': 'reminder-transition',
         'event': 'labeled',
         'created_at': OLD,
         'actor': {'login': 'github-actions[bot]'},
         'label': {'name': monitor._PINGED_LABEL},
     }
-    reminder = {
-        'event': 'commented',
-        'created_at': OLD,
-        'actor': {'login': 'github-actions[bot]'},
-        'body': monitor._reminder([monitor._FALLBACK_OWNER]),
-    }
-    calls = 0
 
     def pages(path: str, *, count: int = 1) -> list[dict[str, Any]]:
-        nonlocal calls
-        calls += 1
         if path.endswith('/events'):
             return [event]
-        if calls == 2:
-            return [event, reminder]
         return [
             event,
-            reminder,
             {
                 'event': 'commented',
                 'created_at': '2026-07-18T00:00:00Z',
@@ -1153,26 +1200,70 @@ def test_reconcile_rechecks_acknowledgement_before_queueing_slack():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
 
 
-def test_finalize_clears_active_state_only_after_slack_delivery():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])})
+def test_finalize_records_initial_notice_only_after_channel_delivery():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
 
-    assert monitor.finalize_escalations(client, 'r', monitor._escalation_numbers({'items': [7]})) == [
-        '#7: delivered private Slack escalation'
-    ]
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]}),
+    ) == ['#7: recorded initial triage channel notice']
+    assert monitor._NOTIFIED_LABEL in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_finalize_advances_reminder_only_after_channel_delivery():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
+
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, 'reminder', 0)]}),
+    ) == ['#7: recorded triage channel reminder']
+    assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_finalize_clears_active_state_only_after_channel_escalation():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._ESCALATED_LABEL],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
+
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, 'escalation', 2)]}),
+    ) == ['#7: recorded terminal triage channel escalation']
     assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
 
 def test_finalize_continues_after_one_delivered_item_fails():
     client = FakeClient(
         {
-            7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL]),
-            8: item(8, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL]),
+            7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL], assignees=[monitor._FALLBACK_OWNER]),
+            8: item(8, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL], assignees=[monitor._FALLBACK_OWNER]),
         }
     )
     client.fail_get.add(7)
 
     with pytest.raises(RuntimeError, match=r'#7: HTTPError'):
-        monitor.finalize_escalations(client, 'r', [7, 8])
+        monitor.finalize_notices(
+            client,
+            'r',
+            monitor._notice_refs({'items': [notice_ref(7, 'escalation', 2), notice_ref(8, 'escalation', 2)]}),
+        )
     assert any(call[0] == 'DELETE' and '/issues/8/' in call[1] for call in client.calls)
 
 
@@ -1181,32 +1272,74 @@ def test_finalize_clears_delivered_state_if_item_closed_during_delivery():
     closed['state'] = 'closed'
     client = FakeClient({7: closed})
 
-    assert monitor.finalize_escalations(client, 'r', [7]) == ['#7: delivered private Slack escalation']
+    assert (
+        monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'escalation', 2)]})) == []
+    )
+    assert not {monitor._ACTION_LABEL, monitor._ESCALATED_LABEL}.intersection(
+        {label['name'] for label in client.items[7]['labels']}
+    )
 
 
 def test_finalize_skips_items_whose_state_was_already_cleared():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL]), 8: item(8)})
 
-    assert monitor.finalize_escalations(client, 'r', [7, 8]) == []
+    assert (
+        monitor.finalize_notices(
+            client,
+            'r',
+            monitor._notice_refs({'items': [notice_ref(7, 'reminder', 1), notice_ref(8, 'initial', 0)]}),
+        )
+        == []
+    )
     assert not any(call[0] == 'DELETE' for call in client.calls)
+
+
+def test_finalize_skips_a_restarted_attention_transition():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    client.timelines[7] = [
+        {
+            'id': 'replacement-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        }
+    ]
+
+    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]})) == []
+    assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_finalize_skips_a_notice_after_the_owner_changes():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
+    client.permissions = {'alice': 'write'}
+
+    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]})) == []
+    assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
 @pytest.mark.parametrize(
     'contents',
     [
         [7],
-        {'items': [7], 'extra': 1},
+        {'items': [notice_ref(7, 'initial', 0)], 'extra': 1},
         {'items': 7},
         {'items': [True]},
         {'items': ['7']},
-        {'items': [0]},
-        {'items': [7, 7]},
-        {'items': list(range(1, monitor._RECONCILE_LIMIT + 2))},
+        {'items': [notice_ref(0, 'initial', 0)]},
+        {'items': [notice_ref(7, 'initial', 0), notice_ref(7, 'initial', 0)]},
+        {'items': [notice_ref(number, 'initial', 0) for number in range(1, monitor._RECONCILE_LIMIT + 2)]},
+        {'items': [notice_ref(7, 'initial', 1)]},
+        {'items': [notice_ref(7, 'unknown', 0)]},
+        {'items': [{**notice_ref(7, 'initial', 0), 'kind': []}]},
+        {'items': [{**notice_ref(7, 'initial', 0), 'transition_id': 'x' * 101}]},
+        {'items': [{**notice_ref(7, 'initial', 0), 'recipients': ['bad login']}]},
+        {'items': [{**notice_ref(7, 'initial', 0), 'recipients': ['Alice', 'alice']}]},
     ],
 )
-def test_escalation_input_rejects_invalid_shapes(contents: object):
-    with pytest.raises(ValueError, match='Escalations must'):
-        monitor._escalation_numbers(contents)
+def test_notice_input_rejects_invalid_shapes(contents: object):
+    with pytest.raises(ValueError, match=r'[Nn]otice'):
+        monitor._notice_refs(contents)
 
 
 def test_snapshot_and_decision_batch_limits_are_enforced(tmp_path: Path):
@@ -1221,20 +1354,36 @@ def test_snapshot_and_decision_batch_limits_are_enforced(tmp_path: Path):
         monitor._parse_decisions(str(output))
 
 
-def test_escalation_output_is_fixed_and_bounded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     output = tmp_path / 'github-output'
     monkeypatch.setenv('GITHUB_OUTPUT', str(output))
 
-    monitor._write_escalations('pydantic/pydantic-ai', [8, 7, 7])
+    monitor._write_notices(
+        'pydantic/pydantic-ai',
+        [
+            {
+                'number': 7,
+                'kind': 'initial',
+                'expected_stage': 0,
+                'transition_id': 'event-7',
+                'title': 'Handle <unsafe> & important',
+                'recipients': ['DouweM'],
+            }
+        ],
+    )
 
     values = dict(line.split('=', 1) for line in output.read_text(encoding='utf-8').splitlines())
-    assert values['has_escalations'] == 'true'
-    assert values['escalation_items'] == '[7,8]'
-    assert json.loads(values['slack_payload']) == {
-        'text': ':warning: Maintainer attention needs your view: '
-        '<https://github.com/pydantic/pydantic-ai/issues/7|#7>, '
-        '<https://github.com/pydantic/pydantic-ai/issues/8|#8>'
-    }
+    assert values['has_notices'] == 'true'
+    assert json.loads(values['notice_items']) == [
+        notice_ref(7, 'initial', 0, transition_id='event-7', recipients=['DouweM'])
+    ]
+    text = json.loads(values['slack_payload'])['text']
+    assert text.startswith('<!channel> *Maintainer attention requested*')
+    assert '#7 Handle &lt;unsafe&gt; &amp; important' in text
+    assert '— @DouweM' in text
+    assert '*Why:*' in text
+    assert '*Expected action:*' in text
+    assert 'Do not remove the attention labels' in text
 
 
 def test_reconcile_rejects_a_foreign_stage_label():
@@ -1253,7 +1402,7 @@ def test_reconcile_rejects_a_foreign_stage_label():
 
 
 def test_recent_activity_delays_the_next_reminder():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
     client.timelines[7] = [
         {
             'event': 'labeled',
@@ -1371,7 +1520,10 @@ def test_bot_assignment_does_not_acknowledge_the_request():
         },
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        ['#7: queued initial triage channel notice'],
+        [],
+    )
 
 
 def test_collaborator_comment_by_non_recipient_completes_the_request():
@@ -1397,9 +1549,8 @@ def test_collaborator_comment_by_non_recipient_completes_the_request():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
 
 
-def test_reconcile_does_not_trust_a_shared_bot_comment_as_state():
+def test_reconcile_does_not_create_public_ping_comments():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    body = monitor._reminder([monitor._FALLBACK_OWNER])
     client.timelines[7] = [
         {
             'event': 'labeled',
@@ -1411,15 +1562,18 @@ def test_reconcile_does_not_trust_a_shared_bot_comment_as_state():
             'event': 'commented',
             'created_at': '2026-07-17T00:00:00Z',
             'actor': {'login': 'github-actions[bot]'},
-            'body': body,
+            'body': '@adtyavrdhn old bot ping',
         },
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
-    assert sum(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls) == 1
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        ['#7: queued initial triage channel notice'],
+        [],
+    )
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
 
 
-def test_reconcile_restores_a_missing_comment_after_label_success():
+def test_reconcile_migrates_legacy_pinged_state_to_channel_notice():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
     client.timelines[7] = [
         {
@@ -1430,12 +1584,17 @@ def test_reconcile_restores_a_missing_comment_after_label_success():
         }
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: restored maintainer reminder'], [])
-    assert any(call[0] == 'POST' and call[2] == {'labels': [monitor._PINGED_LABEL]} for call in client.calls)
-    assert sum(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls) == 1
+    notices: list[monitor.Notice] = []
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: queued reminder triage channel notice'],
+        [],
+    )
+    assert notices[0]['kind'] == 'reminder'
+    assert notices[0]['expected_stage'] == 1
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
 
 
-def test_reassignment_restarts_the_reminder_sla():
+def test_legacy_notice_uses_the_current_maintainer_assignment():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=['bob'])})
     client.permissions = {'bob': 'write'}
     client.timelines[7] = [
@@ -1453,20 +1612,24 @@ def test_reassignment_restarts_the_reminder_sla():
         },
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: restored maintainer reminder'], [])
-    assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
-    assert any(call[0] == 'POST' and call[2] == {'labels': [monitor._PINGED_LABEL]} for call in client.calls)
+    notices: list[monitor.Notice] = []
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: queued reminder triage channel notice'],
+        [],
+    )
+    assert notices[0]['recipients'] == ['bob']
 
 
 def test_closed_item_completes_and_strips_lifecycle_labels():
     # Closing an item is the ultimate resolution: the action and stage labels
     # are removed so a later reopen can't wake an ancient SLA clock.
-    closed = item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])
+    closed = item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])
     closed['state'] = 'closed'
     client = FakeClient({7: closed})
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: completed after the item was closed'], [])
     assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
+    assert any(call[0] == 'DELETE' and monitor._NOTIFIED_LABEL in call[1] for call in client.calls)
     assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
     # No public reminder or private escalation is produced for a closed item.
     assert not any(call[1].endswith('/comments') for call in client.calls)
@@ -1489,7 +1652,7 @@ def test_full_page_processes_a_bounded_batch_instead_of_aborting():
     lines, failures = monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW)
 
     assert failures == []
-    assert sum('reminded assigned maintainer' in line for line in lines) == monitor._RECONCILE_LIMIT
+    assert sum('queued initial triage channel notice' in line for line in lines) == monitor._RECONCILE_LIMIT
     assert lines[-1] == 'additional attention items remain for a later rotated batch'
 
 
@@ -1504,9 +1667,9 @@ def test_one_item_failure_does_not_block_later_items():
 
     lines, failures = monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW)
 
-    assert lines == ['#2: reminded assigned maintainer']
+    assert lines == ['#2: queued initial triage channel notice']
     assert failures and failures[0].startswith('#1: HTTPError')
-    assert any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
 
 
 def test_invalid_event_timestamp_does_not_block_later_items():
@@ -1527,25 +1690,25 @@ def test_invalid_event_timestamp_does_not_block_later_items():
 
     lines, failures = monitor.reconcile(client, 'r', now=NOW)
 
-    assert lines == ['#2: reminded assigned maintainer']
+    assert lines == ['#2: queued initial triage channel notice']
     assert failures and failures[0].startswith('#1: ValueError')
-    assert any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
 
 
-def test_one_item_failure_still_queues_other_escalations():
+def test_one_item_failure_still_queues_other_notices():
     client = FakeClient(
         {
             1: item(1, labels=[monitor._ACTION_LABEL]),
-            2: item(2, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL]),
+            2: item(2, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL]),
         }
     )
     client.fail_get.add(1)
-    escalations: list[int] = []
+    notices: list[monitor.Notice] = []
 
-    lines, failures = monitor.reconcile(client, 'r', now=NOW, escalations=escalations)
+    lines, failures = monitor.reconcile(client, 'r', now=NOW, notices=notices)
 
-    assert lines == ['#2: queued private Slack escalation']
-    assert escalations == [2]
+    assert lines == ['#2: queued terminal triage channel escalation']
+    assert [notice['number'] for notice in notices] == [2]
     assert failures and failures[0].startswith('#1: HTTPError')
 
 
@@ -1562,11 +1725,14 @@ def test_bot_triggered_mention_event_is_not_an_acknowledgement():
         {'event': 'subscribed', 'created_at': '2026-07-17T00:00:00Z', 'actor': {'login': monitor._FALLBACK_OWNER}},
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        ['#7: queued initial triage channel notice'],
+        [],
+    )
 
 
 def test_latest_stage_transition_restarts_the_sla_clock():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
     client.timelines[7] = [
         {
             'event': 'labeled',
@@ -1579,12 +1745,6 @@ def test_latest_stage_transition_restarts_the_sla_clock():
             'created_at': '2026-07-19T00:00:00Z',
             'actor': {'login': 'github-actions[bot]'},
             'label': {'name': monitor._PINGED_LABEL},
-        },
-        {
-            'event': 'commented',
-            'created_at': '2026-07-19T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'body': monitor._reminder([monitor._FALLBACK_OWNER]),
         },
     ]
 
@@ -1696,7 +1856,7 @@ def test_compiled_lock_keeps_agent_read_only_and_stable_artifact_name():
     assert 'name: attention-candidates-${{ github.run_id }}-' not in text
 
 
-def test_operations_workflow_routes_only_terminal_escalation_to_slack():
+def test_operations_workflow_routes_all_actionable_notices_to_the_triage_channel():
     workflow = Path(__file__).parent.parent / 'workflows' / 'issue-pr-attention-monitor.yml'
     text = workflow.read_text()
 
@@ -1704,7 +1864,9 @@ def test_operations_workflow_routes_only_terminal_escalation_to_slack():
     assert 'steps.reconcile.outputs.slack_payload' in text
     assert 'issue_pr_attention_monitor.py finalize' in text
     assert 'permissions: {}' in text
-    assert 'ATTENTION_ESCALATIONS' in text
+    assert 'ATTENTION_NOTICES' in text
+    assert 'outputs.has_notices' in text
+    assert 'Post actionable attention digest to the triage channel' in text
 
 
 def test_monitor_imports_with_stdlib_only():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -50,6 +50,7 @@ class FakeClient:
         self.assignment_succeeds = True
         self.assignment_response_assignees: list[str] = []
         self.assignment_response_state: str | None = None
+        self.assignment_restarts_attention = False
         self.permissions: dict[str, str] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
@@ -88,6 +89,16 @@ class FakeClient:
             response = {**self.items[number], 'assignees': [{'login': login} for login in result]}
             if self.assignment_response_state is not None:
                 response['state'] = self.assignment_response_state
+            if self.assignment_restarts_attention:
+                self.timelines.setdefault(number, []).append(
+                    {
+                        'id': 'concurrent-restart',
+                        'event': 'labeled',
+                        'created_at': '2026-07-17T00:00:00Z',
+                        'actor': {'login': 'github-actions[bot]'},
+                        'label': {'name': monitor._ACTION_LABEL},
+                    }
+                )
             self.items[number] = response
             return response
         if path.endswith('/labels'):
@@ -97,6 +108,16 @@ class FakeClient:
             number = int(path.split('/issues/')[1].split('/')[0])
             existing = {str(value['name']) for value in self.items[number]['labels']}
             self.items[number]['labels'].extend({'name': label} for label in labels if label not in existing)
+            self.timelines.setdefault(number, []).extend(
+                {
+                    'id': f'bot-label-{len(self.timelines.get(number, [])) + index}',
+                    'event': 'labeled',
+                    'created_at': str(self.items[number]['updated_at']),
+                    'actor': {'login': 'github-actions[bot]'},
+                    'label': {'name': label},
+                }
+                for index, label in enumerate(labels)
+            )
         return {}
 
     def delete(self, path: str) -> None:
@@ -843,6 +864,33 @@ def test_reconcile_stops_if_item_closes_during_assignment_request():
     assert monitor.reconcile(client, 'r', now=NOW) == (
         [],
         ['#7: RuntimeError: Attention state changed during owner selection'],
+    )
+    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
+
+
+def test_reconcile_stops_if_lifecycle_restarts_during_assignment_request():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.assignment_restarts_attention = True
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T16:48:57Z',
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention transition changed during owner selection'],
     )
     assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
     assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -817,6 +817,46 @@ def test_reconcile_revalidates_attention_state_before_reminding_assignee():
     assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
 
 
+def test_reconcile_revalidates_transition_before_reminding_existing_assignee():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
+    client.permissions = {'alice': 'write'}
+    client.timelines[7] = [
+        {
+            'id': 'original-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        }
+    ]
+    original_get = client.get
+    item_reads = 0
+
+    def get(path: str):
+        nonlocal item_reads
+        if path.endswith('/issues/7'):
+            item_reads += 1
+            if item_reads == 2:
+                client.timelines[7].append(
+                    {
+                        'id': 'concurrent-restart',
+                        'event': 'labeled',
+                        'created_at': OLD,
+                        'actor': {'login': 'github-actions[bot]'},
+                        'label': {'name': monitor._ACTION_LABEL},
+                    }
+                )
+        return original_get(path)
+
+    client.get = get  # type: ignore[method-assign]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention transition changed during owner selection'],
+    )
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
+
+
 def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
     client.permissions = {'DouweM': 'admin'}
@@ -893,6 +933,37 @@ def test_reconcile_stops_if_lifecycle_restarts_during_assignment_request():
     assert monitor.reconcile(client, 'r', now=NOW) == (
         [],
         ['#7: RuntimeError: Attention transition changed during owner selection'],
+    )
+    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
+
+
+def test_reconcile_rechecks_state_after_assignment_transition_validation():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.timelines[7] = [
+        {
+            'id': 'original-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        }
+    ]
+    original_last_pages = client.last_pages
+
+    def last_pages(path: str, *, count: int = 1):
+        if path.endswith('/events') and any(
+            call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls
+        ):
+            client.items[7] = {**client.items[7], 'state': 'closed'}
+        return original_last_pages(path, count=count)
+
+    client.last_pages = last_pages  # type: ignore[method-assign]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention state changed during owner selection'],
     )
     assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
     assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -762,6 +762,7 @@ def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
     with pytest.raises(RuntimeError, match='Failed to finalize attention'):
         monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 1)]}))
 
+    assert {'labels': [monitor._ESCALATED_LABEL, monitor._DELIVERED_LABEL]} in [call[2] for call in client.calls]
     assert {label['name'] for label in client.items[7]['labels']} == {
         monitor._ACTION_LABEL,
         *monitor._STAGE_LABELS,

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -52,6 +52,7 @@ class FakeClient:
         self.permissions: dict[str, str] = {}
         self.comments: dict[int, list[dict[str, Any]]] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
+        self.roster_reads = 0
 
     def get(self, path: str) -> Any:
         self.calls.append(('GET', path, None))
@@ -153,19 +154,17 @@ class FakeClient:
         return self.last_page(path)
 
     def pages(self, path: str, *, count: int):
-        if '/collaborators?' in path:
-            self.calls.append(('PAGES', path, count))
-            values = {monitor._FALLBACK_OWNER: 'write', **self.permissions}
-            yield [
-                {
-                    'login': login,
-                    'permissions': {'push': permission in {'write', 'maintain', 'admin'}},
-                }
-                for login, permission in values.items()
-            ]
-            return
         number = int(path.split('/issues/')[1].split('/')[0])
         yield self.comments.get(number, [])
+
+    def maintainer_logins(self, repo: str) -> dict[str, str]:
+        self.roster_reads += 1
+        values = {monitor._FALLBACK_OWNER: 'write', **self.permissions}
+        return {
+            login.casefold(): login
+            for login, permission in values.items()
+            if permission in {'write', 'maintain', 'admin'}
+        }
 
 
 class SnapshotClient(FakeClient):
@@ -384,35 +383,6 @@ def test_apply_revalidates_then_assigns_and_labels(tmp_path: Path):
     ) in client.calls
 
 
-def test_apply_assigns_the_first_maintainer_who_discussed_an_issue(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    issue = item(7, assignees=['dsfaccini'])
-    issue['comments'] = 2
-    client = FakeClient({7: issue})
-    client.permissions = {'DouweM': 'admin', 'dsfaccini': 'write', 'later-maintainer': 'write'}
-    client.comments[7] = [
-        {
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-            'created_at': '2026-01-01T00:00:00Z',
-        },
-        {
-            'user': {'login': 'later-maintainer'},
-            'author_association': 'MEMBER',
-            'created_at': '2026-02-01T00:00:00Z',
-        },
-    ]
-
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @DouweM'
-    ]
-    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
-    assert [assignee['login'] for assignee in client.items[7]['assignees']] == ['DouweM']
-
-
 def test_owner_selection_reloads_discussion_after_concurrent_activity():
     stale = item(7, labels=[monitor._ACTION_LABEL])
     current = item(
@@ -425,8 +395,7 @@ def test_owner_selection_reloads_discussion_after_concurrent_activity():
     client.permissions = {'DouweM': 'write'}
     client.comments[7] = [{'user': {'login': 'DouweM'}, 'created_at': '2026-07-17T00:00:00Z'}]
 
-    roster = monitor._maintainer_roster(client, 'r')
-    assert monitor._ensure_recipients(client, 'r', stale, roster) == ['DouweM']
+    assert monitor._ensure_recipients(client, 'r', stale) == ['DouweM']
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
 
 
@@ -440,10 +409,8 @@ def test_owner_selection_uses_one_roster_for_a_large_discussion():
         {'user': {'login': 'DouweM'}},
     ]
 
-    roster = monitor._maintainer_roster(client, 'r')
-
-    assert monitor._first_maintainer_in_discussion(client, 'r', issue, roster) == 'DouweM'
-    assert sum('/collaborators?' in path for method, path, _ in client.calls if method == 'PAGES') == 1
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == 'DouweM'
+    assert client.roster_reads == 1
     assert not any('/permission' in path for method, path, _ in client.calls if method == 'GET')
 
 
@@ -703,7 +670,7 @@ def test_reconcile_queues_channel_escalation_without_advancing_before_delivery()
 
 
 def test_reconcile_retries_preexisting_pending_escalation():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, *monitor._STAGE_LABELS])})
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
@@ -711,11 +678,12 @@ def test_reconcile_retries_preexisting_pending_escalation():
         [],
     )
     assert notices[0]['expected_stage'] == 2
+    assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
     assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
 
 def test_reconcile_finishes_a_delivered_escalation_receipt_without_reposting():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, *monitor._STAGE_LABELS])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._DELIVERED_LABEL])})
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
@@ -839,6 +807,7 @@ def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
     assert {label['name'] for label in client.items[7]['labels']} == {
         monitor._ACTION_LABEL,
         *monitor._STAGE_LABELS,
+        monitor._DELIVERED_LABEL,
     }
     client.fail_delete_labels.clear()
     notices: list[monitor.Notice] = []
@@ -877,6 +846,16 @@ def test_finalize_skips_notice_when_transition_or_owner_changed(ref: dict[str, o
 
     assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [ref]})) == []
     assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_prepare_notices_filters_stale_owners_immediately_before_delivery():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    refs = monitor._notice_refs({'items': [notice_ref(7, 0)]})
+
+    assert [notice['number'] for notice in monitor.prepare_notices(client, 'r', refs)] == [7]
+
+    client.items[7]['assignees'] = []
+    assert monitor.prepare_notices(client, 'r', refs) == []
 
 
 @pytest.mark.parametrize(
@@ -1012,27 +991,6 @@ def test_member_acknowledgement_in_the_same_second_completes_the_request():
     ]
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
-
-
-def test_latest_same_second_transition_restarts_the_lifecycle():
-    events = [
-        {
-            'id': 'old-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'id': 'new-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-
-    assert monitor._transition(events, 0) == (monitor._parse_time(OLD), events[1])
 
 
 def test_recipient_non_comment_event_completes_the_request():
@@ -1259,8 +1217,15 @@ def test_latest_stage_transition_restarts_the_sla_clock():
             'actor': {'login': 'github-actions[bot]'},
             'label': {'name': monitor._PINGED_LABEL},
         },
+        {
+            'event': 'labeled',
+            'created_at': '2026-07-19T00:00:00Z',
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._PINGED_LABEL},
+        },
     ]
 
+    assert monitor._transition(client.last_pages('/repos/r/issues/7/events'), 1)[1]['id'] == 'event-2'
     assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
 
 
@@ -1378,10 +1343,12 @@ def test_operations_workflow_routes_all_notices_to_the_triage_channel():
     text = workflow.read_text()
 
     assert 'PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL' in text
-    assert 'steps.reconcile.outputs.slack_payload' in text
     assert 'issue_pr_attention_monitor.py finalize' in text
     assert 'permissions: {}' in text
     assert 'ATTENTION_NOTICES' in text
+    assert 'issue_pr_attention_monitor.py prepare' in text
+    assert 'needs.notify.outputs.notice_items' in text
+    assert 'steps.prepare.outputs.slack_payload' in text
     assert 'Post actionable attention digest to the triage channel' in text
 
 

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -79,9 +79,6 @@ class FakeClient:
                 if requested in {str(label['name']) for label in value['labels']}
                 and (state == 'all' or value['state'] == state)
             ]
-        if '/collaborators/' in path and path.endswith('/permission'):
-            login = path.split('/collaborators/')[1].split('/')[0]
-            return {'permission': self.permissions.get(login, 'write' if login == monitor._FALLBACK_OWNER else 'read')}
         if '/issues/' in path and '/comments?' not in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             if number in self.fail_get:
@@ -112,8 +109,16 @@ class FakeClient:
             self.items[number]['labels'].extend({'name': label} for label in labels if label not in existing)
         return {}
 
-    def delete(self, path: str) -> None:
-        self.calls.append(('DELETE', path, None))
+    def delete(self, path: str, payload: object | None = None) -> None:
+        self.calls.append(('DELETE', path, payload))
+        if path.endswith('/assignees'):
+            assert isinstance(payload, dict)
+            number = int(path.split('/issues/')[1].split('/')[0])
+            removed = {str(login).casefold() for login in payload['assignees']}
+            self.items[number]['assignees'] = [
+                value for value in self.items[number]['assignees'] if str(value['login']).casefold() not in removed
+            ]
+            return
         if '/labels/' in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             removed = urllib.parse.unquote(path.rsplit('/', 1)[-1])
@@ -148,6 +153,17 @@ class FakeClient:
         return self.last_page(path)
 
     def pages(self, path: str, *, count: int):
+        if '/collaborators?' in path:
+            self.calls.append(('PAGES', path, count))
+            values = {monitor._FALLBACK_OWNER: 'write', **self.permissions}
+            yield [
+                {
+                    'login': login,
+                    'permissions': {'push': permission in {'write', 'maintain', 'admin'}},
+                }
+                for login, permission in values.items()
+            ]
+            return
         number = int(path.split('/issues/')[1].split('/')[0])
         yield self.comments.get(number, [])
 
@@ -394,6 +410,7 @@ def test_apply_assigns_the_first_maintainer_who_discussed_an_issue(tmp_path: Pat
         '#7: requested maintainer attention from @DouweM'
     ]
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+    assert [assignee['login'] for assignee in client.items[7]['assignees']] == ['DouweM']
 
 
 def test_owner_selection_reloads_discussion_after_concurrent_activity():
@@ -408,8 +425,26 @@ def test_owner_selection_reloads_discussion_after_concurrent_activity():
     client.permissions = {'DouweM': 'write'}
     client.comments[7] = [{'user': {'login': 'DouweM'}, 'created_at': '2026-07-17T00:00:00Z'}]
 
-    assert monitor._ensure_recipients(client, 'r', stale, []) == ['DouweM']
+    roster = monitor._maintainer_roster(client, 'r')
+    assert monitor._ensure_recipients(client, 'r', stale, roster) == ['DouweM']
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+
+
+def test_owner_selection_uses_one_roster_for_a_large_discussion():
+    issue = item(7, labels=[monitor._ACTION_LABEL])
+    issue['comments'] = 51
+    client = FakeClient({7: issue})
+    client.permissions = {'DouweM': 'admin'}
+    client.comments[7] = [
+        *[{'user': {'login': f'contributor-{number}'}} for number in range(50)],
+        {'user': {'login': 'DouweM'}},
+    ]
+
+    roster = monitor._maintainer_roster(client, 'r')
+
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue, roster) == 'DouweM'
+    assert sum('/collaborators?' in path for method, path, _ in client.calls if method == 'PAGES') == 1
+    assert not any('/permission' in path for method, path, _ in client.calls if method == 'GET')
 
 
 def test_apply_pings_all_assigned_maintainers_without_reassigning(tmp_path: Path):
@@ -630,6 +665,27 @@ def test_reconcile_routes_existing_action_to_first_maintainer_participant():
     )
     assert notices[0]['recipients'] == ['DouweM']
     assert ('POST', '/repos/r/issues/4261/assignees', {'assignees': ['DouweM']}) in client.calls
+    assert [assignee['login'] for assignee in client.items[4261]['assignees']] == ['DouweM']
+
+
+def test_reconcile_drops_a_notice_if_the_owner_changes_before_queueing():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    original_get = client.get
+    item_reads = 0
+
+    def get(path: str) -> Any:
+        nonlocal item_reads
+        if path.endswith('/issues/7'):
+            item_reads += 1
+            if item_reads == 3:
+                client.items[7]['assignees'] = []
+        return original_get(path)
+
+    client.get = get  # type: ignore[method-assign]
+    notices: list[monitor.Notice] = []
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == ([], [])
+    assert notices == []
 
 
 def test_reconcile_queues_channel_escalation_without_advancing_before_delivery():
@@ -647,7 +703,7 @@ def test_reconcile_queues_channel_escalation_without_advancing_before_delivery()
 
 
 def test_reconcile_retries_preexisting_pending_escalation():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._ESCALATED_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])})
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
@@ -655,8 +711,19 @@ def test_reconcile_retries_preexisting_pending_escalation():
         [],
     )
     assert notices[0]['expected_stage'] == 2
-    assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
     assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
+
+
+def test_reconcile_finishes_a_delivered_escalation_receipt_without_reposting():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, *monitor._STAGE_LABELS])})
+    notices: list[monitor.Notice] = []
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: finished delivered channel escalation'],
+        [],
+    )
+    assert notices == []
+    assert {label['name'] for label in client.items[7]['labels']} == {monitor._ESCALATED_LABEL}
 
 
 def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
@@ -683,6 +750,37 @@ def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
     ]
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
+
+
+def test_terminal_stage_rechecks_acknowledgement_after_owner_selection():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])})
+    initial = client.last_pages
+    timeline_reads = 0
+
+    def last_pages(path: str, *, count: int = 1) -> list[dict[str, Any]]:
+        nonlocal timeline_reads
+        values = initial(path, count=count)
+        if '/timeline' in path:
+            timeline_reads += 1
+            if timeline_reads == 2:
+                return [
+                    *values,
+                    {
+                        'event': 'commented',
+                        'created_at': '2026-07-18T00:00:00Z',
+                        'actor': {'login': monitor._FALLBACK_OWNER},
+                    },
+                ]
+        return values
+
+    client.last_pages = last_pages  # type: ignore[method-assign]
+    notices: list[monitor.Notice] = []
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: maintainer acknowledged the request'],
+        [],
+    )
+    assert notices == []
 
 
 def test_finalize_advances_reminder_only_after_channel_delivery():
@@ -727,6 +825,29 @@ def test_finalize_delivers_a_preexisting_stage_two_escalation():
         monitor._notice_refs({'items': [notice_ref(7, 2)]}),
     ) == ['#7: recorded channel escalation']
     assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
+    client = FakeClient(
+        {7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=[monitor._FALLBACK_OWNER])}
+    )
+    client.fail_delete_labels.add(monitor._ACTION_LABEL)
+
+    with pytest.raises(RuntimeError, match='Failed to finalize attention'):
+        monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 1)]}))
+
+    assert {label['name'] for label in client.items[7]['labels']} == {
+        monitor._ACTION_LABEL,
+        *monitor._STAGE_LABELS,
+    }
+    client.fail_delete_labels.clear()
+    notices: list[monitor.Notice] = []
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: finished delivered channel escalation'],
+        [],
+    )
+    assert notices == []
 
 
 def test_finalize_skips_notice_when_stage_changed_during_delivery():
@@ -891,6 +1012,27 @@ def test_member_acknowledgement_in_the_same_second_completes_the_request():
     ]
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
+
+
+def test_latest_same_second_transition_restarts_the_lifecycle():
+    events = [
+        {
+            'id': 'old-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'id': 'new-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    assert monitor._transition(events, 0) == (monitor._parse_time(OLD), events[1])
 
 
 def test_recipient_non_comment_event_completes_the_request():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -49,9 +49,7 @@ class FakeClient:
         self.fail_get: set[int] = set()
         self.assignment_succeeds = True
         self.assignment_response_assignees: list[str] = []
-        self.fail_remove_assignees_once = False
         self.permissions: dict[str, str] = {}
-        self.events: dict[int, list[dict[str, Any]]] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
     def get(self, path: str) -> Any:
@@ -98,21 +96,9 @@ class FakeClient:
             self.items[number]['labels'].extend({'name': label} for label in labels if label not in existing)
         return {}
 
-    def delete(self, path: str, payload: object = None) -> None:
-        self.calls.append(('DELETE', path, payload))
-        if path.endswith('/assignees'):
-            if self.fail_remove_assignees_once:
-                self.fail_remove_assignees_once = False
-                raise urllib.error.HTTPError(path, 500, 'boom', {}, None)
-            assert isinstance(payload, dict)
-            assignees = payload['assignees']
-            assert isinstance(assignees, list)
-            number = int(path.split('/issues/')[1].split('/')[0])
-            removed = {str(login).casefold() for login in assignees}
-            self.items[number]['assignees'] = [
-                value for value in self.items[number]['assignees'] if str(value['login']).casefold() not in removed
-            ]
-        elif '/labels/' in path:
+    def delete(self, path: str) -> None:
+        self.calls.append(('DELETE', path, None))
+        if '/labels/' in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             removed = urllib.parse.unquote(path.rsplit('/', 1)[-1])
             self.items[number]['labels'] = [
@@ -122,8 +108,6 @@ class FakeClient:
     def last_page(self, path: str) -> list[dict[str, Any]]:
         self.calls.append(('LAST', path, None))
         number = int(path.split('/issues/')[1].split('/')[0])
-        if path.endswith('/events') and number in self.events:
-            return self.events[number]
         if number in self.timelines:
             return self.timelines[number]
         labels = {label['name'] for label in self.items[number]['labels']}
@@ -834,164 +818,6 @@ def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
     assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
 
 
-def test_reconcile_replaces_bot_assigned_fallback_with_issue_owner():
-    client = FakeClient(
-        {
-            7: {
-                **item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER]),
-                'user': {'login': 'DouweM'},
-            }
-        }
-    )
-    client.permissions = {monitor._FALLBACK_OWNER: 'write', 'DouweM': 'admin'}
-    client.events[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'assigned',
-            'created_at': OLD,
-            'actor': {'login': monitor._FALLBACK_OWNER},
-            'assigner': {'login': 'github-actions[bot]'},
-            'assignee': {'login': monitor._FALLBACK_OWNER},
-        },
-    ]
-    client.timelines[7] = []
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
-    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
-    assert (
-        'DELETE',
-        '/repos/r/issues/7/assignees',
-        {'assignees': [monitor._FALLBACK_OWNER]},
-    ) in client.calls
-    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
-    assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
-
-
-def test_reconcile_retries_fallback_cleanup_after_owner_assignment_succeeds():
-    client = FakeClient(
-        {
-            7: {
-                **item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER]),
-                'user': {'login': 'DouweM'},
-            }
-        }
-    )
-    client.permissions = {monitor._FALLBACK_OWNER: 'write', 'DouweM': 'admin'}
-    client.fail_remove_assignees_once = True
-    client.events[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'assigned',
-            'created_at': OLD,
-            'actor': {'login': monitor._FALLBACK_OWNER},
-            'assigner': {'login': 'github-actions[bot]'},
-            'assignee': {'login': monitor._FALLBACK_OWNER},
-        },
-    ]
-    client.timelines[7] = []
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: HTTPError: HTTP Error 500: boom'],
-    )
-    assert {value['login'] for value in client.items[7]['assignees']} == {
-        monitor._FALLBACK_OWNER,
-        'DouweM',
-    }
-
-    client.calls.clear()
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
-    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
-    assert client.items[7]['assignees'] == [{'login': 'DouweM'}]
-
-
-def test_reconcile_preserves_human_assigned_fallback():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.events[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'assigned',
-            'created_at': OLD,
-            'actor': {'login': 'maintainer'},
-            'assigner': {'login': 'maintainer'},
-            'assignee': {'login': monitor._FALLBACK_OWNER},
-        },
-    ]
-    client.timelines[7] = []
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
-    assert not any(call[1].endswith('/assignees') for call in client.calls)
-    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
-    assert comment[2] == {
-        'body': f'@{monitor._FALLBACK_OWNER} this still needs a maintainer decision. Could you take a look?'
-    }
-
-
-def test_reconcile_preserves_fallback_assigned_by_bot_before_attention():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.events[7] = [
-        {
-            'event': 'assigned',
-            'created_at': '2026-07-15T00:00:00Z',
-            'actor': {'login': monitor._FALLBACK_OWNER},
-            'assigner': {'login': 'github-actions[bot]'},
-            'assignee': {'login': monitor._FALLBACK_OWNER},
-        },
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-    client.timelines[7] = []
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
-    assert not any(call[1].endswith('/assignees') for call in client.calls)
-    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
-    assert comment[2] == {
-        'body': f'@{monitor._FALLBACK_OWNER} this still needs a maintainer decision. Could you take a look?'
-    }
-
-
-def test_reconcile_preserves_fallback_assigned_by_another_action_later():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.events[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'assigned',
-            'created_at': '2026-07-16T01:00:00Z',
-            'actor': {'login': monitor._FALLBACK_OWNER},
-            'assigner': {'login': 'github-actions[bot]'},
-            'assignee': {'login': monitor._FALLBACK_OWNER},
-        },
-    ]
-    client.timelines[7] = []
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
-    assert not any(call[1].endswith('/assignees') for call in client.calls)
-
-
 def test_reconcile_stops_if_attention_state_changes_during_owner_selection():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
     client.permissions = {'DouweM': 'admin'}
@@ -1012,6 +838,37 @@ def test_reconcile_stops_if_attention_state_changes_during_owner_selection():
 
     def pages(path: str, *, count: int = 1):
         client.items[7]['state'] = 'closed'
+        yield client.timelines[7]
+
+    client.pages = pages  # type: ignore[method-assign]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention state changed during owner selection'],
+    )
+    assert not any(call[0] == 'POST' and call[1].endswith(('/assignees', '/comments')) for call in client.calls)
+
+
+def test_reconcile_stops_if_attention_lifecycle_restarts_during_owner_selection():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T16:48:57Z',
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    def pages(path: str, *, count: int = 1):
+        client.items[7] = {**client.items[7], 'updated_at': '2026-07-17T00:00:00Z'}
         yield client.timelines[7]
 
     client.pages = pages  # type: ignore[method-assign]

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -49,6 +49,7 @@ class FakeClient:
         self.fail_get: set[int] = set()
         self.assignment_succeeds = True
         self.assignment_response_assignees: list[str] = []
+        self.fail_remove_assignees_once = False
         self.permissions: dict[str, str] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
@@ -84,11 +85,25 @@ class FakeClient:
             existing = [str(value['login']) for value in self.items[number]['assignees']]
             requested = [str(login) for login in assignees] if self.assignment_succeeds else []
             result = dict.fromkeys([*existing, *requested, *self.assignment_response_assignees])
-            return {'assignees': [{'login': login} for login in result]}
+            response = {'assignees': [{'login': login} for login in result]}
+            self.items[number]['assignees'] = response['assignees']
+            return response
         return {}
 
     def delete(self, path: str, payload: object = None) -> None:
         self.calls.append(('DELETE', path, payload))
+        if path.endswith('/assignees'):
+            if self.fail_remove_assignees_once:
+                self.fail_remove_assignees_once = False
+                raise urllib.error.HTTPError(path, 500, 'boom', {}, None)
+            assert isinstance(payload, dict)
+            assignees = payload['assignees']
+            assert isinstance(assignees, list)
+            number = int(path.split('/issues/')[1].split('/')[0])
+            removed = {str(login).casefold() for login in assignees}
+            self.items[number]['assignees'] = [
+                value for value in self.items[number]['assignees'] if str(value['login']).casefold() not in removed
+            ]
 
     def last_page(self, path: str) -> list[dict[str, Any]]:
         self.calls.append(('LAST', path, None))
@@ -119,6 +134,16 @@ class FakeClient:
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         return self.last_page(path)
+
+    def maintainer_logins(self, repo: str) -> frozenset[str]:
+        self.calls.append(('MAINTAINERS', repo, None))
+        maintainers = {
+            login.casefold()
+            for login, permission in self.permissions.items()
+            if permission in monitor._MAINTAINER_PERMISSIONS
+        }
+        maintainers.add(monitor._FALLBACK_OWNER.casefold())
+        return frozenset(maintainers)
 
     def pages(self, path: str, *, count: int = 1):
         self.calls.append(('PAGES', path, count))
@@ -223,6 +248,21 @@ def test_github_client_pages_reject_truncated_history():
 
     with pytest.raises(RuntimeError, match='exceeds the 1-page safety limit'):
         list(client.pages('/items', count=1))
+
+
+def test_github_client_caches_bounded_maintainer_snapshot():
+    client = monitor.GitHubClient('token')
+    calls: list[str] = []
+
+    def request(method: str, path: str, payload: object = None) -> tuple[object, str | None]:
+        calls.append(path)
+        return ([{'login': 'Alice'}, {'login': 'Bob'}], None)
+
+    client._request = request  # type: ignore[method-assign]
+
+    assert client.maintainer_logins('r') == frozenset({'alice', 'bob'})
+    assert client.maintainer_logins('r') == frozenset({'alice', 'bob'})
+    assert calls == ['/repos/r/collaborators?permission=push&per_page=100&page=1']
 
 
 def test_build_and_write_snapshot_are_bounded_and_agent_readable(tmp_path: Path):
@@ -431,7 +471,7 @@ def test_apply_assigns_first_maintainer_who_discussed_the_issue(tmp_path: Path):
         '#7: requested maintainer attention from @DouweM'
     ]
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
-    assert sum('/collaborators/former-maintainer/permission' in call[1] for call in client.calls) == 1
+    assert sum(call[0] == 'MAINTAINERS' for call in client.calls) == 1
 
 
 def test_apply_assigns_maintainer_issue_author_before_commenters(tmp_path: Path):
@@ -550,9 +590,9 @@ def test_apply_preserves_maintainer_assigned_during_assignment_request(tmp_path:
     ]
 
     assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @bob'
+        '#7: requested maintainer attention from @alice @bob'
     ]
-    assert ('DELETE', '/repos/r/issues/7/assignees', {'assignees': ['alice']}) in client.calls
+    assert not any(call[0] == 'DELETE' and call[1].endswith('/assignees') for call in client.calls)
 
 
 def test_apply_restarts_a_prior_terminal_escalation(tmp_path: Path):
@@ -713,6 +753,29 @@ def test_reconcile_reminds_assigned_maintainers():
     assert any(call[0] == 'POST' and call[2] == {'labels': [monitor._PINGED_LABEL]} for call in client.calls)
 
 
+def test_reconcile_revalidates_attention_state_before_reminding_assignee():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
+    client.permissions = {'alice': 'write'}
+    original_get = client.get
+    item_reads = 0
+
+    def get(path: str):
+        nonlocal item_reads
+        if path.endswith('/issues/7'):
+            item_reads += 1
+            if item_reads == 2:
+                client.items[7]['state'] = 'closed'
+        return original_get(path)
+
+    client.get = get  # type: ignore[method-assign]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention state changed during owner selection'],
+    )
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
+
+
 def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
     client.permissions = {'DouweM': 'admin'}
@@ -758,7 +821,8 @@ def test_reconcile_replaces_bot_assigned_fallback_with_issue_owner():
         {
             'event': 'assigned',
             'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
+            'actor': {'login': monitor._FALLBACK_OWNER},
+            'assigner': {'login': 'github-actions[bot]'},
             'assignee': {'login': monitor._FALLBACK_OWNER},
         },
     ]
@@ -774,6 +838,48 @@ def test_reconcile_replaces_bot_assigned_fallback_with_issue_owner():
     assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
 
 
+def test_reconcile_retries_fallback_cleanup_after_owner_assignment_succeeds():
+    client = FakeClient(
+        {
+            7: {
+                **item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER]),
+                'user': {'login': 'DouweM'},
+            }
+        }
+    )
+    client.permissions = {monitor._FALLBACK_OWNER: 'write', 'DouweM': 'admin'}
+    client.fail_remove_assignees_once = True
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'assigned',
+            'created_at': OLD,
+            'actor': {'login': monitor._FALLBACK_OWNER},
+            'assigner': {'login': 'github-actions[bot]'},
+            'assignee': {'login': monitor._FALLBACK_OWNER},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: HTTPError: HTTP Error 500: boom'],
+    )
+    assert {value['login'] for value in client.items[7]['assignees']} == {
+        monitor._FALLBACK_OWNER,
+        'DouweM',
+    }
+
+    client.calls.clear()
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+    assert client.items[7]['assignees'] == [{'login': 'DouweM'}]
+
+
 def test_reconcile_preserves_human_assigned_fallback():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
     client.timelines[7] = [
@@ -787,6 +893,7 @@ def test_reconcile_preserves_human_assigned_fallback():
             'event': 'assigned',
             'created_at': OLD,
             'actor': {'login': 'maintainer'},
+            'assigner': {'login': 'maintainer'},
             'assignee': {'login': monitor._FALLBACK_OWNER},
         },
     ]
@@ -797,6 +904,85 @@ def test_reconcile_preserves_human_assigned_fallback():
     assert comment[2] == {
         'body': f'@{monitor._FALLBACK_OWNER} this still needs a maintainer decision. Could you take a look?'
     }
+
+
+def test_reconcile_preserves_fallback_assigned_by_bot_before_attention():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    client.timelines[7] = [
+        {
+            'event': 'assigned',
+            'created_at': '2026-07-15T00:00:00Z',
+            'actor': {'login': monitor._FALLBACK_OWNER},
+            'assigner': {'login': 'github-actions[bot]'},
+            'assignee': {'login': monitor._FALLBACK_OWNER},
+        },
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert not any(call[1].endswith('/assignees') for call in client.calls)
+    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
+    assert comment[2] == {
+        'body': f'@{monitor._FALLBACK_OWNER} this still needs a maintainer decision. Could you take a look?'
+    }
+
+
+def test_reconcile_preserves_fallback_assigned_by_another_action_later():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'assigned',
+            'created_at': '2026-07-16T01:00:00Z',
+            'actor': {'login': monitor._FALLBACK_OWNER},
+            'assigner': {'login': 'github-actions[bot]'},
+            'assignee': {'login': monitor._FALLBACK_OWNER},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert not any(call[1].endswith('/assignees') for call in client.calls)
+
+
+def test_reconcile_stops_if_attention_state_changes_during_owner_selection():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T16:48:57Z',
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    def pages(path: str, *, count: int = 1):
+        client.items[7]['state'] = 'closed'
+        yield client.timelines[7]
+
+    client.pages = pages  # type: ignore[method-assign]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention state changed during owner selection'],
+    )
+    assert not any(call[0] == 'POST' and call[1].endswith(('/assignees', '/comments')) for call in client.calls)
 
 
 def test_reconcile_queues_private_escalation_without_public_comment():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -1332,6 +1332,48 @@ def test_recipient_non_comment_event_completes_the_request():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
 
 
+def test_recipient_self_assignment_completes_the_request():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
+    client.permissions = {'alice': 'admin'}
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'assigned',
+            'created_at': '2026-07-17T00:00:00Z',
+            'actor': {'login': 'alice'},
+            'assignee': {'login': 'alice'},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
+
+
+def test_bot_assignment_does_not_acknowledge_the_request():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
+    client.permissions = {'alice': 'admin'}
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'assigned',
+            'created_at': '2026-07-17T00:00:00Z',
+            'actor': {'login': 'github-actions[bot]'},
+            'assignee': {'login': 'alice'},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+
+
 def test_collaborator_comment_by_non_recipient_completes_the_request():
     # An outside collaborator with repo access can acknowledge via a comment even
     # when they are not one of the assigned recipients (COLLABORATOR association).

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -47,6 +47,7 @@ class FakeClient:
         self.items = items or {}
         self.calls: list[tuple[str, str, object | None]] = []
         self.fail_get: set[int] = set()
+        self.fail_delete_labels: set[str] = set()
         self.assignment_succeeds = True
         self.permissions: dict[str, str] = {}
         self.comments: dict[int, list[dict[str, Any]]] = {}
@@ -54,12 +55,29 @@ class FakeClient:
 
     def get(self, path: str) -> Any:
         self.calls.append(('GET', path, None))
+        if path.startswith('/search/issues?'):
+            query = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
+            requested_state = 'closed' if 'is:closed' in query.get('q', [''])[0] else 'open'
+            values = [
+                value
+                for value in self.items.values()
+                if value['state'] == requested_state
+                and monitor._ACTION_LABEL in {str(label['name']) for label in value['labels']}
+            ]
+            per_page = int(query.get('per_page', ['30'])[0])
+            page = int(query.get('page', ['1'])[0])
+            start = (page - 1) * per_page
+            return {'total_count': len(values), 'items': values[start : start + per_page]}
         if '/labels/' in path:
             return {'name': path.rsplit('/', 1)[-1]}
         if '/issues?state=' in path and 'labels=' in path:
             requested = urllib.parse.unquote(path.split('labels=')[1].split('&')[0])
+            state = path.split('/issues?state=')[1].split('&')[0]
             return [
-                value for value in self.items.values() if requested in {str(label['name']) for label in value['labels']}
+                value
+                for value in self.items.values()
+                if requested in {str(label['name']) for label in value['labels']}
+                and (state == 'all' or value['state'] == state)
             ]
         if '/collaborators/' in path and path.endswith('/permission'):
             login = path.split('/collaborators/')[1].split('/')[0]
@@ -99,6 +117,8 @@ class FakeClient:
         if '/labels/' in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             removed = urllib.parse.unquote(path.rsplit('/', 1)[-1])
+            if removed in self.fail_delete_labels:
+                raise urllib.error.HTTPError(path, 500, 'boom', {}, None)
             self.items[number]['labels'] = [
                 value for value in self.items[number]['labels'] if str(value['name']) != removed
             ]
@@ -107,12 +127,15 @@ class FakeClient:
         self.calls.append(('LAST', path, None))
         number = int(path.split('/issues/')[1].split('/')[0])
         if number in self.timelines:
-            return self.timelines[number]
+            return [
+                {**event, 'id': event.get('id', f'event-{index}')} for index, event in enumerate(self.timelines[number])
+            ]
         labels = {label['name'] for label in self.items[number]['labels']}
         stage = monitor._stage(labels)
         label = monitor._ACTION_LABEL if stage == 0 else monitor._STAGE_LABELS[stage - 1]
         events = [
             {
+                'id': f'default-stage-{stage}',
                 'event': 'labeled',
                 'created_at': OLD,
                 'actor': {'login': 'github-actions[bot]'},
@@ -350,10 +373,10 @@ def test_apply_assigns_the_first_maintainer_who_discussed_an_issue(tmp_path: Pat
     output = tmp_path / 'output.json'
     write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
     write_output(output, ['7'])
-    issue = item(7)
+    issue = item(7, assignees=['dsfaccini'])
     issue['comments'] = 2
     client = FakeClient({7: issue})
-    client.permissions = {'DouweM': 'write', 'later-maintainer': 'admin'}
+    client.permissions = {'DouweM': 'admin', 'dsfaccini': 'write', 'later-maintainer': 'write'}
     client.comments[7] = [
         {
             'user': {'login': 'DouweM'},
@@ -370,6 +393,22 @@ def test_apply_assigns_the_first_maintainer_who_discussed_an_issue(tmp_path: Pat
     assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
         '#7: requested maintainer attention from @DouweM'
     ]
+    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+
+
+def test_owner_selection_reloads_discussion_after_concurrent_activity():
+    stale = item(7, labels=[monitor._ACTION_LABEL])
+    current = item(
+        7,
+        labels=[monitor._ACTION_LABEL],
+        updated_at='2026-07-17T00:00:00Z',
+    )
+    current['comments'] = 1
+    client = FakeClient({7: current})
+    client.permissions = {'DouweM': 'write'}
+    client.comments[7] = [{'user': {'login': 'DouweM'}, 'created_at': '2026-07-17T00:00:00Z'}]
+
+    assert monitor._ensure_recipients(client, 'r', stale, []) == ['DouweM']
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
 
 
@@ -536,8 +575,19 @@ def test_apply_skips_closed_or_already_actioned_items(tmp_path: Path):
         assert not any(call[0] == 'POST' and '/issues/7/' in call[1] for call in client.calls)
 
 
-def notice_ref(number: int, stage: int) -> dict[str, int]:
-    return {'number': number, 'expected_stage': stage}
+def notice_ref(
+    number: int,
+    stage: int,
+    *,
+    transition_id: int | str | None = None,
+    recipients: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        'number': number,
+        'expected_stage': stage,
+        'transition_id': transition_id if transition_id is not None else f'default-stage-{stage}',
+        'recipients': recipients or [monitor._FALLBACK_OWNER],
+    }
 
 
 def test_reconcile_queues_channel_reminder_for_assigned_maintainers():
@@ -553,12 +603,33 @@ def test_reconcile_queues_channel_reminder_for_assigned_maintainers():
         {
             'number': 7,
             'kind': 'reminder',
+            'expected_stage': 0,
+            'transition_id': 'default-stage-0',
             'title': 'Item 7',
             'recipients': ['alice', 'bob'],
         }
     ]
     assert not any(call[1].endswith('/comments') for call in client.calls)
     assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_reconcile_routes_existing_action_to_first_maintainer_participant():
+    issue = item(4261, labels=[monitor._ACTION_LABEL], assignees=['dsfaccini'])
+    issue['comments'] = 2
+    client = FakeClient({4261: issue})
+    client.permissions = {'DouweM': 'admin', 'dsfaccini': 'write'}
+    client.comments[4261] = [
+        {'user': {'login': 'DouweM'}, 'created_at': '2026-02-09T16:48:57Z'},
+        {'user': {'login': 'dsfaccini'}, 'created_at': '2026-07-01T19:00:34Z'},
+    ]
+    notices: list[monitor.Notice] = []
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#4261: queued channel reminder'],
+        [],
+    )
+    assert notices[0]['recipients'] == ['DouweM']
+    assert ('POST', '/repos/r/issues/4261/assignees', {'assignees': ['DouweM']}) in client.calls
 
 
 def test_reconcile_queues_channel_escalation_without_advancing_before_delivery():
@@ -575,17 +646,17 @@ def test_reconcile_queues_channel_escalation_without_advancing_before_delivery()
     assert monitor._ESCALATED_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
-def test_reconcile_finishes_delivered_escalation_cleanup_without_reposting():
+def test_reconcile_retries_preexisting_pending_escalation():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._ESCALATED_LABEL])})
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: completed delivered channel escalation'],
+        ['#7: queued channel escalation'],
         [],
     )
-    assert notices == []
+    assert notices[0]['expected_stage'] == 2
     assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
-    assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
+    assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
 
 def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
@@ -639,6 +710,25 @@ def test_finalize_records_escalation_then_clears_active_state():
     assert monitor._ESCALATED_LABEL in labels
 
 
+def test_finalize_delivers_a_preexisting_stage_two_escalation():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
+
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, 2)]}),
+    ) == ['#7: recorded channel escalation']
+    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
 def test_finalize_skips_notice_when_stage_changed_during_delivery():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=['alice'])})
     client.permissions = {'alice': 'write'}
@@ -655,6 +745,20 @@ def test_finalize_skips_notice_when_stage_changed_during_delivery():
 
 
 @pytest.mark.parametrize(
+    'ref',
+    [
+        notice_ref(7, 0, transition_id='replacement-transition'),
+        notice_ref(7, 0, recipients=['different-owner']),
+    ],
+)
+def test_finalize_skips_notice_when_transition_or_owner_changed(ref: dict[str, object]):
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+
+    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [ref]})) == []
+    assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+@pytest.mark.parametrize(
     'contents',
     [
         [7],
@@ -665,7 +769,9 @@ def test_finalize_skips_notice_when_stage_changed_during_delivery():
         {'items': [notice_ref(0, 0)]},
         {'items': [notice_ref(7, 0), notice_ref(7, 0)]},
         {'items': [notice_ref(number, 0) for number in range(1, monitor._RECONCILE_LIMIT + 2)]},
-        {'items': [notice_ref(7, 2)]},
+        {'items': [notice_ref(7, 3)]},
+        {'items': [notice_ref(7, 0, transition_id='')]},
+        {'items': [notice_ref(7, 0, recipients=['bad login'])]},
     ],
 )
 def test_notice_input_rejects_invalid_shapes(contents: object):
@@ -695,6 +801,8 @@ def test_notice_output_is_actionable_and_escapes_untrusted_titles(tmp_path: Path
             {
                 'number': 7,
                 'kind': 'reminder',
+                'expected_stage': 0,
+                'transition_id': 'event-7',
                 'title': 'Handle <unsafe>\n*fake owner* | <!channel>',
                 'recipients': ['DouweM'],
             }
@@ -703,12 +811,13 @@ def test_notice_output_is_actionable_and_escapes_untrusted_titles(tmp_path: Path
 
     values = dict(line.split('=', 1) for line in output.read_text(encoding='utf-8').splitlines())
     assert values['has_notices'] == 'true'
-    assert json.loads(values['notice_items']) == [notice_ref(7, 0)]
+    assert json.loads(values['notice_items']) == [notice_ref(7, 0, transition_id='event-7', recipients=['DouweM'])]
     text = json.loads(values['slack_payload'])['text']
     assert text.count('<!channel>') == 1
     assert '#7 Handle &lt;unsafe&gt; fake owner &lt;!channel&gt;' in text
     assert 'owner @DouweM; why: no maintainer has acted for three days' in text
     assert '*Expected action:*' in text
+    assert 'If no work is needed, say so briefly' in text
     assert 'Do not remove the attention labels' in text
 
 
@@ -844,6 +953,42 @@ def test_closed_item_completes_and_strips_lifecycle_labels():
     assert not any(call[1].endswith('/comments') for call in client.calls)
 
 
+def test_close_and_reopen_between_runs_retires_the_old_lifecycle():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._PINGED_LABEL},
+        },
+        {'event': 'closed', 'created_at': '2026-07-18T00:00:00Z', 'actor': {'login': 'contributor'}},
+        {'event': 'reopened', 'created_at': '2026-07-18T00:01:00Z', 'actor': {'login': 'contributor'}},
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        ['#7: completed after the item was closed'],
+        [],
+    )
+    assert not {monitor._ACTION_LABEL, monitor._PINGED_LABEL}.intersection(
+        {label['name'] for label in client.items[7]['labels']}
+    )
+
+
+def test_cleanup_keeps_active_retry_state_if_stage_cleanup_fails():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
+    client.fail_delete_labels.add(monitor._PINGED_LABEL)
+
+    with pytest.raises(urllib.error.HTTPError):
+        monitor._complete(client, 'r', 7, {monitor._ACTION_LABEL, monitor._PINGED_LABEL})
+
+    assert monitor._ACTION_LABEL in {label['name'] for label in client.items[7]['labels']}
+    assert not any(
+        call[0] == 'DELETE' and urllib.parse.unquote(call[1]).endswith(f'/{monitor._ACTION_LABEL}')
+        for call in client.calls
+    )
+
+
 def test_reopened_item_without_action_label_fires_no_reminder():
     # After the closed-item completion strips the labels, a reopen leaves no
     # action label, so no stage transition can fire an instant reminder.
@@ -861,8 +1006,28 @@ def test_full_page_processes_a_bounded_batch_instead_of_aborting():
     lines, failures = monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW)
 
     assert failures == []
-    assert sum('queued channel reminder' in line for line in lines) == monitor._RECONCILE_LIMIT
+    assert sum('queued channel reminder' in line for line in lines) == monitor._ACTIVE_OPEN_LIMIT
     assert lines[-1] == 'additional attention items remain for a later rotated batch'
+
+
+def test_active_attention_pages_rotate_between_runs():
+    client = FakeClient(
+        {
+            number: item(number, labels=[monitor._ACTION_LABEL])
+            for number in range(1, monitor._ACTIVE_OPEN_LIMIT * 2 + 2)
+        }
+    )
+
+    monitor.reconcile(client, 'r', now=NOW)
+    monitor.reconcile(client, 'r', now=NOW + dt.timedelta(hours=6))
+
+    searches = [
+        path
+        for method, path, _ in client.calls
+        if method == 'GET' and path.startswith('/search/issues?') and f'per_page={monitor._ACTIVE_OPEN_LIMIT}&' in path
+    ]
+    assert len(searches) == 2
+    assert searches[0] != searches[1]
 
 
 def test_one_item_failure_does_not_block_later_items():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -35,6 +35,8 @@ def item(
         'title': f'Item {number}',
         'body': 'Please decide the project direction.',
         'comments': 0,
+        'user': {'login': 'contributor'},
+        'author_association': 'NONE',
         'labels': [{'name': label} for label in labels or []],
         'assignees': [{'login': login} for login in assignees or []],
     }
@@ -203,6 +205,18 @@ def test_github_client_pages_follow_oldest_first_pagination():
 
     assert list(client.pages('/items', count=2)) == [[{'id': 1}], [{'id': 2}]]
     assert calls == ['/items?per_page=100&page=1', '/items?per_page=100&page=2']
+
+
+def test_github_client_pages_reject_truncated_history():
+    client = monitor.GitHubClient('token')
+
+    def request(method: str, path: str, payload: object = None) -> tuple[object, str | None]:
+        return ([{'id': 1}], '<https://api.github.com/items?per_page=100&page=2>; rel="next"')
+
+    client._request = request  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match='exceeds the 1-page safety limit'):
+        list(client.pages('/items', count=1))
 
 
 def test_build_and_write_snapshot_are_bounded_and_agent_readable(tmp_path: Path):
@@ -389,6 +403,12 @@ def test_apply_assigns_first_maintainer_who_discussed_the_issue(tmp_path: Path):
         },
         {
             'event': 'commented',
+            'created_at': '2026-02-09T16:00:00Z',
+            'user': {'login': 'former-maintainer'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'commented',
             'created_at': '2026-02-09T16:48:57Z',
             'user': {'login': 'DouweM'},
             'author_association': 'MEMBER',
@@ -405,6 +425,81 @@ def test_apply_assigns_first_maintainer_who_discussed_the_issue(tmp_path: Path):
         '#7: requested maintainer attention from @DouweM'
     ]
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+    assert sum('/collaborators/former-maintainer/permission' in call[1] for call in client.calls) == 1
+
+
+def test_apply_assigns_maintainer_issue_author_before_commenters(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    issue = item(7)
+    issue['user'] = {'login': 'alice'}
+    issue['author_association'] = 'MEMBER'
+    client = FakeClient({7: issue})
+    client.permissions = {'alice': 'write', 'bob': 'write'}
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': OLD,
+            'user': {'login': 'bob'},
+            'author_association': 'MEMBER',
+        }
+    ]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @alice'
+    ]
+
+
+def test_apply_does_not_infer_pull_request_ownership_from_discussion(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    pull = {**item(7), 'pull_request': {'url': 'https://api.github.test/pulls/7'}}
+    client = FakeClient({7: pull})
+    client.permissions = {'alice': 'write'}
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': OLD,
+            'user': {'login': 'alice'},
+            'author_association': 'MEMBER',
+        }
+    ]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @adtyavrdhn'
+    ]
+    assert not any(call[0] == 'PAGES' for call in client.calls)
+
+
+def test_apply_preserves_maintainer_assigned_while_history_is_scanned(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    client = FakeClient({7: item(7)})
+    client.permissions = {'alice': 'write', 'bob': 'write'}
+
+    def pages(path: str, *, count: int = 1):
+        client.items[7]['assignees'] = [{'login': 'bob'}]
+        yield [
+            {
+                'event': 'commented',
+                'created_at': OLD,
+                'user': {'login': 'alice'},
+                'author_association': 'MEMBER',
+            }
+        ]
+
+    client.pages = pages  # type: ignore[method-assign]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @bob'
+    ]
+    assert not any(call[1].endswith('/assignees') for call in client.calls)
 
 
 def test_apply_restarts_a_prior_terminal_escalation(tmp_path: Path):
@@ -563,6 +658,31 @@ def test_reconcile_reminds_assigned_maintainers():
     comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
     assert comment[2] == {'body': '@alice @bob this still needs a maintainer decision. Could you take a look?'}
     assert any(call[0] == 'POST' and call[2] == {'labels': [monitor._PINGED_LABEL]} for call in client.calls)
+
+
+def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T16:48:57Z',
+            'actor': {'login': 'DouweM'},
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
+    assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
 
 
 def test_reconcile_queues_private_escalation_without_public_comment():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -969,6 +969,38 @@ def test_reconcile_rechecks_state_after_assignment_transition_validation():
     assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
 
 
+def test_reconcile_rechecks_update_after_assignment_transition_validation():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.timelines[7] = [
+        {
+            'id': 'original-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        }
+    ]
+    original_last_pages = client.last_pages
+
+    def last_pages(path: str, *, count: int = 1):
+        events = original_last_pages(path, count=count)
+        if path.endswith('/events') and any(
+            call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls
+        ):
+            client.items[7] = {**client.items[7], 'updated_at': '2026-07-17T00:00:00Z'}
+        return events
+
+    client.last_pages = last_pages  # type: ignore[method-assign]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention state changed during owner selection'],
+    )
+    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
+
+
 def test_reconcile_stops_if_attention_state_changes_during_owner_selection():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
     client.permissions = {'DouweM': 'admin'}

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -94,7 +94,7 @@ class FakeClient:
                     {
                         'id': 'concurrent-restart',
                         'event': 'labeled',
-                        'created_at': '2026-07-17T00:00:00Z',
+                        'created_at': OLD,
                         'actor': {'login': 'github-actions[bot]'},
                         'label': {'name': monitor._ACTION_LABEL},
                     }
@@ -829,6 +829,7 @@ def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
             'author_association': 'MEMBER',
         },
         {
+            'id': 'original-transition',
             'event': 'labeled',
             'created_at': OLD,
             'actor': {'login': 'github-actions[bot]'},
@@ -881,6 +882,7 @@ def test_reconcile_stops_if_lifecycle_restarts_during_assignment_request():
             'author_association': 'MEMBER',
         },
         {
+            'id': 'original-transition',
             'event': 'labeled',
             'created_at': OLD,
             'actor': {'login': 'github-actions[bot]'},

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -47,29 +47,13 @@ class FakeClient:
         self.items = items or {}
         self.calls: list[tuple[str, str, object | None]] = []
         self.fail_get: set[int] = set()
-        self.fail_delete_labels: set[str] = set()
         self.assignment_succeeds = True
-        self.assignment_response_assignees: list[str] = []
-        self.assignment_response_state: str | None = None
-        self.assignment_restarts_attention = False
         self.permissions: dict[str, str] = {}
+        self.comments: dict[int, list[dict[str, Any]]] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
     def get(self, path: str) -> Any:
         self.calls.append(('GET', path, None))
-        if path.startswith('/search/issues?'):
-            values = [
-                value
-                for value in self.items.values()
-                if value['state'] == 'open'
-                and monitor._ACTION_LABEL in {str(label['name']) for label in value['labels']}
-                and monitor._NOTIFIED_LABEL not in {str(label['name']) for label in value['labels']}
-            ]
-            query = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
-            per_page = int(query.get('per_page', ['30'])[0])
-            page = int(query.get('page', ['1'])[0])
-            start = (page - 1) * per_page
-            return {'total_count': len(values), 'items': values[start : start + per_page]}
         if '/labels/' in path:
             return {'name': path.rsplit('/', 1)[-1]}
         if '/issues?state=' in path and 'labels=' in path:
@@ -79,8 +63,7 @@ class FakeClient:
             ]
         if '/collaborators/' in path and path.endswith('/permission'):
             login = path.split('/collaborators/')[1].split('/')[0]
-            default = 'write' if login == monitor._FALLBACK_OWNER else 'read'
-            return {'permission': self.permissions.get(login, default)}
+            return {'permission': self.permissions.get(login, 'write' if login == monitor._FALLBACK_OWNER else 'read')}
         if '/issues/' in path and '/comments?' not in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             if number in self.fail_get:
@@ -94,44 +77,21 @@ class FakeClient:
         self.calls.append(('POST', path, payload))
         if path.endswith('/assignees'):
             assert isinstance(payload, dict)
-            assignees = payload['assignees']
-            assert isinstance(assignees, list)
             number = int(path.split('/issues/')[1].split('/')[0])
+            requested = [str(login) for login in payload['assignees']] if self.assignment_succeeds else []
             existing = [str(value['login']) for value in self.items[number]['assignees']]
-            requested = [str(login) for login in assignees] if self.assignment_succeeds else []
-            result = dict.fromkeys([*existing, *requested, *self.assignment_response_assignees])
-            response = {**self.items[number], 'assignees': [{'login': login} for login in result]}
-            if self.assignment_response_state is not None:
-                response['state'] = self.assignment_response_state
-            if self.assignment_restarts_attention:
-                self.timelines.setdefault(number, []).append(
-                    {
-                        'id': 'concurrent-restart',
-                        'event': 'labeled',
-                        'created_at': OLD,
-                        'actor': {'login': 'github-actions[bot]'},
-                        'label': {'name': monitor._ACTION_LABEL},
-                    }
-                )
+            response = {
+                **self.items[number],
+                'assignees': [{'login': login} for login in dict.fromkeys([*existing, *requested])],
+            }
             self.items[number] = response
             return response
         if path.endswith('/labels'):
             assert isinstance(payload, dict)
-            labels = payload['labels']
-            assert isinstance(labels, list)
             number = int(path.split('/issues/')[1].split('/')[0])
             existing = {str(value['name']) for value in self.items[number]['labels']}
+            labels = [str(label) for label in payload['labels']]
             self.items[number]['labels'].extend({'name': label} for label in labels if label not in existing)
-            self.timelines.setdefault(number, []).extend(
-                {
-                    'id': f'bot-label-{len(self.timelines.get(number, [])) + index}',
-                    'event': 'labeled',
-                    'created_at': str(self.items[number]['updated_at']),
-                    'actor': {'login': 'github-actions[bot]'},
-                    'label': {'name': label},
-                }
-                for index, label in enumerate(labels)
-            )
         return {}
 
     def delete(self, path: str) -> None:
@@ -139,8 +99,6 @@ class FakeClient:
         if '/labels/' in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             removed = urllib.parse.unquote(path.rsplit('/', 1)[-1])
-            if removed in self.fail_delete_labels:
-                raise urllib.error.HTTPError(path, 500, 'boom', {}, None)
             self.items[number]['labels'] = [
                 value for value in self.items[number]['labels'] if str(value['name']) != removed
             ]
@@ -149,48 +107,26 @@ class FakeClient:
         self.calls.append(('LAST', path, None))
         number = int(path.split('/issues/')[1].split('/')[0])
         if number in self.timelines:
-            return [
-                {**event, 'id': event.get('id', f'event-{index}')} for index, event in enumerate(self.timelines[number])
-            ]
+            return self.timelines[number]
         labels = {label['name'] for label in self.items[number]['labels']}
         stage = monitor._stage(labels)
         label = monitor._ACTION_LABEL if stage == 0 else monitor._STAGE_LABELS[stage - 1]
-        stage_event = {
-            'id': f'default-stage-{stage}',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': label},
-        }
-        notified_event = {
-            'id': 'default-notified',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._NOTIFIED_LABEL},
-        }
-        events = [stage_event]
-        if monitor._NOTIFIED_LABEL in labels:
-            events = [stage_event, notified_event] if stage == 0 else [notified_event, stage_event]
+        events = [
+            {
+                'event': 'labeled',
+                'created_at': OLD,
+                'actor': {'login': 'github-actions[bot]'},
+                'label': {'name': label},
+            }
+        ]
         return events
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         return self.last_page(path)
 
-    def maintainer_logins(self, repo: str) -> frozenset[str]:
-        self.calls.append(('MAINTAINERS', repo, None))
-        maintainers = {
-            login.casefold()
-            for login, permission in self.permissions.items()
-            if permission in monitor._MAINTAINER_PERMISSIONS
-        }
-        maintainers.add(monitor._FALLBACK_OWNER.casefold())
-        return frozenset(maintainers)
-
-    def pages(self, path: str, *, count: int = 1):
-        self.calls.append(('PAGES', path, count))
+    def pages(self, path: str, *, count: int):
         number = int(path.split('/issues/')[1].split('/')[0])
-        yield self.timelines.get(number, [])
+        yield self.comments.get(number, [])
 
 
 class SnapshotClient(FakeClient):
@@ -256,72 +192,10 @@ def write_output(
     )
 
 
-def notice_ref(
-    number: int,
-    kind: str,
-    stage: int,
-    *,
-    transition_id: int | str | None = None,
-    recipients: list[str] | None = None,
-) -> dict[str, object]:
-    return {
-        'number': number,
-        'kind': kind,
-        'expected_stage': stage,
-        'transition_id': transition_id or f'default-stage-{stage}',
-        'recipients': recipients or [monitor._FALLBACK_OWNER],
-    }
-
-
 def test_last_page_uses_the_page_containing_the_newest_activity():
     assert monitor._last_page(0, 8) == 1
     assert monitor._last_page(8, 8) == 1
     assert monitor._last_page(9, 8) == 2
-
-
-def test_github_client_pages_follow_oldest_first_pagination():
-    client = monitor.GitHubClient('token')
-    calls: list[str] = []
-
-    def request(method: str, path: str, payload: object = None) -> tuple[object, str | None]:
-        assert method == 'GET'
-        assert payload is None
-        calls.append(path)
-        if len(calls) == 1:
-            return ([{'id': 1}], '<https://api.github.com/items?per_page=100&page=2>; rel="next"')
-        return ([{'id': 2}], None)
-
-    client._request = request  # type: ignore[method-assign]
-
-    assert list(client.pages('/items', count=2)) == [[{'id': 1}], [{'id': 2}]]
-    assert calls == ['/items?per_page=100&page=1', '/items?per_page=100&page=2']
-
-
-def test_github_client_pages_reject_truncated_history():
-    client = monitor.GitHubClient('token')
-
-    def request(method: str, path: str, payload: object = None) -> tuple[object, str | None]:
-        return ([{'id': 1}], '<https://api.github.com/items?per_page=100&page=2>; rel="next"')
-
-    client._request = request  # type: ignore[method-assign]
-
-    with pytest.raises(RuntimeError, match='exceeds the 1-page safety limit'):
-        list(client.pages('/items', count=1))
-
-
-def test_github_client_caches_bounded_maintainer_snapshot():
-    client = monitor.GitHubClient('token')
-    calls: list[str] = []
-
-    def request(method: str, path: str, payload: object = None) -> tuple[object, str | None]:
-        calls.append(path)
-        return ([{'login': 'Alice'}, {'login': 'Bob'}], None)
-
-    client._request = request  # type: ignore[method-assign]
-
-    assert client.maintainer_logins('r') == frozenset({'alice', 'bob'})
-    assert client.maintainer_logins('r') == frozenset({'alice', 'bob'})
-    assert calls == ['/repos/r/collaborators?permission=push&per_page=100&page=1']
 
 
 def test_build_and_write_snapshot_are_bounded_and_agent_readable(tmp_path: Path):
@@ -381,40 +255,14 @@ def test_snapshot_skips_active_recent_and_escalated_items():
     assert [candidate['number'] for candidate in candidates] == [2]
 
 
-def test_candidate_search_excludes_active_and_escalated_labels():
+def test_candidate_search_covers_recent_activity_and_the_backlog():
     client = SnapshotClient({})
     monitor._candidate_page(client, 'pydantic/pydantic-ai', now=NOW)
 
-    query = client.calls[0][1]
-    assert urllib.parse.quote_plus(f'-label:"{monitor._ACTION_LABEL}"') in query
-    assert urllib.parse.quote_plus(f'-label:"{monitor._ESCALATED_LABEL}"') in query
-
-
-def test_candidate_search_combines_recent_activity_with_rotating_backlog():
-    class SearchClient:
-        def __init__(self) -> None:
-            self.calls: list[str] = []
-
-        def get(self, path: str) -> object:
-            self.calls.append(path)
-            if 'per_page=1' in path:
-                return {'total_count': 100}
-            if 'order=desc' in path:
-                return {'items': [item(number) for number in range(96, 101)]}
-            return {'items': [item(number) for number in range(1, 6)]}
-
-    client = SearchClient()
-
-    candidates = monitor._candidate_page(client, 'pydantic/pydantic-ai', now=NOW)  # type: ignore[arg-type]
-    later = SearchClient()
-    monitor._candidate_page(later, 'pydantic/pydantic-ai', now=NOW + dt.timedelta(hours=6))  # type: ignore[arg-type]
-
-    assert [candidate['number'] for candidate in candidates] == [*range(96, 101), *range(1, 6)]
-    recent_call = next(call for call in client.calls if 'order=desc&per_page=5&page=' in call)
-    later_recent_call = next(call for call in later.calls if 'order=desc&per_page=5&page=' in call)
-    assert 'updated%3A%3E%3D2026-06-05' in recent_call
-    assert recent_call.rsplit('page=', 1)[1] != later_recent_call.rsplit('page=', 1)[1]
-    assert any('order=asc&per_page=5&page=' in call for call in client.calls)
+    searches = [path for method, path, _ in client.calls if method == 'GET' and path.startswith('/search/issues?')]
+    assert any('updated%3A%3E%3D' in path and 'order=desc' in path for path in searches)
+    assert any('order=asc' in path and f'-label%3A%22{monitor._ACTION_LABEL}%22' in path for path in searches)
+    assert all(f'-label%3A%22{monitor._ESCALATED_LABEL}%22' in path for path in searches)
 
 
 def test_snapshot_recheck_skips_items_closed_after_search():
@@ -497,6 +345,34 @@ def test_apply_revalidates_then_assigns_and_labels(tmp_path: Path):
     ) in client.calls
 
 
+def test_apply_assigns_the_first_maintainer_who_discussed_an_issue(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    issue = item(7)
+    issue['comments'] = 2
+    client = FakeClient({7: issue})
+    client.permissions = {'DouweM': 'write', 'later-maintainer': 'admin'}
+    client.comments[7] = [
+        {
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+            'created_at': '2026-01-01T00:00:00Z',
+        },
+        {
+            'user': {'login': 'later-maintainer'},
+            'author_association': 'MEMBER',
+            'created_at': '2026-02-01T00:00:00Z',
+        },
+    ]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @DouweM'
+    ]
+    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+
+
 def test_apply_pings_all_assigned_maintainers_without_reassigning(tmp_path: Path):
     snapshot = tmp_path / 'snapshot.json'
     output = tmp_path / 'output.json'
@@ -511,191 +387,6 @@ def test_apply_pings_all_assigned_maintainers_without_reassigning(tmp_path: Path
         '#7: requested maintainer attention from @alice @bob'
     ]
     assert not any(call[1].endswith('/assignees') for call in client.calls)
-
-
-def test_apply_assigns_first_maintainer_who_discussed_the_issue(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    client = FakeClient({7: item(7)})
-    client.permissions = {'former-maintainer': 'read', 'DouweM': 'write', 'dsfaccini': 'write'}
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T15:00:00Z',
-            'user': {'login': 'contributor'},
-            'author_association': 'NONE',
-        },
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T15:30:00Z',
-            'user': {'login': 'former-maintainer'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:00:00Z',
-            'user': {'login': 'former-maintainer'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:48:57Z',
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'event': 'commented',
-            'created_at': '2026-07-01T19:00:34Z',
-            'user': {'login': 'dsfaccini'},
-            'author_association': 'MEMBER',
-        },
-    ]
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @DouweM'
-    ]
-    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
-    assert sum(call[0] == 'MAINTAINERS' for call in client.calls) == 1
-
-
-def test_apply_assigns_maintainer_issue_author_before_commenters(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    issue = item(7)
-    issue['user'] = {'login': 'alice'}
-    issue['author_association'] = 'NONE'
-    client = FakeClient({7: issue})
-    client.permissions = {'alice': 'write', 'bob': 'write'}
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': OLD,
-            'user': {'login': 'bob'},
-            'author_association': 'MEMBER',
-        }
-    ]
-
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @alice'
-    ]
-
-
-def test_apply_counts_comment_written_before_maintainer_promotion(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    client = FakeClient({7: item(7)})
-    client.permissions = {'alice': 'write', 'bob': 'write'}
-    client.timelines[7] = [
-        {
-            'created_at': '2026-01-01T00:00:00Z',
-            'user': {'login': 'alice'},
-            'author_association': 'NONE',
-        },
-        {
-            'created_at': '2026-02-01T00:00:00Z',
-            'user': {'login': 'bob'},
-            'author_association': 'MEMBER',
-        },
-    ]
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @alice'
-    ]
-
-
-def test_apply_does_not_infer_pull_request_ownership_from_discussion(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    pull = {**item(7), 'pull_request': {'url': 'https://api.github.test/pulls/7'}}
-    client = FakeClient({7: pull})
-    client.permissions = {'alice': 'write'}
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': OLD,
-            'user': {'login': 'alice'},
-            'author_association': 'MEMBER',
-        }
-    ]
-
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @adtyavrdhn'
-    ]
-    assert not any(call[0] == 'PAGES' for call in client.calls)
-
-
-def test_apply_preserves_maintainer_assigned_while_history_is_scanned(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    client = FakeClient({7: item(7)})
-    client.permissions = {'alice': 'write', 'bob': 'write'}
-
-    def pages(path: str, *, count: int = 1):
-        client.items[7]['assignees'] = [{'login': 'bob'}]
-        yield [
-            {
-                'event': 'commented',
-                'created_at': OLD,
-                'user': {'login': 'alice'},
-                'author_association': 'MEMBER',
-            }
-        ]
-
-    client.pages = pages  # type: ignore[method-assign]
-
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @bob'
-    ]
-    assert not any(call[1].endswith('/assignees') for call in client.calls)
-
-
-def test_apply_stops_if_item_closes_while_history_is_scanned(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    client = FakeClient({7: item(7)})
-    client.permissions = {'alice': 'write'}
-
-    def pages(path: str, *, count: int = 1):
-        client.items[7]['state'] = 'closed'
-        yield [{'user': {'login': 'alice'}, 'author_association': 'MEMBER'}]
-
-    client.pages = pages  # type: ignore[method-assign]
-
-    with pytest.raises(RuntimeError, match='Attention state changed during owner selection'):
-        monitor.apply_decisions(client, 'r', str(output), str(snapshot))
-    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
-
-
-def test_apply_preserves_maintainer_assigned_during_assignment_request(tmp_path: Path):
-    snapshot = tmp_path / 'snapshot.json'
-    output = tmp_path / 'output.json'
-    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
-    write_output(output, ['7'])
-    client = FakeClient({7: item(7)})
-    client.permissions = {'alice': 'write', 'bob': 'write'}
-    client.assignment_response_assignees = ['bob']
-    client.timelines[7] = [
-        {
-            'created_at': OLD,
-            'user': {'login': 'alice'},
-            'author_association': 'MEMBER',
-        }
-    ]
-
-    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
-        '#7: requested maintainer attention from @alice @bob'
-    ]
-    assert not any(call[0] == 'DELETE' and call[1].endswith('/assignees') for call in client.calls)
 
 
 def test_apply_restarts_a_prior_terminal_escalation(tmp_path: Path):
@@ -845,349 +536,56 @@ def test_apply_skips_closed_or_already_actioned_items(tmp_path: Path):
         assert not any(call[0] == 'POST' and '/issues/7/' in call[1] for call in client.calls)
 
 
-def test_active_scan_prioritizes_items_without_a_channel_notice():
-    values = {
-        number: item(number, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])
-        for number in range(1, monitor._RECONCILE_LIMIT + 1)
-    }
-    values[26] = item(26, labels=[monitor._ACTION_LABEL])
-    client = FakeClient(values)
-
-    active = monitor._active_items(client, 'r', now=NOW)
-
-    assert active[0]['number'] == 26
-    assert len(active) == monitor._RECONCILE_LIMIT
+def notice_ref(number: int, stage: int) -> dict[str, int]:
+    return {'number': number, 'expected_stage': stage}
 
 
-def test_reconcile_queues_initial_channel_notice_for_assigned_maintainers():
+def test_reconcile_queues_channel_reminder_for_assigned_maintainers():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['bob', 'alice'])})
     client.permissions = {'alice': 'admin', 'bob': 'write'}
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW, notices=notices) == (
-        ['#7: queued initial triage channel notice'],
+        ['#7: queued channel reminder'],
         [],
     )
     assert notices == [
         {
             'number': 7,
-            'kind': 'initial',
-            'expected_stage': 0,
-            'transition_id': 'default-stage-0',
+            'kind': 'reminder',
             'title': 'Item 7',
             'recipients': ['alice', 'bob'],
         }
     ]
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
+    assert not any(call[1].endswith('/comments') for call in client.calls)
+    assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
-def test_reconcile_revalidates_attention_state_before_reminding_assignee():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
-    client.permissions = {'alice': 'write'}
-    original_get = client.get
-    item_reads = 0
-
-    def get(path: str):
-        nonlocal item_reads
-        if path.endswith('/issues/7'):
-            item_reads += 1
-            if item_reads == 2:
-                client.items[7]['state'] = 'closed'
-        return original_get(path)
-
-    client.get = get  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention state changed during owner selection'],
-    )
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
-
-
-def test_reconcile_revalidates_transition_before_reminding_existing_assignee():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
-    client.permissions = {'alice': 'write'}
-    client.timelines[7] = [
-        {
-            'id': 'original-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        }
-    ]
-    original_get = client.get
-    item_reads = 0
-
-    def get(path: str):
-        nonlocal item_reads
-        if path.endswith('/issues/7'):
-            item_reads += 1
-            if item_reads == 2:
-                client.timelines[7].append(
-                    {
-                        'id': 'concurrent-restart',
-                        'event': 'labeled',
-                        'created_at': OLD,
-                        'actor': {'login': 'github-actions[bot]'},
-                        'label': {'name': monitor._ACTION_LABEL},
-                    }
-                )
-        return original_get(path)
-
-    client.get = get  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention transition changed during owner selection'],
-    )
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
-
-
-def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:48:57Z',
-            'actor': {'login': 'DouweM'},
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'id': 'original-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-
-    notices: list[monitor.Notice] = []
-    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
-    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
-    assert notices[0]['recipients'] == ['DouweM']
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
-
-
-def test_reconcile_stops_if_item_closes_during_assignment_request():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.assignment_response_state = 'closed'
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:48:57Z',
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention state changed during owner selection'],
-    )
-    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
-    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
-
-
-def test_reconcile_stops_if_lifecycle_restarts_during_assignment_request():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.assignment_restarts_attention = True
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:48:57Z',
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'id': 'original-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention transition changed during owner selection'],
-    )
-    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
-    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
-
-
-def test_reconcile_rechecks_state_after_assignment_transition_validation():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.timelines[7] = [
-        {
-            'id': 'original-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        }
-    ]
-    original_last_pages = client.last_pages
-
-    def last_pages(path: str, *, count: int = 1):
-        if path.endswith('/events') and any(
-            call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls
-        ):
-            client.items[7] = {**client.items[7], 'state': 'closed'}
-        return original_last_pages(path, count=count)
-
-    client.last_pages = last_pages  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention state changed during owner selection'],
-    )
-    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
-    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
-
-
-def test_reconcile_rechecks_update_after_assignment_transition_validation():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.timelines[7] = [
-        {
-            'id': 'original-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        }
-    ]
-    original_last_pages = client.last_pages
-
-    def last_pages(path: str, *, count: int = 1):
-        events = original_last_pages(path, count=count)
-        if path.endswith('/events') and any(
-            call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls
-        ):
-            client.items[7] = {**client.items[7], 'updated_at': '2026-07-17T00:00:00Z'}
-        return events
-
-    client.last_pages = last_pages  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention state changed during owner selection'],
-    )
-    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
-    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
-
-
-def test_reconcile_stops_if_attention_state_changes_during_owner_selection():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:48:57Z',
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-
-    def pages(path: str, *, count: int = 1):
-        client.items[7]['state'] = 'closed'
-        yield client.timelines[7]
-
-    client.pages = pages  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention state changed during owner selection'],
-    )
-    assert not any(call[0] == 'POST' and call[1].endswith(('/assignees', '/comments')) for call in client.calls)
-
-
-def test_reconcile_stops_if_attention_lifecycle_restarts_during_owner_selection():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.permissions = {'DouweM': 'admin'}
-    client.timelines[7] = [
-        {
-            'event': 'commented',
-            'created_at': '2026-02-09T16:48:57Z',
-            'user': {'login': 'DouweM'},
-            'author_association': 'MEMBER',
-        },
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-    ]
-
-    def pages(path: str, *, count: int = 1):
-        client.items[7] = {**client.items[7], 'updated_at': '2026-07-17T00:00:00Z'}
-        yield client.timelines[7]
-
-    client.pages = pages  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        [],
-        ['#7: RuntimeError: Attention state changed during owner selection'],
-    )
-    assert not any(call[0] == 'POST' and call[1].endswith(('/assignees', '/comments')) for call in client.calls)
-
-
-def test_reconcile_queues_channel_escalation_without_public_comment():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
+def test_reconcile_queues_channel_escalation_without_advancing_before_delivery():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW, notices=notices) == (
-        ['#7: queued terminal triage channel escalation'],
+        ['#7: queued channel escalation'],
         [],
     )
-    assert notices == [
-        {
-            'number': 7,
-            'kind': 'escalation',
-            'expected_stage': 1,
-            'transition_id': 'default-stage-1',
-            'title': 'Item 7',
-            'recipients': [monitor._FALLBACK_OWNER],
-        }
-    ]
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
+    assert notices[0]['kind'] == 'escalation'
+    assert not any(call[1].endswith('/comments') for call in client.calls)
     assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
+    assert monitor._ESCALATED_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
-def test_reconcile_retries_channel_escalation_until_delivery():
+def test_reconcile_finishes_delivered_escalation_cleanup_without_reposting():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._ESCALATED_LABEL])})
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued terminal triage channel escalation'],
+        ['#7: completed delivered channel escalation'],
         [],
     )
-    assert notices[0]['kind'] == 'escalation'
-    assert notices[0]['expected_stage'] == 2
+    assert notices == []
     assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
-    assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
+    assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
 
 def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
@@ -1216,367 +614,62 @@ def test_terminal_stage_preserves_the_reminder_acknowledgement_boundary():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
 
 
-def test_reconcile_rechecks_acknowledgement_before_queueing_slack():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
-    event = {
-        'id': 'reminder-transition',
-        'event': 'labeled',
-        'created_at': OLD,
-        'actor': {'login': 'github-actions[bot]'},
-        'label': {'name': monitor._PINGED_LABEL},
-    }
-
-    def pages(path: str, *, count: int = 1) -> list[dict[str, Any]]:
-        if path.endswith('/events'):
-            return [event]
-        return [
-            event,
-            {
-                'event': 'commented',
-                'created_at': '2026-07-18T00:00:00Z',
-                'actor': {'login': monitor._FALLBACK_OWNER},
-            },
-        ]
-
-    client.last_pages = pages  # type: ignore[method-assign]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
-
-
-def test_finalize_records_initial_notice_only_after_channel_delivery():
+def test_finalize_advances_reminder_only_after_channel_delivery():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
 
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]}),
-    ) == ['#7: recorded initial triage channel notice']
-    assert monitor._NOTIFIED_LABEL in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_advances_reminder_only_after_channel_delivery():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL],
-                assignees=[monitor._FALLBACK_OWNER],
-            )
-        }
-    )
-
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 'reminder', 0)]}),
-    ) == ['#7: recorded triage channel reminder']
-    assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_clears_active_state_only_after_channel_escalation():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._ESCALATED_LABEL],
-                assignees=[monitor._FALLBACK_OWNER],
-            )
-        }
-    )
-
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 'escalation', 2)]}),
-    ) == ['#7: recorded terminal triage channel escalation']
-    assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
-
-
-def test_finalize_continues_after_one_delivered_item_fails():
-    client = FakeClient(
-        {
-            7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL], assignees=[monitor._FALLBACK_OWNER]),
-            8: item(8, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL], assignees=[monitor._FALLBACK_OWNER]),
-        }
-    )
-    client.fail_get.add(7)
-
-    with pytest.raises(RuntimeError, match=r'#7: HTTPError'):
-        monitor.finalize_notices(
-            client,
-            'r',
-            monitor._notice_refs({'items': [notice_ref(7, 'escalation', 2), notice_ref(8, 'escalation', 2)]}),
-        )
-    assert any(call[0] == 'DELETE' and '/issues/8/' in call[1] for call in client.calls)
-
-
-def test_finalize_clears_delivered_state_if_item_closed_during_delivery():
-    closed = item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])
-    closed['state'] = 'closed'
-    client = FakeClient({7: closed})
-
-    assert (
-        monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'escalation', 2)]})) == []
-    )
-    assert not {monitor._ACTION_LABEL, monitor._ESCALATED_LABEL}.intersection(
-        {label['name'] for label in client.items[7]['labels']}
-    )
-
-
-@pytest.mark.parametrize(
-    ('labels', 'kind', 'stage', 'transition_label', 'transition_id'),
-    [
-        (
-            [monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL],
-            'reminder',
-            0,
-            monitor._ACTION_LABEL,
-            'action-transition',
-        ),
-        (
-            [monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL],
-            'escalation',
-            1,
-            monitor._PINGED_LABEL,
-            'reminder-transition',
-        ),
-    ],
-)
-def test_finalize_retires_a_lifecycle_closed_and_reopened_during_channel_delivery(
-    labels: list[str],
-    kind: str,
-    stage: int,
-    transition_label: str,
-    transition_id: str,
-):
-    client = FakeClient({7: item(7, labels=labels, assignees=[monitor._FALLBACK_OWNER])})
-    client.timelines[7] = [
-        {
-            'id': transition_id,
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': transition_label},
-        },
-        {'event': 'closed', 'created_at': '2026-07-18T00:00:00Z', 'actor': {'login': 'contributor'}},
-        {'event': 'reopened', 'created_at': '2026-07-18T00:01:00Z', 'actor': {'login': 'contributor'}},
+    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 0)]})) == [
+        '#7: recorded channel reminder'
     ]
+    assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
+    assert monitor._ACTION_LABEL in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_finalize_records_escalation_then_clears_active_state():
+    client = FakeClient(
+        {7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=[monitor._FALLBACK_OWNER])}
+    )
 
     assert monitor.finalize_notices(
         client,
         'r',
-        monitor._notice_refs({'items': [notice_ref(7, kind, stage, transition_id=transition_id)]}),
-    ) == ['#7: completed after the item was closed']
-    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
+        monitor._notice_refs({'items': [notice_ref(7, 1)]}),
+    ) == ['#7: recorded channel escalation']
+    labels = {label['name'] for label in client.items[7]['labels']}
+    assert monitor._ACTION_LABEL not in labels
+    assert monitor._ESCALATED_LABEL in labels
 
 
-def test_finalize_skips_items_whose_state_was_already_cleared():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL]), 8: item(8)})
+def test_finalize_skips_notice_when_stage_changed_during_delivery():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=['alice'])})
+    client.permissions = {'alice': 'write'}
 
     assert (
         monitor.finalize_notices(
             client,
             'r',
-            monitor._notice_refs({'items': [notice_ref(7, 'reminder', 1), notice_ref(8, 'initial', 0)]}),
+            monitor._notice_refs({'items': [notice_ref(7, 0)]}),
         )
         == []
     )
-    assert not any(call[0] == 'DELETE' for call in client.calls)
-
-
-def test_finalize_skips_a_restarted_attention_transition():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.timelines[7] = [
-        {
-            'id': 'replacement-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        }
-    ]
-
-    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]})) == []
-    assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_skips_a_notice_after_the_owner_changes():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
-    client.permissions = {'alice': 'write'}
-
-    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]})) == []
-    assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_revalidates_a_restart_during_the_timeline_read():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    original_last_pages = client.last_pages
-
-    def last_pages(path: str, *, count: int = 1) -> list[dict[str, Any]]:
-        values = original_last_pages(path, count=count)
-        if path.endswith('/timeline'):
-            client.items[7]['updated_at'] = '2026-07-19T00:00:00Z'
-            client.timelines[7] = [
-                *values,
-                {
-                    'id': 'replacement-transition',
-                    'event': 'labeled',
-                    'created_at': '2026-07-19T00:00:00Z',
-                    'actor': {'login': 'github-actions[bot]'},
-                    'label': {'name': monitor._ACTION_LABEL},
-                },
-            ]
-        return values
-
-    client.last_pages = last_pages  # type: ignore[method-assign]
-
-    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]})) == []
-    assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_catches_acknowledgement_during_stage_advance():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL],
-                assignees=[monitor._FALLBACK_OWNER],
-            )
-        }
-    )
-    client.timelines[7] = [
-        {
-            'id': 'action-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        }
-    ]
-    original_post = client.post
-
-    def post(path: str, payload: object) -> object:
-        result = original_post(path, payload)
-        if isinstance(payload, dict) and payload.get('labels') == [monitor._PINGED_LABEL]:
-            client.timelines[7].append(
-                {
-                    'event': 'commented',
-                    'created_at': '2026-07-18T00:00:00Z',
-                    'actor': {'login': monitor._FALLBACK_OWNER},
-                }
-            )
-        return result
-
-    client.post = post  # type: ignore[method-assign]
-
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 'reminder', 0, transition_id='action-transition')]}),
-    ) == ['#7: maintainer acknowledged the delivered notice']
-    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
-
-
-def test_finalize_catches_acknowledgement_during_terminal_escalation():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL],
-                assignees=[monitor._FALLBACK_OWNER],
-            )
-        }
-    )
-    client.timelines[7] = [
-        {
-            'id': 'reminder-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._PINGED_LABEL},
-        }
-    ]
-    original_post = client.post
-
-    def post(path: str, payload: object) -> object:
-        result = original_post(path, payload)
-        if isinstance(payload, dict) and payload.get('labels') == [monitor._ESCALATED_LABEL]:
-            client.timelines[7].append(
-                {
-                    'event': 'commented',
-                    'created_at': OLD,
-                    'actor': {'login': monitor._FALLBACK_OWNER},
-                }
-            )
-        return result
-
-    client.post = post  # type: ignore[method-assign]
-
-    assert monitor.finalize_notices(
-        client,
-        'r',
-        monitor._notice_refs({'items': [notice_ref(7, 'escalation', 1, transition_id='reminder-transition')]}),
-    ) == ['#7: maintainer acknowledged the delivered notice']
-    assert not {monitor._ACTION_LABEL, monitor._ESCALATED_LABEL}.intersection(
-        {label['name'] for label in client.items[7]['labels']}
-    )
-
-
-def test_finalize_resumes_a_partially_recorded_terminal_escalation():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL],
-                assignees=[monitor._FALLBACK_OWNER],
-            )
-        }
-    )
-    client.timelines[7] = [
-        {
-            'id': 'reminder-transition',
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._PINGED_LABEL},
-        }
-    ]
-    notice = monitor._notice_refs({'items': [notice_ref(7, 'escalation', 1, transition_id='reminder-transition')]})
-    client.fail_delete_labels.add(monitor._PINGED_LABEL)
-
-    with pytest.raises(RuntimeError, match=r'#7: HTTPError'):
-        monitor.finalize_notices(client, 'r', notice)
-    assert {monitor._ACTION_LABEL, monitor._PINGED_LABEL, monitor._ESCALATED_LABEL}.issubset(
-        {label['name'] for label in client.items[7]['labels']}
-    )
-
-    client.fail_delete_labels.clear()
-    assert monitor.finalize_notices(client, 'r', notice) == ['#7: recorded terminal triage channel escalation']
-    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
-    assert monitor._ESCALATED_LABEL in {label['name'] for label in client.items[7]['labels']}
+    assert monitor._ESCALATED_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
 @pytest.mark.parametrize(
     'contents',
     [
         [7],
-        {'items': [notice_ref(7, 'initial', 0)], 'extra': 1},
+        {'items': [notice_ref(7, 0)], 'extra': 1},
         {'items': 7},
         {'items': [True]},
         {'items': ['7']},
-        {'items': [notice_ref(0, 'initial', 0)]},
-        {'items': [notice_ref(7, 'initial', 0), notice_ref(7, 'initial', 0)]},
-        {'items': [notice_ref(number, 'initial', 0) for number in range(1, monitor._RECONCILE_LIMIT + 2)]},
-        {'items': [notice_ref(7, 'initial', 2)]},
-        {'items': [notice_ref(7, 'unknown', 0)]},
-        {'items': [{**notice_ref(7, 'initial', 0), 'kind': []}]},
-        {'items': [{**notice_ref(7, 'initial', 0), 'transition_id': 'x' * 101}]},
-        {'items': [{**notice_ref(7, 'initial', 0), 'recipients': ['bad login']}]},
-        {'items': [{**notice_ref(7, 'initial', 0), 'recipients': ['Alice', 'alice']}]},
+        {'items': [notice_ref(0, 0)]},
+        {'items': [notice_ref(7, 0), notice_ref(7, 0)]},
+        {'items': [notice_ref(number, 0) for number in range(1, monitor._RECONCILE_LIMIT + 2)]},
+        {'items': [notice_ref(7, 2)]},
     ],
 )
 def test_notice_input_rejects_invalid_shapes(contents: object):
-    with pytest.raises(ValueError, match=r'[Nn]otice'):
+    with pytest.raises(ValueError, match='Notice'):
         monitor._notice_refs(contents)
 
 
@@ -1592,7 +685,7 @@ def test_snapshot_and_decision_batch_limits_are_enforced(tmp_path: Path):
         monitor._parse_decisions(str(output))
 
 
-def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_notice_output_is_actionable_and_escapes_untrusted_titles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     output = tmp_path / 'github-output'
     monkeypatch.setenv('GITHUB_OUTPUT', str(output))
 
@@ -1601,10 +694,8 @@ def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, mo
         [
             {
                 'number': 7,
-                'kind': 'initial',
-                'expected_stage': 0,
-                'transition_id': 'event-7',
-                'title': 'Handle <unsafe>\n*fake owner* | <!channel> & important',
+                'kind': 'reminder',
+                'title': 'Handle <unsafe>\n*fake owner* | <!channel>',
                 'recipients': ['DouweM'],
             }
         ],
@@ -1612,15 +703,11 @@ def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, mo
 
     values = dict(line.split('=', 1) for line in output.read_text(encoding='utf-8').splitlines())
     assert values['has_notices'] == 'true'
-    assert json.loads(values['notice_items']) == [
-        notice_ref(7, 'initial', 0, transition_id='event-7', recipients=['DouweM'])
-    ]
+    assert json.loads(values['notice_items']) == [notice_ref(7, 0)]
     text = json.loads(values['slack_payload'])['text']
-    assert text.startswith('<!channel> *Maintainer attention requested*')
-    assert '#7 Handle &lt;unsafe&gt; fake owner &lt;!channel&gt; &amp; important' in text
     assert text.count('<!channel>') == 1
-    assert '\n*fake owner*' not in text
-    assert '— owner @DouweM; why: triage identified a maintainer as the next actor' in text
+    assert '#7 Handle &lt;unsafe&gt; fake owner &lt;!channel&gt;' in text
+    assert 'owner @DouweM; why: no maintainer has acted for three days' in text
     assert '*Expected action:*' in text
     assert 'Do not remove the attention labels' in text
 
@@ -1641,93 +728,17 @@ def test_reconcile_rejects_a_foreign_stage_label():
 
 
 def test_recent_activity_delays_the_next_reminder():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
     client.timelines[7] = [
         {
             'event': 'labeled',
             'created_at': '2026-07-19T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'labeled',
-            'created_at': '2026-07-19T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._NOTIFIED_LABEL},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW) == ([], [])
-
-
-@pytest.mark.parametrize('actor', ['outside-collaborator', ''])
-def test_foreign_or_unverifiable_notified_label_cannot_suppress_initial_channel_notice(actor: str):
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
             'actor': {'login': 'github-actions[bot]'},
             'label': {'name': monitor._ACTION_LABEL},
         }
     ]
-    if actor:
-        client.timelines[7].append(
-            {
-                'event': 'labeled',
-                'created_at': '2026-07-19T00:00:00Z',
-                'actor': {'login': actor},
-                'label': {'name': monitor._NOTIFIED_LABEL},
-            }
-        )
 
-    notices: list[monitor.Notice] = []
-    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
-    assert notices[0]['kind'] == 'initial'
-    assert any(call[0] == 'DELETE' and monitor._NOTIFIED_LABEL in call[1] for call in client.calls)
-
-
-def test_initial_channel_delivery_starts_a_fresh_reminder_sla():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'labeled',
-            'created_at': '2026-07-19T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._NOTIFIED_LABEL},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
-
-
-def test_migrated_legacy_reminder_starts_a_fresh_escalation_sla():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._PINGED_LABEL},
-        },
-        {
-            'event': 'labeled',
-            'created_at': '2026-07-19T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._NOTIFIED_LABEL},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
+    assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW) == ([], [])
 
 
 def test_maintainer_comment_completes_the_request():
@@ -1796,51 +807,6 @@ def test_recipient_non_comment_event_completes_the_request():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
 
 
-def test_recipient_self_assignment_completes_the_request():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
-    client.permissions = {'alice': 'admin'}
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'assigned',
-            'created_at': '2026-07-17T00:00:00Z',
-            'actor': {'login': 'alice'},
-            'assignee': {'login': 'alice'},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
-
-
-def test_bot_assignment_does_not_acknowledge_the_request():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
-    client.permissions = {'alice': 'admin'}
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'assigned',
-            'created_at': '2026-07-17T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'assignee': {'login': 'alice'},
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
-
-
 def test_collaborator_comment_by_non_recipient_completes_the_request():
     # An outside collaborator with repo access can acknowledge via a comment even
     # when they are not one of the assigned recipients (COLLABORATOR association).
@@ -1864,126 +830,18 @@ def test_collaborator_comment_by_non_recipient_completes_the_request():
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
 
 
-def test_reconcile_does_not_create_public_ping_comments():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {
-            'event': 'commented',
-            'created_at': '2026-07-17T00:00:00Z',
-            'actor': {'login': 'github-actions[bot]'},
-            'body': '@adtyavrdhn old bot ping',
-        },
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
-
-
-def test_reconcile_migrates_legacy_pinged_state_to_channel_notice():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._PINGED_LABEL},
-        }
-    ]
-
-    notices: list[monitor.Notice] = []
-    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
-    assert notices[0]['kind'] == 'initial'
-    assert notices[0]['expected_stage'] == 1
-    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
-
-
-def test_legacy_notice_uses_the_current_maintainer_assignment():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=['bob'])})
-    client.permissions = {'bob': 'write'}
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._PINGED_LABEL},
-        },
-        {
-            'event': 'commented',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'body': '@alice this still needs a maintainer decision. Could you take a look?',
-        },
-    ]
-
-    notices: list[monitor.Notice] = []
-    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
-    assert notices[0]['recipients'] == ['bob']
-
-
 def test_closed_item_completes_and_strips_lifecycle_labels():
     # Closing an item is the ultimate resolution: the action and stage labels
     # are removed so a later reopen can't wake an ancient SLA clock.
-    closed = item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])
+    closed = item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])
     closed['state'] = 'closed'
     client = FakeClient({7: closed})
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: completed after the item was closed'], [])
     assert any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
-    assert any(call[0] == 'DELETE' and monitor._NOTIFIED_LABEL in call[1] for call in client.calls)
     assert any(call[0] == 'DELETE' and monitor._PINGED_LABEL in call[1] for call in client.calls)
-    # No public reminder or private escalation is produced for a closed item.
+    # No channel notice is produced for a closed item.
     assert not any(call[1].endswith('/comments') for call in client.calls)
-
-
-def test_close_and_reopen_between_runs_retires_the_old_lifecycle():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ACTION_LABEL},
-        },
-        {'event': 'closed', 'created_at': '2026-07-18T00:00:00Z', 'actor': {'login': 'contributor'}},
-        {'event': 'reopened', 'created_at': '2026-07-18T00:01:00Z', 'actor': {'login': 'contributor'}},
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        ['#7: completed after the item was closed'],
-        [],
-    )
-    assert not {monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL}.intersection(
-        {label['name'] for label in client.items[7]['labels']}
-    )
-
-
-def test_cleanup_keeps_the_action_label_if_auxiliary_cleanup_fails():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
-    client.fail_delete_labels.add(monitor._NOTIFIED_LABEL)
-
-    with pytest.raises(urllib.error.HTTPError):
-        monitor._complete(client, 'r', 7, {monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL})
-
-    assert monitor._ACTION_LABEL in {label['name'] for label in client.items[7]['labels']}
-    assert not any(
-        call[0] == 'DELETE' and urllib.parse.unquote(call[1]).endswith(f'/{monitor._ACTION_LABEL}')
-        for call in client.calls
-    )
 
 
 def test_reopened_item_without_action_label_fires_no_reminder():
@@ -2003,7 +861,7 @@ def test_full_page_processes_a_bounded_batch_instead_of_aborting():
     lines, failures = monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW)
 
     assert failures == []
-    assert sum('queued initial triage channel notice' in line for line in lines) == monitor._RECONCILE_LIMIT
+    assert sum('queued channel reminder' in line for line in lines) == monitor._RECONCILE_LIMIT
     assert lines[-1] == 'additional attention items remain for a later rotated batch'
 
 
@@ -2018,7 +876,7 @@ def test_one_item_failure_does_not_block_later_items():
 
     lines, failures = monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW)
 
-    assert lines == ['#2: queued initial triage channel notice']
+    assert lines == ['#2: queued channel reminder']
     assert failures and failures[0].startswith('#1: HTTPError')
     assert not any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
 
@@ -2041,7 +899,7 @@ def test_invalid_event_timestamp_does_not_block_later_items():
 
     lines, failures = monitor.reconcile(client, 'r', now=NOW)
 
-    assert lines == ['#2: queued initial triage channel notice']
+    assert lines == ['#2: queued channel reminder']
     assert failures and failures[0].startswith('#1: ValueError')
     assert not any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
 
@@ -2050,7 +908,7 @@ def test_one_item_failure_still_queues_other_notices():
     client = FakeClient(
         {
             1: item(1, labels=[monitor._ACTION_LABEL]),
-            2: item(2, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL]),
+            2: item(2, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL]),
         }
     )
     client.fail_get.add(1)
@@ -2058,7 +916,7 @@ def test_one_item_failure_still_queues_other_notices():
 
     lines, failures = monitor.reconcile(client, 'r', now=NOW, notices=notices)
 
-    assert lines == ['#2: queued terminal triage channel escalation']
+    assert lines == ['#2: queued channel escalation']
     assert [notice['number'] for notice in notices] == [2]
     assert failures and failures[0].startswith('#1: HTTPError')
 
@@ -2076,21 +934,12 @@ def test_bot_triggered_mention_event_is_not_an_acknowledgement():
         {'event': 'subscribed', 'created_at': '2026-07-17T00:00:00Z', 'actor': {'login': monitor._FALLBACK_OWNER}},
     ]
 
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        ['#7: queued initial triage channel notice'],
-        [],
-    )
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: queued channel reminder'], [])
 
 
 def test_latest_stage_transition_restarts_the_sla_clock():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
     client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._NOTIFIED_LABEL},
-        },
         {
             'event': 'labeled',
             'created_at': OLD,
@@ -2123,7 +972,7 @@ def test_sweep_restores_eligibility_after_new_activity():
             'actor': {'login': 'github-actions[bot]'},
             'label': {'name': monitor._ACTION_LABEL},
         },
-        {'event': 'commented', 'created_at': '2026-07-18T00:00:00Z', 'actor': {'login': 'contributor'}},
+        {'event': 'commented', 'created_at': OLD, 'actor': {'login': 'contributor'}},
     ]
 
     assert monitor.reconcile(client, 'r', now=NOW) == (
@@ -2131,23 +980,9 @@ def test_sweep_restores_eligibility_after_new_activity():
         [],
     )
     assert any(call[0] == 'DELETE' and monitor._ESCALATED_LABEL in call[1] for call in client.calls)
-
-
-def test_sweep_restores_same_second_activity_after_escalation():
-    client = FakeClient({7: item(7, labels=[monitor._ESCALATED_LABEL])})
-    client.timelines[7] = [
-        {
-            'event': 'labeled',
-            'created_at': OLD,
-            'actor': {'login': 'github-actions[bot]'},
-            'label': {'name': monitor._ESCALATED_LABEL},
-        },
-        {'event': 'commented', 'created_at': OLD, 'actor': {'login': 'contributor'}},
-    ]
-
-    assert monitor.reconcile(client, 'r', now=NOW) == (
-        ['#7: restored attention eligibility after new activity'],
-        [],
+    assert any(
+        call[0] == 'GET' and monitor._ESCALATED_LABEL in urllib.parse.unquote(call[1]) and 'direction=desc' in call[1]
+        for call in client.calls
     )
 
 
@@ -2170,10 +1005,6 @@ def test_sweep_keeps_untouched_escalated_item_dormant():
 
     assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
     assert not any(call[0] == 'DELETE' for call in client.calls)
-    assert any(
-        call[0] == 'GET' and monitor._ESCALATED_LABEL in urllib.parse.unquote(call[1]) and 'direction=desc' in call[1]
-        for call in client.calls
-    )
 
 
 def test_sweep_removes_a_foreign_escalation_marker():
@@ -2235,7 +1066,7 @@ def test_compiled_lock_keeps_agent_read_only_and_stable_artifact_name():
     assert 'name: attention-candidates-${{ github.run_id }}-' not in text
 
 
-def test_operations_workflow_routes_all_actionable_notices_to_the_triage_channel():
+def test_operations_workflow_routes_all_notices_to_the_triage_channel():
     workflow = Path(__file__).parent.parent / 'workflows' / 'issue-pr-attention-monitor.yml'
     text = workflow.read_text()
 
@@ -2244,7 +1075,6 @@ def test_operations_workflow_routes_all_actionable_notices_to_the_triage_channel
     assert 'issue_pr_attention_monitor.py finalize' in text
     assert 'permissions: {}' in text
     assert 'ATTENTION_NOTICES' in text
-    assert 'outputs.has_notices' in text
     assert 'Post actionable attention digest to the triage channel' in text
 
 

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -49,6 +49,7 @@ class FakeClient:
         self.fail_get: set[int] = set()
         self.assignment_succeeds = True
         self.assignment_response_assignees: list[str] = []
+        self.assignment_response_state: str | None = None
         self.permissions: dict[str, str] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
@@ -84,8 +85,10 @@ class FakeClient:
             existing = [str(value['login']) for value in self.items[number]['assignees']]
             requested = [str(login) for login in assignees] if self.assignment_succeeds else []
             result = dict.fromkeys([*existing, *requested, *self.assignment_response_assignees])
-            response = {'assignees': [{'login': login} for login in result]}
-            self.items[number]['assignees'] = response['assignees']
+            response = {**self.items[number], 'assignees': [{'login': login} for login in result]}
+            if self.assignment_response_state is not None:
+                response['state'] = self.assignment_response_state
+            self.items[number] = response
             return response
         if path.endswith('/labels'):
             assert isinstance(payload, dict)
@@ -816,6 +819,33 @@ def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
     comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
     assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
+
+
+def test_reconcile_stops_if_item_closes_during_assignment_request():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.assignment_response_state = 'closed'
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T16:48:57Z',
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        [],
+        ['#7: RuntimeError: Attention state changed during owner selection'],
+    )
+    assert any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith(('/labels', '/comments')) for call in client.calls)
 
 
 def test_reconcile_stops_if_attention_state_changes_during_owner_selection():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -47,6 +47,7 @@ class FakeClient:
         self.items = items or {}
         self.calls: list[tuple[str, str, object | None]] = []
         self.fail_get: set[int] = set()
+        self.fail_delete_labels: set[str] = set()
         self.assignment_succeeds = True
         self.assignment_response_assignees: list[str] = []
         self.assignment_response_state: str | None = None
@@ -56,6 +57,19 @@ class FakeClient:
 
     def get(self, path: str) -> Any:
         self.calls.append(('GET', path, None))
+        if path.startswith('/search/issues?'):
+            values = [
+                value
+                for value in self.items.values()
+                if value['state'] == 'open'
+                and monitor._ACTION_LABEL in {str(label['name']) for label in value['labels']}
+                and monitor._NOTIFIED_LABEL not in {str(label['name']) for label in value['labels']}
+            ]
+            query = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
+            per_page = int(query.get('per_page', ['30'])[0])
+            page = int(query.get('page', ['1'])[0])
+            start = (page - 1) * per_page
+            return {'total_count': len(values), 'items': values[start : start + per_page]}
         if '/labels/' in path:
             return {'name': path.rsplit('/', 1)[-1]}
         if '/issues?state=' in path and 'labels=' in path:
@@ -125,6 +139,8 @@ class FakeClient:
         if '/labels/' in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             removed = urllib.parse.unquote(path.rsplit('/', 1)[-1])
+            if removed in self.fail_delete_labels:
+                raise urllib.error.HTTPError(path, 500, 'boom', {}, None)
             self.items[number]['labels'] = [
                 value for value in self.items[number]['labels'] if str(value['name']) != removed
             ]
@@ -382,9 +398,14 @@ def test_candidate_search_combines_recent_activity_with_rotating_backlog():
     client = SearchClient()
 
     candidates = monitor._candidate_page(client, 'pydantic/pydantic-ai', now=NOW)  # type: ignore[arg-type]
+    later = SearchClient()
+    monitor._candidate_page(later, 'pydantic/pydantic-ai', now=NOW + dt.timedelta(hours=6))  # type: ignore[arg-type]
 
     assert [candidate['number'] for candidate in candidates] == [*range(96, 101), *range(1, 6)]
-    assert any('order=desc&per_page=5&page=1' in call for call in client.calls)
+    recent_call = next(call for call in client.calls if 'order=desc&per_page=5&page=' in call)
+    later_recent_call = next(call for call in later.calls if 'order=desc&per_page=5&page=' in call)
+    assert 'updated%3A%3E%3D2026-06-05' in recent_call
+    assert recent_call.rsplit('page=', 1)[1] != later_recent_call.rsplit('page=', 1)[1]
     assert any('order=asc&per_page=5&page=' in call for call in client.calls)
 
 
@@ -814,6 +835,20 @@ def test_apply_skips_closed_or_already_actioned_items(tmp_path: Path):
             '#7: skipped because the item changed after classification'
         ]
         assert not any(call[0] == 'POST' and '/issues/7/' in call[1] for call in client.calls)
+
+
+def test_active_scan_prioritizes_items_without_a_channel_notice():
+    values = {
+        number: item(number, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])
+        for number in range(1, monitor._RECONCILE_LIMIT + 1)
+    }
+    values[26] = item(26, labels=[monitor._ACTION_LABEL])
+    client = FakeClient(values)
+
+    active = monitor._active_items(client, 'r', now=NOW)
+
+    assert active[0]['number'] == 26
+    assert len(active) == monitor._RECONCILE_LIMIT
 
 
 def test_reconcile_queues_initial_channel_notice_for_assigned_maintainers():
@@ -1318,6 +1353,120 @@ def test_finalize_skips_a_notice_after_the_owner_changes():
     assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
+def test_finalize_revalidates_a_restart_during_the_timeline_read():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    original_last_pages = client.last_pages
+
+    def last_pages(path: str, *, count: int = 1) -> list[dict[str, Any]]:
+        values = original_last_pages(path, count=count)
+        if path.endswith('/timeline'):
+            client.items[7]['updated_at'] = '2026-07-19T00:00:00Z'
+            client.timelines[7] = [
+                *values,
+                {
+                    'id': 'replacement-transition',
+                    'event': 'labeled',
+                    'created_at': '2026-07-19T00:00:00Z',
+                    'actor': {'login': 'github-actions[bot]'},
+                    'label': {'name': monitor._ACTION_LABEL},
+                },
+            ]
+        return values
+
+    client.last_pages = last_pages  # type: ignore[method-assign]
+
+    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 'initial', 0)]})) == []
+    assert monitor._NOTIFIED_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_finalize_catches_acknowledgement_during_stage_advance():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
+    client.timelines[7] = [
+        {
+            'id': 'action-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        }
+    ]
+    original_post = client.post
+
+    def post(path: str, payload: object) -> object:
+        result = original_post(path, payload)
+        if isinstance(payload, dict) and payload.get('labels') == [monitor._PINGED_LABEL]:
+            client.timelines[7].append(
+                {
+                    'event': 'commented',
+                    'created_at': '2026-07-18T00:00:00Z',
+                    'actor': {'login': monitor._FALLBACK_OWNER},
+                }
+            )
+        return result
+
+    client.post = post  # type: ignore[method-assign]
+
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, 'reminder', 0, transition_id='action-transition')]}),
+    ) == ['#7: maintainer acknowledged the delivered notice']
+    assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
+
+
+def test_finalize_catches_acknowledgement_during_terminal_escalation():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
+    client.timelines[7] = [
+        {
+            'id': 'reminder-transition',
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._PINGED_LABEL},
+        }
+    ]
+    original_post = client.post
+
+    def post(path: str, payload: object) -> object:
+        result = original_post(path, payload)
+        if isinstance(payload, dict) and payload.get('labels') == [monitor._ESCALATED_LABEL]:
+            client.timelines[7].append(
+                {
+                    'event': 'commented',
+                    'created_at': OLD,
+                    'actor': {'login': monitor._FALLBACK_OWNER},
+                }
+            )
+        return result
+
+    client.post = post  # type: ignore[method-assign]
+
+    assert monitor.finalize_notices(
+        client,
+        'r',
+        monitor._notice_refs({'items': [notice_ref(7, 'escalation', 1, transition_id='reminder-transition')]}),
+    ) == ['#7: maintainer acknowledged the delivered notice']
+    assert not {monitor._ACTION_LABEL, monitor._ESCALATED_LABEL}.intersection(
+        {label['name'] for label in client.items[7]['labels']}
+    )
+
+
 @pytest.mark.parametrize(
     'contents',
     [
@@ -1380,8 +1529,7 @@ def test_notice_output_is_fixed_actionable_and_escapes_titles(tmp_path: Path, mo
     text = json.loads(values['slack_payload'])['text']
     assert text.startswith('<!channel> *Maintainer attention requested*')
     assert '#7 Handle &lt;unsafe&gt; &amp; important' in text
-    assert '— @DouweM' in text
-    assert '*Why:*' in text
+    assert '— owner @DouweM; why: triage identified a maintainer as the next actor' in text
     assert '*Expected action:*' in text
     assert 'Do not remove the attention labels' in text
 
@@ -1413,6 +1561,46 @@ def test_recent_activity_delays_the_next_reminder():
     ]
 
     assert monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW) == ([], [])
+
+
+def test_initial_channel_delivery_starts_a_fresh_reminder_sla():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'labeled',
+            'created_at': '2026-07-19T00:00:00Z',
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._NOTIFIED_LABEL},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
+
+
+def test_migrated_legacy_reminder_starts_a_fresh_escalation_sla():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL, monitor._PINGED_LABEL])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._PINGED_LABEL},
+        },
+        {
+            'event': 'labeled',
+            'created_at': '2026-07-19T00:00:00Z',
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._NOTIFIED_LABEL},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
 
 
 def test_maintainer_comment_completes_the_request():
@@ -1635,6 +1823,42 @@ def test_closed_item_completes_and_strips_lifecycle_labels():
     assert not any(call[1].endswith('/comments') for call in client.calls)
 
 
+def test_close_and_reopen_between_runs_retires_the_old_lifecycle():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {'event': 'closed', 'created_at': '2026-07-18T00:00:00Z', 'actor': {'login': 'contributor'}},
+        {'event': 'reopened', 'created_at': '2026-07-18T00:01:00Z', 'actor': {'login': 'contributor'}},
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        ['#7: completed after the item was closed'],
+        [],
+    )
+    assert not {monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL}.intersection(
+        {label['name'] for label in client.items[7]['labels']}
+    )
+
+
+def test_cleanup_keeps_the_action_label_if_auxiliary_cleanup_fails():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL])})
+    client.fail_delete_labels.add(monitor._NOTIFIED_LABEL)
+
+    with pytest.raises(urllib.error.HTTPError):
+        monitor._complete(client, 'r', 7, {monitor._ACTION_LABEL, monitor._NOTIFIED_LABEL})
+
+    assert monitor._ACTION_LABEL in {label['name'] for label in client.items[7]['labels']}
+    assert not any(
+        call[0] == 'DELETE' and urllib.parse.unquote(call[1]).endswith(f'/{monitor._ACTION_LABEL}')
+        for call in client.calls
+    )
+
+
 def test_reopened_item_without_action_label_fires_no_reminder():
     # After the closed-item completion strips the labels, a reopen leaves no
     # action label, so no stage transition can fire an instant reminder.
@@ -1776,6 +2000,24 @@ def test_sweep_restores_eligibility_after_new_activity():
     assert any(call[0] == 'DELETE' and monitor._ESCALATED_LABEL in call[1] for call in client.calls)
 
 
+def test_sweep_restores_same_second_activity_after_escalation():
+    client = FakeClient({7: item(7, labels=[monitor._ESCALATED_LABEL])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ESCALATED_LABEL},
+        },
+        {'event': 'commented', 'created_at': OLD, 'actor': {'login': 'contributor'}},
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (
+        ['#7: restored attention eligibility after new activity'],
+        [],
+    )
+
+
 def test_sweep_keeps_untouched_escalated_item_dormant():
     client = FakeClient({7: item(7, labels=[monitor._ESCALATED_LABEL])})
     client.timelines[7] = [
@@ -1795,6 +2037,10 @@ def test_sweep_keeps_untouched_escalated_item_dormant():
 
     assert monitor.reconcile(client, 'r', now=NOW) == ([], [])
     assert not any(call[0] == 'DELETE' for call in client.calls)
+    assert any(
+        call[0] == 'GET' and monitor._ESCALATED_LABEL in urllib.parse.unquote(call[1]) and 'direction=desc' in call[1]
+        for call in client.calls
+    )
 
 
 def test_sweep_removes_a_foreign_escalation_marker():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -48,6 +48,7 @@ class FakeClient:
         self.calls: list[tuple[str, str, object | None]] = []
         self.fail_get: set[int] = set()
         self.assignment_succeeds = True
+        self.assignment_response_assignees: list[str] = []
         self.permissions: dict[str, str] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
@@ -62,7 +63,8 @@ class FakeClient:
             ]
         if '/collaborators/' in path and path.endswith('/permission'):
             login = path.split('/collaborators/')[1].split('/')[0]
-            return {'permission': self.permissions.get(login, 'read')}
+            default = 'write' if login == monitor._FALLBACK_OWNER else 'read'
+            return {'permission': self.permissions.get(login, default)}
         if '/issues/' in path and '/comments?' not in path:
             number = int(path.split('/issues/')[1].split('/')[0])
             if number in self.fail_get:
@@ -78,11 +80,15 @@ class FakeClient:
             assert isinstance(payload, dict)
             assignees = payload['assignees']
             assert isinstance(assignees, list)
-            return {'assignees': [{'login': assignees[0]}]} if self.assignment_succeeds else {'assignees': []}
+            number = int(path.split('/issues/')[1].split('/')[0])
+            existing = [str(value['login']) for value in self.items[number]['assignees']]
+            requested = [str(login) for login in assignees] if self.assignment_succeeds else []
+            result = dict.fromkeys([*existing, *requested, *self.assignment_response_assignees])
+            return {'assignees': [{'login': login} for login in result]}
         return {}
 
-    def delete(self, path: str) -> None:
-        self.calls.append(('DELETE', path, None))
+    def delete(self, path: str, payload: object = None) -> None:
+        self.calls.append(('DELETE', path, payload))
 
     def last_page(self, path: str) -> list[dict[str, Any]]:
         self.calls.append(('LAST', path, None))
@@ -435,7 +441,7 @@ def test_apply_assigns_maintainer_issue_author_before_commenters(tmp_path: Path)
     write_output(output, ['7'])
     issue = item(7)
     issue['user'] = {'login': 'alice'}
-    issue['author_association'] = 'MEMBER'
+    issue['author_association'] = 'NONE'
     client = FakeClient({7: issue})
     client.permissions = {'alice': 'write', 'bob': 'write'}
     client.timelines[7] = [
@@ -445,6 +451,31 @@ def test_apply_assigns_maintainer_issue_author_before_commenters(tmp_path: Path)
             'user': {'login': 'bob'},
             'author_association': 'MEMBER',
         }
+    ]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @alice'
+    ]
+
+
+def test_apply_counts_comment_written_before_maintainer_promotion(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    client = FakeClient({7: item(7)})
+    client.permissions = {'alice': 'write', 'bob': 'write'}
+    client.timelines[7] = [
+        {
+            'created_at': '2026-01-01T00:00:00Z',
+            'user': {'login': 'alice'},
+            'author_association': 'NONE',
+        },
+        {
+            'created_at': '2026-02-01T00:00:00Z',
+            'user': {'login': 'bob'},
+            'author_association': 'MEMBER',
+        },
     ]
 
     assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
@@ -500,6 +531,28 @@ def test_apply_preserves_maintainer_assigned_while_history_is_scanned(tmp_path: 
         '#7: requested maintainer attention from @bob'
     ]
     assert not any(call[1].endswith('/assignees') for call in client.calls)
+
+
+def test_apply_preserves_maintainer_assigned_during_assignment_request(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    client = FakeClient({7: item(7)})
+    client.permissions = {'alice': 'write', 'bob': 'write'}
+    client.assignment_response_assignees = ['bob']
+    client.timelines[7] = [
+        {
+            'created_at': OLD,
+            'user': {'login': 'alice'},
+            'author_association': 'MEMBER',
+        }
+    ]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @bob'
+    ]
+    assert ('DELETE', '/repos/r/issues/7/assignees', {'assignees': ['alice']}) in client.calls
 
 
 def test_apply_restarts_a_prior_terminal_escalation(tmp_path: Path):
@@ -685,6 +738,67 @@ def test_reconcile_assigns_first_maintainer_who_discussed_the_issue():
     assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
 
 
+def test_reconcile_replaces_bot_assigned_fallback_with_issue_owner():
+    client = FakeClient(
+        {
+            7: {
+                **item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER]),
+                'user': {'login': 'DouweM'},
+            }
+        }
+    )
+    client.permissions = {monitor._FALLBACK_OWNER: 'write', 'DouweM': 'admin'}
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'assigned',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'assignee': {'login': monitor._FALLBACK_OWNER},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+    assert (
+        'DELETE',
+        '/repos/r/issues/7/assignees',
+        {'assignees': [monitor._FALLBACK_OWNER]},
+    ) in client.calls
+    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
+    assert comment[2] == {'body': '@DouweM this still needs a maintainer decision. Could you take a look?'}
+
+
+def test_reconcile_preserves_human_assigned_fallback():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
+    client.timelines[7] = [
+        {
+            'event': 'labeled',
+            'created_at': OLD,
+            'actor': {'login': 'github-actions[bot]'},
+            'label': {'name': monitor._ACTION_LABEL},
+        },
+        {
+            'event': 'assigned',
+            'created_at': OLD,
+            'actor': {'login': 'maintainer'},
+            'assignee': {'login': monitor._FALLBACK_OWNER},
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
+    assert not any(call[1].endswith('/assignees') for call in client.calls)
+    comment = next(call for call in client.calls if call[0] == 'POST' and call[1].endswith('/comments'))
+    assert comment[2] == {
+        'body': f'@{monitor._FALLBACK_OWNER} this still needs a maintainer decision. Could you take a look?'
+    }
+
+
 def test_reconcile_queues_private_escalation_without_public_comment():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
     escalations: list[int] = []
@@ -694,7 +808,7 @@ def test_reconcile_queues_private_escalation_without_public_comment():
         [],
     )
     assert escalations == [7]
-    assert not any(call[1].endswith('/comments') for call in client.calls)
+    assert not any(call[0] == 'POST' and call[1].endswith('/comments') for call in client.calls)
     assert not any(call[0] == 'DELETE' and monitor._ACTION_LABEL in call[1] for call in client.calls)
 
 

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -73,9 +73,10 @@ class FakeClient:
     def post(self, path: str, payload: object) -> Any:
         self.calls.append(('POST', path, payload))
         if path.endswith('/assignees'):
-            return (
-                {'assignees': [{'login': monitor._FALLBACK_OWNER}]} if self.assignment_succeeds else {'assignees': []}
-            )
+            assert isinstance(payload, dict)
+            assignees = payload['assignees']
+            assert isinstance(assignees, list)
+            return {'assignees': [{'login': assignees[0]}]} if self.assignment_succeeds else {'assignees': []}
         return {}
 
     def delete(self, path: str) -> None:
@@ -110,6 +111,11 @@ class FakeClient:
 
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         return self.last_page(path)
+
+    def pages(self, path: str, *, count: int = 1):
+        self.calls.append(('PAGES', path, count))
+        number = int(path.split('/issues/')[1].split('/')[0])
+        yield self.timelines.get(number, [])
 
 
 class SnapshotClient(FakeClient):
@@ -179,6 +185,24 @@ def test_last_page_uses_the_page_containing_the_newest_activity():
     assert monitor._last_page(0, 8) == 1
     assert monitor._last_page(8, 8) == 1
     assert monitor._last_page(9, 8) == 2
+
+
+def test_github_client_pages_follow_oldest_first_pagination():
+    client = monitor.GitHubClient('token')
+    calls: list[str] = []
+
+    def request(method: str, path: str, payload: object = None) -> tuple[object, str | None]:
+        assert method == 'GET'
+        assert payload is None
+        calls.append(path)
+        if len(calls) == 1:
+            return ([{'id': 1}], '<https://api.github.com/items?per_page=100&page=2>; rel="next"')
+        return ([{'id': 2}], None)
+
+    client._request = request  # type: ignore[method-assign]
+
+    assert list(client.pages('/items', count=2)) == [[{'id': 1}], [{'id': 2}]]
+    assert calls == ['/items?per_page=100&page=1', '/items?per_page=100&page=2']
 
 
 def test_build_and_write_snapshot_are_bounded_and_agent_readable(tmp_path: Path):
@@ -341,6 +365,46 @@ def test_apply_pings_all_assigned_maintainers_without_reassigning(tmp_path: Path
         '#7: requested maintainer attention from @alice @bob'
     ]
     assert not any(call[1].endswith('/assignees') for call in client.calls)
+
+
+def test_apply_assigns_first_maintainer_who_discussed_the_issue(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    client = FakeClient({7: item(7)})
+    client.permissions = {'former-maintainer': 'read', 'DouweM': 'write', 'dsfaccini': 'write'}
+    client.timelines[7] = [
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T15:00:00Z',
+            'user': {'login': 'contributor'},
+            'author_association': 'NONE',
+        },
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T15:30:00Z',
+            'user': {'login': 'former-maintainer'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'commented',
+            'created_at': '2026-02-09T16:48:57Z',
+            'user': {'login': 'DouweM'},
+            'author_association': 'MEMBER',
+        },
+        {
+            'event': 'commented',
+            'created_at': '2026-07-01T19:00:34Z',
+            'user': {'login': 'dsfaccini'},
+            'author_association': 'MEMBER',
+        },
+    ]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: requested maintainer attention from @DouweM'
+    ]
+    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
 
 
 def test_apply_restarts_a_prior_terminal_escalation(tmp_path: Path):

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -51,6 +51,7 @@ class FakeClient:
         self.assignment_response_assignees: list[str] = []
         self.fail_remove_assignees_once = False
         self.permissions: dict[str, str] = {}
+        self.events: dict[int, list[dict[str, Any]]] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
     def get(self, path: str) -> Any:
@@ -88,6 +89,13 @@ class FakeClient:
             response = {'assignees': [{'login': login} for login in result]}
             self.items[number]['assignees'] = response['assignees']
             return response
+        if path.endswith('/labels'):
+            assert isinstance(payload, dict)
+            labels = payload['labels']
+            assert isinstance(labels, list)
+            number = int(path.split('/issues/')[1].split('/')[0])
+            existing = {str(value['name']) for value in self.items[number]['labels']}
+            self.items[number]['labels'].extend({'name': label} for label in labels if label not in existing)
         return {}
 
     def delete(self, path: str, payload: object = None) -> None:
@@ -104,10 +112,18 @@ class FakeClient:
             self.items[number]['assignees'] = [
                 value for value in self.items[number]['assignees'] if str(value['login']).casefold() not in removed
             ]
+        elif '/labels/' in path:
+            number = int(path.split('/issues/')[1].split('/')[0])
+            removed = urllib.parse.unquote(path.rsplit('/', 1)[-1])
+            self.items[number]['labels'] = [
+                value for value in self.items[number]['labels'] if str(value['name']) != removed
+            ]
 
     def last_page(self, path: str) -> list[dict[str, Any]]:
         self.calls.append(('LAST', path, None))
         number = int(path.split('/issues/')[1].split('/')[0])
+        if path.endswith('/events') and number in self.events:
+            return self.events[number]
         if number in self.timelines:
             return self.timelines[number]
         labels = {label['name'] for label in self.items[number]['labels']}
@@ -466,7 +482,6 @@ def test_apply_assigns_first_maintainer_who_discussed_the_issue(tmp_path: Path):
             'author_association': 'MEMBER',
         },
     ]
-
     assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
         '#7: requested maintainer attention from @DouweM'
     ]
@@ -517,7 +532,6 @@ def test_apply_counts_comment_written_before_maintainer_promotion(tmp_path: Path
             'author_association': 'MEMBER',
         },
     ]
-
     assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
         '#7: requested maintainer attention from @alice'
     ]
@@ -571,6 +585,25 @@ def test_apply_preserves_maintainer_assigned_while_history_is_scanned(tmp_path: 
         '#7: requested maintainer attention from @bob'
     ]
     assert not any(call[1].endswith('/assignees') for call in client.calls)
+
+
+def test_apply_stops_if_item_closes_while_history_is_scanned(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    client = FakeClient({7: item(7)})
+    client.permissions = {'alice': 'write'}
+
+    def pages(path: str, *, count: int = 1):
+        client.items[7]['state'] = 'closed'
+        yield [{'user': {'login': 'alice'}, 'author_association': 'MEMBER'}]
+
+    client.pages = pages  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match='Attention state changed during owner selection'):
+        monitor.apply_decisions(client, 'r', str(output), str(snapshot))
+    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
 
 
 def test_apply_preserves_maintainer_assigned_during_assignment_request(tmp_path: Path):
@@ -811,7 +844,7 @@ def test_reconcile_replaces_bot_assigned_fallback_with_issue_owner():
         }
     )
     client.permissions = {monitor._FALLBACK_OWNER: 'write', 'DouweM': 'admin'}
-    client.timelines[7] = [
+    client.events[7] = [
         {
             'event': 'labeled',
             'created_at': OLD,
@@ -826,6 +859,7 @@ def test_reconcile_replaces_bot_assigned_fallback_with_issue_owner():
             'assignee': {'login': monitor._FALLBACK_OWNER},
         },
     ]
+    client.timelines[7] = []
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
@@ -849,7 +883,7 @@ def test_reconcile_retries_fallback_cleanup_after_owner_assignment_succeeds():
     )
     client.permissions = {monitor._FALLBACK_OWNER: 'write', 'DouweM': 'admin'}
     client.fail_remove_assignees_once = True
-    client.timelines[7] = [
+    client.events[7] = [
         {
             'event': 'labeled',
             'created_at': OLD,
@@ -864,6 +898,7 @@ def test_reconcile_retries_fallback_cleanup_after_owner_assignment_succeeds():
             'assignee': {'login': monitor._FALLBACK_OWNER},
         },
     ]
+    client.timelines[7] = []
 
     assert monitor.reconcile(client, 'r', now=NOW) == (
         [],
@@ -882,7 +917,7 @@ def test_reconcile_retries_fallback_cleanup_after_owner_assignment_succeeds():
 
 def test_reconcile_preserves_human_assigned_fallback():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.timelines[7] = [
+    client.events[7] = [
         {
             'event': 'labeled',
             'created_at': OLD,
@@ -897,6 +932,7 @@ def test_reconcile_preserves_human_assigned_fallback():
             'assignee': {'login': monitor._FALLBACK_OWNER},
         },
     ]
+    client.timelines[7] = []
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
     assert not any(call[1].endswith('/assignees') for call in client.calls)
@@ -908,7 +944,7 @@ def test_reconcile_preserves_human_assigned_fallback():
 
 def test_reconcile_preserves_fallback_assigned_by_bot_before_attention():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.timelines[7] = [
+    client.events[7] = [
         {
             'event': 'assigned',
             'created_at': '2026-07-15T00:00:00Z',
@@ -923,6 +959,7 @@ def test_reconcile_preserves_fallback_assigned_by_bot_before_attention():
             'label': {'name': monitor._ACTION_LABEL},
         },
     ]
+    client.timelines[7] = []
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
     assert not any(call[1].endswith('/assignees') for call in client.calls)
@@ -934,7 +971,7 @@ def test_reconcile_preserves_fallback_assigned_by_bot_before_attention():
 
 def test_reconcile_preserves_fallback_assigned_by_another_action_later():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
-    client.timelines[7] = [
+    client.events[7] = [
         {
             'event': 'labeled',
             'created_at': OLD,
@@ -949,6 +986,7 @@ def test_reconcile_preserves_fallback_assigned_by_another_action_later():
             'assignee': {'login': monitor._FALLBACK_OWNER},
         },
     ]
+    client.timelines[7] = []
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: reminded assigned maintainer'], [])
     assert not any(call[1].endswith('/assignees') for call in client.calls)

--- a/.github/workflows/issue-pr-attention-monitor.yml
+++ b/.github/workflows/issue-pr-attention-monitor.yml
@@ -22,7 +22,6 @@ jobs:
     outputs:
       notice_items: ${{ steps.reconcile.outputs.notice_items }}
       has_notices: ${{ steps.reconcile.outputs.has_notices }}
-      slack_payload: ${{ steps.reconcile.outputs.slack_payload }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -42,13 +41,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: pydantic-ai-triage
-    permissions: {}
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      notice_items: ${{ steps.prepare.outputs.notice_items }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Revalidate attention notices immediately before delivery
+        id: prepare
+        env:
+          ATTENTION_NOTICES: '{"items":${{ needs.reconcile.outputs.notice_items }}}'
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python .github/scripts/issue_pr_attention_monitor.py prepare
       - name: Post actionable attention digest to the triage channel
+        if: ${{ steps.prepare.outputs.has_notices == 'true' }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           errors: true
-          payload: ${{ needs.reconcile.outputs.slack_payload }}
+          payload: ${{ steps.prepare.outputs.slack_payload }}
           webhook: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
 
@@ -67,7 +81,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
       - name: Finalize delivered attention notices
         env:
-          ATTENTION_NOTICES: '{"items":${{ needs.reconcile.outputs.notice_items }}}'
+          ATTENTION_NOTICES: '{"items":${{ needs.notify.outputs.notice_items }}}'
           GITHUB_TOKEN: ${{ github.token }}
         run: python .github/scripts/issue_pr_attention_monitor.py finalize
 

--- a/.github/workflows/issue-pr-attention-monitor.yml
+++ b/.github/workflows/issue-pr-attention-monitor.yml
@@ -20,8 +20,8 @@ jobs:
       contents: read
       issues: write
     outputs:
-      escalation_items: ${{ steps.reconcile.outputs.escalation_items }}
-      has_escalations: ${{ steps.reconcile.outputs.has_escalations }}
+      notice_items: ${{ steps.reconcile.outputs.notice_items }}
+      has_notices: ${{ steps.reconcile.outputs.has_notices }}
       slack_payload: ${{ steps.reconcile.outputs.slack_payload }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,14 +37,14 @@ jobs:
   notify:
     needs: reconcile
     # not cancelled(): a reconcile run that failed on one item still queues
-    # escalations from its healthy items, and they must reach Slack.
-    if: ${{ !cancelled() && needs.reconcile.outputs.has_escalations == 'true' }}
+    # notices from its healthy items, and they must reach the triage channel.
+    if: ${{ !cancelled() && needs.reconcile.outputs.has_notices == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: pydantic-ai-triage
     permissions: {}
     steps:
-      - name: Escalate unresolved items privately
+      - name: Post actionable attention digest to the triage channel
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           errors: true
@@ -65,9 +65,9 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
-      - name: Finalize delivered escalations
+      - name: Finalize delivered attention notices
         env:
-          ATTENTION_ESCALATIONS: '{"items":${{ needs.reconcile.outputs.escalation_items }}}'
+          ATTENTION_NOTICES: '{"items":${{ needs.reconcile.outputs.notice_items }}}'
           GITHUB_TOKEN: ${{ github.token }}
         run: python .github/scripts/issue_pr_attention_monitor.py finalize
 


### PR DESCRIPTION
- Related to #4261 (attention workflow only; does not close the issue)

## Summary

- Make the first current maintainer who authored or commented on an issue its attention owner, and remove displaced maintainer assignees while preserving non-maintainer assignees. Pull-request ownership remains unchanged.
- Send reminders and escalations only to the triage channel. Each message names the owner, explains why it fired, and states the expected action; maintainers do not need to remove workflow labels.
- Split candidate discovery between recent activity and a rotating backlog, rotate active reconciliation pages, and revisit dormant escalations recent-first so old issues with new activity are not starved.
- Revalidate the live transition, exact recipient set, closure, and acknowledgement immediately before channel delivery and finalization. Record the terminal transition and delivery receipt in one GitHub write so cleanup retries cannot repost a delivered escalation.

## Validation

- `uv run pytest .github/scripts/test_issue_pr_attention_monitor.py -q` (83 passed)
- Ruff format and lint
- Pyright on `.github/scripts/issue_pr_attention_monitor.py`
- workflow YAML and Zizmor checks
- full pre-commit hooks on each commit

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
