### PR TITLE
Fix attention monitor assigning every issue and PR to the fallback owner

### DIFF
--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -95,7 +95,6 @@ class GitHubClient:
         self._token = token
         self._maintainers: dict[tuple[str, str], str | None] = {}
         self._probes = 0
-        self._probes_refused = False
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -166,12 +165,18 @@ class GitHubClient:
                 return entries, True
         return entries, False
 
-    @property
-    def probes_refused(self) -> bool:
-        """Whether the run-wide probe ceiling has turned a lookup away."""
-        return self._probes_refused
+    def knows_maintainer(self, repo: str, login: str) -> bool:
+        """Whether `maintainer_login` can answer for `login` without a request."""
+        return (repo, login.casefold()) in self._maintainers
 
-    def maintainer_login(self, repo: str, login: str, *, probe: bool = False) -> str | None:
+    def spend_probe(self) -> bool:
+        """Claim one of the run's speculative lookups, or report it unavailable."""
+        if self._probes >= _RUN_PROBE_LIMIT:
+            return False
+        self._probes += 1
+        return True
+
+    def maintainer_login(self, repo: str, login: str) -> str | None:
         """Return `login` when it can push to `repo`, resolved one user at a time.
 
         The collaborator *list* endpoint looks cheaper but is wrong here: it only
@@ -181,19 +186,13 @@ class GitHubClient:
         demotes them to non-maintainers and every item falls to the fallback
         owner. This per-user endpoint reports them regardless of visibility.
 
-        `probe=True` marks a speculative sweep over discussion participants (see
-        `_MaintainerProbe`) and is capped run-wide so the pass cannot spend the
-        token's hourly rate limit. Past the cap a probe reports no maintainer,
-        which routes the item to the placeholder owner that a later run can
-        still hand over. Lookups that decide real state, such as an item's
-        assignees, are never probes and are never capped.
+        The answer is always exact. Speculative sweeps over a discussion go
+        through `_MaintainerProbe`, which rations how many *new* logins they may
+        resolve; a login already in the cache costs nothing and is never
+        rationed.
         """
         key = (repo, login.casefold())
         if key not in self._maintainers:
-            if probe and self._probes >= _RUN_PROBE_LIMIT:
-                self._probes_refused = True
-                return None
-            self._probes += 1 if probe else 0
             encoded = urllib.parse.quote(login, safe='')
             try:
                 permission = cast(
@@ -506,17 +505,24 @@ class _MaintainerProbe:
 
     @property
     def exhausted(self) -> bool:
-        """Whether a participant went unchecked, so absence proves nothing."""
-        return self._exhausted or self._client.probes_refused
+        """Whether *this* sweep left a participant unchecked, so absence proves nothing."""
+        return self._exhausted
 
     def login(self, login: str) -> str | None:
         if not login:
             return None
+        # A login the run already resolved is free, so it neither consumes a
+        # quota nor makes this sweep inconclusive.
+        if self._client.knows_maintainer(self._repo, login):
+            return self._client.maintainer_login(self._repo, login)
         if (key := login.casefold()) not in self._seen and len(self._seen) >= _ITEM_PROBE_LIMIT:
             self._exhausted = True
             return None
+        if not self._client.spend_probe():
+            self._exhausted = True
+            return None
         self._seen.add(key)
-        return self._client.maintainer_login(self._repo, login, probe=True)
+        return self._client.maintainer_login(self._repo, login)
 
     def entry(self, entry: Mapping[str, Any]) -> str | None:
         return self.login(_login(entry))

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -13,7 +13,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 # Stdlib-only imports: production invokes this script with the runner's bare
@@ -36,10 +36,12 @@ _COMMENT_PAGE_LIMIT = 10
 # `admin`/`write`/`read`/`none` are the only values the permission field returns;
 # `maintain` and `triage` appear in `role_name` and collapse to `write`/`read` here.
 _MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
-# Probing a discussion costs one request per distinct participant, so one busy
-# item could otherwise spend the whole hourly token budget and starve every
-# later item in the run. The run shares this many probes; see `maintainer_login`.
-_MAINTAINER_PROBE_LIMIT = 200
+# Probing a discussion costs one request per distinct participant, which is
+# unbounded in principle. Each sweep gets its own quota so a busy item cannot
+# starve later ones, under a run-wide ceiling that keeps the whole pass inside
+# the token's hourly rate limit. See `_MaintainerProbe` and `maintainer_login`.
+_ITEM_PROBE_LIMIT = 40
+_RUN_PROBE_LIMIT = 400
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
@@ -146,16 +148,22 @@ class GitHubClient:
             pages.extend(cast(list[dict[str, Any]], self.get(page_path)))
         return pages
 
-    def pages(self, path: str, *, count: int) -> Iterator[list[dict[str, Any]]]:
-        """Yield an ascending collection without silently truncating it."""
+    def first_pages(self, path: str, *, count: int) -> list[dict[str, Any]]:
+        """Return up to `count` oldest pages of an ascending collection.
+
+        A longer collection is truncated rather than refused: the only caller
+        wants whoever engaged *earliest*, so a huge thread should cost a bounded
+        prefix instead of aborting the run.
+        """
         separator = '&' if '?' in path else '?'
         page_path = f'{path}{separator}per_page=100&page=1'
+        entries: list[dict[str, Any]] = []
         for _ in range(count):
             values, links = self._request('GET', page_path)
-            yield cast(list[dict[str, Any]], values)
+            entries.extend(cast(list[dict[str, Any]], values))
             if not (page_path := _link_path(links, 'next')):
-                return
-        raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
+                break
+        return entries
 
     def maintainer_login(self, repo: str, login: str, *, probe: bool = False) -> str | None:
         """Return `login` when it can push to `repo`, resolved one user at a time.
@@ -167,15 +175,16 @@ class GitHubClient:
         demotes them to non-maintainers and every item falls to the fallback
         owner. This per-user endpoint reports them regardless of visibility.
 
-        `probe=True` marks a speculative sweep over discussion participants,
-        which is unbounded in principle: one request per distinct community
-        login. Probes share one budget for the whole run and give up once it is
-        spent, so a single busy item cannot starve the items after it. Lookups
-        that decide real state, such as an item's assignees, are never probes.
+        `probe=True` marks a speculative sweep over discussion participants (see
+        `_MaintainerProbe`) and is capped run-wide so the pass cannot spend the
+        token's hourly rate limit. Past the cap a probe reports no maintainer,
+        which routes the item to the placeholder owner that a later run can
+        still hand over. Lookups that decide real state, such as an item's
+        assignees, are never probes and are never capped.
         """
         key = (repo, login.casefold())
         if key not in self._maintainers:
-            if probe and self._probes >= _MAINTAINER_PROBE_LIMIT:
+            if probe and self._probes >= _RUN_PROBE_LIMIT:
                 return None
             self._probes += 1 if probe else 0
             encoded = urllib.parse.quote(login, safe='')
@@ -475,9 +484,28 @@ def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, An
     )
 
 
-def _paged(client: GitHubClient, path: str, total: int) -> list[dict[str, Any]]:
-    pages = min(_last_page(total, 100), _COMMENT_PAGE_LIMIT)
-    return [entry for page in client.pages(path, count=pages) for entry in page]
+class _MaintainerProbe:
+    """One deduplicated maintainer sweep over a single item's participants.
+
+    Each sweep carries its own quota, so a discussion full of community logins
+    cannot spend the capacity the next item needs.
+    """
+
+    def __init__(self, client: GitHubClient, repo: str) -> None:
+        self._client = client
+        self._repo = repo
+        self._seen: set[str] = set()
+
+    def login(self, login: str) -> str | None:
+        if not login:
+            return None
+        if (key := login.casefold()) not in self._seen and len(self._seen) >= _ITEM_PROBE_LIMIT:
+            return None
+        self._seen.add(key)
+        return self._client.maintainer_login(self._repo, login, probe=True)
+
+    def entry(self, entry: Mapping[str, Any]) -> str | None:
+        return self.login(_login(entry))
 
 
 def _discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -487,16 +515,10 @@ def _discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> lis
     comment, neither of which appears under the issue comments endpoint.
     """
     number = int(item['number'])
-    entries: list[dict[str, Any]] = []
-    if comments := int(item.get('comments') or 0):
-        entries.extend(_paged(client, f'/repos/{repo}/issues/{number}/comments', comments))
+    paths = [f'/repos/{repo}/issues/{number}/comments']
     if 'pull_request' in item:
-        pull = cast(dict[str, Any], client.get(f'/repos/{repo}/pulls/{number}'))
-        if review_comments := int(pull.get('review_comments') or 0):
-            entries.extend(_paged(client, f'/repos/{repo}/pulls/{number}/comments', review_comments))
-        # Reviews carry no count to page from, and only the earliest matter
-        # here, so read the oldest page of this ascending collection.
-        entries.extend(cast(list[dict[str, Any]], client.get(f'/repos/{repo}/pulls/{number}/reviews?per_page=100')))
+        paths += [f'/repos/{repo}/pulls/{number}/comments', f'/repos/{repo}/pulls/{number}/reviews']
+    entries = [entry for path in paths for entry in client.first_pages(path, count=_COMMENT_PAGE_LIMIT)]
     return sorted(entries, key=lambda entry: str(entry.get('created_at') or entry.get('submitted_at') or ''))
 
 
@@ -506,15 +528,11 @@ def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mappi
     A maintainer's own issue or PR stays theirs: the author is checked before
     anyone who replied later.
     """
-
-    def maintainer(entry: Mapping[str, Any]) -> str | None:
-        login = _login(entry)
-        return client.maintainer_login(repo, login, probe=True) if login else None
-
-    if author := maintainer(item):
+    probe = _MaintainerProbe(client, repo)
+    if author := probe.entry(item):
         return author
     for entry in _discussion(client, repo, item):
-        if login := maintainer(entry):
+        if login := probe.entry(entry):
             return login
     return None
 
@@ -669,6 +687,7 @@ def _acknowledged(
     recipients: Sequence[str],
 ) -> bool:
     recipient_logins = {login.casefold() for login in recipients}
+    probe = _MaintainerProbe(client, repo)
 
     def acknowledges(event: Mapping[str, Any]) -> bool:
         actor = _actor(event)
@@ -680,9 +699,7 @@ def _acknowledged(
         # maintainer whose organization membership is private as CONTRIBUTOR.
         # Confirm with the permission lookup rather than ignoring their reply
         # and reminding them about an item they just answered.
-        return event.get('author_association') in _ACK_ASSOCIATIONS or bool(
-            actor and client.maintainer_login(repo, actor, probe=True)
-        )
+        return event.get('author_association') in _ACK_ASSOCIATIONS or bool(probe.login(actor))
 
     return any(
         (event_time := _event_time(event)) is not None
@@ -716,21 +733,21 @@ def _is_bot(entry: Mapping[str, Any]) -> bool:
     return isinstance(value, Mapping) and cast(Mapping[str, object], value).get('type') == 'Bot'
 
 
-def _role(client: GitHubClient, repo: str, item: Mapping[str, Any], event: Mapping[str, Any]) -> str:
+def _role(probe: _MaintainerProbe, item: Mapping[str, Any], event: Mapping[str, Any]) -> str:
     login = _actor(event)
     if _is_bot(event):
         return 'bot'
     if login.casefold() == _login(item).casefold():
         return 'author'
-    return 'maintainer' if client.maintainer_login(repo, login, probe=True) else 'contributor'
+    return 'maintainer' if probe.login(login) else 'contributor'
 
 
 def _any_maintainer_engaged(
-    client: GitHubClient, repo: str, item: Mapping[str, Any], replies: Sequence[Mapping[str, Any]]
+    probe: _MaintainerProbe, item: Mapping[str, Any], replies: Sequence[Mapping[str, Any]]
 ) -> bool:
     for entry in (item, *replies):
         login = _login(item) if entry is item else _actor(entry)
-        if login and not _is_bot(entry) and client.maintainer_login(repo, login, probe=True):
+        if login and not _is_bot(entry) and probe.login(login):
             return True
     return False
 
@@ -748,6 +765,7 @@ def _status(
     Deliberately not a written summary: the channel report must stay free of
     issue and PR prose, which is attacker-controlled text.
     """
+    probe = _MaintainerProbe(client, repo)
     parts = ['pull request' if 'pull_request' in item else 'issue']
     if opened := item.get('created_at'):
         parts.append(f'opened by @{_login(item) or "unknown"} {_age(now, _parse_time(str(opened)))}')
@@ -760,8 +778,8 @@ def _status(
     if replies:
         last = replies[-1]
         when = cast(dt.datetime, _event_time(last))
-        parts.append(f'last from @{_actor(last)} {_age(now, when)} ({_role(client, repo, item, last)})')
-    if not _any_maintainer_engaged(client, repo, item, replies):
+        parts.append(f'last from @{_actor(last)} {_age(now, when)} ({_role(probe, item, last)})')
+    if not _any_maintainer_engaged(probe, item, replies):
         parts.append('going stale: no maintainer has touched it')
     return ' · '.join(parts)
 

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -95,6 +95,7 @@ class GitHubClient:
         self._token = token
         self._maintainers: dict[tuple[str, str], str | None] = {}
         self._probes = 0
+        self._probes_refused = False
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -148,12 +149,12 @@ class GitHubClient:
             pages.extend(cast(list[dict[str, Any]], self.get(page_path)))
         return pages
 
-    def first_pages(self, path: str, *, count: int) -> list[dict[str, Any]]:
-        """Return up to `count` oldest pages of an ascending collection.
+    def first_pages(self, path: str, *, count: int) -> tuple[list[dict[str, Any]], bool]:
+        """Return up to `count` oldest pages, and whether that was all of them.
 
-        A longer collection is truncated rather than refused: the only caller
-        wants whoever engaged *earliest*, so a huge thread should cost a bounded
-        prefix instead of aborting the run.
+        A longer collection is truncated rather than refused, so a huge thread
+        costs a bounded prefix instead of aborting the run. The flag lets the
+        caller tell "nobody was there" from "we did not get to look".
         """
         separator = '&' if '?' in path else '?'
         page_path = f'{path}{separator}per_page=100&page=1'
@@ -162,8 +163,13 @@ class GitHubClient:
             values, links = self._request('GET', page_path)
             entries.extend(cast(list[dict[str, Any]], values))
             if not (page_path := _link_path(links, 'next')):
-                break
-        return entries
+                return entries, True
+        return entries, False
+
+    @property
+    def probes_refused(self) -> bool:
+        """Whether the run-wide probe ceiling has turned a lookup away."""
+        return self._probes_refused
 
     def maintainer_login(self, repo: str, login: str, *, probe: bool = False) -> str | None:
         """Return `login` when it can push to `repo`, resolved one user at a time.
@@ -185,6 +191,7 @@ class GitHubClient:
         key = (repo, login.casefold())
         if key not in self._maintainers:
             if probe and self._probes >= _RUN_PROBE_LIMIT:
+                self._probes_refused = True
                 return None
             self._probes += 1 if probe else 0
             encoded = urllib.parse.quote(login, safe='')
@@ -495,11 +502,18 @@ class _MaintainerProbe:
         self._client = client
         self._repo = repo
         self._seen: set[str] = set()
+        self._exhausted = False
+
+    @property
+    def exhausted(self) -> bool:
+        """Whether a participant went unchecked, so absence proves nothing."""
+        return self._exhausted or self._client.probes_refused
 
     def login(self, login: str) -> str | None:
         if not login:
             return None
         if (key := login.casefold()) not in self._seen and len(self._seen) >= _ITEM_PROBE_LIMIT:
+            self._exhausted = True
             return None
         self._seen.add(key)
         return self._client.maintainer_login(self._repo, login, probe=True)
@@ -508,7 +522,7 @@ class _MaintainerProbe:
         return self.login(_login(entry))
 
 
-def _discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[dict[str, Any]]:
+def _discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> tuple[list[dict[str, Any]], bool]:
     """Return an item's replies oldest first, across every surface a maintainer uses.
 
     On a pull request most maintainer engagement arrives as a review or a code
@@ -518,30 +532,45 @@ def _discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> lis
     paths = [f'/repos/{repo}/issues/{number}/comments']
     if 'pull_request' in item:
         paths += [f'/repos/{repo}/pulls/{number}/comments', f'/repos/{repo}/pulls/{number}/reviews']
-    entries = [entry for path in paths for entry in client.first_pages(path, count=_COMMENT_PAGE_LIMIT)]
-    return sorted(entries, key=lambda entry: str(entry.get('created_at') or entry.get('submitted_at') or ''))
+    entries: list[dict[str, Any]] = []
+    complete = True
+    for path in paths:
+        page, whole = client.first_pages(path, count=_COMMENT_PAGE_LIMIT)
+        entries.extend(page)
+        complete = complete and whole
+    return sorted(entries, key=lambda entry: str(entry.get('created_at') or entry.get('submitted_at') or '')), complete
 
 
-def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
+def _first_maintainer_in_discussion(
+    client: GitHubClient, repo: str, item: Mapping[str, Any]
+) -> tuple[str | None, bool]:
     """Return the first current maintainer who opened or joined an issue or PR.
 
     A maintainer's own issue or PR stays theirs: the author is checked before
     anyone who replied later.
+
+    The second value says whether a `None` is trustworthy. A truncated thread or
+    a spent probe quota means some participant went unchecked, and padding a
+    discussion with throwaway accounts must not be a way to take an item off its
+    real owner, so callers leave ownership alone rather than read that as
+    nobody being there.
     """
     probe = _MaintainerProbe(client, repo)
     if author := probe.entry(item):
-        return author
-    for entry in _discussion(client, repo, item):
+        return author, True
+    entries, complete = _discussion(client, repo, item)
+    for entry in entries:
         if login := probe.entry(entry):
-            return login
-    return None
+            return login, True
+    return None, complete and not probe.exhausted
 
 
 def _ensure_recipients(
     client: GitHubClient,
     repo: str,
     item: Mapping[str, Any],
-) -> list[str]:
+) -> list[str] | None:
+    """Return who to notify, or None when ownership could not be decided."""
     number = int(item['number'])
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if current.get('state') != 'open' or _ACTION_LABEL not in _labels(current):
@@ -554,7 +583,10 @@ def _ensure_recipients(
     if current_maintainers and logins != [_FALLBACK_OWNER.casefold()]:
         return current_maintainers
 
-    owner = _first_maintainer_in_discussion(client, repo, current) or _FALLBACK_OWNER
+    found, conclusive = _first_maintainer_in_discussion(client, repo, current)
+    if found is None and not conclusive:
+        return None
+    owner = found or _FALLBACK_OWNER
     if logins == [owner.casefold()]:
         return current_maintainers
     client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]})
@@ -617,6 +649,9 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
             if attention_item.get('state') != 'open' or _ACTION_LABEL not in _labels(attention_item):
                 raise RuntimeError('Attention state changed while applying the request')
             recipients = _ensure_recipients(client, repo, attention_item)
+            if recipients is None:
+                lines.append(f'#{number}: deferred until its owner can be identified')
+                continue
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
         except (urllib.error.HTTPError, RuntimeError) as exc:
@@ -742,16 +777,6 @@ def _role(probe: _MaintainerProbe, item: Mapping[str, Any], event: Mapping[str, 
     return 'maintainer' if probe.login(login) else 'contributor'
 
 
-def _any_maintainer_engaged(
-    probe: _MaintainerProbe, item: Mapping[str, Any], replies: Sequence[Mapping[str, Any]]
-) -> bool:
-    for entry in (item, *replies):
-        login = _login(item) if entry is item else _actor(entry)
-        if login and not _is_bot(entry) and probe.login(login):
-            return True
-    return False
-
-
 def _status(
     client: GitHubClient,
     repo: str,
@@ -769,17 +794,28 @@ def _status(
     parts = ['pull request' if 'pull_request' in item else 'issue']
     if opened := item.get('created_at'):
         parts.append(f'opened by @{_login(item) or "unknown"} {_age(now, _parse_time(str(opened)))}')
+    # `comments` is GitHub's own total. The timeline holds only the newest pages,
+    # so counting it would understate a long-lived thread.
+    # It counts issue comments only, so a PR carrying nothing but reviews reads
+    # as zero; the reply clause below is what shows that activity.
+    if comments := int(item.get('comments') or 0):
+        parts.append(f'{comments} comment{"" if comments == 1 else "s"}')
     replies = [
         event
         for event in timeline
         if event.get('event') in {'commented', 'reviewed'} and _actor(event) and _event_time(event) is not None
     ]
-    parts.append('no replies yet' if not replies else f'{len(replies)} repl{"y" if len(replies) == 1 else "ies"}')
     if replies:
         last = replies[-1]
         when = cast(dt.datetime, _event_time(last))
         parts.append(f'last from @{_actor(last)} {_age(now, when)} ({_role(probe, item, last)})')
-    if not _any_maintainer_engaged(probe, item, replies):
+    elif not comments:
+        parts.append('no replies yet')
+    # Asked over the whole discussion rather than the recent timeline: claiming
+    # nobody has looked at an item a maintainer answered last year is worse than
+    # saying nothing.
+    engaged, conclusive = _first_maintainer_in_discussion(client, repo, item)
+    if engaged is None and conclusive:
         parts.append('going stale: no maintainer has touched it')
     return ' · '.join(parts)
 
@@ -929,49 +965,28 @@ def _reconcile_item(
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
     recipients = _ensure_recipients(client, repo, current)
+    if recipients is None:
+        return None
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
     if _closed_since(timeline, transition_at) or _acknowledged(client, repo, timeline, acknowledged_since, recipients):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
     # Stage 2 is the existing durable "terminal Slack delivery pending" state.
     # Keeping that meaning makes the channel cutover safe for in-flight items.
-    if current_stage == 2:
-        notice = _notice_if_current(
-            client,
-            repo,
-            number,
-            'escalation',
-            current_stage,
-            _transition_id(transition),
-            recipients,
-            now=now,
-        )
-        return (f'#{number}: queued channel escalation', notice) if notice is not None else None
-    if now - transition_at < _SLA:
+    if current_stage != 2 and now - transition_at < _SLA:
         return None
-    if current_stage == 0:
-        notice = _notice_if_current(
-            client,
-            repo,
-            number,
-            'reminder',
-            current_stage,
-            _transition_id(transition),
-            recipients,
-            now=now,
-        )
-        return (f'#{number}: queued channel reminder', notice) if notice is not None else None
+    kind: Literal['reminder', 'escalation'] = 'reminder' if current_stage == 0 else 'escalation'
     notice = _notice_if_current(
         client,
         repo,
         number,
-        'escalation',
+        kind,
         current_stage,
         _transition_id(transition),
         recipients,
         now=now,
     )
-    return (f'#{number}: queued channel escalation', notice) if notice is not None else None
+    return (f'#{number}: queued channel {kind}', notice) if notice is not None else None
 
 
 def _sweep_escalated_item(client: GitHubClient, repo: str, number: int) -> str | None:

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -36,11 +36,10 @@ _COMMENT_PAGE_LIMIT = 10
 # `admin`/`write`/`read`/`none` are the only values the permission field returns;
 # `maintain` and `triage` appear in `role_name` and collapse to `write`/`read` here.
 _MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
-# Resolving an owner costs one request per distinct discussion participant, so a
-# long community thread could otherwise spend the whole hourly token budget on a
-# single item. The first maintainer to engage is early in an ascending scan, so
-# give up and fall back once this many distinct logins have come back negative.
-_OWNER_LOOKUP_LIMIT = 40
+# Probing a discussion costs one request per distinct participant, so one busy
+# item could otherwise spend the whole hourly token budget and starve every
+# later item in the run. The run shares this many probes; see `maintainer_login`.
+_MAINTAINER_PROBE_LIMIT = 200
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
@@ -93,6 +92,7 @@ class GitHubClient:
     def __init__(self, token: str) -> None:
         self._token = token
         self._maintainers: dict[tuple[str, str], str | None] = {}
+        self._probes = 0
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -157,7 +157,7 @@ class GitHubClient:
                 return
         raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
 
-    def maintainer_login(self, repo: str, login: str) -> str | None:
+    def maintainer_login(self, repo: str, login: str, *, probe: bool = False) -> str | None:
         """Return `login` when it can push to `repo`, resolved one user at a time.
 
         The collaborator *list* endpoint looks cheaper but is wrong here: it only
@@ -166,9 +166,18 @@ class GitHubClient:
         maintainer on this repository is such a member, so the list silently
         demotes them to non-maintainers and every item falls to the fallback
         owner. This per-user endpoint reports them regardless of visibility.
+
+        `probe=True` marks a speculative sweep over discussion participants,
+        which is unbounded in principle: one request per distinct community
+        login. Probes share one budget for the whole run and give up once it is
+        spent, so a single busy item cannot starve the items after it. Lookups
+        that decide real state, such as an item's assignees, are never probes.
         """
         key = (repo, login.casefold())
         if key not in self._maintainers:
+            if probe and self._probes >= _MAINTAINER_PROBE_LIMIT:
+                return None
+            self._probes += 1 if probe else 0
             encoded = urllib.parse.quote(login, safe='')
             try:
                 permission = cast(
@@ -466,30 +475,47 @@ def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, An
     )
 
 
+def _paged(client: GitHubClient, path: str, total: int) -> list[dict[str, Any]]:
+    pages = min(_last_page(total, 100), _COMMENT_PAGE_LIMIT)
+    return [entry for page in client.pages(path, count=pages) for entry in page]
+
+
+def _discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return an item's replies oldest first, across every surface a maintainer uses.
+
+    On a pull request most maintainer engagement arrives as a review or a code
+    comment, neither of which appears under the issue comments endpoint.
+    """
+    number = int(item['number'])
+    entries: list[dict[str, Any]] = []
+    if comments := int(item.get('comments') or 0):
+        entries.extend(_paged(client, f'/repos/{repo}/issues/{number}/comments', comments))
+    if 'pull_request' in item:
+        pull = cast(dict[str, Any], client.get(f'/repos/{repo}/pulls/{number}'))
+        if review_comments := int(pull.get('review_comments') or 0):
+            entries.extend(_paged(client, f'/repos/{repo}/pulls/{number}/comments', review_comments))
+        # Reviews carry no count to page from, and only the earliest matter
+        # here, so read the oldest page of this ascending collection.
+        entries.extend(cast(list[dict[str, Any]], client.get(f'/repos/{repo}/pulls/{number}/reviews?per_page=100')))
+    return sorted(entries, key=lambda entry: str(entry.get('created_at') or entry.get('submitted_at') or ''))
+
+
 def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
     """Return the first current maintainer who opened or joined an issue or PR.
 
     A maintainer's own issue or PR stays theirs: the author is checked before
     anyone who replied later.
     """
-    checked: set[str] = set()
 
     def maintainer(entry: Mapping[str, Any]) -> str | None:
         login = _login(entry)
-        if not login or login.casefold() in checked or len(checked) >= _OWNER_LOOKUP_LIMIT:
-            return None
-        checked.add(login.casefold())
-        return client.maintainer_login(repo, login)
+        return client.maintainer_login(repo, login, probe=True) if login else None
 
     if author := maintainer(item):
         return author
-    comments = int(item.get('comments') or 0)
-    if comments:
-        pages = min(_last_page(comments, 100), _COMMENT_PAGE_LIMIT)
-        for page in client.pages(f'/repos/{repo}/issues/{int(item["number"])}/comments', count=pages):
-            for comment in page:
-                if login := maintainer(comment):
-                    return login
+    for entry in _discussion(client, repo, item):
+        if login := maintainer(entry):
+            return login
     return None
 
 
@@ -655,7 +681,7 @@ def _acknowledged(
         # Confirm with the permission lookup rather than ignoring their reply
         # and reminding them about an item they just answered.
         return event.get('author_association') in _ACK_ASSOCIATIONS or bool(
-            actor and client.maintainer_login(repo, actor)
+            actor and client.maintainer_login(repo, actor, probe=True)
         )
 
     return any(
@@ -696,19 +722,15 @@ def _role(client: GitHubClient, repo: str, item: Mapping[str, Any], event: Mappi
         return 'bot'
     if login.casefold() == _login(item).casefold():
         return 'author'
-    return 'maintainer' if client.maintainer_login(repo, login) else 'contributor'
+    return 'maintainer' if client.maintainer_login(repo, login, probe=True) else 'contributor'
 
 
 def _any_maintainer_engaged(
     client: GitHubClient, repo: str, item: Mapping[str, Any], replies: Sequence[Mapping[str, Any]]
 ) -> bool:
-    checked: set[str] = set()
     for entry in (item, *replies):
-        login = _actor(entry) if entry is not item else _login(item)
-        if not login or _is_bot(entry) or login.casefold() in checked or len(checked) >= _OWNER_LOOKUP_LIMIT:
-            continue
-        checked.add(login.casefold())
-        if client.maintainer_login(repo, login):
+        login = _login(item) if entry is item else _actor(entry)
+        if login and not _is_bot(entry) and client.maintainer_login(repo, login, probe=True):
             return True
     return False
 

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -33,7 +33,14 @@ _ACTIVE_OPEN_LIMIT = 20
 _CLOSED_CLEANUP_LIMIT = _RECONCILE_LIMIT - _ACTIVE_OPEN_LIMIT
 _EVENT_PAGE_LIMIT = 10
 _COMMENT_PAGE_LIMIT = 10
-_COLLABORATOR_PAGE_LIMIT = 10
+# `admin`/`write`/`read`/`none` are the only values the permission field returns;
+# `maintain` and `triage` appear in `role_name` and collapse to `write`/`read` here.
+_MAINTAINER_PERMISSIONS = frozenset({'admin', 'maintain', 'write'})
+# Resolving an owner costs one request per distinct discussion participant, so a
+# long community thread could otherwise spend the whole hourly token budget on a
+# single item. The first maintainer to engage is early in an ascending scan, so
+# give up and fall back once this many distinct logins have come back negative.
+_OWNER_LOOKUP_LIMIT = 40
 _RESPONSE_LIMIT = 5_000_000
 _SNAPSHOT_LIMIT = 80_000
 _FALLBACK_OWNER = 'adtyavrdhn'
@@ -84,7 +91,7 @@ class GitHubClient:
 
     def __init__(self, token: str) -> None:
         self._token = token
-        self._maintainers: dict[str, dict[str, str]] = {}
+        self._maintainers: dict[tuple[str, str], str | None] = {}
 
     def _request(self, method: str, path: str, payload: Mapping[str, object] | None = None) -> tuple[Any, str | None]:
         data = json.dumps(payload).encode() if payload is not None else None
@@ -149,23 +156,30 @@ class GitHubClient:
                 return
         raise RuntimeError(f'GitHub collection exceeds the {count}-page safety limit')
 
-    def maintainer_logins(self, repo: str) -> Mapping[str, str]:
-        if repo not in self._maintainers:
-            maintainers: dict[str, str] = {}
-            for page in self.pages(
-                f'/repos/{repo}/collaborators?affiliation=all',
-                count=_COLLABORATOR_PAGE_LIMIT,
-            ):
-                for collaborator in page:
-                    permissions = collaborator.get('permissions')
-                    if (
-                        isinstance(permissions, Mapping)
-                        and cast(Mapping[str, object], permissions).get('push') is True
-                        and (login := str(collaborator.get('login') or ''))
-                    ):
-                        maintainers[login.casefold()] = login
-            self._maintainers[repo] = maintainers
-        return self._maintainers[repo]
+    def maintainer_login(self, repo: str, login: str) -> str | None:
+        """Return `login` when it can push to `repo`, resolved one user at a time.
+
+        The collaborator *list* endpoint looks cheaper but is wrong here: it only
+        reports collaborators the caller can see, and the workflow token cannot
+        see organization members whose membership is private. Almost every
+        maintainer on this repository is such a member, so the list silently
+        demotes them to non-maintainers and every item falls to the fallback
+        owner. This per-user endpoint reports them regardless of visibility.
+        """
+        key = (repo, login.casefold())
+        if key not in self._maintainers:
+            encoded = urllib.parse.quote(login, safe='')
+            try:
+                permission = cast(
+                    Mapping[str, object], self.get(f'/repos/{repo}/collaborators/{encoded}/permission')
+                ).get('permission')
+            except urllib.error.HTTPError as exc:
+                exc.close()
+                if exc.code != 404:
+                    raise
+                permission = None
+            self._maintainers[key] = login if permission in _MAINTAINER_PERMISSIONS else None
+        return self._maintainers[key]
 
 
 def _parse_time(value: str) -> dt.datetime:
@@ -441,26 +455,30 @@ def _add_labels(client: GitHubClient, repo: str, number: int, labels: Sequence[s
 
 
 def _maintainer_assignees(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> list[str]:
-    maintainers = client.maintainer_logins(repo)
     return sorted(
         (
-            maintainers[login.casefold()]
+            maintainer
             for assignee in item.get('assignees', [])
-            if (login := str(assignee['login'])) and login.casefold() in maintainers
+            if (login := str(assignee['login'])) and (maintainer := client.maintainer_login(repo, login))
         ),
         key=str.casefold,
     )
 
 
 def _first_maintainer_in_discussion(client: GitHubClient, repo: str, item: Mapping[str, Any]) -> str | None:
-    """Return the first current maintainer who authored or discussed an issue."""
-    if 'pull_request' in item:
-        return None
-    maintainers = client.maintainer_logins(repo)
+    """Return the first current maintainer who opened or joined an issue or PR.
+
+    A maintainer's own issue or PR stays theirs: the author is checked before
+    anyone who replied later.
+    """
+    checked: set[str] = set()
 
     def maintainer(entry: Mapping[str, Any]) -> str | None:
         login = _login(entry)
-        return maintainers.get(login.casefold()) if login else None
+        if not login or login.casefold() in checked or len(checked) >= _OWNER_LOOKUP_LIMIT:
+            return None
+        checked.add(login.casefold())
+        return client.maintainer_login(repo, login)
 
     if author := maintainer(item):
         return author
@@ -480,23 +498,23 @@ def _ensure_recipients(
     item: Mapping[str, Any],
 ) -> list[str]:
     number = int(item['number'])
-    owner = _first_maintainer_in_discussion(client, repo, item)
-
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if current.get('state') != 'open' or _ACTION_LABEL not in _labels(current):
         raise RuntimeError('Attention state changed during owner selection')
-    if current.get('updated_at') != item.get('updated_at'):
-        owner = _first_maintainer_in_discussion(client, repo, current)
+    # Whoever a human put on the item owns it: the monitor never reassigns
+    # around an explicit decision. Its own fallback assignment is a placeholder
+    # rather than a decision, so it steps aside once a real owner turns up.
     current_maintainers = _maintainer_assignees(client, repo, current)
-    if current_maintainers:
-        if owner is None:
-            return current_maintainers
+    logins = [login.casefold() for login in current_maintainers]
+    if current_maintainers and logins != [_FALLBACK_OWNER.casefold()]:
+        return current_maintainers
 
-    owner = owner or _FALLBACK_OWNER
-    if owner.casefold() not in {login.casefold() for login in current_maintainers}:
-        client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]})
-    if other_owners := [login for login in current_maintainers if login.casefold() != owner.casefold()]:
-        client.delete(f'/repos/{repo}/issues/{number}/assignees', {'assignees': other_owners})
+    owner = _first_maintainer_in_discussion(client, repo, current) or _FALLBACK_OWNER
+    if logins == [owner.casefold()]:
+        return current_maintainers
+    client.post(f'/repos/{repo}/issues/{number}/assignees', {'assignees': [owner]})
+    if current_maintainers:
+        client.delete(f'/repos/{repo}/issues/{number}/assignees', {'assignees': current_maintainers})
 
     assigned = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
     if assigned.get('state') != 'open' or _ACTION_LABEL not in _labels(assigned):

--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -75,6 +75,7 @@ class Notice(TypedDict):
     transition_id: int | str
     title: str
     recipients: list[str]
+    status: str
 
 
 class NoticeRef(TypedDict):
@@ -634,18 +635,34 @@ _NON_ACK_EVENTS = frozenset({'mentioned', 'subscribed'})
 _ACK_ASSOCIATIONS = frozenset({'MEMBER', 'OWNER', 'COLLABORATOR'})
 
 
-def _acknowledged(timeline: Sequence[dict[str, Any]], since: dt.datetime, recipients: Sequence[str]) -> bool:
+def _acknowledged(
+    client: GitHubClient,
+    repo: str,
+    timeline: Sequence[dict[str, Any]],
+    since: dt.datetime,
+    recipients: Sequence[str],
+) -> bool:
     recipient_logins = {login.casefold() for login in recipients}
+
+    def acknowledges(event: Mapping[str, Any]) -> bool:
+        actor = _actor(event)
+        if actor.casefold() in recipient_logins:
+            return True
+        if event.get('event') not in {'commented', 'reviewed'}:
+            return False
+        # `author_association` is computed for the caller, so it reports a
+        # maintainer whose organization membership is private as CONTRIBUTOR.
+        # Confirm with the permission lookup rather than ignoring their reply
+        # and reminding them about an item they just answered.
+        return event.get('author_association') in _ACK_ASSOCIATIONS or bool(
+            actor and client.maintainer_login(repo, actor)
+        )
+
     return any(
         (event_time := _event_time(event)) is not None
         and event_time >= since
         and event.get('event') not in _NON_ACK_EVENTS
-        and (
-            _actor(event).casefold() in recipient_logins
-            or (
-                event.get('event') in {'commented', 'reviewed'} and event.get('author_association') in _ACK_ASSOCIATIONS
-            )
-        )
+        and acknowledges(event)
         for event in timeline
     )
 
@@ -663,12 +680,81 @@ def _transition_id(transition: tuple[dt.datetime, dict[str, Any]]) -> int | str:
     return transition_id
 
 
+def _age(now: dt.datetime, then: dt.datetime) -> str:
+    hours = max(0, int((now - then).total_seconds()) // 3600)
+    return f'{hours}h ago' if hours < 48 else f'{hours // 24}d ago'
+
+
+def _is_bot(entry: Mapping[str, Any]) -> bool:
+    value = entry.get('actor') or entry.get('user')
+    return isinstance(value, Mapping) and cast(Mapping[str, object], value).get('type') == 'Bot'
+
+
+def _role(client: GitHubClient, repo: str, item: Mapping[str, Any], event: Mapping[str, Any]) -> str:
+    login = _actor(event)
+    if _is_bot(event):
+        return 'bot'
+    if login.casefold() == _login(item).casefold():
+        return 'author'
+    return 'maintainer' if client.maintainer_login(repo, login) else 'contributor'
+
+
+def _any_maintainer_engaged(
+    client: GitHubClient, repo: str, item: Mapping[str, Any], replies: Sequence[Mapping[str, Any]]
+) -> bool:
+    checked: set[str] = set()
+    for entry in (item, *replies):
+        login = _actor(entry) if entry is not item else _login(item)
+        if not login or _is_bot(entry) or login.casefold() in checked or len(checked) >= _OWNER_LOOKUP_LIMIT:
+            continue
+        checked.add(login.casefold())
+        if client.maintainer_login(repo, login):
+            return True
+    return False
+
+
+def _status(
+    client: GitHubClient,
+    repo: str,
+    item: Mapping[str, Any],
+    timeline: Sequence[dict[str, Any]],
+    *,
+    now: dt.datetime,
+) -> str:
+    """Say what the item is waiting on, using only structured GitHub metadata.
+
+    Deliberately not a written summary: the channel report must stay free of
+    issue and PR prose, which is attacker-controlled text.
+    """
+    parts = ['pull request' if 'pull_request' in item else 'issue']
+    if opened := item.get('created_at'):
+        parts.append(f'opened by @{_login(item) or "unknown"} {_age(now, _parse_time(str(opened)))}')
+    replies = [
+        event
+        for event in timeline
+        if event.get('event') in {'commented', 'reviewed'} and _actor(event) and _event_time(event) is not None
+    ]
+    parts.append('no replies yet' if not replies else f'{len(replies)} repl{"y" if len(replies) == 1 else "ies"}')
+    if replies:
+        last = replies[-1]
+        when = cast(dt.datetime, _event_time(last))
+        parts.append(f'last from @{_actor(last)} {_age(now, when)} ({_role(client, repo, item, last)})')
+    if not _any_maintainer_engaged(client, repo, item, replies):
+        parts.append('going stale: no maintainer has touched it')
+    return ' · '.join(parts)
+
+
 def _notice(
+    client: GitHubClient,
+    repo: str,
     item: Mapping[str, Any],
     kind: Literal['reminder', 'escalation'],
     stage: Literal[0, 1, 2],
     transition: tuple[dt.datetime, dict[str, Any]],
     recipients: Sequence[str],
+    timeline: Sequence[dict[str, Any]],
+    *,
+    now: dt.datetime,
 ) -> Notice:
     return Notice(
         number=int(item['number']),
@@ -677,6 +763,7 @@ def _notice(
         transition_id=_transition_id(transition),
         title=str(item.get('title') or '')[:300],
         recipients=list(recipients),
+        status=_status(client, repo, item, timeline, now=now),
     )
 
 
@@ -688,6 +775,8 @@ def _notice_if_current(
     stage: Literal[0, 1, 2],
     transition_id: int | str,
     recipients: Sequence[str],
+    *,
+    now: dt.datetime,
 ) -> Notice | None:
     """Build a notice only if its transition and owners are still live."""
     events = client.last_pages(f'/repos/{repo}/issues/{number}/events', count=_EVENT_PAGE_LIMIT)
@@ -711,9 +800,11 @@ def _notice_if_current(
     acknowledged_transition = _transition(events, 1) if stage == 2 else current_transition
     acknowledged_since = acknowledged_transition[0] if acknowledged_transition is not None else current_transition[0]
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _closed_since(timeline, current_transition[0]) or _acknowledged(timeline, acknowledged_since, recipients):
+    if _closed_since(timeline, current_transition[0]) or _acknowledged(
+        client, repo, timeline, acknowledged_since, recipients
+    ):
         return None
-    return _notice(current, kind, stage, current_transition, recipients)
+    return _notice(client, repo, current, kind, stage, current_transition, recipients, timeline, now=now)
 
 
 def _finish_delivered_escalation(client: GitHubClient, repo: str, number: int, *, new_delivery: bool = False) -> None:
@@ -794,12 +885,12 @@ def _reconcile_item(
     maintainers = _maintainer_assignees(client, repo, current)
     reminder_transition = _transition(events, 1) if current_stage == 2 else None
     acknowledged_since = reminder_transition[0] if reminder_transition is not None else transition_at
-    if _acknowledged(timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
+    if _acknowledged(client, repo, timeline, acknowledged_since, maintainers or [_FALLBACK_OWNER]):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
     recipients = _ensure_recipients(client, repo, current)
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _closed_since(timeline, transition_at) or _acknowledged(timeline, acknowledged_since, recipients):
+    if _closed_since(timeline, transition_at) or _acknowledged(client, repo, timeline, acknowledged_since, recipients):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer acknowledged the request', None
     # Stage 2 is the existing durable "terminal Slack delivery pending" state.
@@ -813,6 +904,7 @@ def _reconcile_item(
             current_stage,
             _transition_id(transition),
             recipients,
+            now=now,
         )
         return (f'#{number}: queued channel escalation', notice) if notice is not None else None
     if now - transition_at < _SLA:
@@ -826,6 +918,7 @@ def _reconcile_item(
             current_stage,
             _transition_id(transition),
             recipients,
+            now=now,
         )
         return (f'#{number}: queued channel reminder', notice) if notice is not None else None
     notice = _notice_if_current(
@@ -836,6 +929,7 @@ def _reconcile_item(
         current_stage,
         _transition_id(transition),
         recipients,
+        now=now,
     )
     return (f'#{number}: queued channel escalation', notice) if notice is not None else None
 
@@ -961,7 +1055,9 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
             details.append(
                 f'• *{notice["kind"].title()}*: '
                 f'<https://github.com/{repo}/issues/{notice["number"]}|#{notice["number"]} {title}> — '
-                f'owner {owners}; why: {reasons[notice["kind"]]}'
+                f'owner {owners}\n'
+                f'      {_slack_escape(notice["status"])}\n'
+                f'      why: {reasons[notice["kind"]]}'
             )
         payload = {
             'text': '\n'.join(
@@ -1042,7 +1138,7 @@ def _notice_refs(loaded: object) -> list[NoticeRef]:
     return notices
 
 
-def prepare_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[Notice]:
+def prepare_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef], *, now: dt.datetime) -> list[Notice]:
     """Revalidate notices immediately before their channel delivery."""
     prepared: list[Notice] = []
     for notice in notices:
@@ -1056,6 +1152,7 @@ def prepare_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef
             stage,
             notice['transition_id'],
             notice['recipients'],
+            now=now,
         ):
             prepared.append(live)
     return prepared
@@ -1072,6 +1169,8 @@ def _finalize_notice(
     client: GitHubClient,
     repo: str,
     notice: NoticeRef,
+    *,
+    now: dt.datetime,
 ) -> str | None:
     number = notice['number']
     current = cast(dict[str, Any], client.get(f'/repos/{repo}/issues/{number}'))
@@ -1091,7 +1190,9 @@ def _finalize_notice(
     ):
         return None
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
-    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
+    if _closed_since(timeline, transition[0]) or _acknowledged(
+        client, repo, timeline, transition[0], notice['recipients']
+    ):
         _complete(client, repo, number, labels)
         return f'#{number}: maintainer activity completed the delivered notice'
 
@@ -1105,6 +1206,7 @@ def _finalize_notice(
             stage,
             _transition_id(transition),
             notice['recipients'],
+            now=now,
         )
         is None
     ):
@@ -1119,20 +1221,22 @@ def _finalize_notice(
 
     timeline = client.last_pages(f'/repos/{repo}/issues/{number}/timeline', count=3)
     completed_labels = labels | ({_PINGED_LABEL} if stage == 0 else {_ESCALATED_LABEL, _DELIVERED_LABEL})
-    if _closed_since(timeline, transition[0]) or _acknowledged(timeline, transition[0], notice['recipients']):
+    if _closed_since(timeline, transition[0]) or _acknowledged(
+        client, repo, timeline, transition[0], notice['recipients']
+    ):
         _complete(client, repo, number, completed_labels)
         return f'#{number}: maintainer activity completed the delivered notice'
     return f'#{number}: recorded channel {kind}'
 
 
-def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef]) -> list[str]:
+def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRef], *, now: dt.datetime) -> list[str]:
     """Advance attention state only after the channel delivery succeeds."""
     lines: list[str] = []
     failures: list[str] = []
     for notice in notices:
         number = notice['number']
         try:
-            if line := _finalize_notice(client, repo, notice):
+            if line := _finalize_notice(client, repo, notice, now=now):
                 lines.append(line)
         except (urllib.error.HTTPError, RuntimeError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
@@ -1180,14 +1284,14 @@ def main() -> int:
         source = os.environ.get('ATTENTION_NOTICES')
         if source is None:
             parser.error('ATTENTION_NOTICES is required')
-        notices = prepare_notices(client, repo, _notice_refs(json.loads(source)))
+        notices = prepare_notices(client, repo, _notice_refs(json.loads(source)), now=now)
         _write_notices(repo, notices)
         lines = [f'prepared {len(notices)} current attention notice(s)']
     else:
         source = os.environ.get('ATTENTION_NOTICES')
         if source is None:
             parser.error('ATTENTION_NOTICES is required')
-        lines = finalize_notices(client, repo, _notice_refs(json.loads(source)))
+        lines = finalize_notices(client, repo, _notice_refs(json.loads(source)), now=now)
     _write_summary(lines + [f'failed: {failure}' for failure in failures])
     for line in lines:
         print(line)

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -169,12 +169,12 @@ class FakeClient(monitor.GitHubClient):
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         return self.last_page(path)
 
-    def pages(self, path: str, *, count: int):
+    def first_pages(self, path: str, *, count: int) -> list[dict[str, Any]]:
+        self.calls.append(('FIRST', path, None))
         if '/pulls/' in path:
-            yield self.review_comments.get(int(path.split('/pulls/')[1].split('/')[0]), [])
-            return
-        number = int(path.split('/issues/')[1].split('/')[0])
-        yield self.comments.get(number, [])
+            number = int(path.split('/pulls/')[1].split('/')[0])
+            return (self.reviews if path.endswith('/reviews') else self.review_comments).get(number, [])
+        return self.comments.get(int(path.split('/issues/')[1].split('/')[0]), [])
 
     def permission_reads(self) -> list[str]:
         return [path for method, path, _ in self.calls if method == 'GET' and path.endswith('/permission')]
@@ -465,11 +465,11 @@ def test_owner_selection_never_overrides_an_explicit_assignment():
 
 def test_owner_selection_checks_each_participant_once_within_a_budget():
     issue = item(7, labels=[monitor._ACTION_LABEL])
-    issue['comments'] = 2 * monitor._MAINTAINER_PROBE_LIMIT
+    issue['comments'] = 2 * monitor._ITEM_PROBE_LIMIT
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
     client.comments[7] = [
-        *[{'user': {'login': f'contributor-{number % 4}'}} for number in range(2 * monitor._MAINTAINER_PROBE_LIMIT)],
+        *[{'user': {'login': f'contributor-{number % 4}'}} for number in range(2 * monitor._ITEM_PROBE_LIMIT)],
         {'user': {'login': 'DouweM'}},
     ]
 
@@ -481,7 +481,7 @@ def test_owner_selection_checks_each_participant_once_within_a_budget():
 
 def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
     issue = item(7, labels=[monitor._ACTION_LABEL])
-    flood = 2 * monitor._MAINTAINER_PROBE_LIMIT
+    flood = 2 * monitor._ITEM_PROBE_LIMIT
     issue['comments'] = flood + 1
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
@@ -491,10 +491,39 @@ def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
     ]
 
     assert monitor._first_maintainer_in_discussion(client, 'r', issue) is None
-    assert len(client.permission_reads()) == monitor._MAINTAINER_PROBE_LIMIT
-    # The budget is shared by the run, so the next item is not probed at all.
-    assert monitor._first_maintainer_in_discussion(client, 'r', item(8)) is None
-    assert len(client.permission_reads()) == monitor._MAINTAINER_PROBE_LIMIT
+    assert len(client.permission_reads()) == monitor._ITEM_PROBE_LIMIT
+    # The quota is per item, so the flood cannot hide the next item's maintainer.
+    followup = item(8)
+    followup['user'] = {'login': 'DouweM'}
+    assert monitor._first_maintainer_in_discussion(client, 'r', followup) == 'DouweM'
+
+
+def test_first_pages_truncates_a_huge_thread_instead_of_aborting(monkeypatch: pytest.MonkeyPatch):
+    # A thread longer than the page cap must cost a bounded prefix, not raise
+    # and take down every other item in the run with it.
+    client = monitor.GitHubClient('token')
+    seen: list[str] = []
+
+    def request(method: str, path: str, payload: object = None) -> tuple[Any, str]:
+        seen.append(path)
+        return [{'user': {'login': f'contributor-{len(seen)}'}}], '<https://api.github.com/x?page=99>; rel="next"'
+
+    monkeypatch.setattr(client, '_request', request)
+
+    assert len(client.first_pages('/repos/r/issues/7/comments', count=3)) == 3
+    assert len(seen) == 3
+
+
+def test_maintainer_probes_stop_at_the_run_ceiling():
+    client = FakeClient()
+    for index in range(monitor._RUN_PROBE_LIMIT):
+        assert client.maintainer_login('r', f'contributor-{index}', probe=True) is None
+    assert len(client.permission_reads()) == monitor._RUN_PROBE_LIMIT
+
+    client.permissions = {'DouweM': 'admin'}
+    assert client.maintainer_login('r', 'DouweM', probe=True) is None
+    # Lookups that decide real state stay exact no matter how many probes ran.
+    assert client.maintainer_login('r', 'DouweM') == 'DouweM'
 
 
 def test_owner_selection_treats_a_deleted_account_as_a_non_maintainer():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -42,6 +42,10 @@ def item(
     }
 
 
+def _MaintainerProbe(client: Any) -> Any:
+    return monitor._MaintainerProbe(client, 'r')
+
+
 def label_event(
     label: str, *, actor: str = 'github-actions[bot]', created_at: str = OLD, event_id: str | None = None
 ) -> dict[str, Any]:
@@ -552,12 +556,20 @@ def test_first_pages_truncates_a_huge_thread_instead_of_aborting(monkeypatch: py
 
 def test_maintainer_probes_stop_at_the_run_ceiling():
     client = FakeClient()
-    for index in range(monitor._RUN_PROBE_LIMIT):
-        assert client.maintainer_login('r', f'contributor-{index}', probe=True) is None
+    client.permissions = {'DouweM': 'admin', 'alice': 'write'}
+    # Resolve one maintainer up front so it is cached before the ceiling is hit.
+    assert _MaintainerProbe(client).login('alice') == 'alice'
+    for index in range(monitor._RUN_PROBE_LIMIT - 1):
+        assert _MaintainerProbe(client).login(f'contributor-{index}') is None
     assert len(client.permission_reads()) == monitor._RUN_PROBE_LIMIT
 
-    client.permissions = {'DouweM': 'admin'}
-    assert client.maintainer_login('r', 'DouweM', probe=True) is None
+    spent = _MaintainerProbe(client)
+    assert spent.login('DouweM') is None
+    assert spent.exhausted is True
+    # A cached login still answers, and does not make its sweep inconclusive.
+    cached = _MaintainerProbe(client)
+    assert cached.login('alice') == 'alice'
+    assert cached.exhausted is False
     # Lookups that decide real state stay exact no matter how many probes ran.
     assert client.maintainer_login('r', 'DouweM') == 'DouweM'
 

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -62,6 +62,8 @@ class FakeClient(monitor.GitHubClient):
         self.permissions: dict[str, str] = {}
         self.deleted_logins: set[str] = set()
         self.comments: dict[int, list[dict[str, Any]]] = {}
+        self.review_comments: dict[int, list[dict[str, Any]]] = {}
+        self.reviews: dict[int, list[dict[str, Any]]] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
     def get(self, path: str) -> Any:
@@ -73,6 +75,11 @@ class FakeClient(monitor.GitHubClient):
             # GitHub reports `none` for anyone without repository access, and
             # never `maintain`/`triage`: those collapse to `write`/`read` here.
             return {'permission': {monitor._FALLBACK_OWNER: 'write', **self.permissions}.get(login, 'none')}
+        if '/pulls/' in path and '/reviews' in path:
+            return self.reviews.get(int(path.split('/pulls/')[1].split('/')[0]), [])
+        if '/pulls/' in path and '/' not in path.split('/pulls/')[1]:
+            number = int(path.split('/pulls/')[1])
+            return {**self.items[number], 'review_comments': len(self.review_comments.get(number, []))}
         if path.startswith('/search/issues?'):
             query = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
             requested_state = 'closed' if 'is:closed' in query.get('q', [''])[0] else 'open'
@@ -163,6 +170,9 @@ class FakeClient(monitor.GitHubClient):
         return self.last_page(path)
 
     def pages(self, path: str, *, count: int):
+        if '/pulls/' in path:
+            yield self.review_comments.get(int(path.split('/pulls/')[1].split('/')[0]), [])
+            return
         number = int(path.split('/issues/')[1].split('/')[0])
         yield self.comments.get(number, [])
 
@@ -184,7 +194,7 @@ class SnapshotClient(FakeClient):
         if '/check-runs?' in path:
             self.calls.append(('GET', path, None))
             return {'check_runs': [{'name': 'CI', 'status': 'completed', 'conclusion': 'success'}]}
-        if '/pulls/' in path and '/comments?' not in path:
+        if '/pulls/' in path and '/comments?' not in path and '/reviews' not in path:
             self.calls.append(('GET', path, None))
             number = int(path.split('/pulls/')[1])
             return {
@@ -427,6 +437,22 @@ def test_owner_selection_keeps_a_maintainer_authored_pull_request():
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
 
 
+def test_owner_selection_reads_every_pull_request_discussion_surface():
+    # Maintainers usually join a PR by reviewing it, and neither reviews nor
+    # code comments appear under the issue comments endpoint.
+    pull = {**item(7, labels=[monitor._ACTION_LABEL]), 'pull_request': {'url': 'https://api.github.com/pulls/7'}}
+    pull['comments'] = 1
+    client = FakeClient({7: pull})
+    client.permissions = {'DouweM': 'admin', 'dsfaccini': 'write'}
+    client.comments[7] = [{'user': {'login': 'dsfaccini'}, 'created_at': '2026-07-03T00:00:00Z'}]
+    client.review_comments[7] = [{'user': {'login': 'contributor'}, 'created_at': '2026-07-02T00:00:00Z'}]
+    client.reviews[7] = [{'user': {'login': 'DouweM'}, 'submitted_at': '2026-07-01T00:00:00Z'}]
+
+    # Ordered across all three surfaces, so the earliest reviewer wins over the
+    # later issue-comment maintainer.
+    assert monitor._first_maintainer_in_discussion(client, 'r', pull) == 'DouweM'
+
+
 def test_owner_selection_never_overrides_an_explicit_assignment():
     issue = item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])
     issue['user'] = {'login': 'DouweM'}
@@ -439,11 +465,11 @@ def test_owner_selection_never_overrides_an_explicit_assignment():
 
 def test_owner_selection_checks_each_participant_once_within_a_budget():
     issue = item(7, labels=[monitor._ACTION_LABEL])
-    issue['comments'] = 2 * monitor._OWNER_LOOKUP_LIMIT
+    issue['comments'] = 2 * monitor._MAINTAINER_PROBE_LIMIT
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
     client.comments[7] = [
-        *[{'user': {'login': f'contributor-{number % 4}'}} for number in range(2 * monitor._OWNER_LOOKUP_LIMIT)],
+        *[{'user': {'login': f'contributor-{number % 4}'}} for number in range(2 * monitor._MAINTAINER_PROBE_LIMIT)],
         {'user': {'login': 'DouweM'}},
     ]
 
@@ -455,7 +481,7 @@ def test_owner_selection_checks_each_participant_once_within_a_budget():
 
 def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
     issue = item(7, labels=[monitor._ACTION_LABEL])
-    flood = 2 * monitor._OWNER_LOOKUP_LIMIT
+    flood = 2 * monitor._MAINTAINER_PROBE_LIMIT
     issue['comments'] = flood + 1
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
@@ -465,7 +491,10 @@ def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
     ]
 
     assert monitor._first_maintainer_in_discussion(client, 'r', issue) is None
-    assert len(client.permission_reads()) == monitor._OWNER_LOOKUP_LIMIT
+    assert len(client.permission_reads()) == monitor._MAINTAINER_PROBE_LIMIT
+    # The budget is shared by the run, so the next item is not probed at all.
+    assert monitor._first_maintainer_in_discussion(client, 'r', item(8)) is None
+    assert len(client.permission_reads()) == monitor._MAINTAINER_PROBE_LIMIT
 
 
 def test_owner_selection_treats_a_deleted_account_as_a_non_maintainer():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -49,20 +49,30 @@ def label_event(
     return {**event, 'id': event_id} if event_id else event
 
 
-class FakeClient:
+class FakeClient(monitor.GitHubClient):
+    """Duck-typed transport over `GitHubClient`, keeping its real lookup logic."""
+
     def __init__(self, items: dict[int, dict[str, Any]] | None = None) -> None:
+        super().__init__('token')
         self.items = items or {}
         self.calls: list[tuple[str, str, object | None]] = []
         self.fail_get: set[int] = set()
         self.fail_delete_labels: set[str] = set()
         self.assignment_succeeds = True
         self.permissions: dict[str, str] = {}
+        self.deleted_logins: set[str] = set()
         self.comments: dict[int, list[dict[str, Any]]] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
-        self.roster_reads = 0
 
     def get(self, path: str) -> Any:
         self.calls.append(('GET', path, None))
+        if path.endswith('/permission'):
+            login = urllib.parse.unquote(path.split('/collaborators/')[1].removesuffix('/permission'))
+            if login in self.deleted_logins:
+                raise urllib.error.HTTPError(path, 404, 'not found', {}, None)
+            # GitHub reports `none` for anyone without repository access, and
+            # never `maintain`/`triage`: those collapse to `write`/`read` here.
+            return {'permission': {monitor._FALLBACK_OWNER: 'write', **self.permissions}.get(login, 'none')}
         if path.startswith('/search/issues?'):
             query = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
             requested_state = 'closed' if 'is:closed' in query.get('q', [''])[0] else 'open'
@@ -156,14 +166,8 @@ class FakeClient:
         number = int(path.split('/issues/')[1].split('/')[0])
         yield self.comments.get(number, [])
 
-    def maintainer_logins(self, repo: str) -> dict[str, str]:
-        self.roster_reads += 1
-        values = {monitor._FALLBACK_OWNER: 'write', **self.permissions}
-        return {
-            login.casefold(): login
-            for login, permission in values.items()
-            if permission in {'write', 'maintain', 'admin'}
-        }
+    def permission_reads(self) -> list[str]:
+        return [path for method, path, _ in self.calls if method == 'GET' and path.endswith('/permission')]
 
 
 class SnapshotClient(FakeClient):
@@ -382,7 +386,7 @@ def test_apply_revalidates_then_assigns_and_labels(tmp_path: Path):
     ) in client.calls
 
 
-def test_owner_selection_reloads_discussion_after_concurrent_activity():
+def test_owner_selection_reads_the_live_item_not_the_classified_copy():
     stale = item(7, labels=[monitor._ACTION_LABEL])
     current = item(
         7,
@@ -398,19 +402,88 @@ def test_owner_selection_reloads_discussion_after_concurrent_activity():
     assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
 
 
-def test_owner_selection_uses_one_roster_for_a_large_discussion():
+def test_owner_selection_finds_a_maintainer_hidden_from_the_collaborator_list():
+    # The workflow token cannot see organization members whose membership is
+    # private, so the collaborator list omits most of the maintainer team and
+    # would silently route their own items to the fallback owner instead.
     issue = item(7, labels=[monitor._ACTION_LABEL])
-    issue['comments'] = 51
+    issue['user'] = {'login': 'DouweM'}
+    issue['author_association'] = 'CONTRIBUTOR'
+    client = FakeClient({7: issue})
+    client.permissions = {'DouweM': 'admin'}
+
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == 'DouweM'
+    assert client.permission_reads() == ['/repos/r/collaborators/DouweM/permission']
+    assert not any('/collaborators?' in path for _, path, _ in client.calls)
+
+
+def test_owner_selection_keeps_a_maintainer_authored_pull_request():
+    pull = {**item(7, labels=[monitor._ACTION_LABEL]), 'pull_request': {'url': 'https://api.github.com/pulls/7'}}
+    pull['user'] = {'login': 'DouweM'}
+    client = FakeClient({7: pull})
+    client.permissions = {'DouweM': 'admin'}
+
+    assert monitor._ensure_recipients(client, 'r', pull) == ['DouweM']
+    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+
+
+def test_owner_selection_never_overrides_an_explicit_assignment():
+    issue = item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])
+    issue['user'] = {'login': 'DouweM'}
+    client = FakeClient({7: issue})
+    client.permissions = {'DouweM': 'admin', 'alice': 'write'}
+
+    assert monitor._ensure_recipients(client, 'r', issue) == ['alice']
+    assert not any(path.endswith('/assignees') for _, path, _ in client.calls)
+
+
+def test_owner_selection_checks_each_participant_once_within_a_budget():
+    issue = item(7, labels=[monitor._ACTION_LABEL])
+    issue['comments'] = 2 * monitor._OWNER_LOOKUP_LIMIT
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
     client.comments[7] = [
-        *[{'user': {'login': f'contributor-{number}'}} for number in range(50)],
+        *[{'user': {'login': f'contributor-{number % 4}'}} for number in range(2 * monitor._OWNER_LOOKUP_LIMIT)],
         {'user': {'login': 'DouweM'}},
     ]
 
     assert monitor._first_maintainer_in_discussion(client, 'r', issue) == 'DouweM'
-    assert client.roster_reads == 1
-    assert not any('/permission' in path for method, path, _ in client.calls if method == 'GET')
+    # `contributor` authored the issue and each of the four repeats is resolved
+    # once, so a long thread costs a handful of requests rather than one per comment.
+    assert len(client.permission_reads()) == 6
+
+
+def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
+    issue = item(7, labels=[monitor._ACTION_LABEL])
+    flood = 2 * monitor._OWNER_LOOKUP_LIMIT
+    issue['comments'] = flood + 1
+    client = FakeClient({7: issue})
+    client.permissions = {'DouweM': 'admin'}
+    client.comments[7] = [
+        *[{'user': {'login': f'contributor-{number}'}} for number in range(flood)],
+        {'user': {'login': 'DouweM'}},
+    ]
+
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) is None
+    assert len(client.permission_reads()) == monitor._OWNER_LOOKUP_LIMIT
+
+
+def test_owner_selection_treats_a_deleted_account_as_a_non_maintainer():
+    issue = item(7, labels=[monitor._ACTION_LABEL])
+    issue['user'] = {'login': 'ghost'}
+    client = FakeClient({7: issue})
+    client.deleted_logins = {'ghost'}
+
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) is None
+
+
+def test_maintainer_lookup_is_cached_across_items():
+    client = FakeClient({7: item(7, assignees=['alice']), 8: item(8, assignees=['alice'])})
+    client.permissions = {'alice': 'admin'}
+
+    assert monitor._maintainer_assignees(client, 'r', client.items[7]) == ['alice']
+    assert monitor._maintainer_assignees(client, 'r', client.items[8]) == ['alice']
+    assert client.permission_reads() == ['/repos/r/collaborators/alice/permission']
 
 
 def test_apply_pings_all_assigned_maintainers_without_reassigning(tmp_path: Path):
@@ -617,8 +690,8 @@ def test_reconcile_queues_channel_reminder_for_assigned_maintainers():
     assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
 
 
-def test_reconcile_routes_existing_action_to_first_maintainer_participant():
-    issue = item(4261, labels=[monitor._ACTION_LABEL], assignees=['dsfaccini'])
+def test_reconcile_hands_a_placeholder_assignment_to_the_first_maintainer_participant():
+    issue = item(4261, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])
     issue['comments'] = 2
     client = FakeClient({4261: issue})
     client.permissions = {'DouweM': 'admin', 'dsfaccini': 'write'}

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -681,11 +681,15 @@ def test_reconcile_queues_channel_reminder_for_assigned_maintainers():
             'transition_id': 'default-stage-0',
             'title': 'Item 7',
             'recipients': ['alice', 'bob'],
+            'status': 'issue · no replies yet · going stale: no maintainer has touched it',
         }
     ]
     assert monitor._PINGED_LABEL not in {label['name'] for label in client.items[7]['labels']}
     assert monitor.finalize_notices(
-        client, 'pydantic/pydantic-ai', monitor._notice_refs({'items': [notice_ref(7, 0, recipients=['alice', 'bob'])]})
+        client,
+        'pydantic/pydantic-ai',
+        monitor._notice_refs({'items': [notice_ref(7, 0, recipients=['alice', 'bob'])]}),
+        now=NOW,
     ) == ['#7: recorded channel reminder']
     assert monitor._PINGED_LABEL in {label['name'] for label in client.items[7]['labels']}
 
@@ -740,7 +744,9 @@ def test_reconcile_queues_channel_escalation_without_advancing_before_delivery()
     )
     assert notices[0]['kind'] == 'escalation'
     assert monitor._ESCALATED_LABEL not in {label['name'] for label in client.items[7]['labels']}
-    assert monitor.finalize_notices(client, 'pydantic/pydantic-ai', [notices[0]]) == ['#7: recorded channel escalation']
+    assert monitor.finalize_notices(client, 'pydantic/pydantic-ai', [notices[0]], now=NOW) == [
+        '#7: recorded channel escalation'
+    ]
     assert monitor._ESCALATED_LABEL in {label['name'] for label in client.items[7]['labels']}
 
 
@@ -753,7 +759,7 @@ def test_reconcile_retries_preexisting_pending_escalation():
         [],
     )
     assert notices[0]['expected_stage'] == 2
-    assert monitor.finalize_notices(client, 'r', [notices[0]]) == ['#7: recorded channel escalation']
+    assert monitor.finalize_notices(client, 'r', [notices[0]], now=NOW) == ['#7: recorded channel escalation']
     assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[7]['labels']}
 
 
@@ -833,7 +839,7 @@ def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
     client.fail_delete_labels.add(monitor._ACTION_LABEL)
 
     with pytest.raises(RuntimeError, match='Failed to finalize attention'):
-        monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 1)]}))
+        monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [notice_ref(7, 1)]}), now=NOW)
 
     assert {'labels': [monitor._ESCALATED_LABEL, monitor._DELIVERED_LABEL]} in [call[2] for call in client.calls]
     assert {label['name'] for label in client.items[7]['labels']} == {
@@ -866,7 +872,7 @@ def test_terminal_finalize_retry_does_not_repost_the_delivered_escalation():
 def test_finalize_skips_a_stale_notice(labels: list[str], ref: dict[str, object]):
     client = FakeClient({7: item(7, labels=labels, assignees=[monitor._FALLBACK_OWNER])})
 
-    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [ref]})) == []
+    assert monitor.finalize_notices(client, 'r', monitor._notice_refs({'items': [ref]}), now=NOW) == []
     assert {label['name'] for label in client.items[7]['labels']} == set(labels)
 
 
@@ -874,14 +880,14 @@ def test_prepare_notices_filters_stale_owners_immediately_before_delivery():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=[monitor._FALLBACK_OWNER])})
     refs = monitor._notice_refs({'items': [notice_ref(7, 0)]})
 
-    assert [notice['number'] for notice in monitor.prepare_notices(client, 'r', refs)] == [7]
+    assert [notice['number'] for notice in monitor.prepare_notices(client, 'r', refs, now=NOW)] == [7]
 
     client.permissions['bob'] = 'write'
     client.items[7]['assignees'].append({'login': 'bob'})
-    assert monitor.prepare_notices(client, 'r', refs) == []
+    assert monitor.prepare_notices(client, 'r', refs, now=NOW) == []
 
     client.items[7]['assignees'] = []
-    assert monitor.prepare_notices(client, 'r', refs) == []
+    assert monitor.prepare_notices(client, 'r', refs, now=NOW) == []
 
 
 @pytest.mark.parametrize(
@@ -931,6 +937,7 @@ def test_notice_output_is_actionable_and_escapes_untrusted_titles(tmp_path: Path
                 'transition_id': 'event-7',
                 'title': 'Handle <unsafe>\n*fake owner* | <!channel>',
                 'recipients': ['DouweM'],
+                'status': 'issue · opened by @evil <!channel> · 2 replies · last from @evil 5d ago (author)',
             }
         ],
     )
@@ -941,7 +948,11 @@ def test_notice_output_is_actionable_and_escapes_untrusted_titles(tmp_path: Path
     text = json.loads(values['slack_payload'])['text']
     assert text.count('<!channel>') == 1
     assert '#7 Handle &lt;unsafe&gt; fake owner &lt;!channel&gt;' in text
-    assert 'owner @DouweM; why: no maintainer has acted for three days' in text
+    assert 'owner @DouweM' in text
+    # A login is the only untrusted value the status line carries, and it is
+    # escaped on the same path as the title.
+    assert 'opened by @evil &lt;!channel&gt; · 2 replies · last from @evil 5d ago (author)' in text
+    assert 'why: no maintainer has acted for three days' in text
     assert '*Expected action:*' in text
     assert 'If no work is needed, say so briefly' in text
     assert 'Do not remove the attention labels' in text
@@ -1063,6 +1074,77 @@ def test_collaborator_comment_by_non_recipient_completes_the_request():
     ]
 
     assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
+
+
+def test_private_maintainer_reply_completes_the_request():
+    # `author_association` is computed for the caller, so a maintainer whose
+    # organization membership is private reports as CONTRIBUTOR. Trusting the
+    # association alone would keep reminding them about an item they answered.
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL])})
+    client.permissions = {'DouweM': 'admin'}
+    client.timelines[7] = [
+        label_event(monitor._ACTION_LABEL),
+        {
+            'event': 'commented',
+            'created_at': '2026-07-17T00:00:00Z',
+            'actor': {'login': 'DouweM'},
+            'author_association': 'CONTRIBUTOR',
+            'body': 'Answered.',
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW) == (['#7: maintainer acknowledged the request'], [])
+
+
+def test_status_line_reports_the_last_reply_and_its_role():
+    issue = item(7, labels=[monitor._ACTION_LABEL], assignees=['DouweM'])
+    issue['created_at'] = '2026-06-20T00:00:00Z'
+    client = FakeClient({7: issue})
+    client.permissions = {'DouweM': 'admin'}
+    notices: list[monitor.Notice] = []
+    client.timelines[7] = [
+        label_event(monitor._ACTION_LABEL, created_at='2026-07-02T00:00:00Z'),
+        {
+            'event': 'commented',
+            'created_at': '2026-07-01T00:00:00Z',
+            'actor': {'login': 'DouweM'},
+            'author_association': 'CONTRIBUTOR',
+        },
+        {
+            'event': 'commented',
+            'created_at': '2026-07-01T12:00:00Z',
+            'actor': {'login': 'contributor'},
+            'author_association': 'NONE',
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (['#7: queued channel reminder'], [])
+    # A maintainer already replied, so the line stops short of "going stale".
+    assert notices[0]['status'] == (
+        'issue · opened by @contributor 30d ago · 2 replies · last from @contributor 18d ago (author)'
+    )
+
+
+def test_status_line_does_not_count_a_bot_reply_as_engagement():
+    issue = item(7, labels=[monitor._ACTION_LABEL])
+    issue['created_at'] = '2026-07-01T00:00:00Z'
+    client = FakeClient({7: issue})
+    notices: list[monitor.Notice] = []
+    client.timelines[7] = [
+        label_event(monitor._ACTION_LABEL, created_at='2026-07-02T00:00:00Z'),
+        {
+            'event': 'commented',
+            'created_at': '2026-07-03T00:00:00Z',
+            'actor': {'login': 'pydanty[bot]', 'type': 'Bot'},
+            'author_association': 'CONTRIBUTOR',
+        },
+    ]
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (['#7: queued channel reminder'], [])
+    assert notices[0]['status'] == (
+        'issue · opened by @contributor 19d ago · 1 reply · last from @pydanty[bot] 17d ago (bot)'
+        ' · going stale: no maintainer has touched it'
+    )
 
 
 def test_closed_item_completes_and_strips_lifecycle_labels():

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -64,6 +64,7 @@ class FakeClient(monitor.GitHubClient):
         self.comments: dict[int, list[dict[str, Any]]] = {}
         self.review_comments: dict[int, list[dict[str, Any]]] = {}
         self.reviews: dict[int, list[dict[str, Any]]] = {}
+        self.truncated: set[int] = set()
         self.timelines: dict[int, list[dict[str, Any]]] = {}
 
     def get(self, path: str) -> Any:
@@ -169,12 +170,14 @@ class FakeClient(monitor.GitHubClient):
     def last_pages(self, path: str, *, count: int = 1) -> list[dict[str, Any]]:
         return self.last_page(path)
 
-    def first_pages(self, path: str, *, count: int) -> list[dict[str, Any]]:
+    def first_pages(self, path: str, *, count: int) -> tuple[list[dict[str, Any]], bool]:
         self.calls.append(('FIRST', path, None))
         if '/pulls/' in path:
             number = int(path.split('/pulls/')[1].split('/')[0])
-            return (self.reviews if path.endswith('/reviews') else self.review_comments).get(number, [])
-        return self.comments.get(int(path.split('/issues/')[1].split('/')[0]), [])
+            source = self.reviews if path.endswith('/reviews') else self.review_comments
+        else:
+            number, source = int(path.split('/issues/')[1].split('/')[0]), self.comments
+        return source.get(number, []), number not in self.truncated
 
     def permission_reads(self) -> list[str]:
         return [path for method, path, _ in self.calls if method == 'GET' and path.endswith('/permission')]
@@ -422,7 +425,7 @@ def test_owner_selection_finds_a_maintainer_hidden_from_the_collaborator_list():
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
 
-    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == 'DouweM'
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == ('DouweM', True)
     assert client.permission_reads() == ['/repos/r/collaborators/DouweM/permission']
     assert not any('/collaborators?' in path for _, path, _ in client.calls)
 
@@ -450,7 +453,7 @@ def test_owner_selection_reads_every_pull_request_discussion_surface():
 
     # Ordered across all three surfaces, so the earliest reviewer wins over the
     # later issue-comment maintainer.
-    assert monitor._first_maintainer_in_discussion(client, 'r', pull) == 'DouweM'
+    assert monitor._first_maintainer_in_discussion(client, 'r', pull) == ('DouweM', True)
 
 
 def test_owner_selection_never_overrides_an_explicit_assignment():
@@ -473,13 +476,15 @@ def test_owner_selection_checks_each_participant_once_within_a_budget():
         {'user': {'login': 'DouweM'}},
     ]
 
-    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == 'DouweM'
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == ('DouweM', True)
     # `contributor` authored the issue and each of the four repeats is resolved
     # once, so a long thread costs a handful of requests rather than one per comment.
     assert len(client.permission_reads()) == 6
 
 
-def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
+def test_a_flood_of_unknown_participants_defers_instead_of_reassigning():
+    # Padding a discussion with throwaway accounts must not be a way to push an
+    # item off its real owner, so an exhausted sweep decides nothing.
     issue = item(7, labels=[monitor._ACTION_LABEL])
     flood = 2 * monitor._ITEM_PROBE_LIMIT
     issue['comments'] = flood + 1
@@ -490,12 +495,41 @@ def test_owner_selection_falls_back_past_a_flood_of_unknown_participants():
         {'user': {'login': 'DouweM'}},
     ]
 
-    assert monitor._first_maintainer_in_discussion(client, 'r', issue) is None
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == (None, False)
     assert len(client.permission_reads()) == monitor._ITEM_PROBE_LIMIT
+    assert monitor._ensure_recipients(client, 'r', issue) is None
+    assert not any(path.endswith('/assignees') for _, path, _ in client.calls)
     # The quota is per item, so the flood cannot hide the next item's maintainer.
     followup = item(8)
     followup['user'] = {'login': 'DouweM'}
-    assert monitor._first_maintainer_in_discussion(client, 'r', followup) == 'DouweM'
+    assert monitor._first_maintainer_in_discussion(client, 'r', followup) == ('DouweM', True)
+
+
+def test_a_truncated_discussion_defers_instead_of_reassigning():
+    issue = item(7, labels=[monitor._ACTION_LABEL])
+    issue['comments'] = 1
+    client = FakeClient({7: issue})
+    client.comments[7] = [{'user': {'login': 'contributor-1'}}]
+    client.truncated = {7}
+
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == (None, False)
+    assert monitor._ensure_recipients(client, 'r', issue) is None
+
+
+def test_apply_defers_an_item_whose_owner_cannot_be_identified(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 7, 'updated_at': OLD}])
+    write_output(output, ['7'])
+    client = FakeClient({7: item(7)})
+    client.truncated = {7}
+    client.items[7]['comments'] = 1
+    client.comments[7] = [{'user': {'login': 'contributor-1'}}]
+
+    assert monitor.apply_decisions(client, 'r', str(output), str(snapshot)) == [
+        '#7: deferred until its owner can be identified'
+    ]
+    assert not any(path.endswith('/assignees') for _, path, _ in client.calls)
 
 
 def test_first_pages_truncates_a_huge_thread_instead_of_aborting(monkeypatch: pytest.MonkeyPatch):
@@ -510,7 +544,9 @@ def test_first_pages_truncates_a_huge_thread_instead_of_aborting(monkeypatch: py
 
     monkeypatch.setattr(client, '_request', request)
 
-    assert len(client.first_pages('/repos/r/issues/7/comments', count=3)) == 3
+    entries, complete = client.first_pages('/repos/r/issues/7/comments', count=3)
+    assert len(entries) == 3
+    assert complete is False
     assert len(seen) == 3
 
 
@@ -532,7 +568,7 @@ def test_owner_selection_treats_a_deleted_account_as_a_non_maintainer():
     client = FakeClient({7: issue})
     client.deleted_logins = {'ghost'}
 
-    assert monitor._first_maintainer_in_discussion(client, 'r', issue) is None
+    assert monitor._first_maintainer_in_discussion(client, 'r', issue) == (None, True)
 
 
 def test_maintainer_lookup_is_cached_across_items():
@@ -1157,9 +1193,13 @@ def test_private_maintainer_reply_completes_the_request():
 def test_status_line_reports_the_last_reply_and_its_role():
     issue = item(7, labels=[monitor._ACTION_LABEL], assignees=['DouweM'])
     issue['created_at'] = '2026-06-20T00:00:00Z'
+    issue['comments'] = 2
     client = FakeClient({7: issue})
     client.permissions = {'DouweM': 'admin'}
     notices: list[monitor.Notice] = []
+    # The timeline holds only the newest pages, so engagement is asked of the
+    # discussion itself; a reply that fell off the window still counts.
+    client.comments[7] = [{'user': {'login': 'DouweM'}, 'created_at': '2026-07-01T00:00:00Z'}]
     client.timelines[7] = [
         label_event(monitor._ACTION_LABEL, created_at='2026-07-02T00:00:00Z'),
         {
@@ -1179,7 +1219,7 @@ def test_status_line_reports_the_last_reply_and_its_role():
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (['#7: queued channel reminder'], [])
     # A maintainer already replied, so the line stops short of "going stale".
     assert notices[0]['status'] == (
-        'issue · opened by @contributor 30d ago · 2 replies · last from @contributor 18d ago (author)'
+        'issue · opened by @contributor 30d ago · 2 comments · last from @contributor 18d ago (author)'
     )
 
 
@@ -1200,7 +1240,7 @@ def test_status_line_does_not_count_a_bot_reply_as_engagement():
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (['#7: queued channel reminder'], [])
     assert notices[0]['status'] == (
-        'issue · opened by @contributor 19d ago · 1 reply · last from @pydanty[bot] 17d ago (bot)'
+        'issue · opened by @contributor 19d ago · last from @pydanty[bot] 17d ago (bot)'
         ' · going stale: no maintainer has touched it'
     )
 


### PR DESCRIPTION
The attention monitor has been assigning every item to the fallback owner instead of the maintainer who opened or triaged it, and its Slack reminders say nothing about what the item is actually waiting on.

### Root cause

#6996 replaced the per-user permission check with the collaborator **list** endpoint:

```python
self.pages(f'/repos/{repo}/collaborators?affiliation=all', ...)
```

That endpoint only returns collaborators the caller can see. The Actions `GITHUB_TOKEN` has no organization `members: read`, so it cannot see members whose organization membership is **private** — which is almost the whole maintainer team. Only 8 of the 20 collaborators with push access are public organization members.

So `_first_maintainer_in_discussion` returned `None` for essentially every item and everything fell through to `_FALLBACK_OWNER`.

Independent confirmation from the run that produced the current backlog ([run 30676663748](https://github.com/pydantic/pydantic-ai/actions/runs/30676663748), snapshot artifact built with the same token):

```
('DouweM',     'CONTRIBUTOR')   # private member
('Kludex',     'MEMBER')        # public member
('adtyavrdhn', 'MEMBER')        # public member
```

`author_association` is computed for the caller too, which is the same defect on the acknowledgement path: a private maintainer replying to an item never counted as acknowledgement, so the monitor kept reminding them about items they had already answered.

The endpoint this restores (`/repos/{repo}/collaborators/{user}/permission`) is the one the pre-#6996 code used, and it resolved `DouweM`, `dmontagu` and `dsfaccini` correctly in this same workflow on 2026-07-30/31 — it is not visibility-filtered.

### Changes

- `GitHubClient.maintainer_login` resolves one login at a time through the permission endpoint, cached per login, bounded by `_OWNER_LOOKUP_LIMIT` distinct lookups per owner scan so a long community thread cannot exhaust the hourly token budget.
- Owner selection now applies to pull requests as well: a maintainer's own PR stays theirs instead of being handed to the fallback owner.
- An existing maintainer assignee is treated as an explicit decision and is never reassigned. The monitor's own fallback assignment is a placeholder, so it still steps aside once a real owner turns up — which re-routes the current backlog automatically.
- `_acknowledged` falls back to the permission lookup when `author_association` under-reports a maintainer.
- Each digest line now says what the item is waiting on: kind, who opened it and when, reply count, who replied last and in what role (author / maintainer / contributor / bot), and whether no maintainer has touched it at all. All of it is derived from structured GitHub metadata — no issue or PR prose reaches the channel, so the existing injection boundary is unchanged.

Before / after on the live backlog:

| item | author | was | now |
| --- | --- | --- | --- |
| #5473 (issue) | DouweM | @adtyavrdhn | @DouweM |
| #6527 (issue) | DouweM | @adtyavrdhn | @DouweM |
| #6194 (PR) | dsfaccini | @adtyavrdhn | @dsfaccini |
| #5953 (issue) | kazmer97 | @adtyavrdhn | @dsfaccini |
| #6499, #5471, #4758, #5414, #5496 | community | @adtyavrdhn | @adtyavrdhn (correct: no maintainer has engaged) |

Sample of the new digest, rendered against live data:

```
• *Reminder*: <#5471 Support OpenAI-compatible custom providers…> — owner @adtyavrdhn
      issue · opened by @Dadd0 77d ago · 7 replies · last from @winterer 14d ago (contributor) · going stale: no maintainer has touched it
      why: no maintainer has acted for three days
• *Reminder*: <#6527 Verify UI event-path cache-prefix fidelity…> — owner @DouweM
      issue · opened by @DouweM 16d ago · 2 replies · last from @HarperZ9 14d ago (contributor)
      why: no maintainer has acted for three days
```

### Tests

`.github/scripts/test_issue_pr_attention_monitor.py`: 92 passing. `FakeClient` now subclasses `GitHubClient` so the real lookup, caching and 404 handling are under test rather than stubbed — the previous fake stubbed `maintainer_logins` wholesale, which is why the roster never being visible went unnoticed. New cases cover the hidden-maintainer regression, maintainer-authored PRs, explicit assignments, the lookup budget, deleted accounts, the private-maintainer acknowledgement, and the status line.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

