### PR TITLE
Omit empty `search_tools` for deferred capabilities

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -553,6 +553,9 @@ class Model(ABC, Generic[InterfaceClient]):
           the user asked explicitly. Other native tools don't have a corpus and aren't subject
           to this drop, so making `optional` a base-class field doesn't accidentally cause
           e.g. `WebSearchTool(optional=True)` to be dropped here.
+        * On models without native tool search, the local `search_tools` fallback is omitted when
+          every deferred tool belongs to a deferred capability. Those tools are unavailable before
+          the capability loads and immediately revealed afterwards, so the local corpus is always empty.
         """
         supported_types = self.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
 
@@ -582,6 +585,11 @@ class Model(ABC, Generic[InterfaceClient]):
         tool_search_resolution = _resolve_tool_search_native_for_capability_owned_corpus(supported_natives, params)
         supported_natives = tool_search_resolution.native_tools
         tool_search_kept_local = tool_search_resolution.keep_search_tools_local
+        has_locally_searchable_tool = any(
+            t.with_native == ToolSearchTool.kind
+            and (t.capability_id is None or t.capability_id not in params.deferred_capability_ids)
+            for t in params.function_tools
+        )
 
         function_tools: list[ToolDefinition] = []
         for t in params.function_tools:
@@ -592,6 +600,12 @@ class Model(ABC, Generic[InterfaceClient]):
             if t.unless_native and t.unless_native in supported_ids:
                 if not (tool_search_kept_local and t.unless_native == ToolSearchTool.kind):
                     continue
+            if (
+                t.tool_kind == 'tool-search'
+                and ToolSearchTool.kind in unsupported_ids
+                and not has_locally_searchable_tool
+            ):
+                continue
             # Rule 3: a corpus member whose native tool is unsupported can't be paired with that
             # native tool on this provider; its fate turns on whether it's been discovered yet.
             if t.with_native and t.with_native not in supported_ids:

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -1018,7 +1018,7 @@ async def test_tool_search_handles_search_gated_tools_from_eager_capability():
 
 
 async def test_tool_search_handles_capability_deferred_and_loaded_tools():
-    """Deferred capability tools become visible as a unit after loading."""
+    """Deferred capability tools become visible as a unit without exposing an empty search tool."""
     toolset: FunctionToolset = FunctionToolset()
 
     @toolset.tool_plain
@@ -1076,75 +1076,11 @@ async def test_tool_search_handles_capability_deferred_and_loaded_tools():
     assert result.output == 'final: also-deferred-result'
     assert seen_tool_names == snapshot(
         [
-            ['load_capability', 'search_tools'],
-            ['load_capability', 'inherited_tool', 'also_deferred_tool', 'search_tools'],
-            ['load_capability', 'inherited_tool', 'also_deferred_tool', 'search_tools'],
+            ['load_capability'],
+            ['load_capability', 'inherited_tool', 'also_deferred_tool'],
+            ['load_capability', 'inherited_tool', 'also_deferred_tool'],
         ]
     )
-
-
-async def test_explicit_tool_search_gets_empty_capability_only_corpus_before_and_after_load():
-    """Capability-owned tools are never searchable: unavailable before loading and revealed after."""
-    toolset: FunctionToolset = FunctionToolset()
-
-    @toolset.tool_plain
-    def capability_tool() -> str:  # pragma: no cover
-        """A tool owned by the deferred capability."""
-        return 'capability-result'
-
-    capability = Capability(
-        id='example',
-        description='Example capability.',
-        defer_loading=True,
-        toolsets=[toolset],
-    )
-
-    seen_corpora: list[list[str]] = []
-
-    def search_strategy(
-        ctx: RunContext[object], queries: Sequence[str], tool_defs: Sequence[ToolDefinition]
-    ) -> list[str]:
-        seen_corpora.append([tool_def.name for tool_def in tool_defs])
-        return []
-
-    request_count = 0
-
-    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
-        nonlocal request_count
-        request_count += 1
-        if request_count == 1:
-            return ModelResponse(
-                parts=[
-                    ToolCallPart(tool_name=_SEARCH_TOOLS_NAME, args={'queries': ['example']}, tool_call_id='search-1')
-                ]
-            )
-        if request_count == 2:
-            return ModelResponse(
-                parts=[
-                    ToolCallPart(
-                        tool_name=LOAD_CAPABILITY_TOOL_NAME,
-                        args={'id': 'example'},
-                        tool_call_id='load-example',
-                    )
-                ]
-            )
-        if request_count == 3:
-            return ModelResponse(
-                parts=[
-                    ToolCallPart(tool_name=_SEARCH_TOOLS_NAME, args={'queries': ['example']}, tool_call_id='search-2')
-                ]
-            )
-        return ModelResponse(parts=[TextPart(content='done')])
-
-    agent: Agent[object, str] = Agent(
-        NoNativeToolSearchModel(model_fn),
-        capabilities=[capability, ToolSearch(strategy=search_strategy)],
-    )
-
-    result = await agent.run('search before and after loading the capability')
-
-    assert result.output == 'done'
-    assert seen_corpora == [[], []]
 
 
 async def test_tool_search_ignores_malformed_loaded_capability_history():


### PR DESCRIPTION
- Closes #6997

### Summary

On models without native tool search, omit the local `search_tools` fallback when every deferred tool belongs to a deferred capability. Those tools are unavailable before the capability loads and immediately revealed afterwards, so the local search corpus is empty on every request.

The filtering happens during model request preparation, where native support is known. This preserves native tool-search and cross-provider replay behavior, keeps search available for eager capabilities and standalone deferred tools, and retains the existing prompt-cache stability behavior after ordinary tools are discovered.

The obsolete test that explicitly invoked `search_tools` against an empty capability-only corpus is removed; the public agent test now asserts the corrected tool surface both before and after loading the capability.

### Validation

- `pytest tests/test_tool_search.py -q` — 207 passed
- `ruff check` and `ruff format --check` on changed files
- `pyright` on changed files — 0 errors, 0 warnings
- Independent Codex review — no actionable findings

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

