### PR TITLE
Memoize Temporal payload `TypeAdapter`s

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -14,7 +14,7 @@ from dataclasses import replace
 from typing import Any
 
 from pydantic.errors import PydanticUserError
-from temporalio.contrib.pydantic import PydanticPayloadConverter, pydantic_data_converter
+from temporalio.contrib.pydantic import PydanticPayloadConverter
 from temporalio.converter import DataConverter, DefaultPayloadConverter
 from temporalio.plugin import SimplePlugin
 from temporalio.worker import WorkerConfig, WorkflowRunner
@@ -27,6 +27,7 @@ from ...exceptions import AgentRunError, UserError
 from ._agent import TemporalAgent  # pyright: ignore[reportDeprecated]
 from ._durability import TemporalDurability
 from ._logfire import LogfirePlugin
+from ._payload_converter import PydanticAIPayloadConverter
 from ._run_context import TemporalRunContext
 from ._toolset import TemporalWrapperToolset
 from ._workflow import PydanticAIWorkflow
@@ -40,6 +41,7 @@ __all__ = [
     'TemporalRunContext',
     'TemporalWrapperToolset',
     'PydanticAIWorkflow',
+    'PydanticAIPayloadConverter',
 ]
 
 # We need eagerly import the anyio backends or it will happens inside workflow code and temporal has issues
@@ -56,22 +58,25 @@ except ImportError:
 
 def _data_converter(converter: DataConverter | None) -> DataConverter:
     if converter is None:
-        return pydantic_data_converter
+        return DataConverter(payload_converter_class=PydanticAIPayloadConverter)
 
-    # If the payload converter class is already a subclass of PydanticPayloadConverter,
-    # the converter is already compatible with Pydantic AI - return it as-is.
-    if issubclass(converter.payload_converter_class, PydanticPayloadConverter):
+    # Preserve genuine subclasses because replacing one could silently discard custom behavior. Authors
+    # can inherit from `PydanticAIPayloadConverter` when they also want memoized adapter construction.
+    if converter.payload_converter_class is not PydanticPayloadConverter and issubclass(
+        converter.payload_converter_class, PydanticPayloadConverter
+    ):
         return converter
 
     # If using a non-Pydantic payload converter, warn and replace just the payload converter class,
     # preserving any custom payload_codec or failure_converter_class.
-    if converter.payload_converter_class is not DefaultPayloadConverter:
+    if converter.payload_converter_class not in (DefaultPayloadConverter, PydanticPayloadConverter):
         warnings.warn(
-            'A non-Pydantic Temporal payload converter was used which has been replaced with PydanticPayloadConverter. '
-            'To suppress this warning, ensure your payload_converter_class inherits from PydanticPayloadConverter.'
+            'A non-Pydantic Temporal payload converter was used which has been replaced with '
+            '`PydanticAIPayloadConverter`. To suppress this warning and retain memoized `TypeAdapter` construction, '
+            'ensure your `payload_converter_class` inherits from `PydanticAIPayloadConverter`.'
         )
 
-    return replace(converter, payload_converter_class=PydanticPayloadConverter)
+    return replace(converter, payload_converter_class=PydanticAIPayloadConverter)
 
 
 def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from pydantic import TypeAdapter
+from temporalio.api.common.v1 import Payload
+from temporalio.contrib.pydantic import (
+    PydanticJSONPlainPayloadConverter,
+    PydanticPayloadConverter,
+    ToJsonOptions,
+)
+from temporalio.converter import CompositePayloadConverter, DefaultPayloadConverter, JSONPlainPayloadConverter
+
+
+@lru_cache(maxsize=128)
+def _type_adapter(type_hint: Any) -> TypeAdapter[Any]:
+    """Build an adapter once for each recently used type hint.
+
+    The cache is replay-safe: a `TypeAdapter` is a pure function of its type hint, so cache hits and
+    misses validate identically and cannot change workflow history. The 128-entry bound comfortably
+    covers the code-defined set of hints used by a worker while preventing accidental growth if an
+    application constructs hints dynamically.
+    """
+    return TypeAdapter(type_hint)
+
+
+class PydanticAIJSONPlainPayloadConverter(PydanticJSONPlainPayloadConverter):
+    """Pydantic JSON converter that reuses `TypeAdapter` instances during deserialization."""
+
+    def from_payload(self, payload: Payload, type_hint: type | None = None) -> Any:
+        hint = type_hint if type_hint is not None else Any
+        adapter: TypeAdapter[Any]
+        try:
+            hash(hint)
+        except TypeError:
+            # Pydantic accepts some unhashable hints; they remain valid but cannot be cached.
+            adapter = TypeAdapter(hint)
+        else:
+            adapter = _type_adapter(hint)
+        return adapter.validate_json(payload.data)
+
+
+class PydanticAIPayloadConverter(PydanticPayloadConverter):
+    """Temporal Pydantic payload converter with memoized deserialization adapters.
+
+    Custom payload converters can inherit from this class to retain the adapter cache while replacing
+    or extending other conversion behavior.
+    """
+
+    def __init__(self, to_json_options: ToJsonOptions | None = None) -> None:
+        json_payload_converter = PydanticAIJSONPlainPayloadConverter(to_json_options)
+        CompositePayloadConverter.__init__(
+            self,
+            *(
+                converter if not isinstance(converter, JSONPlainPayloadConverter) else json_payload_converter
+                for converter in DefaultPayloadConverter.default_encoding_payload_converters
+            ),
+        )

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 from unittest.mock import patch
 
 import anyio
@@ -142,10 +142,12 @@ try:
     from pydantic_ai.durable_exec.temporal import (
         AgentPlugin,
         LogfirePlugin,
+        PydanticAIPayloadConverter,
         PydanticAIPlugin,
         PydanticAIWorkflow,
         TemporalAgent,  # pyright: ignore[reportDeprecated]
         TemporalDurability,
+        _payload_converter as temporal_payload_converter,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.durable_exec.temporal._activity_execution import (
         execute_activity as execute_temporal_activity,
@@ -5569,13 +5571,83 @@ class MockPayloadCodec(PayloadCodec):
         return list(payloads)
 
 
-def test_pydantic_ai_plugin_no_converter_returns_pydantic_data_converter() -> None:
-    """When no converter is provided, PydanticAIPlugin uses the standard pydantic_data_converter."""
+async def test_pydantic_ai_payload_converter_builds_type_adapter_once() -> None:
+    """Repeated decoding reuses one adapter instead of rebuilding it for every payload."""
+    temporal_payload_converter._type_adapter.cache_clear()  # pyright: ignore[reportPrivateUsage]
+    converter = DataConverter(payload_converter_class=PydanticAIPayloadConverter)
+    payloads = await converter.encode(['result'])
+
+    with patch.object(
+        temporal_payload_converter, 'TypeAdapter', wraps=temporal_payload_converter.TypeAdapter
+    ) as type_adapter:
+        for _ in range(5):
+            assert await converter.decode(payloads, [str]) == ['result']
+
+    assert type_adapter.call_count == 1
+
+
+async def test_pydantic_ai_payload_converter_separates_type_hints() -> None:
+    """Different hints use distinct adapters and preserve their respective output types."""
+    temporal_payload_converter._type_adapter.cache_clear()  # pyright: ignore[reportPrivateUsage]
+    converter = DataConverter(payload_converter_class=PydanticAIPayloadConverter)
+    str_payloads = await converter.encode(['1'])
+    int_payloads = await converter.encode([1])
+
+    with patch.object(
+        temporal_payload_converter, 'TypeAdapter', wraps=temporal_payload_converter.TypeAdapter
+    ) as type_adapter:
+        assert await converter.decode(str_payloads, [str]) == ['1']
+        assert await converter.decode(int_payloads, [int]) == [1]
+
+    assert type_adapter.call_count == 2
+
+
+async def test_pydantic_ai_payload_converter_accepts_unhashable_type_hint() -> None:
+    """Unhashable Pydantic-compatible hints are built uncached rather than rejected."""
+    converter = DataConverter(payload_converter_class=PydanticAIPayloadConverter)
+    payloads = await converter.encode([1])
+    unhashable_hint = Annotated[int, []]
+
+    with patch.object(
+        temporal_payload_converter, 'TypeAdapter', wraps=temporal_payload_converter.TypeAdapter
+    ) as type_adapter:
+        assert await converter.decode(payloads, [unhashable_hint]) == [1]  # pyright: ignore[reportArgumentType]
+        assert await converter.decode(payloads, [unhashable_hint]) == [1]  # pyright: ignore[reportArgumentType]
+
+    assert type_adapter.call_count == 2
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        {'metadata': {'reason': 'review'}, 'kind': 'approval_required'},
+        {'metadata': {'reason': 'later'}, 'kind': 'call_deferred'},
+        {'message': 'retry this', 'kind': 'model_retry'},
+        {'result': 'result', 'kind': 'tool_return'},
+        {'result': {'kind': 'tool-return', 'value': 1}, 'kind': 'tool_content_result'},
+        {'message': 'failed', 'kind': 'tool_failed'},
+    ],
+)
+async def test_pydantic_ai_payload_converter_matches_stock_for_call_tool_result(value: dict[str, Any]) -> None:
+    """Every `CallToolResult` variant round-trips identically through stock and memoized converters."""
+    stock_payloads = await pydantic_data_converter.encode([value])
+    stock_result = await pydantic_data_converter.decode(stock_payloads, [CallToolResult])  # pyright: ignore[reportArgumentType]
+
+    converter = DataConverter(payload_converter_class=PydanticAIPayloadConverter)
+    memoized_payloads = await converter.encode([value])
+    memoized_result = await converter.decode(memoized_payloads, [CallToolResult])  # pyright: ignore[reportArgumentType]
+
+    assert memoized_payloads == stock_payloads
+    assert memoized_result == stock_result
+
+
+def test_pydantic_ai_plugin_no_converter_uses_memoizing_converter() -> None:
+    """When no converter is provided, `PydanticAIPlugin` uses its memoizing converter."""
     plugin = PydanticAIPlugin()
     # Create a minimal config without data_converter
     config: dict[str, Any] = {}
     result = plugin.configure_client(config)  # type: ignore[arg-type]
-    assert result['data_converter'] is pydantic_data_converter
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
 
 
 def test_pydantic_ai_plugin_passes_pydantic_monty_through_sandbox() -> None:
@@ -5608,13 +5680,17 @@ async def test_pydantic_ai_plugin_runs_workflow_in_sandbox(temporal_env: Workflo
     assert result == 'sandboxed'
 
 
-def test_pydantic_ai_plugin_with_pydantic_payload_converter_unchanged() -> None:
-    """When converter already uses PydanticPayloadConverter, return it unchanged."""
+def test_pydantic_ai_plugin_with_stock_pydantic_payload_converter_upgraded() -> None:
+    """The exact stock `PydanticPayloadConverter` is upgraded to the memoizing converter."""
     plugin = PydanticAIPlugin()
-    converter = DataConverter(payload_converter_class=PydanticPayloadConverter)
+    codec = MockPayloadCodec()
+    converter = DataConverter(payload_converter_class=PydanticPayloadConverter, payload_codec=codec)
     config: dict[str, Any] = {'data_converter': converter}
     result = plugin.configure_client(config)  # type: ignore[arg-type]
-    assert result['data_converter'] is converter
+    assert result['data_converter'] is not converter
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
+    assert result['data_converter'].payload_codec is codec
+    assert result['data_converter'].failure_converter_class is converter.failure_converter_class
 
 
 def test_pydantic_ai_plugin_with_custom_pydantic_subclass_unchanged() -> None:
@@ -5634,7 +5710,7 @@ def test_pydantic_ai_plugin_with_default_payload_converter_replaced() -> None:
     config: dict[str, Any] = {'data_converter': converter}
     result = plugin.configure_client(config)  # type: ignore[arg-type]
     assert result['data_converter'] is not converter
-    assert result['data_converter'].payload_converter_class is PydanticPayloadConverter
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
 
 
 def test_pydantic_ai_plugin_preserves_custom_payload_codec() -> None:
@@ -5648,8 +5724,9 @@ def test_pydantic_ai_plugin_preserves_custom_payload_codec() -> None:
     config: dict[str, Any] = {'data_converter': converter}
     result = plugin.configure_client(config)  # type: ignore[arg-type]
     assert result['data_converter'] is not converter
-    assert result['data_converter'].payload_converter_class is PydanticPayloadConverter
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
     assert result['data_converter'].payload_codec is codec
+    assert result['data_converter'].failure_converter_class is converter.failure_converter_class
 
 
 def test_pydantic_ai_plugin_with_non_pydantic_converter_warns() -> None:
@@ -5659,10 +5736,11 @@ def test_pydantic_ai_plugin_with_non_pydantic_converter_warns() -> None:
     config: dict[str, Any] = {'data_converter': converter}
     with pytest.warns(
         UserWarning,
-        match='A non-Pydantic Temporal payload converter was used which has been replaced with PydanticPayloadConverter',
+        match='A non-Pydantic Temporal payload converter was used which has been replaced with '
+        '`PydanticAIPayloadConverter`',
     ):
         result = plugin.configure_client(config)  # type: ignore[arg-type]
-    assert result['data_converter'].payload_converter_class is PydanticPayloadConverter
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
 
 
 def test_pydantic_ai_plugin_with_non_pydantic_converter_preserves_codec() -> None:
@@ -5676,7 +5754,7 @@ def test_pydantic_ai_plugin_with_non_pydantic_converter_preserves_codec() -> Non
     config: dict[str, Any] = {'data_converter': converter}
     with pytest.warns(UserWarning):
         result = plugin.configure_client(config)  # type: ignore[arg-type]
-    assert result['data_converter'].payload_converter_class is PydanticPayloadConverter
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
     assert result['data_converter'].payload_codec is codec
 
 


### PR DESCRIPTION
- Closes #6959

Caches Pydantic `TypeAdapter` instances at the JSON-plain converter beneath Temporal's composite `PydanticPayloadConverter`. This keeps every stock encoding converter intact and changes only the expensive Pydantic JSON deserialization path.

The cache is bounded to 128 type hints. Worker type hints are defined by application code and naturally bounded, while the explicit limit also protects applications that construct hints dynamically. Unhashable Pydantic-compatible hints fall back to uncached construction.

This is replay-safe by construction: a `TypeAdapter` is a pure function of its type hint, so a cache hit and a cache miss perform identical validation and produce identical workflow history. The module-level cache is safe inside the workflow sandbox because `pydantic_ai` is in `_workflow_runner`'s passthrough list, so the converter module and cache are shared rather than re-imported into sandbox-local state.

`_data_converter` now handles its three branches as follows:

1. No converter: use `PydanticAIPayloadConverter`.
2. Exactly Temporal's stock `PydanticPayloadConverter`: upgrade it while preserving `payload_codec` and `failure_converter_class`.
3. Default or non-Pydantic converter: replace only the payload converter class, preserving the other converter settings.

A genuine `PydanticPayloadConverter` subclass is deliberately left unchanged. Replacing it could silently discard user behavior, which is worse than leaving performance on the table. Custom converter authors can inherit from `PydanticAIPayloadConverter` to retain their behavior and gain memoization.

Local median benchmark for `CallToolResult` on Python 3.13 / Temporal 1.24.0:

| Path | Median per deserialize |
|---|---:|
| Stock Temporal converter | 2.830 ms |
| Memoized converter (warm) | 0.00196 ms |
| Speedup | 1,444× |

`TypeAdapter(CallToolResult)` construction alone measured 2.559 ms median. Timing is intentionally not asserted in tests: the regression test spies on construction and proves five same-hint deserializations build exactly one adapter. Separate tests assert two hints build two adapters, unhashable hints build uncached without crashing, and every `CallToolResult` union variant round-trips identically to Temporal's stock converter.

Upstreaming the same cache to `temporalio.contrib.pydantic` is worthwhile because all Temporal Pydantic users would benefit, but is intentionally outside this PR's scope. This change does not edit the open durable-execution PRs listed in the issue brief; no direct conflict was found in this worktree.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

