### PR TITLE
Link the tracking issue from the skipped Temporal MCP toolset tests

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -8847,7 +8847,8 @@ class DurabilityMCPDynamicToolsetAgentWorkflow:
 @pytest.mark.skip(
     reason=(
         'Pending: replays of this MCP toolset workflow trip the Temporal sandbox with '
-        '`Module certifi was imported after initial workflow load`. Issue tracked.'
+        '`Module certifi was imported after initial workflow load`. '
+        'See https://github.com/pydantic/platform/issues/30434'
     )
 )
 async def test_durability_mcp_dynamic_toolset_in_workflow(allow_model_requests: None, client: Client):
@@ -8894,7 +8895,8 @@ class DurabilityMCPToolsetAgentWorkflow:
 @pytest.mark.skip(
     reason=(
         'Pending: replays of this MCP toolset workflow trip the Temporal sandbox with '
-        '`Module certifi was imported after initial workflow load`. Issue tracked.'
+        '`Module certifi was imported after initial workflow load`. '
+        'See https://github.com/pydantic/platform/issues/30434'
     )
 )
 async def test_durability_mcptoolset_in_workflow(allow_model_requests: None, client: Client):


### PR DESCRIPTION
`test_durability_mcp_dynamic_toolset_in_workflow` and `test_durability_mcptoolset_in_workflow` are skipped with a reason that ends in "Issue tracked." but never says *which* issue, so there's no way to get from the skip to the tracking work.

Replaces that with a link to the tracking issue, matching the `See <url>` convention already used by the `xfail` reasons in `tests/test_streaming.py`:

```
'Pending: replays of this MCP toolset workflow trip the Temporal sandbox with '
'`Module certifi was imported after initial workflow load`. '
'See https://github.com/pydantic/platform/issues/30434'
```

Tracking issue: https://github.com/pydantic/platform/issues/30434 (not a `Closes` — it's in another repo and stays open until the sandbox issue is actually fixed and the tests are un-skipped).

Comment-only change to two `pytest.mark.skip` reason strings; no behavior change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


---
_Generated by [Claude Code](https://claude.ai/code/session_017JG81So26Q6b4oA7RkYNDK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

