### PR TITLE
Add `max_tool_concurrency` to `Agent`

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -862,6 +862,22 @@ a [`ConcurrencyLimitExceeded`][pydantic_ai.exceptions.ConcurrencyLimitExceeded] 
 When instrumentation is enabled, waiting operations appear as "waiting for concurrency" spans
 with attributes showing queue depth and limits.
 
+Use `max_tool_concurrency` to limit how many tool calls can execute at once within each agent run:
+
+```python
+agent = Agent('openai:gpt-5', max_tool_concurrency=8)
+```
+
+This accepts the same values as `max_concurrency`. An integer or
+[`ConcurrencyLimit`][pydantic_ai.ConcurrencyLimit] creates an independent limiter for each run, so
+concurrent runs do not contend with one another. Passing an
+[`AbstractConcurrencyLimiter`][pydantic_ai.AbstractConcurrencyLimiter] shares that limiter across
+runs or agents instead.
+
+When using [durable execution](durable_execution/overview.md), prefer an integer or
+`ConcurrencyLimit`. A shared custom limiter runs in workflow code and must itself satisfy the
+durable runtime's determinism requirements.
+
 ### Model specific settings
 
 If you wish to further customize model behavior, you can use a subclass of [`ModelSettings`][pydantic_ai.settings.ModelSettings], like

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -864,7 +864,9 @@ with attributes showing queue depth and limits.
 
 Use `max_tool_concurrency` to limit how many tool calls can execute at once within each agent run:
 
-```python
+```python {title="agent_tool_concurrency.py"}
+from pydantic_ai import Agent
+
 agent = Agent('openai:gpt-5', max_tool_concurrency=8)
 ```
 

--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -202,6 +202,10 @@ It's equivalent to the behavior of [`with agent.parallel_tool_call_execution_mod
 
 If you prefer strict ordering, you can configure the agent to run tools sequentially by setting `parallel_execution_mode='sequential'` on [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability].
 
+Set `max_tool_concurrency` on [`Agent`][pydantic_ai.Agent] to bound parallel step fan-out within
+each run. This limit is independent of `parallel_execution_mode`; sequential mode remains a
+stricter limit of one.
+
 ### Toolsets at Runtime
 
 Additional toolsets can be passed per run via `agent.run(toolsets=...)`. Non-executing toolsets like [`ExternalToolset`][pydantic_ai.toolsets.ExternalToolset], and [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset]s whose tools DBOS runs inline, are supported. [`MCPToolset`][pydantic_ai.mcp.MCPToolset]s and dynamic toolsets must be set when constructing the agent so their steps are registered before the workflow runs; passing them at runtime raises a `UserError`.

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -335,6 +335,29 @@ class MultiModelWorkflow:
 
 Additional toolsets can be passed per run via `agent.run(toolsets=...)`, but only toolsets that don't need durable wrapping are supported: non-executing toolsets like [`ExternalToolset`][pydantic_ai.toolsets.ExternalToolset], whose tools are executed outside the agent run, and [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset]s whose tools all opt out of activity wrapping with [`metadata={'temporal': False}`](#per-tool-activity-config). Other executing toolsets ([`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset] and [`MCPToolset`][pydantic_ai.mcp.MCPToolset]) and dynamic toolsets must be set when constructing the agent so their activities can be registered with the worker before the workflow runs; passing them at runtime raises a `UserError`.
 
+### Limiting Tool Concurrency
+
+Set `max_tool_concurrency` on [`Agent`][pydantic_ai.Agent] to bound the number of tool activities
+scheduled concurrently by each workflow:
+
+```python
+agent = Agent(
+    'openai:gpt-5',
+    name='bounded_agent',
+    max_tool_concurrency=8,
+    capabilities=[TemporalDurability()],
+)
+```
+
+Use an integer or [`ConcurrencyLimit`][pydantic_ai.ConcurrencyLimit], which creates a fresh limiter
+for every run and is safe for workflow replay. Do not pass a process-shared concurrency limiter
+unless its acquisition behavior is deterministic under Temporal workflow replay.
+
+Tool execution ordering remains controlled by
+[`Agent.parallel_tool_call_execution_mode()`][pydantic_ai.agent.AbstractAgent.parallel_tool_call_execution_mode].
+Temporal needs no durability-specific ordering setting: its default parallel completion order is
+recorded in workflow history and replays deterministically.
+
 ## Activity Configuration
 
 Temporal activity configuration, like timeouts and retry policies, can be customized by passing [`temporalio.workflow.ActivityConfig`](https://python.temporal.io/temporalio.workflow._activities.ActivityConfig.html) objects to the [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability] constructor:

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -340,7 +340,10 @@ Additional toolsets can be passed per run via `agent.run(toolsets=...)`, but onl
 Set `max_tool_concurrency` on [`Agent`][pydantic_ai.Agent] to bound the number of tool activities
 scheduled concurrently by each workflow:
 
-```python
+```python {title="temporal_tool_concurrency.py"}
+from pydantic_ai import Agent
+from pydantic_ai.durable_exec.temporal import TemporalDurability
+
 agent = Agent(
     'openai:gpt-5',
     name='bounded_agent',

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -376,6 +376,29 @@ _(This example is complete, it can be run "as is")_
 
     This visibility helps you understand why an agent made specific decisions and identify issues in tool implementations.
 
+## Limiting Concurrent Tool Calls
+
+When a model returns several tool calls in one response, Pydantic AI runs them concurrently by
+default. Set `max_tool_concurrency` on [`Agent`][pydantic_ai.Agent] to bound the number that execute
+at once within each agent run:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5', max_tool_concurrency=8)
+```
+
+The limit applies across function and output tools, including tools routed through a
+[durable execution](durable_execution/overview.md) integration. An integer or
+[`ConcurrencyLimit`][pydantic_ai.ConcurrencyLimit] creates an independent limiter for every run;
+pass an [`AbstractConcurrencyLimiter`][pydantic_ai.AbstractConcurrencyLimiter] to deliberately
+share a limit across runs or agents.
+
+[`Agent.parallel_tool_call_execution_mode()`][pydantic_ai.agent.AbstractAgent.parallel_tool_call_execution_mode]
+controls ordering separately. The numeric bound applies to both `'parallel'` and
+`'parallel_ordered_events'`. The `'sequential'` mode and a tool configured with `sequential=True`
+remain stricter: those tools execute one at a time, regardless of a higher numeric limit.
+
 ## Injecting Follow-up Messages from a Tool
 
 A tool can push extra messages into the conversation via

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
@@ -130,6 +130,7 @@ Reach for these features when the user needs more than a simple function tool:
 - `ToolReturn` for rich return values plus separate content/metadata
 - `prepare=` for dynamic tool definitions
 - `timeout=` for tool execution limits
+- `Agent(max_tool_concurrency=N)` to bound concurrent tool calls within each run
 - `sequential=True` to make a tool a barrier — it runs alone (tools emitted before it finish first, tools after it start once it finishes) while other tools parallelize around it; works on function tools and on output tools via `ToolOutput(sequential=True)`
 
 Example with `ToolReturn`:

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -5,7 +5,7 @@ import dataclasses
 import inspect
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 
@@ -633,18 +633,15 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
 
                 return _messages.FunctionToolResultEvent(tool_part, content=tool_user_content)
 
-        def call_tool(
+        async def call_tool(
             index: int,
-        ) -> Coroutine[
-            Any,
-            Any,
-            tuple[_messages.ToolReturnPart | _messages.RetryPromptPart, str | Sequence[_messages.UserContent] | None],
-        ]:
+        ) -> tuple[_messages.ToolReturnPart | _messages.RetryPromptPart, str | Sequence[_messages.UserContent] | None]:
             call = tool_calls[index]
-            return self._call_tool(
-                validated_calls.get(call.tool_call_id, call),
-                tool_call_result=tool_call_results.get(call.tool_call_id),
-            )
+            async with self.tool_manager.acquire_tool_call_capacity(call.tool_name):
+                return await self._call_tool(
+                    validated_calls.get(call.tool_call_id, call),
+                    tool_call_result=tool_call_results.get(call.tool_call_id),
+                )
 
         mode = self.tool_manager.get_parallel_execution_mode()
         ordered_events = mode == 'parallel_ordered_events'
@@ -1017,15 +1014,16 @@ class _ExhaustiveProcessor(_ToolCallProcessor[DepsT, NodeRunEndT]):
 
         async def run_one(index: int) -> tuple[int, _ToolCallPayload[NodeRunEndT]]:
             call = self.tool_calls[index]
-            if self.call_kinds[index] == 'output':
-                return index, await self._run_output_tool_call(call)
-            try:
-                return index, await self._call_tool(
-                    validated_calls.get(call.tool_call_id, call),
-                    tool_call_result=self.calls_to_run_results.get(call.tool_call_id),
-                )
-            except (exceptions.CallDeferred, exceptions.ApprovalRequired) as e:
-                return index, e
+            async with self.tool_manager.acquire_tool_call_capacity(call.tool_name):
+                if self.call_kinds[index] == 'output':
+                    return index, await self._run_output_tool_call(call)
+                try:
+                    return index, await self._call_tool(
+                        validated_calls.get(call.tool_call_id, call),
+                        tool_call_result=self.calls_to_run_results.get(call.tool_call_id),
+                    )
+                except (exceptions.CallDeferred, exceptions.ApprovalRequired) as e:
+                    return index, e
 
         appended = False
         try:

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -506,6 +506,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self._event_stream_handler = None
 
         self._concurrency_limiter = _concurrency.normalize_to_limiter(max_concurrency)
+        # Unlike `max_concurrency`, an `int` or `ConcurrencyLimit` is normalized once *per run* (in `iter()`)
+        # so every run gets its own tool budget; only an explicitly passed limiter is shared across runs.
+        # Normalize eagerly here as well and discard the result, so an invalid value raises at construction
+        # time rather than at the first run.
         if not isinstance(max_tool_concurrency, _concurrency.AbstractConcurrencyLimiter):
             _concurrency.normalize_to_limiter(max_tool_concurrency)
         self._max_tool_concurrency = max_tool_concurrency

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -273,6 +273,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
     _event_stream_handler: EventStreamHandler[AgentDepsT] | None = dataclasses.field(repr=False)
 
     _concurrency_limiter: _concurrency.AbstractConcurrencyLimiter | None = dataclasses.field(repr=False)
+    _max_tool_concurrency: _concurrency.AnyConcurrencyLimit = dataclasses.field(repr=False)
 
     _entered_count: int = dataclasses.field(repr=False)
     _exit_stack: AsyncExitStack | None = dataclasses.field(repr=False)
@@ -309,6 +310,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[AgentDepsT] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
     ) -> None: ...
 
@@ -333,6 +335,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[AgentDepsT] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
     ) -> None: ...
 
@@ -356,6 +359,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[AgentDepsT] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
     ) -> None:
         """Create an agent.
@@ -420,6 +424,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 a [`ConcurrencyLimiter`][pydantic_ai.ConcurrencyLimiter] for sharing limits across
                 multiple agents, or None (default) for no limiting. When the limit is reached, additional calls
                 to `run()` or `iter()` will wait until a slot becomes available.
+            max_tool_concurrency: Optional limit on concurrent tool calls within each agent run.
+                Accepts the same values as `max_concurrency`, including a [`ConcurrencyLimit`][pydantic_ai.ConcurrencyLimit]
+                for backpressure or an [`AbstractConcurrencyLimiter`][pydantic_ai.AbstractConcurrencyLimiter]
+                to share a custom limiter across runs or agents. Integer and `ConcurrencyLimit` values create
+                an independent limiter for each run. Defaults to `None` for no limiting.
             capabilities: Optional list of [capabilities](https://ai.pydantic.dev/capabilities/overview/) to configure the agent with,
                 including functions which take a run context and return a capability.
                 See [`CapabilityFunc`][pydantic_ai.capabilities.CapabilityFunc] for more information.
@@ -497,6 +506,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self._event_stream_handler = None
 
         self._concurrency_limiter = _concurrency.normalize_to_limiter(max_concurrency)
+        if not isinstance(max_tool_concurrency, _concurrency.AbstractConcurrencyLimiter):
+            _concurrency.normalize_to_limiter(max_tool_concurrency)
+        self._max_tool_concurrency = max_tool_concurrency
 
         self._override_name: ContextVar[_utils.Option[str]] = ContextVar('_override_name', default=None)
         self._override_deps: ContextVar[_utils.Option[AgentDepsT]] = ContextVar('_override_deps', default=None)
@@ -591,6 +603,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[Any] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[Any]] | None = None,
     ) -> Agent[object, str]: ...
 
@@ -618,6 +631,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[Any] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[Any]] | None = None,
     ) -> Agent[T, str]: ...
 
@@ -644,6 +658,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[Any] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[Any]] | None = None,
     ) -> Agent[Any, Any]:
         """Construct an Agent from a spec dict or `AgentSpec`.
@@ -679,6 +694,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             tool_timeout: Default timeout for tool execution, overrides spec `tool_timeout` if provided.
 
             max_concurrency: Limit on concurrent agent runs.
+            max_tool_concurrency: Limit on concurrent tool calls within each agent run.
             capabilities: Additional capabilities merged with those from the spec.
 
         Returns:
@@ -731,6 +747,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             metadata=metadata if metadata is not None else validated_spec.metadata,
             tool_timeout=tool_timeout if tool_timeout is not None else validated_spec.tool_timeout,
             max_concurrency=max_concurrency,
+            max_tool_concurrency=max_tool_concurrency,
             capabilities=all_capabilities,
         )
         return agent
@@ -759,6 +776,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[Any] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[Any]] | None = None,
     ) -> Agent[object, str]: ...
 
@@ -787,6 +805,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[Any] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[Any]] | None = None,
     ) -> Agent[T, str]: ...
 
@@ -814,6 +833,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         metadata: AgentMetadata[Any] | None = None,
         tool_timeout: float | None = None,
         max_concurrency: _concurrency.AnyConcurrencyLimit = None,
+        max_tool_concurrency: _concurrency.AnyConcurrencyLimit = None,
         capabilities: Sequence[AgentCapability[Any]] | None = None,
     ) -> Agent[Any, Any]:
         """Construct an Agent from a YAML or JSON spec file.
@@ -847,6 +867,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             metadata=metadata,
             tool_timeout=tool_timeout,
             max_concurrency=max_concurrency,
+            max_tool_concurrency=max_tool_concurrency,
             capabilities=capabilities,
         )
         return agent
@@ -1498,7 +1519,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         )
         toolset = await toolset.for_run(initial_ctx)
         tool_manager = ToolManager[AgentDepsT](
-            toolset, root_capability=run_capability, default_max_retries=effective_tool_retries_resolved
+            toolset,
+            root_capability=run_capability,
+            default_max_retries=effective_tool_retries_resolved,
+            _tool_concurrency_limiter=_concurrency.normalize_to_limiter(self._max_tool_concurrency),
         )
 
         # Build instructions with per-run capability contributions

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import AbstractAsyncContextManager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal
@@ -17,6 +17,7 @@ from ._output import (
     run_output_validate_hooks,
 )
 from ._run_context import AgentDepsT, RunContext
+from .concurrency import AbstractConcurrencyLimiter, get_concurrency_context
 from .exceptions import (
     ApprovalRequired,
     CallDeferred,
@@ -136,6 +137,8 @@ class ToolManager(Generic[AgentDepsT]):
     """Names of tools that succeeded in this run step."""
     default_max_retries: int = 1
     """Default number of times to retry a tool"""
+    _tool_concurrency_limiter: AbstractConcurrencyLimiter | None = None
+    """Optional limiter shared by tool calls made by this agent."""
 
     @classmethod
     @contextmanager
@@ -174,13 +177,13 @@ class ToolManager(Generic[AgentDepsT]):
             ctx = replace(ctx, retries=retries)
 
         toolset = await self.toolset.for_run_step(ctx)
-
         new_tm = self.__class__(
             toolset=toolset,
             root_capability=self.root_capability,
             ctx=ctx,
             tools=await toolset.get_tools(ctx),
             default_max_retries=self.default_max_retries,
+            _tool_concurrency_limiter=self._tool_concurrency_limiter,
         )
         # Make the prepared ToolManager accessible from RunContext so that
         # wrapper toolsets (e.g. CodeModeToolset) can dispatch tool calls
@@ -205,6 +208,10 @@ class ToolManager(Generic[AgentDepsT]):
         run into serial execution.
         """
         return _parallel_execution_mode_ctx_var.get()
+
+    def acquire_tool_call_capacity(self, tool_name: str) -> AbstractAsyncContextManager[None]:
+        """Acquire capacity to execute a tool call."""
+        return get_concurrency_context(self._tool_concurrency_limiter, f'tool:{tool_name}')
 
     def is_sequential(self, call: ToolCallPart) -> bool:
         """Whether a tool call must run as a barrier (`sequential=True`), executing alone.

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2227,6 +2227,40 @@ async def test_dbos_durability_simple_agent(dbos: DBOS) -> None:
     assert output == 'Echo: Hello DBOS'
 
 
+async def test_dbos_durability_max_tool_concurrency(dbos: DBOS) -> None:
+    """`max_tool_concurrency` bounds DBOS parallel step fan-out, as `docs/durable_execution/dbos.md` claims."""
+    active = 0
+    peak = 0
+
+    def model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('bounded_work', {'value': value}) for value in range(6)])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(
+        FunctionModel(model),
+        name='durability_bounded_tools',
+        max_tool_concurrency=2,
+        capabilities=[DBOSDurability()],
+    )
+
+    @agent.tool_plain
+    async def bounded_work(value: int) -> int:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return value
+
+    @DBOS.workflow()
+    async def run_bounded_agent() -> str:
+        return (await agent.run('run bounded tools')).output
+
+    assert await run_bounded_agent() == 'done'
+    assert peak == 2
+
+
 async def test_dbos_durability_registers_legacy_workflows_opt_in(dbos: DBOS) -> None:
     agent = Agent(
         _durability_fn_model,

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -6167,6 +6167,41 @@ _durability_fn_model = FunctionModel(_durability_model_fn)
 simple_durability = TemporalDurability(activity_config=BASE_ACTIVITY_CONFIG)
 simple_durable_agent = Agent(_durability_fn_model, name='durability_simple_agent', capabilities=[simple_durability])
 
+_bounded_tool_active = 0
+_bounded_tool_peak = 0
+_bounded_tool_active_by_workflow: dict[str, int] = {}
+_bounded_tool_peak_by_workflow: dict[str, int] = {}
+
+
+def _bounded_tool_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    if len(messages) == 1:
+        return ModelResponse(parts=[ToolCallPart('bounded_work', {'value': value}) for value in range(6)])
+    return ModelResponse(parts=[TextPart('done')])
+
+
+async def bounded_work(value: int) -> int:
+    global _bounded_tool_active, _bounded_tool_peak
+    workflow_id = activity.info().workflow_id
+    assert workflow_id is not None
+    _bounded_tool_active += 1
+    _bounded_tool_peak = max(_bounded_tool_peak, _bounded_tool_active)
+    active = _bounded_tool_active_by_workflow.get(workflow_id, 0) + 1
+    _bounded_tool_active_by_workflow[workflow_id] = active
+    _bounded_tool_peak_by_workflow[workflow_id] = max(_bounded_tool_peak_by_workflow.get(workflow_id, 0), active)
+    await asyncio.sleep(0.05)
+    _bounded_tool_active -= 1
+    _bounded_tool_active_by_workflow[workflow_id] -= 1
+    return value
+
+
+bounded_tool_agent = Agent(
+    FunctionModel(_bounded_tool_model),
+    name='bounded_tool_agent',
+    tools=[bounded_work],
+    max_tool_concurrency=2,
+    capabilities=[TemporalDurability(activity_config=BASE_ACTIVITY_CONFIG)],
+)
+
 
 @workflow.defn
 class SimpleDurableAgentWorkflow:
@@ -6174,6 +6209,55 @@ class SimpleDurableAgentWorkflow:
     async def run(self, prompt: str) -> str:
         result = await simple_durable_agent.run(prompt)
         return result.output
+
+
+@workflow.defn
+class BoundedToolDurableAgentWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return (await bounded_tool_agent.run('run bounded tools')).output
+
+
+async def test_max_tool_concurrency_temporal_replay(client: Client) -> None:
+    """Each workflow gets an independent agent-level bound and replays deterministically."""
+    global _bounded_tool_active, _bounded_tool_peak
+    _bounded_tool_active = 0
+    _bounded_tool_peak = 0
+    _bounded_tool_active_by_workflow.clear()
+    _bounded_tool_peak_by_workflow.clear()
+    workflow_ids = [f'{BoundedToolDurableAgentWorkflow.__name__}-{uuid.uuid4()}' for _ in range(4)]
+
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[BoundedToolDurableAgentWorkflow],
+        plugins=[AgentPlugin(bounded_tool_agent)],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        outputs = await asyncio.gather(
+            *[
+                client.execute_workflow(
+                    BoundedToolDurableAgentWorkflow.run,
+                    id=workflow_id,
+                    task_queue=TASK_QUEUE,
+                )
+                for workflow_id in workflow_ids
+            ]
+        )
+        histories = await asyncio.gather(
+            *[client.get_workflow_handle(workflow_id).fetch_history() for workflow_id in workflow_ids]
+        )
+
+    assert outputs == ['done'] * 4
+    assert _bounded_tool_peak_by_workflow == {workflow_id: 2 for workflow_id in workflow_ids}
+    assert _bounded_tool_peak > 2
+    replayer = Replayer(
+        workflows=[BoundedToolDurableAgentWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        data_converter=pydantic_data_converter,
+    )
+    for history in histories:
+        await replayer.replay_workflow(history)
 
 
 @workflow.defn

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 from collections.abc import Callable
@@ -14,6 +15,7 @@ from typing_extensions import TypedDict
 
 from pydantic_ai import (
     Agent,
+    ConcurrencyLimiter,
     EndStrategy,
     ExternalToolset,
     FunctionToolset,
@@ -48,6 +50,78 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 
 from ._inline_snapshot import snapshot
 from .conftest import IsDatetime, IsStr, iter_message_parts, message, message_part
+
+
+@pytest.mark.parametrize(
+    ('execution_mode', 'max_concurrent', 'expected_peak'),
+    [
+        ('parallel', None, 6),
+        ('parallel', 2, 2),
+        ('parallel_ordered_events', 2, 2),
+        ('sequential', 2, 1),
+    ],
+)
+async def test_max_tool_concurrency(
+    execution_mode: Literal['parallel', 'sequential', 'parallel_ordered_events'],
+    max_concurrent: int | None,
+    expected_peak: int,
+) -> None:
+    """The numeric bound caps actual concurrent tool bodies and composes with execution modes."""
+    active = 0
+    peak = 0
+
+    def model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('work', {'value': value}) for value in range(6)])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(model), max_tool_concurrency=max_concurrent)
+
+    @agent.tool_plain
+    async def work(value: int) -> int:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return value
+
+    with agent.parallel_tool_call_execution_mode(execution_mode):
+        await agent.run('run tools')
+
+    assert peak == expected_peak
+
+
+@pytest.mark.parametrize(('shared', 'expected_peak'), [(False, 4), (True, 2)])
+async def test_max_tool_concurrency_across_runs(shared: bool, expected_peak: int) -> None:
+    """Config values are per-run while explicit limiter instances are shared."""
+    active = 0
+    peak = 0
+
+    def model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('work') for _ in range(3)])
+        return ModelResponse(parts=[TextPart('done')])
+
+    limit = ConcurrencyLimiter(2) if shared else 2
+    agent = Agent(FunctionModel(model), max_tool_concurrency=limit)
+
+    @agent.tool_plain
+    async def work() -> None:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    await asyncio.gather(agent.run('first'), agent.run('second'))
+
+    assert peak == expected_peak
+
+
+def test_max_tool_concurrency_requires_positive_limit() -> None:
+    with pytest.raises(UserError, match='max_running must be >= 1'):
+        Agent(TestModel(), max_tool_concurrency=0)
 
 
 def test_tool_no_ctx():


### PR DESCRIPTION
- Closes #6884

There is no way to bound how many tool calls from a single model turn execute concurrently. You can bound to 1 (`parallel_tool_call_execution_mode('sequential')`) or to unbounded — not to N. `max_concurrency` is a *run* limiter, not a tool limiter.

Production motivation from the reporter: a wide turn's completions exceeded the 4 MiB gRPC workflow-task cap and Temporal terminated **104 child workflows in one day**; single streaming turns fanned out to **792/798/799** concurrent tool activities (healthy peak for the same agent: 1), breaching the worker's deadlock-detection ceiling and stalling one run for **2 h 42 m**, while driving ~800 concurrent queries into the database behind the tools.

### API

`Agent(max_tool_concurrency=...)`, alongside the existing `max_concurrency` and accepting the same `AnyConcurrencyLimit` values — `int`, `ConcurrencyLimit` (backpressure), or a shared `AbstractConcurrencyLimiter`. Enforcement lives in `ToolManager` (per @dsfaccini's direction on the issue), where every toolset funnels, so the durable paths inherit it without opting in. Acquisitions use source `tool:<tool_name>` for telemetry.

### Per-run limiters, and why that matters

An `int`/`ConcurrencyLimit` normalizes to a **fresh limiter per run**. That keeps the bound per-turn as asked, and it is what makes it safe under Temporal: tool-call scheduling happens in workflow code, so a process-wide semaphore contended by other workflows would be non-deterministic. Passing an explicit limiter instance opts into sharing and is documented as the caller's responsibility.

`test_max_tool_concurrency_temporal_replay` starts four workflows concurrently on one worker and asserts each sees a peak of exactly 2 while the global peak exceeds 2 — proving independent limiters rather than accidental serialization — then replays all four histories with `Replayer`.

### Measured

| Configuration | Peak concurrent tool bodies |
|---|---:|
| default `'parallel'`, no bound | 6 |
| `'parallel'`, `max_tool_concurrency=2` | 2 |
| `'parallel_ordered_events'`, `max_tool_concurrency=2` | 2 |
| `'sequential'`, `max_tool_concurrency=2` | 1 |

### Deliberately not included

The issue also asked for `parallel_execution_mode=` on `TemporalDurability` for DBOS parity. On investigation that isn't a real gap: `DBOSDurability` exposes it because DBOS needs a **non-default default** (`'parallel_ordered_events'`) for its checkpoint model, whereas Temporal's would be `'parallel'` — identical to the global default — and `Agent.parallel_tool_call_execution_mode()` already lets anyone pick another mode on any backend. Adding the kwarg would duplicate configuration without adding capability.

Also uncovered while testing this: `Agent(max_concurrency=...)` hangs workflows under `TemporalDurability`. Pre-existing and out of scope here — filed as #7002.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

