### PR TITLE
Document `ToolsetTool` in the toolsets API reference

### DIFF
--- a/docs/api/toolsets.md
+++ b/docs/api/toolsets.md
@@ -4,6 +4,7 @@
     options:
         members:
         - AbstractToolset
+        - ToolsetTool
         - CombinedToolset
         - ExternalToolset
         - ApprovalRequiredToolset


### PR DESCRIPTION
`ToolsetTool` is exported in `pydantic_ai.toolsets.__all__` (and from `pydantic_ai` itself), and the custom-toolset example in `docs/toolsets.md` has users import it and annotate their `call_tool` signature with it. But it is the one entry in that `__all__` missing from the members list in `docs/api/toolsets.md`, so it has no rendered API docs: before this change there is no `id="pydantic_ai.toolsets.ToolsetTool"` anchor on the page, and it only shows up incidentally inside other members' signatures.

Added it to the members list right after `AbstractToolset`, since the two go together when you are implementing a toolset. Ran `uv run mkdocs build --strict`: the anchor is present afterwards and no new warnings appear.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built this with Claude Code's help and read the diff myself before pushing. happy to move it further down the list if you would rather keep the concrete toolsets together at the top.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

