### PR TITLE
Document `SentenceTransformersProvider` in the providers API reference

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -28,6 +28,8 @@
 
 ::: pydantic_ai.providers.voyageai.VoyageAIProvider
 
+::: pydantic_ai.providers.sentence_transformers.SentenceTransformersProvider
+
 ::: pydantic_ai.providers.cerebras.CerebrasProvider
 
 ::: pydantic_ai.providers.mistral.MistralProvider


### PR DESCRIPTION
`SentenceTransformersProvider` is missing from the providers API reference, so it has no rendered docs page even though it is a public provider (`from pydantic_ai.providers.sentence_transformers import SentenceTransformersProvider` works) and sentence-transformers usage is documented in `docs/embeddings.md`.

The gap is specific to this one page. `docs/api/embeddings.md` lists both `pydantic_ai.embeddings.voyageai` and `pydantic_ai.embeddings.sentence_transformers`, and `docs/api/providers.md` lists `providers.voyageai.VoyageAIProvider`, so the two embeddings providers are documented identically everywhere except here. Added the matching entry next to the VoyageAI one, following the same class-level style.

Ran `uv run mkdocs build --strict` before and after: no new warnings, and the class renders on the providers page.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: I put this together with Claude Code and checked the diff myself. freshman still finding my way around the docs setup, so tell me if you would rather list it somewhere else.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

