### PR TITLE
Require `ctx` in `tool_for_tool_def` and fix the `FunctionToolset` retry budget

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
@@ -42,7 +42,7 @@ def temporalize_function_toolset(
                 if params.tool_def is not None:
                     # Rebuild the tool from the definition the workflow prepared, so a tool's `prepare`
                     # function isn't run a second time here against the activity's limited run context.
-                    tool = toolset.tool_for_tool_def(params.tool_def, params.original_name)
+                    tool = toolset.tool_for_tool_def(params.tool_def, ctx=ctx, original_name=params.original_name)
                 else:
                     # Only reachable for an activity scheduled by a worker predating `tool_def` on these
                     # params; re-prepare so in-flight executions still complete across the upgrade.

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1169,7 +1169,17 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             )
         return tools
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT]) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT], original_name: str | None = None
+    ) -> ToolsetTool[AgentDepsT]:
+        """Build the tool to call for a tool definition that was already prepared elsewhere.
+
+        Args:
+            tool_def: The prepared tool definition to build the tool from.
+            ctx: The run context used to resolve the tool's retry budget.
+            original_name: The name the toolset originally held the tool under. This is accepted for
+                consistency with `FunctionToolset`; MCP tools cannot be renamed during preparation.
+        """
         return ToolsetTool[AgentDepsT](
             toolset=self,
             tool_def=tool_def,

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1169,16 +1169,12 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             )
         return tools
 
-    def tool_for_tool_def(
-        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT], original_name: str | None = None
-    ) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT]) -> ToolsetTool[AgentDepsT]:
         """Build the tool to call for a tool definition that was already prepared elsewhere.
 
         Args:
             tool_def: The prepared tool definition to build the tool from.
             ctx: The run context used to resolve the tool's retry budget.
-            original_name: The name the toolset originally held the tool under. This is accepted for
-                consistency with `FunctionToolset`; MCP tools cannot be renamed during preparation.
         """
         return ToolsetTool[AgentDepsT](
             toolset=self,

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -632,7 +632,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         return tools
 
     def tool_for_tool_def(
-        self, tool_def: ToolDefinition, original_name: str | None = None
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT], original_name: str | None = None
     ) -> FunctionToolsetTool[AgentDepsT]:
         """Build the tool to call for a tool definition that was already prepared elsewhere.
 
@@ -643,6 +643,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
 
         Args:
             tool_def: The prepared tool definition to build the tool from.
+            ctx: The run context used to resolve the tool's retry budget.
             original_name: The name this toolset holds the tool under, from the built tool's
                 `original_name`. Defaults to `tool_def.name`, which is only the same when no
                 `prepare` function renamed the tool.
@@ -653,7 +654,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         original_name = original_name if original_name is not None else tool_def.name
         tool = self.tools[original_name]
         max_retries = tool.max_retries if tool.max_retries is not None else self.max_retries
-        return self._tool_for(tool, tool_def, max_retries if max_retries is not None else 1, original_name)
+        return self._tool_for(
+            tool, tool_def, max_retries if max_retries is not None else ctx.max_retries, original_name
+        )
 
     def _tool_for(
         self, tool: Tool[AgentDepsT], tool_def: ToolDefinition, max_retries: int, original_name: str

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -646,7 +646,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             ctx: The run context used to resolve the tool's retry budget.
             original_name: The name this toolset holds the tool under, from the built tool's
                 `original_name`. Defaults to `tool_def.name`, which is only the same when no
-                `prepare` function renamed the tool.
+                `prepare` function renamed the tool. This is specific to `FunctionToolset` because
+                per-tool preparation runs inside its own `get_tools()` and can change the exposed name
+                without changing the key in `tools`.
 
         Raises:
             KeyError: If the toolset holds no tool under that name.

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -117,6 +117,26 @@ async def test_function_toolset_instructions():
     assert instructions is None
 
 
+async def test_function_toolset_tool_for_tool_def_preserves_rename_and_retry_budget():
+    ctx = build_run_context(None, max_retries=5)
+    toolset = FunctionToolset[None]()
+
+    async def rename_tool(ctx: RunContext[None], tool_def: ToolDefinition) -> ToolDefinition:
+        return replace(tool_def, name='renamed')
+
+    @toolset.tool_plain(prepare=rename_tool)
+    def original(value: int) -> int:
+        return value * 2
+
+    prepared_tool = (await toolset.get_tools(ctx))['renamed']
+    rebuilt_tool = toolset.tool_for_tool_def(prepared_tool.tool_def, ctx=ctx, original_name='original')
+
+    assert rebuilt_tool.tool_def.name == 'renamed'
+    assert rebuilt_tool.original_name == 'original'
+    assert rebuilt_tool.max_retries == 5
+    assert await toolset.call_tool('renamed', {'value': 3}, ctx, rebuilt_tool) == 6
+
+
 async def test_function_toolset():
     @dataclass
     class PrefixDeps:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -133,7 +133,7 @@ async def test_function_toolset_tool_for_tool_def_preserves_rename_and_retry_bud
 
     assert rebuilt_tool.tool_def.name == 'renamed'
     assert rebuilt_tool.original_name == 'original'
-    assert rebuilt_tool.max_retries == 5
+    assert prepared_tool.max_retries == rebuilt_tool.max_retries == 5
     assert await toolset.call_tool('renamed', {'value': 3}, ctx, rebuilt_tool) == 6
 
 


### PR DESCRIPTION
### Summary

Fixes an unreported retry-budget mismatch introduced by #6890. For a function tool with no explicit `max_retries`, `FunctionToolset.get_tools` falls back through the toolset setting to `ctx.max_retries`, while `FunctionToolset.tool_for_tool_def` used a hardcoded `1`. The two paths therefore disagreed, and a durable function tool rebuilt inside an activity could receive the wrong retry budget.

The regression test prepares and rebuilds the same renamed function tool with no explicit retry setting, then verifies that `get_tools` and `tool_for_tool_def` both use the run context's budget.

This also requires the keyword-only `ctx` argument in both `FunctionToolset.tool_for_tool_def` and `MCPToolset.tool_for_tool_def`. Both implementations need the run context to reconstruct the same retry budget as `get_tools`.

`original_name` deliberately remains specific to `FunctionToolset`; the two method signatures are not otherwise unified. `FunctionToolset` is the only leaf toolset whose own `get_tools` can emit a `tool_def.name` that differs from the key in its internal `tools` dictionary, because per-tool `Tool.prepare` / `prepare_tool_def` runs inside `FunctionToolset.get_tools`. `MCPToolset.get_tools` keys by `mcp_tool.name` and gives `tool_def.name` that same value, so its names cannot differ. `PreparedToolset` explicitly refuses to rename: “Prepare function cannot add or rename tools. Use `FunctionToolset.add_function()` or `RenamedToolset` instead.”

`RenamedToolset` can rename tools, but it is a wrapper. Durable execution wraps leaf toolsets, so `RenamedToolset` remains outside the durable boundary and maps names back in `call_tool`; the activity only sees native names. `original_name` is therefore a consequence of one leaf toolset performing its own per-tool preparation, not a general toolset contract. It is deliberately not declared on the widely subclassed `AbstractToolset`, where only one implementation could meaningfully use it.

Neither #6449 nor #6890 shipped in v2.21.0, so no deprecation or compatibility shim is needed.

### Tests

- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright` on changed files
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest tests/test_toolsets.py tests/test_mcp.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in Cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

