### PR TITLE
Declare `anyio` as a direct dependency of `pydantic-ai-slim` and `pydantic-graph`

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -56,6 +56,7 @@ Changelog = "https://github.com/pydantic/pydantic-ai/releases"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
+    "anyio>=4.8.0",
     "griffelib>=2.0",
     "httpx>=0.27",
     "pydantic>=2.12",

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -56,7 +56,9 @@ Changelog = "https://github.com/pydantic/pydantic-ai/releases"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
-    "anyio>=4.8.0",
+    # `anyio>=4.7.0` is required for cancellation delivery our streaming teardown relies on:
+    # on 4.6.0 and below, `test_streaming_handoff_survives_absorbed_cancellation` deadlocks (#6422).
+    "anyio>=4.7.0",
     "griffelib>=2.0",
     "httpx>=0.27",
     "pydantic>=2.12",

--- a/pydantic_evals/pyproject.toml
+++ b/pydantic_evals/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "logfire-api>=3.14.1",
     "pydantic>=2.12",
     "pydantic-ai-slim=={{ version }}",
-    "anyio>=4.8.0",
+    "anyio>=4.7.0",
     "pyyaml>=6.0.2",
 ]
 

--- a/pydantic_evals/pyproject.toml
+++ b/pydantic_evals/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "logfire-api>=3.14.1",
     "pydantic>=2.12",
     "pydantic-ai-slim=={{ version }}",
-    "anyio>=0",
+    "anyio>=4.8.0",
     "pyyaml>=6.0.2",
 ]
 

--- a/pydantic_graph/pyproject.toml
+++ b/pydantic_graph/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+    "anyio>=4.8.0",
     "httpx>=0.27",
     "logfire-api>=3.14.1",
     "pydantic>=2.12",

--- a/pydantic_graph/pyproject.toml
+++ b/pydantic_graph/pyproject.toml
@@ -46,7 +46,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "anyio>=4.8.0",
+    # `anyio>=4.7.0` is required for cancellation delivery our streaming teardown relies on:
+    # on 4.6.0 and below, `test_streaming_handoff_survives_absorbed_cancellation` deadlocks (#6422).
+    "anyio>=4.7.0",
     "httpx>=0.27",
     "logfire-api>=3.14.1",
     "pydantic>=2.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ logfire-api = false
 
 [dependency-groups]
 dev = [
-    "anyio>=4.5.0",
+    "anyio>=4.8.0",
     "asgi-lifespan>=2.1.0",
     "devtools>=0.12.2",
     "coverage[toml]>=7.10.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ logfire-api = false
 
 [dependency-groups]
 dev = [
-    "anyio>=4.8.0",
+    "anyio>=4.7.0",
     "asgi-lifespan>=2.1.0",
     "devtools>=0.12.2",
     "coverage[toml]>=7.10.7",

--- a/uv.lock
+++ b/uv.lock
@@ -5483,7 +5483,7 @@ provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duck
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "anyio", specifier = ">=4.8.0" },
+    { name = "anyio", specifier = ">=4.7.0" },
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "boto3-stubs", extras = ["bedrock-runtime"], specifier = ">=1.42.63" },
     { name = "brotli", specifier = ">=1.2.0" },
@@ -5697,7 +5697,7 @@ zai = [
 requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.108.0" },
-    { name = "anyio", specifier = ">=4.8.0" },
+    { name = "anyio", specifier = ">=4.7.0" },
     { name = "argcomplete", marker = "extra == 'cli'", specifier = ">=3.5.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.63" },
     { name = "botocore", marker = "extra == 'bedrock-mantle'", specifier = ">=1.42.63" },
@@ -5896,7 +5896,7 @@ logfire = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=4.8.0" },
+    { name = "anyio", specifier = ">=4.7.0" },
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=3.14.1" },
     { name = "logfire-api", specifier = ">=3.14.1" },
     { name = "pydantic", specifier = ">=2.12" },
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=4.8.0" },
+    { name = "anyio", specifier = ">=4.7.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "logfire-api", specifier = ">=3.14.1" },
     { name = "pydantic", specifier = ">=2.12" },

--- a/uv.lock
+++ b/uv.lock
@@ -5483,7 +5483,7 @@ provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duck
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "anyio", specifier = ">=4.5.0" },
+    { name = "anyio", specifier = ">=4.8.0" },
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "boto3-stubs", extras = ["bedrock-runtime"], specifier = ">=1.42.63" },
     { name = "brotli", specifier = ">=1.2.0" },
@@ -5577,6 +5577,7 @@ requires-dist = [
 name = "pydantic-ai-slim"
 source = { editable = "pydantic_ai_slim" }
 dependencies = [
+    { name = "anyio" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "genai-prices" },
     { name = "griffelib" },
@@ -5696,6 +5697,7 @@ zai = [
 requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.108.0" },
+    { name = "anyio", specifier = ">=4.8.0" },
     { name = "argcomplete", marker = "extra == 'cli'", specifier = ">=3.5.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.63" },
     { name = "botocore", marker = "extra == 'bedrock-mantle'", specifier = ">=1.42.63" },
@@ -5894,7 +5896,7 @@ logfire = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=0" },
+    { name = "anyio", specifier = ">=4.8.0" },
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=3.14.1" },
     { name = "logfire-api", specifier = ">=3.14.1" },
     { name = "pydantic", specifier = ">=2.12" },
@@ -5921,6 +5923,7 @@ wheels = [
 name = "pydantic-graph"
 source = { editable = "pydantic_graph" }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
@@ -5929,6 +5932,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.8.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "logfire-api", specifier = ">=3.14.1" },
     { name = "pydantic", specifier = ">=2.12" },


### PR DESCRIPTION
`pydantic-ai-slim` imports `anyio` in a dozen runtime modules (`concurrency.py`, `_sync_stream.py`, `mcp.py`, `result.py`, `agent/__init__.py`, `durable_exec/temporal/_activity_execution.py`, …) and `pydantic-graph` imports it in `graph_builder.py` — but **neither declares it**. It arrives only because `httpx` requires it, *unversioned*, so a user who pins an old `anyio` satisfies `httpx` and breaks us. `pydantic-evals` declared `anyio>=0`, which has the same hole.

All three now declare `anyio>=4.7.0`.

### Why 4.7.0

Bisected against our own test suite rather than picked:

| anyio | `test_streaming_handoff_survives_absorbed_cancellation` |
|---|---|
| 4.5.0 | fails — `deadlock: run task still pending after cancellation (#6422)` |
| 4.6.0 | fails |
| **4.7.0** | **passes** |
| 4.8.0+ | passes |

That test is the #6422 cancellation-deadlock regression test, so the floor reflects a real behavioural dependency. Verified 1050 tests pass on 4.7.0 (`test_tools`, `test_agent`, `test_streaming`, `graph`, `test_mcp`). A comment in each pyproject records the reason so it isn't lowered blindly.

Note that CI's `test-lowest-versions` job (`uv sync --all-extras --resolution lowest-direct`) still resolves `anyio==4.8.0`, because `google-genai` requires `>=4.8.0`. Declaring 4.8.0 ourselves would have over-restricted anyone installing bare `pydantic-ai-slim` for a reason that only applies with the `google` extra.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

