### PR TITLE
Document nested approval for deferred tool calls in delegated agents

### DIFF
--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -312,6 +312,104 @@ _(This example is complete, it can be run "as is")_
 !!! note "Tool result ordering"
     Tool results follow the order in which the model emitted the corresponding tool calls. In the message history above, `delete_file`'s denied result appears before `update_file`'s result for `.env` because the model emitted `delete_file` first. This is an intentional behavior change in v2: results are no longer grouped by tool kind, so the ordering you see reflects the model's emission order.
 
+### Nested approval in delegated tool calls
+
+When a tool [delegates work to another agent](multi-agent-applications.md#agent-delegation) and that delegate agent calls a tool of its own that requires approval, the delegate's [`DeferredToolRequests`][pydantic_ai.tools.DeferredToolRequests] output needs to bubble up through the delegating tool before it can reach the caller. A tool can only pause the run it's part of by raising [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] — it can't return a nested `DeferredToolRequests` object — so the delegating tool needs to:
+
+1. Run the delegate agent and check whether its output is `DeferredToolRequests`.
+2. If so, stash the delegate's [message history](message-history.md) and the `DeferredToolRequests` somewhere the tool can find them again on the next call — typically [dependencies](dependencies.md) — keyed by [`RunContext.tool_call_id`][pydantic_ai.tools.RunContext.tool_call_id], then raise `ApprovalRequired` so the *delegating* tool call itself shows up in the parent agent's own `DeferredToolRequests.approvals`.
+3. Once the parent run is resumed with that call approved ([`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] is `True`), look up the stashed delegate history and requests, build a `DeferredToolResults` for the delegate from them, and resume the delegate agent with it.
+
+This works at any depth of delegation, since each level only ever has to resolve the approval for the tool call directly below it.
+
+```python {title="nested_deferred_tool_approval.py"}
+from dataclasses import dataclass, field
+
+from pydantic_ai import (
+    Agent,
+    ApprovalRequired,
+    DeferredToolRequests,
+    DeferredToolResults,
+    ModelMessage,
+    RunContext,
+)
+
+specialist_agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
+
+
+@specialist_agent.tool_plain(requires_approval=True)
+def get_answer(question: str) -> str:
+    return 'The answer is 42.'
+
+
+@dataclass
+class CoordinatorDeps:
+    pending_specialist_calls: dict[str, tuple[list[ModelMessage], DeferredToolRequests]] = field(
+        default_factory=dict
+    )  # (1)!
+
+
+coordinator_agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests], deps_type=CoordinatorDeps)
+
+
+@coordinator_agent.tool
+def run_specialist(ctx: RunContext[CoordinatorDeps], question: str) -> str:
+    message_history: list[ModelMessage] = []
+    deferred_tool_results: DeferredToolResults | None = None
+    user_prompt: str | None = question
+
+    if ctx.tool_call_approved and ctx.tool_call_id is not None:
+        stashed = ctx.deps.pending_specialist_calls.pop(ctx.tool_call_id, None)
+        if stashed is not None:  # (2)!
+            message_history, pending_requests = stashed
+            deferred_tool_results = DeferredToolResults(
+                approvals={call.tool_call_id: True for call in pending_requests.approvals}
+            )
+            user_prompt = None
+
+    result = specialist_agent.run_sync(
+        user_prompt, message_history=message_history, deferred_tool_results=deferred_tool_results
+    )
+    if isinstance(result.output, DeferredToolRequests):
+        assert ctx.tool_call_id is not None
+        ctx.deps.pending_specialist_calls[ctx.tool_call_id] = (result.all_messages(), result.output)  # (3)!
+        raise ApprovalRequired
+    return result.output
+
+
+deps = CoordinatorDeps()
+user_prompt: str | None = 'What is the answer to the question of life, the universe, and everything?'
+message_history: list[ModelMessage] = []
+deferred_tool_results: DeferredToolResults | None = None
+output: str | None = None
+while output is None:
+    result = coordinator_agent.run_sync(
+        user_prompt,
+        deps=deps,
+        message_history=message_history,
+        deferred_tool_results=deferred_tool_results,
+    )
+    if isinstance(result.output, DeferredToolRequests):
+        user_prompt = None
+        message_history = result.all_messages()
+        # Gather approvals from the user here, e.g. via a UI:
+        deferred_tool_results = DeferredToolResults(
+            approvals={call.tool_call_id: True for call in result.output.approvals}
+        )  # (4)!
+    else:
+        output = result.output
+
+print(output)
+#> The answer to the question of life, the universe, and everything is 42.
+```
+
+1. Keyed by the *delegating* tool call's ID, so a coordinator handling several pending specialist calls at once can look up the right one.
+2. `stashed` is only found once: after the delegate is resumed to completion, its entry is popped and won't be looked up again on a later, unrelated approved call with the same tool.
+3. Store the delegate's `DeferredToolRequests` itself, not just the tool call IDs, since `deferred_tool_results` above needs to know which of its `approvals` and `calls` to resolve.
+4. This example approves every pending request outright; in a real application, you'd present `result.output.approvals` (and `.calls`) to a human or external system and build `DeferredToolResults` from their response, as in the [handler example](#resolving-deferred-calls-with-a-handler) above.
+
+_(This example is complete, it can be run "as is")_
+
 ## External Tool Execution
 
 When the result of a tool call cannot be generated inside the same agent run in which it was called, the tool is considered to be external.

--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -22,6 +22,9 @@ You'll generally want to pass [`ctx.usage`][pydantic_ai.tools.RunContext.usage] 
 !!! note "Multiple models"
     Agent delegation doesn't need to use the same model for each agent. If you choose to use different models within a run, calculating the monetary cost from the final [`result.usage`][pydantic_ai.agent.AgentRunResult.usage] of the run will not be possible, but you can still use [`UsageLimits`][pydantic_ai.usage.UsageLimits] — including `request_limit`, `total_tokens_limit`, and `tool_calls_limit` — to avoid unexpected costs or runaway tool loops.
 
+!!! tip "Deferred tools in a delegate agent"
+    If the delegate agent calls a [tool that requires approval or is executed externally](deferred-tools.md), its `DeferredToolRequests` output needs to be propagated up through the delegating tool call. See [Nested approval in delegated tool calls](deferred-tools.md#nested-approval-in-delegated-tool-calls).
+
 ```python {title="agent_delegation_simple.py"}
 from pydantic_ai import Agent, RunContext, UsageLimits
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -637,6 +637,16 @@ text_responses: dict[str, str | ToolCallPart | Sequence[ToolCallPart]] = {
     'Continue from where you left off': 'Python is a versatile programming language.',
     'What are people saying about AI on X today?': "There's a lot of excitement about new AI models being released...",
     'What have AI companies been posting about?': 'OpenAI announced their latest model updates, while Anthropic shared research on AI safety...',
+    'What is the answer to the question of life, the universe, and everything?': ToolCallPart(
+        tool_name='run_specialist',
+        args={'question': 'What is the answer to the ultimate question of life, the universe, and everything?'},
+        tool_call_id='run_specialist',
+    ),
+    'What is the answer to the ultimate question of life, the universe, and everything?': ToolCallPart(
+        tool_name='get_answer',
+        args={'question': 'What is the answer to the ultimate question of life, the universe, and everything?'},
+        tool_call_id='get_answer',
+    ),
 }
 
 tool_responses: dict[tuple[str, str], str] = {
@@ -1069,6 +1079,10 @@ async def model_logic(  # noqa: C901
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'calculate_answer':
         return ModelResponse(
             parts=[TextPart('The answer to the ultimate question of life, the universe, and everything is 42.')]
+        )
+    elif isinstance(m, ToolReturnPart) and m.tool_name in ('get_answer', 'run_specialist'):
+        return ModelResponse(
+            parts=[TextPart('The answer to the question of life, the universe, and everything is 42.')]
         )
     else:
         sys.stdout.write(str(debug.format(messages, info)))


### PR DESCRIPTION
Fixes #3274

## Summary

Adds a documented recipe for the recurring "nested human-in-the-loop approval"
question in multi-agent (delegated-agent) setups: when a delegate agent's tool
requires approval, its `DeferredToolRequests` output needs to be propagated up
through the delegating tool call before the top-level caller ever sees it,
since a tool can only pause its own run via `ApprovalRequired`, not by
returning a nested `DeferredToolRequests`.

This has come up repeatedly (see #3274, open since 2025-10-28 with 40+
comments) and the maintainer already spelled out the correct pattern in that
thread; this PR turns that into a tested docs example so future users don't
have to rediscover it.

- Adds "Nested approval in delegated tool calls" to `docs/deferred-tools.md`,
  with a complete, runnable example (stash the delegate's message history +
  `DeferredToolRequests` in `deps` keyed by `tool_call_id`, raise
  `ApprovalRequired`, then resume both agents once the parent call is
  approved).
- Cross-links it from the "Agent delegation" section of
  `docs/multi-agent-applications.md`.
- Adds the mock responses needed for the new example to run deterministically
  under `tests/test_examples.py::test_docs_examples` (no new public API, so no
  other tests are affected).

## Test plan

- [x] `uv run pytest tests/test_examples.py -k "docs/deferred-tools.md or docs/multi-agent-applications.md"` — 9 passed
- [x] `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/test_examples.py` — 0 errors
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] `uv run mkdocs build --strict` — no new warnings from this change (pre-existing `cairosvg`/libcairo warnings in this environment are unrelated)

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

