### PR TITLE
Expose `tool_name` on `ToolResultEvent`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -3483,6 +3483,16 @@ class ToolResultEvent:
         """An ID used to match the result to its original call."""
         return self.part.tool_call_id
 
+    @property
+    def tool_name(self) -> str | None:
+        """The name of the tool that was called, if known.
+
+        Always set for [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart]. May be `None` for a
+        [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart] used for output-validation retries
+        (not a tool call).
+        """
+        return self.part.tool_name
+
     __repr__ = _utils.dataclasses_no_defaults_repr
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2210,3 +2210,21 @@ def test_narrow_message_parts_promotes_valid_claims_and_leaves_plain_parts():
     assert type(narrowed[0].parts[0]) is LoadCapabilityCallPart
     assert narrowed[0].parts[1] is messages[0].parts[1]
     assert type(narrowed[1].parts[0]) is LoadCapabilityReturnPart
+
+def test_tool_result_event_tool_name():
+    """ToolResultEvent exposes tool_name next to tool_call_id for stream consumers."""
+    return_part = ToolReturnPart(tool_name='search', content='ok', tool_call_id='call_1')
+    result_event = FunctionToolResultEvent(part=return_part)
+    assert result_event.tool_call_id == 'call_1'
+    assert result_event.tool_name == 'search'
+
+    retry_part = RetryPromptPart(content='bad args', tool_name='search', tool_call_id='call_2')
+    retry_event = FunctionToolResultEvent(part=retry_part)
+    assert retry_event.tool_call_id == 'call_2'
+    assert retry_event.tool_name == 'search'
+
+    output_retry = RetryPromptPart(content='invalid output', tool_call_id='call_3')
+    output_event = OutputToolResultEvent(part=output_retry)
+    assert output_event.tool_call_id == 'call_3'
+    assert output_event.tool_name is None
+

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -54,8 +54,10 @@ from pydantic_ai._parts_manager import ModelResponsePartsManager
 from pydantic_ai.messages import (
     INVALID_JSON_KEY,
     MULTI_MODAL_CONTENT_TYPES,
+    FunctionToolResultEvent,
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
+    OutputToolResultEvent,
     ToolReturnContent,
     is_multi_modal_content,
     narrow_message_parts,

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2213,6 +2213,7 @@ def test_narrow_message_parts_promotes_valid_claims_and_leaves_plain_parts():
     assert narrowed[0].parts[1] is messages[0].parts[1]
     assert type(narrowed[1].parts[0]) is LoadCapabilityReturnPart
 
+
 def test_tool_result_event_tool_name():
     """ToolResultEvent exposes tool_name next to tool_call_id for stream consumers."""
     return_part = ToolReturnPart(tool_name='search', content='ok', tool_call_id='call_1')
@@ -2229,4 +2230,3 @@ def test_tool_result_event_tool_name():
     output_event = OutputToolResultEvent(part=output_retry)
     assert output_event.tool_call_id == 'call_3'
     assert output_event.tool_name is None
-


### PR DESCRIPTION
<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

Approach matches the shape proposed in #6971 and called out by @brianstrauch on #6639 as a real core gap.

- Closes #6971

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Notes

- Additive property only: `ToolResultEvent.tool_name` mirrors existing `tool_call_id` and returns `self.part.tool_name` as `str`.
- Asserts `tool_name` is set — `ToolResultEvent` never wraps a `RetryPromptPart` without one.
- No change to event construction, streaming, or serialization.
- Test covers success (`ToolReturnPart`) and tool/output retries (`RetryPromptPart` with name).