### PR TITLE
Document the Temporal large-payload claim-check codec

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -224,6 +224,86 @@ The activity's `RunContext` is rebuilt from the serialized payload, so its field
 
 A tool's [`prepare`](../tools-advanced.md#tool-prepare) function is not affected by these limitations: for tools in a [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset] (including those defined on the agent itself), it runs in workflow code with the complete `RunContext`, once per run step like outside a workflow. The tool definition it returns is sent to the tool-call activity, which uses it as-is, so the tool the model saw is the tool that runs, down to its [`timeout`](../tools-advanced.md#tool-timeout). Tools from a `DynamicToolset` are the exception: as the toolset is re-resolved inside activities, their `prepare` functions run there as well and see the limited `RunContext`.
 
+### Large Payloads
+
+Temporal records activity arguments in workflow history and enforces payload-size limits. As a result, a
+large [dependencies object](../dependencies.md) is copied into history every time Pydantic AI schedules a
+model, tool, MCP, or event-handler activity. A [Temporal payload codec](https://docs.temporal.io/develop/python/converters-and-encryption#custom-payload-codec)
+can apply the [claim check pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html):
+store a large payload outside Temporal and put only its key in workflow history.
+
+This complete codec uses an in-memory dictionary to keep the example runnable. In production, replace
+`payload_store` with durable object storage, keep stored values available for at least as long as workflow
+histories can be replayed, and authenticate and encrypt access as appropriate.
+
+```python {title="temporal_claim_check.py"}
+from collections.abc import Sequence
+from hashlib import sha256
+
+from temporalio.api.common.v1 import Payload
+from temporalio.converter import DataConverter, PayloadCodec
+
+payload_store: dict[str, bytes] = {}
+claim_check_encoding = b'binary/claim-check'
+
+
+class ClaimCheckCodec(PayloadCodec):
+    def __init__(self, threshold: int = 128 * 1024):
+        self.threshold = threshold
+
+    async def encode(self, payloads: Sequence[Payload]) -> list[Payload]:
+        encoded: list[Payload] = []
+        for payload in payloads:
+            serialized = payload.SerializeToString()
+            if len(serialized) < self.threshold:
+                encoded.append(payload)
+                continue
+
+            key = sha256(serialized).hexdigest()
+            payload_store.setdefault(key, serialized)
+            encoded.append(Payload(metadata={'encoding': claim_check_encoding}, data=key.encode()))
+        return encoded
+
+    async def decode(self, payloads: Sequence[Payload]) -> list[Payload]:
+        decoded: list[Payload] = []
+        for payload in payloads:
+            if payload.metadata.get('encoding') != claim_check_encoding:
+                decoded.append(payload)
+                continue
+
+            restored = Payload()
+            restored.ParseFromString(payload_store[payload.data.decode()])
+            decoded.append(restored)
+        return decoded
+
+
+data_converter = DataConverter(payload_codec=ClaimCheckCodec())
+```
+
+Pass the converter to the Temporal client; [`PydanticAIPlugin`][pydantic_ai.durable_exec.temporal.PydanticAIPlugin]
+keeps the codec while replacing Temporal's default payload converter with its Pydantic-aware converter:
+
+```python {title="temporal_claim_check_client.py" requires="temporal_claim_check.py"}
+from temporalio.client import Client
+
+from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
+
+from temporal_claim_check import data_converter
+
+
+async def connect() -> Client:
+    return await Client.connect(
+        'localhost:7233',
+        data_converter=data_converter,
+        plugins=[PydanticAIPlugin()],
+    )
+```
+
+Content-addressing means the example stores identical bytes once, but the codec still emits one reference
+payload for every activity argument in a fan-out. It therefore avoids the payload ceiling and large history
+entries, but it does not deduplicate those reference payloads within a workflow-task completion. A missing,
+expired, or inaccessible stored payload prevents workers from decoding and replaying the workflow.
+
 ### Streaming
 
 [`Agent.run_stream()`][pydantic_ai.agent.Agent.run_stream], [`Agent.run_stream_events()`][pydantic_ai.agent.Agent.run_stream_events], and [`Agent.iter()`][pydantic_ai.agent.Agent.iter] work inside a Temporal workflow, but their events are buffered rather than delivered in real time. The model stream runs inside the durable activity, and its events are replayed to the workflow after the activity completes.

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -226,72 +226,33 @@ A tool's [`prepare`](../tools-advanced.md#tool-prepare) function is not affected
 
 ### Large Payloads
 
-Temporal records activity arguments in workflow history and enforces payload-size limits. As a result, a
-large [dependencies object](../dependencies.md) is copied into history every time Pydantic AI schedules a
-model, tool, MCP, or event-handler activity. A [Temporal payload codec](https://docs.temporal.io/develop/python/converters-and-encryption#custom-payload-codec)
-can apply the [claim check pattern](https://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html):
-store a large payload outside Temporal and put only its key in workflow history.
+Temporal records activity arguments in workflow history and enforces payload-size limits. A large
+[dependencies object](../dependencies.md) is therefore copied into history every time Pydantic AI schedules
+a model, tool, MCP, or event-handler activity, so a wide tool fan-out can both bloat history permanently and
+breach the per-payload limit.
 
-This complete codec uses an in-memory dictionary to keep the example runnable. In production, replace
-`payload_store` with durable object storage, keep stored values available for at least as long as workflow
-histories can be replayed, and authenticate and encrypt access as appropriate.
+Temporal solves this itself with [external storage](https://docs.temporal.io/external-storage), which
+transparently offloads any payload above a size threshold to your own store and puts a reference in history
+instead. Configure it with an
+[`ExternalStorage`](https://docs.temporal.io/develop/python/data-handling/external-storage) on your
+`DataConverter`:
 
-```python {title="temporal_claim_check.py"}
-from collections.abc import Sequence
-from hashlib import sha256
+```python {title="temporal_external_storage.py" test="skip" lint="skip"}
+import dataclasses
 
-from temporalio.api.common.v1 import Payload
-from temporalio.converter import DataConverter, PayloadCodec
-
-payload_store: dict[str, bytes] = {}
-claim_check_encoding = b'binary/claim-check'
-
-
-class ClaimCheckCodec(PayloadCodec):
-    def __init__(self, threshold: int = 128 * 1024):
-        self.threshold = threshold
-
-    async def encode(self, payloads: Sequence[Payload]) -> list[Payload]:
-        encoded: list[Payload] = []
-        for payload in payloads:
-            serialized = payload.SerializeToString()
-            if len(serialized) < self.threshold:
-                encoded.append(payload)
-                continue
-
-            key = sha256(serialized).hexdigest()
-            payload_store.setdefault(key, serialized)
-            encoded.append(Payload(metadata={'encoding': claim_check_encoding}, data=key.encode()))
-        return encoded
-
-    async def decode(self, payloads: Sequence[Payload]) -> list[Payload]:
-        decoded: list[Payload] = []
-        for payload in payloads:
-            if payload.metadata.get('encoding') != claim_check_encoding:
-                decoded.append(payload)
-                continue
-
-            restored = Payload()
-            restored.ParseFromString(payload_store[payload.data.decode()])
-            decoded.append(restored)
-        return decoded
-
-
-data_converter = DataConverter(payload_codec=ClaimCheckCodec())
-```
-
-Pass the converter to the Temporal client; [`PydanticAIPlugin`][pydantic_ai.durable_exec.temporal.PydanticAIPlugin]
-keeps the codec while replacing Temporal's default payload converter with its Pydantic-aware converter:
-
-```python {title="temporal_claim_check_client.py" requires="temporal_claim_check.py"}
 from temporalio.client import Client
+from temporalio.converter import DataConverter, ExternalStorage
 
 from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
 
-from temporal_claim_check import data_converter
+from my_app.storage import my_storage_driver  # your `StorageDriver` implementation
 
 
 async def connect() -> Client:
+    data_converter = dataclasses.replace(
+        DataConverter.default,
+        external_storage=ExternalStorage(drivers=[my_storage_driver]),
+    )
     return await Client.connect(
         'localhost:7233',
         data_converter=data_converter,
@@ -299,10 +260,26 @@ async def connect() -> Client:
     )
 ```
 
-Content-addressing means the example stores identical bytes once, but the codec still emits one reference
-payload for every activity argument in a fan-out. It therefore avoids the payload ceiling and large history
-entries, but it does not deduplicate those reference payloads within a workflow-task completion. A missing,
-expired, or inaccessible stored payload prevents workers from decoding and replaying the workflow.
+[`PydanticAIPlugin`][pydantic_ai.durable_exec.temporal.PydanticAIPlugin] replaces only Temporal's default
+payload *converter* with its Pydantic-aware one, so your `external_storage` — like a custom `payload_codec`
+or `failure_converter_class` — is preserved.
+
+Payloads below the threshold (256 KiB by default) are untouched, so this costs nothing on runs with small
+dependencies. See Temporal's documentation for the available storage drivers and for writing your own; note
+that external storage is in public preview, so its API may still change.
+
+!!! warning "Stored payloads are part of your workflow history"
+    A payload that is missing, expired, or inaccessible prevents workers from decoding and replaying the
+    workflow. Keep stored payloads available for at least as long as their histories can be replayed.
+
+Because offloading happens per payload, a fan-out of N activities still emits N (small) references. External
+storage removes the size ceiling and the history bloat; it does not deduplicate identical dependencies within
+a single workflow-task completion.
+
+If you cannot adopt a public-preview API, Temporal also documents a hand-written
+[claim check codec](https://docs.temporal.io/ai-cookbook/claim-check-pattern-python) built on
+[`PayloadCodec`](https://docs.temporal.io/develop/python/converters-and-encryption#custom-payload-codec),
+which `PydanticAIPlugin` preserves in the same way.
 
 ### Streaming
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -128,7 +128,13 @@ try:
     from temporalio.common import RetryPolicy
     from temporalio.contrib.opentelemetry import TracingInterceptor
     from temporalio.contrib.pydantic import PydanticPayloadConverter, pydantic_data_converter
-    from temporalio.converter import DataConverter, DefaultPayloadConverter, PayloadCodec
+    from temporalio.converter import (
+        DataConverter,
+        DefaultPayloadConverter,
+        ExternalStorage,
+        PayloadCodec,
+        StorageDriver,
+    )
     from temporalio.exceptions import ApplicationError, CancelledError as TemporalCancelledError
     from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
     from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
@@ -5737,6 +5743,37 @@ def test_pydantic_ai_plugin_preserves_custom_payload_codec() -> None:
     assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
     assert result['data_converter'].payload_codec is codec
     assert result['data_converter'].failure_converter_class is converter.failure_converter_class
+
+
+def test_pydantic_ai_plugin_preserves_external_storage() -> None:
+    """A user's Temporal external storage config survives the payload converter swap.
+
+    The Temporal docs point large-payload users at `external_storage`, so this has to keep working.
+    """
+
+    class MockStorageDriver(StorageDriver):
+        def name(self) -> str:
+            return 'mock'
+
+        def type(self) -> str:
+            return 'mock'
+
+        async def store(self, context: Any, payloads: Any) -> Any:
+            raise NotImplementedError
+
+        async def retrieve(self, context: Any, claims: Any) -> Any:
+            raise NotImplementedError
+
+    external_storage = ExternalStorage(drivers=[MockStorageDriver()])
+    plugin = PydanticAIPlugin()
+    converter = DataConverter(
+        payload_converter_class=DefaultPayloadConverter,
+        external_storage=external_storage,
+    )
+    config: dict[str, Any] = {'data_converter': converter}
+    result = plugin.configure_client(config)  # type: ignore[arg-type]
+    assert result['data_converter'].payload_converter_class is PydanticAIPayloadConverter
+    assert result['data_converter'].external_storage is external_storage
 
 
 def test_pydantic_ai_plugin_with_non_pydantic_converter_warns() -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -5755,9 +5755,6 @@ def test_pydantic_ai_plugin_preserves_external_storage() -> None:
         def name(self) -> str:
             return 'mock'
 
-        def type(self) -> str:
-            return 'mock'
-
         async def store(self, context: Any, payloads: Any) -> Any:
             raise NotImplementedError
 


### PR DESCRIPTION
Under Temporal, `ctx.deps` is serialized into **every** activity dispatch. On a 200 KB deps object a 20-wide tool fan-out produces 4,013,160 bytes in one workflow-task completion — over the 4 MiB gRPC limit — and every copy is written to workflow history permanently.

A user-supplied `payload_codec` is already preserved by `TemporalDurability` (`durable_exec/temporal/__init__.py`, `_data_converter`), so a claim-check codec solves the size ceiling **today**. Nothing documented it, so nobody finds it.

This adds the recipe to `docs/durable_execution/temporal.md`: the problem, a worked codec example, and its limits — notably that it does not dedup N identical payloads within a single fan-out.

Context: #6976. That issue asks for deps-by-reference as first-class API; this is the part that works today and is worth documenting regardless of what we decide there.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

