### PR TITLE
Pass Temporal `deps` by reference (design spike)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -25,6 +25,7 @@ from pydantic_graph.exceptions import UnsupportedEventLoopError
 from ...agent.abstract import AbstractAgent
 from ...exceptions import AgentRunError, UserError
 from ._agent import TemporalAgent  # pyright: ignore[reportDeprecated]
+from ._dependencies import TemporalDependencyResolver
 from ._durability import TemporalDurability
 from ._logfire import LogfirePlugin
 from ._payload_converter import PydanticAIPayloadConverter
@@ -35,6 +36,7 @@ from ._workflow import PydanticAIWorkflow
 __all__ = [
     'TemporalAgent',
     'TemporalDurability',
+    'TemporalDependencyResolver',
     'PydanticAIPlugin',
     'LogfirePlugin',
     'AgentPlugin',

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dependencies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dependencies.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import KW_ONLY, dataclass
+from typing import Generic, TypeVar
+
+DepsT = TypeVar('DepsT')
+DepsRefT = TypeVar('DepsRefT')
+
+
+@dataclass(frozen=True)
+class TemporalDependencyResolver(Generic[DepsT, DepsRefT]):
+    """Convert agent dependencies to a small durable reference and rehydrate them in activities."""
+
+    reference_type: type[DepsRefT]
+    """The concrete reference type Temporal should deserialize."""
+
+    _: KW_ONLY
+    to_reference: Callable[[DepsT], DepsRefT]
+    """Return a deterministic reference without performing I/O."""
+
+    from_reference: Callable[[DepsRefT], Awaitable[DepsT]]
+    """Load dependencies from a reference inside a Temporal activity."""

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -45,6 +45,7 @@ from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import AbstractToolset, WrapperToolset
 
 from ._activity_execution import execute_activity
+from ._dependencies import TemporalDependencyResolver
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
     TemporalWrapperToolset,
@@ -165,6 +166,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         event_stream_handler_activity_config: ActivityConfig | None = None,
         toolset_activity_config: dict[str, ActivityConfig] | None = None,
         run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
+        dependency_resolver: TemporalDependencyResolver[AgentDepsT, Any] | None = None,
     ):
         """Create a TemporalDurability capability.
 
@@ -204,6 +206,8 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                 merged on top of the base config.
             run_context_type: The `TemporalRunContext` subclass for run context
                 serialization/deserialization.
+            dependency_resolver: Typed conversion between dependencies and the small reference
+                passed to activities.
 
         Note:
             Per-tool activity config (custom timeouts, retry policies, or disabling
@@ -221,6 +225,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         super().__init__(models=models, event_stream_handler=event_stream_handler, name=name)
         self.run_context_type = run_context_type
         self._deps_type = deps_type
+        self.dependency_resolver = dependency_resolver
 
         # An unknown key, or a value Temporal's own types don't accept, would only fail when the
         # config is splatted into `workflow.start_activity()` inside the workflow, where the
@@ -294,6 +299,8 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         activity_name_prefix = f'agent__{self.name}'
         assert self._deps_type is not None  # set by `for_agent` before activities are registered
         deps_type = self._deps_type
+        dependency_resolver = self.dependency_resolver
+        activity_deps_type = dependency_resolver.reference_type if dependency_resolver else deps_type
         run_context_type = self.run_context_type
         activities: list[Callable[..., Any]] = []
 
@@ -301,12 +308,18 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             # Temporal's Pydantic payload converter deserializes `deps` by introspecting the activity's
             # annotation, and the concrete deps type is only known once the capability is bound to an agent.
             # Set it here so serialization uses the real type instead of the placeholder the closure declares.
-            fn.__annotations__['deps'] = deps_type | None
+            fn.__annotations__['deps'] = activity_deps_type | None
             return activity.defn(name=name)(fn)
+
+        async def resolve_deps(deps: Any) -> Any:
+            if dependency_resolver is None:
+                return deps
+            return await dependency_resolver.from_reference(deps)
 
         # --- Model request activities ---
 
         async def request_activity(params: _RequestParams, deps: Any | None = None) -> ModelResponse:
+            deps = await resolve_deps(deps)
             run_context = deserialize_run_context(
                 run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
             )
@@ -323,6 +336,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         activities.append(self.request_activity)
 
         async def request_stream_activity(params: _RequestParams, deps: Any) -> _StreamedActivityPayload:
+            deps = await resolve_deps(deps)
             run_context = deserialize_run_context(
                 run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
             )
@@ -351,6 +365,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             handler = self._event_stream_handler
 
             async def event_stream_handler_activity(params: _EventStreamHandlerParams, deps: Any) -> None:
+                deps = await resolve_deps(deps)
                 async with heartbeating():
                     run_context = deserialize_run_context(
                         run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
@@ -370,6 +385,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                     model = infer_model(params.model_id)
                 run_context = None
             else:
+                deps = await resolve_deps(deps)
                 run_context = deserialize_run_context(
                     run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
                 )
@@ -408,6 +424,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             self._deps_type,
             self.run_context_type,
             self._agent,
+            self.dependency_resolver,
         )
         return wrapped if isinstance(wrapped, (TemporalWrapperToolset, DurableToolsetBase)) else None
 
@@ -436,7 +453,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             activity=self.event_stream_handler_activity,
             args=[
                 _EventStreamHandlerParams(event=event, serialized_run_context=serialized_run_context),
-                ctx.deps,
+                self._activity_deps(ctx.deps),
             ],
             **config,
         )
@@ -501,7 +518,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         model_id = self._model_id_for_request(ctx, request_context)
         serialized_run_context = self.run_context_type.serialize_run_context(ctx)
         model_name = model_id or request_context.model.model_id
-        deps = ctx.deps
+        deps = self._activity_deps(ctx.deps)
 
         def params(request: ModelRequestContext) -> _RequestParams:
             return _RequestParams(
@@ -558,6 +575,11 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
             cancel_suspended_response_segment=cancel_suspended_response_segment,
         )
         return await handler(request_context)
+
+    def _activity_deps(self, deps: AgentDepsT) -> Any:
+        if self.dependency_resolver is None:
+            return deps
+        return self.dependency_resolver.to_reference(deps)
 
     def _validate_model_request_parameters(self, model_request_parameters: ModelRequestParameters) -> None:
         if model_request_parameters.allow_image_output:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
@@ -22,6 +22,7 @@ from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._activity_execution import execute_activity
+from ._dependencies import TemporalDependencyResolver
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
     CallToolParams,
@@ -43,6 +44,7 @@ def temporalize_dynamic_toolset(
     deps_type: type[AgentDepsT],
     run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
     agent: AbstractAgent[AgentDepsT, Any] | None = None,
+    dependency_resolver: TemporalDependencyResolver[AgentDepsT, Any] | None = None,
 ) -> DurableDynamicToolset[AgentDepsT]:
     """Temporalize a dynamic toolset.
 
@@ -50,22 +52,30 @@ def temporalize_dynamic_toolset(
     toolset resolution happens inside the activities, where I/O is allowed.
     """
 
-    async def get_tools_activity(params: GetToolsParams, deps: AgentDepsT) -> DynamicToolsResult:
+    async def get_tools_activity(params: GetToolsParams, deps: Any) -> DynamicToolsResult:
+        if dependency_resolver:
+            deps = await dependency_resolver.from_reference(deps)
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
             return await get_dynamic_tools(toolset, ctx)
 
-    get_tools_activity.__annotations__['deps'] = deps_type
+    get_tools_activity.__annotations__['deps'] = (
+        dependency_resolver.reference_type if dependency_resolver else deps_type
+    )
     registered_get_tools = activity.defn(name=f'{activity_name_prefix}__dynamic_toolset__{toolset.id}__get_tools')(
         get_tools_activity
     )
 
-    async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
+    async def call_tool_activity(params: CallToolParams, deps: Any) -> CallToolResult:
+        if dependency_resolver:
+            deps = await dependency_resolver.from_reference(deps)
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
             return await wrap_tool_call_result(call_dynamic_tool(toolset, params.name, params.tool_args, ctx))
 
-    call_tool_activity.__annotations__['deps'] = deps_type
+    call_tool_activity.__annotations__['deps'] = (
+        dependency_resolver.reference_type if dependency_resolver else deps_type
+    )
     registered_call_tool = activity.defn(name=f'{activity_name_prefix}__dynamic_toolset__{toolset.id}__call_tool')(
         call_tool_activity
     )
@@ -76,7 +86,7 @@ def temporalize_dynamic_toolset(
             activity=registered_get_tools,
             args=[
                 GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)),
-                ctx.deps,
+                dependency_resolver.to_reference(ctx.deps) if dependency_resolver else ctx.deps,
             ],
             **config,
         )
@@ -105,7 +115,7 @@ def temporalize_dynamic_toolset(
                     serialized_run_context=run_context_type.serialize_run_context(ctx),
                     tool_def=tool.tool_def,
                 ),
-                ctx.deps,
+                dependency_resolver.to_reference(ctx.deps) if dependency_resolver else ctx.deps,
             ],
             **merged_config,
         )

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
@@ -18,6 +18,7 @@ from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 from ._activity_execution import execute_activity
+from ._dependencies import TemporalDependencyResolver
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import CallToolParams, call_tool_in_activity, heartbeating, resolve_tool_activity_config
 
@@ -34,8 +35,11 @@ def temporalize_function_toolset(
     deps_type: type[AgentDepsT],
     run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
     agent: AbstractAgent[AgentDepsT, Any] | None = None,
+    dependency_resolver: TemporalDependencyResolver[AgentDepsT, Any] | None = None,
 ) -> DurableFunctionToolset[AgentDepsT]:
-    async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
+    async def call_tool_activity(params: CallToolParams, deps: Any) -> CallToolResult:
+        if dependency_resolver:
+            deps = await dependency_resolver.from_reference(deps)
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
             try:
@@ -54,7 +58,9 @@ def temporalize_function_toolset(
                 ) from exc
             return await call_tool_in_activity(toolset, params.name, params.tool_args, ctx, tool)
 
-    call_tool_activity.__annotations__['deps'] = deps_type
+    call_tool_activity.__annotations__['deps'] = (
+        dependency_resolver.reference_type if dependency_resolver else deps_type
+    )
     registered_activity = activity.defn(name=f'{activity_name_prefix}__toolset__{toolset.id}__call_tool')(
         call_tool_activity
     )
@@ -97,7 +103,7 @@ def temporalize_function_toolset(
                     # holds it under; the activity needs the latter to find the function to call.
                     original_name=tool.original_name if isinstance(tool, FunctionToolsetTool) else None,
                 ),
-                ctx.deps,
+                dependency_resolver.to_reference(ctx.deps) if dependency_resolver else ctx.deps,
             ],
             **merged_config,
         )

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
@@ -20,6 +20,7 @@ from pydantic_ai.messages import InstructionPart
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
 from ._activity_execution import execute_activity
+from ._dependencies import TemporalDependencyResolver
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import CallToolParams, GetToolsParams, heartbeating, resolve_tool_activity_config
 
@@ -36,6 +37,7 @@ def temporalize_mcp_toolset(
     deps_type: type[AgentDepsT],
     run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
     agent: AbstractAgent[AgentDepsT, Any] | None = None,
+    dependency_resolver: TemporalDependencyResolver[AgentDepsT, Any] | None = None,
 ) -> DurableMCPToolset[AgentDepsT]:
     for tool_name, config in tool_activity_config.items():
         if config is False:
@@ -44,20 +46,26 @@ def temporalize_mcp_toolset(
                 'but MCP tools require the use of IO and so cannot be run outside of an activity.'
             )
 
-    async def get_tools_activity(params: GetToolsParams, deps: AgentDepsT) -> dict[str, ToolDefinition]:
+    async def get_tools_activity(params: GetToolsParams, deps: Any) -> dict[str, ToolDefinition]:
+        if dependency_resolver:
+            deps = await dependency_resolver.from_reference(deps)
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
             return {name: tool.tool_def for name, tool in (await toolset.get_tools(ctx)).items()}
 
     async def get_instructions_activity(
-        params: GetToolsParams, deps: AgentDepsT
+        params: GetToolsParams, deps: Any
     ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
+        if dependency_resolver:
+            deps = await dependency_resolver.from_reference(deps)
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
             async with toolset:
                 return await toolset.get_instructions(ctx)
 
-    async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
+    async def call_tool_activity(params: CallToolParams, deps: Any) -> CallToolResult:
+        if dependency_resolver:
+            deps = await dependency_resolver.from_reference(deps)
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
             assert isinstance(params.tool_def, ToolDefinition)
@@ -68,7 +76,7 @@ def temporalize_mcp_toolset(
             )
 
     for activity_func in (get_tools_activity, get_instructions_activity, call_tool_activity):
-        activity_func.__annotations__['deps'] = deps_type
+        activity_func.__annotations__['deps'] = dependency_resolver.reference_type if dependency_resolver else deps_type
     get_tools_activity_def = activity.defn(name=f'{activity_name_prefix}__mcp_server__{toolset.id}__get_tools')(
         get_tools_activity
     )
@@ -93,7 +101,10 @@ def temporalize_mcp_toolset(
         config: ActivityConfig = {'summary': f'get tools: {toolset.id}', **activity_config}
         return await execute_activity(
             activity=get_tools_activity_def,
-            args=[GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)), ctx.deps],
+            args=[
+                GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)),
+                dependency_resolver.to_reference(ctx.deps) if dependency_resolver else ctx.deps,
+            ],
             **config,
         )
 
@@ -103,7 +114,10 @@ def temporalize_mcp_toolset(
         config: ActivityConfig = {'summary': f'get instructions: {toolset.id}', **activity_config}
         return await execute_activity(
             activity=get_instructions_activity_def,
-            args=[GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)), ctx.deps],
+            args=[
+                GetToolsParams(serialized_run_context=run_context_type.serialize_run_context(ctx)),
+                dependency_resolver.to_reference(ctx.deps) if dependency_resolver else ctx.deps,
+            ],
             **config,
         )
 
@@ -127,7 +141,7 @@ def temporalize_mcp_toolset(
                     serialized_run_context=run_context_type.serialize_run_context(ctx),
                     tool_def=tool.tool_def,
                 ),
-                ctx.deps,
+                dependency_resolver.to_reference(ctx.deps) if dependency_resolver else ctx.deps,
             ],
             **merged_config,
         )

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -27,6 +27,7 @@ from pydantic_ai.exceptions import FallbackExceptionGroup, UnexpectedModelBehavi
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
+from ._dependencies import TemporalDependencyResolver
 from ._run_context import TemporalRunContext
 
 if TYPE_CHECKING:
@@ -258,6 +259,7 @@ def temporalize_toolset(
     deps_type: type[AgentDepsT],
     run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
     agent: AbstractAgent[AgentDepsT, Any] | None = None,
+    dependency_resolver: TemporalDependencyResolver[AgentDepsT, Any] | None = None,
 ) -> AbstractToolset[AgentDepsT]:
     """Temporalize a toolset.
 
@@ -269,6 +271,7 @@ def temporalize_toolset(
         deps_type: The type of agent's dependencies object. It needs to be serializable using Pydantic's `TypeAdapter`.
         run_context_type: The `TemporalRunContext` (sub)class that's used to serialize and deserialize the run context.
         agent: The agent instance to attach to deserialized run contexts in activities.
+        dependency_resolver: Optional typed conversion between dependencies and their activity reference.
     """
     if isinstance(toolset, FunctionToolset):
         from ._function_toolset import temporalize_function_toolset
@@ -281,6 +284,7 @@ def temporalize_toolset(
             deps_type=deps_type,
             run_context_type=run_context_type,
             agent=agent,
+            dependency_resolver=dependency_resolver,
         )
 
     if isinstance(toolset, DynamicToolset):
@@ -294,6 +298,7 @@ def temporalize_toolset(
             deps_type=deps_type,
             run_context_type=run_context_type,
             agent=agent,
+            dependency_resolver=dependency_resolver,
         )
 
     try:
@@ -312,6 +317,7 @@ def temporalize_toolset(
                 deps_type=deps_type,
                 run_context_type=run_context_type,
                 agent=agent,
+                dependency_resolver=dependency_resolver,
             )
 
     return toolset

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -146,6 +146,7 @@ try:
         PydanticAIPlugin,
         PydanticAIWorkflow,
         TemporalAgent,  # pyright: ignore[reportDeprecated]
+        TemporalDependencyResolver,
         TemporalDurability,
         _payload_converter as temporal_payload_converter,  # pyright: ignore[reportPrivateUsage]
     )
@@ -6323,6 +6324,55 @@ async def test_durability_agent_with_tools_in_workflow(client: Client):
             ComplexDurableAgentWorkflow.run,
             args=['What country?', Deps(country='France')],
             id=ComplexDurableAgentWorkflow.__name__,
+            task_queue=TASK_QUEUE,
+        )
+        assert output == 'The country is: France'
+
+
+_referenced_deps_store = {'france': Deps(country='France')}
+
+
+async def _resolve_referenced_deps(key: str) -> Deps:
+    return _referenced_deps_store[key]
+
+
+referenced_deps_durability = TemporalDurability[Deps](
+    deps_type=Deps,
+    activity_config=BASE_ACTIVITY_CONFIG,
+    dependency_resolver=TemporalDependencyResolver(
+        str,
+        to_reference=lambda deps: deps.country.lower(),
+        from_reference=_resolve_referenced_deps,
+    ),
+)
+referenced_deps_agent = Agent(
+    _tool_fn_model,
+    deps_type=Deps,
+    toolsets=[FunctionToolset[Deps](tools=[get_country], id='referenced_deps_country')],
+    capabilities=[referenced_deps_durability],
+    name='referenced_deps_agent',
+)
+
+
+@workflow.defn
+class ReferencedDepsWorkflow:
+    @workflow.run
+    async def run(self, prompt: str, deps: Deps) -> str:
+        result = await referenced_deps_agent.run(prompt, deps=deps)
+        return result.output
+
+
+async def test_durability_rehydrates_referenced_deps_in_model_and_tool_activities(client: Client):
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[ReferencedDepsWorkflow],
+        plugins=[AgentPlugin(referenced_deps_agent)],
+    ):
+        output = await client.execute_workflow(
+            ReferencedDepsWorkflow.run,
+            args=['What country?', Deps(country='France')],
+            id=ReferencedDepsWorkflow.__name__,
             task_queue=TASK_QUEUE,
         )
         assert output == 'The country is: France'


### PR DESCRIPTION
**Design spike for #6976 — not for merge as-is.** Opening it so the design and its measurements are reviewable.

Adds `TemporalDurability(dependency_resolver=...)` backed by a generic `TemporalDependencyResolver[DepsT, RefT]`: `to_reference` runs synchronously in workflow code, `from_reference` runs async worker-side, and activities carry `RefT` while all Pydantic AI callbacks still receive `RunContext[DepsT]`. Applied to all dispatch sites (model request, streamed request, cancellation, event handler, function tool, dynamic toolset, all three MCP paths).

### Measured

| fan-out | current full `DepsT` | prototype `RefT` |
|---:|---:|---:|
| 1 | 200,658 B | 32 B |
| 10 | 2,006,580 B | 320 B |
| 20 | 4,013,160 B | 640 B |

### Why I recommend holding it

- Temporal 1.24 exposes `DataConverter.external_storage`, and Temporal shipped External Storage in public preview in May 2026. That is the upstream claim-check primitive.
- The resolver still emits N references for N activities — it does **not** dedup within a fan-out, which was the one gap a codec couldn't close.
- The documented codec recipe (separate PR) already addresses the size ceiling and history bloat.

So the marginal value over docs + upstream external storage is narrow: natural `DepsT` worker-side with application-versioned references, and discoverability.

Full design write-up including rejected alternatives and failure modes is in the issue thread.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

