### PR TITLE
Deliver tool-tied `'asap'` enqueue content into the same `ModelRequest` as the tool's `ToolReturnPart'

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -577,7 +577,7 @@ A `priority` controls when the enqueued content is delivered:
 
 Adjacent part-style items (user content and [`ModelRequestPart`][pydantic_ai.messages.ModelRequestPart]s) are coalesced into one [`ModelRequest`][pydantic_ai.messages.ModelRequest]; complete messages stay separate. This lets a single call inject an interleaved exchange — for example a synthetic tool call (a [`ModelResponse`][pydantic_ai.messages.ModelResponse]) followed by its result (a [`ModelRequest`][pydantic_ai.messages.ModelRequest]). The content must end in a request, so the agent has something to respond to.
 
-Both `enqueue` methods return an `enqueue_id` (`str`) for a non-empty call, or `None` when called with no content. When the queued content is actually delivered into run history, the [event stream](agent.md#streaming-all-events) yields an [`EnqueuedMessagesEvent`][pydantic_ai.messages.EnqueuedMessagesEvent] carrying that `enqueue_id` and the delivered messages (exactly as they landed in history), so a client can observe when its steering message took effect. The event carries the delivered message objects themselves — the same objects held in the run's message history. A history processor that replaces history with new message objects does not affect the event, but [in-place mutation](#editing-existing-messages) of a delivered message will be visible through it.
+Both `enqueue` methods return an `enqueue_id` (`str`) for a non-empty call, or `None` when called with no content. When the queued content is actually delivered into run history, the [event stream](agent.md#streaming-all-events) yields an [`EnqueuedMessagesEvent`][pydantic_ai.messages.EnqueuedMessagesEvent] carrying that `enqueue_id` and the delivered content, so a client can observe when its steering message took effect. The event carries the delivered content itself — either whole [`ModelMessage`][pydantic_ai.messages.ModelMessage]s (`messages`), or, when the content was spliced into a tool call's own request (see [below](#from-inside-a-tool-or-hook)), just the delivered [`ModelRequestPart`][pydantic_ai.messages.ModelRequestPart]s (`parts`) — either way, the same objects held in the run's message history. A history processor that replaces history with new message objects does not affect the event, but [in-place mutation](#editing-existing-messages) of delivered content will be visible through it.
 
 ### From inside a tool or hook
 
@@ -604,8 +604,15 @@ def enter_incident_mode(ctx: RunContext[None]) -> str:
     return 'incident mode enabled'
 ```
 
-The `'asap'` message is appended to the agent's message history and is visible to the
-model on the next request, alongside any tool returns from the same step. A
+The `'asap'` message is delivered into the agent's message history and is visible to the model on
+the next request. When `enqueue` is called during a tool call — from the tool body itself, or a
+capability hook wrapping that call — with the default `priority='asap'`, and the enqueued content
+forms a single request's worth of parts (as both examples above do), it's spliced into the same
+[`ModelRequest`][pydantic_ai.messages.ModelRequest] as that tool call's
+[`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart], immediately after it — the enqueued content
+is a side effect of the call, and its position in history says so. (An enqueue made outside a tool
+call, or whose content is a passthrough `ModelRequest`/`ModelResponse` rather than part-style items,
+is still delivered as its own message, as before.) A
 [`SystemPromptPart`][pydantic_ai.messages.SystemPromptPart] is delivered the same way, and lands as
 a [mid-conversation system prompt](#mid-conversation-system-prompts) — it keeps its position in the
 history instead of being lifted into the top-level system prompt, so it doesn't invalidate the

--- a/pydantic_ai_slim/pydantic_ai/_enqueue.py
+++ b/pydantic_ai_slim/pydantic_ai/_enqueue.py
@@ -64,7 +64,7 @@ respond to.
 """
 
 
-def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessage]:
+def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> tuple[list[ModelMessage], bool]:
     """Assemble enqueue items into a list of [`ModelMessage`][pydantic_ai.messages.ModelMessage]s.
 
     Adjacent [`UserContent`][pydantic_ai.messages.UserContent] items are gathered into one
@@ -73,10 +73,16 @@ def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessag
     [`ModelRequest`][pydantic_ai.messages.ModelRequest]; complete `ModelMessage`s are emitted as-is.
     Order is preserved, so a `ModelResponse` followed by part-style items produces the response then
     a request built from those parts.
+
+    Also returns whether every item was part-style (no raw [`ModelMessage`][pydantic_ai.messages.ModelMessage]
+    passed through verbatim) — callers use this to decide whether the result is eligible for splicing
+    into an existing request rather than delivered as its own message; a passthrough `ModelRequest`
+    (which may carry its own `instructions` or other message-level fields) always stays a message.
     """
     messages: list[ModelMessage] = []
     parts: list[ModelRequestPart] = []
     content: list[UserContent] = []
+    all_parts_style = True
 
     def flush_content() -> None:
         if content:
@@ -94,6 +100,7 @@ def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessag
 
     for item in items:
         if isinstance(item, (ModelRequest, ModelResponse)):
+            all_parts_style = False
             flush_request()
             messages.append(item)
         elif isinstance(
@@ -104,7 +111,7 @@ def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessag
         else:
             content.append(item)
     flush_request()
-    return messages
+    return messages, all_parts_style
 
 
 @dataclass
@@ -133,8 +140,32 @@ class PendingMessage:
     [`EnqueuedMessagesEvent`][pydantic_ai.messages.EnqueuedMessagesEvent] emitted when the messages
     are delivered, and returned by [`enqueue`][pydantic_ai.tools.RunContext.enqueue]."""
 
+    tool_call_id: str | None = None
+    """The `tool_call_id` of the tool call this was enqueued from, or `None` if it wasn't enqueued
+    during a tool call (or was enqueued with `priority='when_idle'`).
+
+    Set by [`RunContext.enqueue`][pydantic_ai.tools.RunContext.enqueue] so a `spliceable` `'asap'`
+    message enqueued from within a tool call — by the tool body itself, or by a capability hook
+    wrapping that call — can be delivered into the same [`ModelRequest`][pydantic_ai.messages.ModelRequest]
+    as that tool's [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart], immediately after it,
+    rather than as a separate trailing request.
+    """
+
+    spliceable: bool = False
+    """Whether `messages` is eligible to be spliced into an existing tool-call request rather than
+    delivered as its own message: exactly one [`ModelRequest`][pydantic_ai.messages.ModelRequest],
+    built entirely from part-style items (user content / [`ModelRequestPart`][pydantic_ai.messages.ModelRequestPart]s)
+    rather than a passthrough `ModelMessage`, which may carry its own `instructions` or other
+    message-level fields and so always stays a separate message.
+    """
+
     @classmethod
-    def from_content(cls, *content: EnqueueContent, priority: PendingMessagePriority = 'asap') -> PendingMessage | None:
+    def from_content(
+        cls,
+        *content: EnqueueContent,
+        priority: PendingMessagePriority = 'asap',
+        tool_call_id: str | None = None,
+    ) -> PendingMessage | None:
         """Build a `PendingMessage` from `enqueue` arguments, or `None` when there's nothing to send.
 
         Returns `None` for an empty call (enqueueing nothing is a no-op rather than an error).
@@ -144,7 +175,7 @@ class PendingMessage:
                 [`ModelRequest`][pydantic_ai.messages.ModelRequest] — e.g. a lone `ModelResponse` —
                 since the agent needs a request to respond to.
         """
-        messages = _build_enqueue_messages(content)
+        messages, all_parts_style = _build_enqueue_messages(content)
         if not messages:
             return None
         if not isinstance(messages[-1], ModelRequest):
@@ -152,4 +183,5 @@ class PendingMessage:
                 'Enqueued content must end with a `ModelRequest` (or user content / `ModelRequestPart` '
                 'items that form one), so the agent has a request to respond to.'
             )
-        return cls(messages=messages, priority=priority)
+        spliceable = all_parts_style and len(messages) == 1
+        return cls(messages=messages, priority=priority, tool_call_id=tool_call_id, spliceable=spliceable)

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -319,6 +319,15 @@ class RunContext(Generic[RunContextAgentDepsT]):
         with the tool body, so `list.append` from a worker thread doesn't race
         the drain.
 
+        When called during a tool call (from the tool body itself or a capability hook wrapping
+        that call) with the default `priority='asap'`, and the assembled content is a single
+        [`ModelRequest`][pydantic_ai.messages.ModelRequest]'s worth of parts, delivery splices those
+        parts into the same `ModelRequest` as that tool call's
+        [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart], immediately after it — the enqueued
+        content is a side effect of the call, and adjacency in history says so. Every other case
+        (outside a tool call, `priority='when_idle'`, or content that isn't a single request's worth
+        of parts) is delivered as its own message, as before.
+
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
                 Adjacent [`UserContent`][pydantic_ai.messages.UserContent] (a `str` or multi-modal
@@ -350,7 +359,8 @@ class RunContext(Generic[RunContextAgentDepsT]):
                 '`enqueue` is only available during an agent run (from tools, capability hooks, or '
                 '`AgentRun.enqueue`). This `RunContext` has no pending-message queue to drain.'
             )
-        pending = PendingMessage.from_content(*content, priority=priority)
+        tool_call_id = self.tool_call_id if priority == 'asap' else None
+        pending = PendingMessage.from_content(*content, priority=priority, tool_call_id=tool_call_id)
         if pending is None:
             return None
         self.pending_messages.append(pending)

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from pydantic_ai._agent_graph import ModelRequestNode
@@ -9,7 +11,13 @@ from pydantic_ai._enqueue import PendingMessage, PendingMessagePriority
 from pydantic_ai._utils import fill_run_metadata
 from pydantic_ai.capabilities.abstract import AbstractCapability, CapabilityOrdering
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.messages import EnqueuedMessagesEvent, ModelMessage, ModelRequest
+from pydantic_ai.messages import (
+    EnqueuedMessagesEvent,
+    ModelMessage,
+    ModelRequest,
+    ModelRequestPart,
+    ToolReturnPart,
+)
 from pydantic_ai.tools import RunContext
 from pydantic_graph import End
 
@@ -33,6 +41,18 @@ def _drain_by_priority(
             remaining.append(msg)
     queue[:] = remaining
     return drained
+
+
+def _tool_return_index(parts: Sequence[ModelRequestPart], tool_call_id: str) -> int | None:
+    """Index right after the `ToolReturnPart` for `tool_call_id` in `parts`, or `None` if absent."""
+    return next(
+        (
+            i + 1
+            for i, part in enumerate(parts)
+            if isinstance(part, ToolReturnPart) and part.tool_call_id == tool_call_id
+        ),
+        None,
+    )
 
 
 def _stamped_messages(
@@ -88,26 +108,69 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
     ) -> ModelRequestContext:
         """Drain `'asap'` messages into the upcoming model request.
 
-        Each drained request is appended to both `request_context.messages` (so the model
-        sees it this step) and `ctx.messages` (so it persists in the agent's message
-        history). Stamps `timestamp`/`run_id`/`conversation_id` if the producer didn't —
-        `ModelRequestNode.run()` only stamps `self.request` (the current node's request),
-        and capabilities downstream of us might append more messages, so we can't rely on
-        that fixup.
+        A drained message tied to a tool call (`tool_call_id` set — enqueued with the default
+        `priority='asap'` from within that call, by the tool body or a capability hook wrapping it)
+        whose content is a single [`ModelRequest`][pydantic_ai.messages.ModelRequest]'s worth of parts
+        is spliced into the existing `ModelRequest` that carries that tool call's
+        [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart] (`ctx.messages[-1]` at the start of
+        this drain — this capability runs outermost, before any other `before_model_request` hook, so
+        that request hasn't been touched yet), immediately after it — the enqueued content is a side
+        effect of that call, and adjacency in history says so. That request's position is captured
+        once and reused for every splice in this drain, so a non-spliceable pending message (e.g. a
+        passthrough `ModelRequest`) appended in between doesn't shift where later same-call splices
+        land. Everything else is appended to both `request_context.messages`
+        (so the model sees it this step) and `ctx.messages` (so it persists in history), as before.
+        Stamps `timestamp`/`run_id`/`conversation_id` if the producer didn't — `ModelRequestNode.run()`
+        only stamps `self.request` (the current node's request), and capabilities downstream of us
+        might append more messages, so we can't rely on that fixup.
 
         Emits one [`EnqueuedMessagesEvent`][pydantic_ai.messages.EnqueuedMessagesEvent] per drained
         [`enqueue`][pydantic_ai.tools.RunContext.enqueue] call, in enqueue order, describing the
-        messages exactly as delivered here.
+        content exactly as delivered here.
         """
         assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
         drained = _drain_by_priority(ctx.pending_messages, 'asap')
+
+        # The request carrying this step's ToolReturnPart(s) — the only splice target, captured once
+        # since it stays at this index even if a non-spliceable pending message (e.g. a passthrough
+        # `ModelRequest`) gets appended after it later in this same loop.
+        base_index = len(ctx.messages) - 1 if ctx.messages else None
+
+        # Per tool_call_id, where the *next* enqueue from that same call should land — so a second
+        # `ctx.enqueue(...)` from one tool body lands after the first one's parts, not before them.
+        insert_at: dict[str, int] = {}
+
         for pending in drained:
             messages = _stamped_messages(
                 pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id
             )
-            request_context.messages.extend(messages)
-            ctx.messages.extend(messages)
-            ctx._emit_event(EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, messages=tuple(messages)))  # pyright: ignore[reportPrivateUsage]
+
+            base_request = ctx.messages[base_index] if base_index is not None else None
+            idx = None
+            if pending.tool_call_id is not None and pending.spliceable and isinstance(base_request, ModelRequest):
+                idx = insert_at.get(pending.tool_call_id)
+                if idx is None:
+                    idx = _tool_return_index(base_request.parts, pending.tool_call_id)
+
+            if idx is not None:
+                assert isinstance(base_request, ModelRequest) and isinstance(messages[0], ModelRequest)  # for pyright
+                assert base_index is not None
+                new_parts = list(messages[0].parts)
+                spliced = dataclasses.replace(
+                    base_request, parts=[*base_request.parts[:idx], *new_parts, *base_request.parts[idx:]]
+                )
+                ctx.messages[base_index] = spliced
+                request_context.messages[base_index] = spliced
+                insert_at[pending.tool_call_id] = idx + len(new_parts)  # pyright: ignore[reportArgumentType]
+                ctx._emit_event(  # pyright: ignore[reportPrivateUsage]
+                    EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, parts=tuple(new_parts))
+                )
+            else:
+                request_context.messages.extend(messages)
+                ctx.messages.extend(messages)
+                ctx._emit_event(  # pyright: ignore[reportPrivateUsage]
+                    EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, messages=tuple(messages))
+                )
         return request_context
 
     async def after_node_run(

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -3403,17 +3403,31 @@ ModelResponseStreamEvent = Annotated[
 class EnqueuedMessagesEvent:
     """An event indicating that messages enqueued via [`enqueue`][pydantic_ai.tools.RunContext.enqueue] were delivered into the run's message history.
 
-    Emitted at delivery time, carrying the delivered message objects themselves — the same objects
-    held in the run's message history, exactly as they landed there (with `timestamp` / `run_id` /
+    Emitted at delivery time, carrying the delivered content itself — the same objects held in the
+    run's message history, exactly as they landed there (with `timestamp` / `run_id` /
     `conversation_id` stamped). A history processor that replaces history with new message objects
-    does not affect the event, but in-place mutation of a delivered message will be visible through it.
+    does not affect the event, but in-place mutation of delivered content will be visible through it.
+
+    Exactly one of `messages` / `parts` is non-empty, depending on how delivery happened:
+
+    - `messages`: the common case — one or more whole
+      [`ModelMessage`][pydantic_ai.messages.ModelMessage]s were appended to history as their own
+      entries.
+    - `parts`: an `'asap'` enqueue made during a tool call, whose content was a single
+      [`ModelRequest`][pydantic_ai.messages.ModelRequest]'s worth of parts, was instead spliced into
+      the existing `ModelRequest` that carries that tool call's
+      [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart], immediately after it — there's no
+      standalone message to point to, only the parts that were inserted.
     """
 
     enqueue_id: str
-    """The ID of the [`enqueue`][pydantic_ai.tools.RunContext.enqueue] call that produced these messages."""
+    """The ID of the [`enqueue`][pydantic_ai.tools.RunContext.enqueue] call that produced this content."""
 
-    messages: tuple[ModelMessage, ...]
-    """The messages delivered into the run's message history."""
+    messages: tuple[ModelMessage, ...] = ()
+    """The whole messages delivered into the run's message history, or `()` when delivered as `parts` instead."""
+
+    parts: tuple[ModelRequestPart, ...] = ()
+    """The parts spliced into an existing tool-call `ModelRequest`, or `()` when delivered as whole `messages` instead."""
 
     event_kind: Literal['enqueued_messages'] = 'enqueued_messages'
     """Event type identifier, used as a discriminator."""

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -16014,7 +16014,7 @@ async def test_resolve_model_id_capability_defers_to_infer_model() -> None:
 
 
 async def test_enqueue_asap_message_from_tool():
-    """`'asap'` messages enqueued from a tool are injected before the next model request."""
+    """`'asap'` messages enqueued from a tool land in the same request as that tool's `ToolReturnPart`, immediately after it (#7014)."""
 
     def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if any(isinstance(msg, ModelResponse) for msg in messages):
@@ -16059,14 +16059,9 @@ async def test_enqueue_asap_message_from_tool():
                         content='ok',
                         tool_call_id=IsStr(),
                         timestamp=IsDatetime(),
-                    )
+                    ),
+                    UserPromptPart(content='Injected asap message', timestamp=IsDatetime()),
                 ],
-                timestamp=IsDatetime(),
-                run_id=IsStr(),
-                conversation_id=IsStr(),
-            ),
-            ModelRequest(
-                parts=[UserPromptPart(content='Injected asap message', timestamp=IsDatetime())],
                 timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -16110,7 +16105,9 @@ async def test_enqueue_asap_delivery_event_from_tool():
 
     assert enqueue_id is not None
     delivery_events = [event for event in events if isinstance(event, EnqueuedMessagesEvent)]
-    assert delivery_events == [EnqueuedMessagesEvent(enqueue_id=enqueue_id, messages=(result.all_messages()[3],))]
+    tool_request = result.all_messages()[2]
+    assert isinstance(tool_request, ModelRequest)
+    assert delivery_events == [EnqueuedMessagesEvent(enqueue_id=enqueue_id, parts=(tool_request.parts[1],))]
     # The delivery event precedes the model response that can depend on the delivered message.
     delivery_index = events.index(delivery_events[0])
     done_index = next(
@@ -16191,9 +16188,12 @@ async def test_multiple_enqueue_delivery_events_keep_order():
 
     assert result is not None
     messages = result.all_messages()
+    tool_request = messages[2]
+    assert isinstance(tool_request, ModelRequest)
+    # Both calls are tied to the same tool call, so both splice into its request, in enqueue order.
     assert delivery_events == [
-        EnqueuedMessagesEvent(enqueue_id=enqueue_ids[0], messages=(messages[3],)),
-        EnqueuedMessagesEvent(enqueue_id=enqueue_ids[1], messages=(messages[4],)),
+        EnqueuedMessagesEvent(enqueue_id=enqueue_ids[0], parts=(tool_request.parts[1],)),
+        EnqueuedMessagesEvent(enqueue_id=enqueue_ids[1], parts=(tool_request.parts[2],)),
     ]
 
 
@@ -16228,7 +16228,9 @@ async def test_enqueue_delivery_event_survives_history_processor_rebuild():
 
     assert enqueue_id is not None
     delivery_events = [event for event in events if isinstance(event, EnqueuedMessagesEvent)]
-    assert delivery_events == [EnqueuedMessagesEvent(enqueue_id=enqueue_id, messages=(result.all_messages()[3],))]
+    tool_request = result.all_messages()[2]
+    assert isinstance(tool_request, ModelRequest)
+    assert delivery_events == [EnqueuedMessagesEvent(enqueue_id=enqueue_id, parts=(tool_request.parts[1],))]
 
 
 async def test_empty_enqueue_emits_no_delivery_event():
@@ -16353,7 +16355,9 @@ async def test_enqueue_delivery_event_via_run_stream():
     assert output == 'done'
     assert enqueue_id is not None
     delivery_events = [event for event in events if isinstance(event, EnqueuedMessagesEvent)]
-    assert delivery_events == [EnqueuedMessagesEvent(enqueue_id=enqueue_id, messages=(result.all_messages()[3],))]
+    tool_request = result.all_messages()[2]
+    assert isinstance(tool_request, ModelRequest)
+    assert delivery_events == [EnqueuedMessagesEvent(enqueue_id=enqueue_id, parts=(tool_request.parts[1],))]
 
 
 async def test_with_event_stream_buffer_drains_around_node_stream():
@@ -16791,14 +16795,9 @@ async def test_pending_messages_accessible_on_run_context():
                         content='done',
                         tool_call_id=IsStr(),
                         timestamp=IsDatetime(),
-                    )
+                    ),
+                    UserPromptPart(content='observed', timestamp=IsDatetime()),
                 ],
-                timestamp=IsDatetime(),
-                run_id=IsStr(),
-                conversation_id=IsStr(),
-            ),
-            ModelRequest(
-                parts=[UserPromptPart(content='observed', timestamp=IsDatetime())],
                 timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -17004,14 +17003,13 @@ def test_enqueue_without_live_queue_raises():
         ctx.enqueue('this has nowhere to go')
 
 
-async def test_enqueue_parts_style_calls_produce_one_request_per_call():
-    """Each `enqueue` call produces its own `ModelRequest` in history.
+async def test_enqueue_parts_style_calls_from_tool_land_as_separate_parts_in_order():
+    """Each tool-tied `enqueue` call keeps its own part, spliced into that tool's request in call order (#7014).
 
-    Each `enqueue` call pre-packages its content into a `ModelRequest` at enqueue time,
-    so two calls produce two `PendingMessage`s with two separate `ModelRequest`s. The
-    history reflects per-call structure; wire-level `_clean_message_history` still merges
-    adjacent compatible `ModelRequest`s so the model sees one turn. Producers wanting a
-    single message should pass a single `ModelRequest(parts=[...])` themselves.
+    Two calls produce two `PendingMessage`s, each pre-packaged into its own `ModelRequest` at enqueue
+    time. Since both are `'asap'` enqueues made from the same tool call, both splice into that tool's
+    own request rather than becoming separate top-level messages — but they stay two distinct parts
+    (not coalesced into one), each still attributable to its own enqueue call, in the order enqueued.
     """
 
     def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -17040,7 +17038,7 @@ async def test_enqueue_parts_style_calls_produce_one_request_per_call():
         if isinstance(msg, ModelRequest)
         and any(isinstance(p, UserPromptPart) and p.content in ('first hint', 'second hint') for p in msg.parts)
     ]
-    assert len(drained) == 2, 'expected one ModelRequest per enqueue call'
+    assert len(drained) == 1, 'both calls are tied to the same tool call, so both land in its own request'
     assert [p.content for p in iter_message_parts(drained, ModelRequest, UserPromptPart)] == [
         'first hint',
         'second hint',
@@ -17048,7 +17046,15 @@ async def test_enqueue_parts_style_calls_produce_one_request_per_call():
 
 
 async def test_enqueue_passthrough_stays_separate_from_parts_style():
-    """A passthrough `ModelRequest` stays its own message even when surrounded by parts-style enqueues."""
+    """A passthrough `ModelRequest` always stays its own message; spliceable calls around it still splice (#7014).
+
+    `enqueue(ModelRequest(...))` passes a whole message through verbatim — it may carry its own
+    `instructions` or other message-level fields, so it's never spliced into anything, unlike
+    part-style calls. The two spliceable calls tied to this tool call ('before' and 'after') still
+    both land in the tool's own request, in their own enqueue order, even though a non-spliceable
+    passthrough was enqueued in between — the passthrough doesn't break that adjacency for the calls
+    around it, it just doesn't participate in it itself.
+    """
 
     def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if any(isinstance(msg, ModelResponse) for msg in messages):
@@ -17073,27 +17079,142 @@ async def test_enqueue_passthrough_stays_separate_from_parts_style():
         return 'ok'
 
     result = await agent.run('Hello')
-    # Three drained requests: synthesized(["before"]), passthrough, synthesized(["after"]).
+    # Two drained requests: the tool's own request (return + spliced "before" + spliced "after"),
+    # and the passthrough, kept separate.
     drained = [
         msg
         for msg in result.all_messages()
         if isinstance(msg, ModelRequest)
         and any(isinstance(p, UserPromptPart) and p.content in ('before', 'passthrough', 'after') for p in msg.parts)
     ]
-    assert len(drained) == 3
-    contents = [
-        next(
-            p.content
-            for p in r.parts
-            if isinstance(p, UserPromptPart) and p.content in ('before', 'passthrough', 'after')
-        )
-        for r in drained
-    ]
-    assert contents == ['before', 'passthrough', 'after']
+    assert len(drained) == 2
+    tool_request, passthrough_request = drained
+    assert [p.content for p in tool_request.parts if isinstance(p, UserPromptPart)] == ['before', 'after']
+    assert any(isinstance(p, ToolReturnPart) for p in tool_request.parts)
+    assert tool_request.instructions is None
+    assert [p.content for p in passthrough_request.parts if isinstance(p, UserPromptPart)] == ['passthrough']
     # Passthrough preserved its instructions.
-    assert drained[1].instructions == 'careful'
-    assert drained[0].instructions is None
-    assert drained[2].instructions is None
+    assert passthrough_request.instructions == 'careful'
+
+
+async def test_parallel_tool_calls_each_enqueue_asap_next_to_own_return():
+    """Each tool in a parallel batch splices into its own return, never a sibling's (#7014).
+
+    Two tools are called in the same step and each calls `ctx.enqueue` from its own body. Each
+    enqueued part must land immediately after that specific tool's `ToolReturnPart`, regardless of
+    which tool's return happens to come first in the request.
+    """
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if any(isinstance(msg, ModelResponse) for msg in messages):
+            return ModelResponse(
+                parts=[TextPart(content='done')],
+                usage=RequestUsage(input_tokens=10, output_tokens=5),
+            )
+        return ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='tool_a', args='{}', tool_call_id='call-a'),
+                ToolCallPart(tool_name='tool_b', args='{}', tool_call_id='call-b'),
+            ],
+            usage=RequestUsage(input_tokens=10, output_tokens=5),
+        )
+
+    agent = Agent(FunctionModel(model_fn))
+
+    @agent.tool
+    def tool_a(ctx: RunContext[object]) -> str:
+        ctx.enqueue('from a')
+        return 'a-result'
+
+    @agent.tool
+    def tool_b(ctx: RunContext[object]) -> str:
+        ctx.enqueue('from b')
+        return 'b-result'
+
+    result = await agent.run('Hello')
+    assert result.output == 'done'
+
+    tool_request = result.all_messages()[2]
+    assert isinstance(tool_request, ModelRequest)
+    parts = tool_request.parts
+    assert len(parts) == 4
+    return_indices = {part.tool_name: i for i, part in enumerate(parts) if isinstance(part, ToolReturnPart)}
+    assert set(return_indices) == {'tool_a', 'tool_b'}
+    assert parts[return_indices['tool_a'] + 1] == UserPromptPart(content='from a', timestamp=IsDatetime())
+    assert parts[return_indices['tool_b'] + 1] == UserPromptPart(content='from b', timestamp=IsDatetime())
+
+
+async def test_enqueue_asap_from_tool_wire_output_matches_pre_fix_two_request_merge():
+    """The spliced history renders on the wire byte-for-byte like the old separate-request-plus-merge shape (#7014).
+
+    Before this fix, the enqueued content arrived as its own trailing `ModelRequest`, and
+    `_clean_message_history`'s merge pass combined it with the tool-return request before sending to
+    the model. This reconstructs that old two-request shape from the tool's own (now-spliced) request
+    and independently runs it through the same merge, then compares the serialized bytes against what
+    the model actually received — pinning that this fix is purely a history-shape change, invisible to
+    the model. `run_id`/`conversation_id` are cleared on the final request of both sides before
+    comparing: `_merge_consecutive_messages` itself drops them on merge (its own comment: "never part
+    of what gets sent to the model"), while splicing preserves them (a plain `dataclasses.replace`
+    keeps the original request's other fields) — a difference in pydantic-ai's own bookkeeping, not in
+    what a model provider receives.
+    """
+    from pydantic_ai._agent_graph import _clean_message_history  # pyright: ignore[reportPrivateUsage]
+
+    captured_wire_messages: list[list[ModelMessage]] = []
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured_wire_messages.append(messages)
+        if any(isinstance(msg, ModelResponse) for msg in messages):
+            return ModelResponse(
+                parts=[TextPart(content='done')],
+                usage=RequestUsage(input_tokens=10, output_tokens=5),
+            )
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name='inject_msg', args='{}', tool_call_id='call-1')],
+            usage=RequestUsage(input_tokens=10, output_tokens=5),
+        )
+
+    agent = Agent(FunctionModel(model_fn))
+
+    @agent.tool
+    def inject_msg(ctx: RunContext[object]) -> str:
+        ctx.enqueue('Injected asap message')
+        return 'ok'
+
+    result = await agent.run('Hello')
+    assert result.output == 'done'
+    new_wire = captured_wire_messages[-1]
+
+    all_messages = result.all_messages()
+    tool_request = all_messages[2]
+    assert isinstance(tool_request, ModelRequest)
+    tool_return_parts = [p for p in tool_request.parts if isinstance(p, ToolReturnPart)]
+    enqueued_parts = [p for p in tool_request.parts if not isinstance(p, ToolReturnPart)]
+
+    # Reconstruct the pre-fix, two-request shape: the tool-return request and the enqueue request
+    # kept separate, as `all_messages()` would have shown before this fix. The enqueue request is
+    # stamped with the same run/conversation id, matching what `_stamped_messages` did pre-fix
+    # before appending it to history.
+    old_shape_history = [
+        *all_messages[:2],
+        ModelRequest(
+            parts=tool_return_parts,
+            timestamp=tool_request.timestamp,
+            run_id=tool_request.run_id,
+            conversation_id=tool_request.conversation_id,
+        ),
+        ModelRequest(
+            parts=enqueued_parts,
+            timestamp=tool_request.timestamp,
+            run_id=tool_request.run_id,
+            conversation_id=tool_request.conversation_id,
+        ),
+    ]
+    merged = _clean_message_history(old_shape_history, repair_last_response=True)
+    merged[-1] = replace(merged[-1], run_id=None, conversation_id=None)
+    new_wire[-1] = replace(new_wire[-1], run_id=None, conversation_id=None)
+
+    assert ModelMessagesTypeAdapter.dump_json(merged) == ModelMessagesTypeAdapter.dump_json(new_wire)
 
 
 async def test_enqueue_system_prompt_part():


### PR DESCRIPTION
Fixes #7014

`ctx.enqueue(.....)` called during a tool's execution currently delivers the enqueued
content as its own trailing `ModelRequest`, appended after the request carrying the
tool's `ToolReturnPart`. The wire-level `_clean_message_history` merge already hides
this (adjacent requests with no assistant turn between them get combined before
sending to the model), but `all_messages()` keeps them separate, so the causal tie
between a tool call and its enqueued side effect isn't visible in history.

When `enqueue` is called during a tool call (the tool body itself, or a capability
hook wrapping that call) with the default `priority='asap'`, and the enqueued
content is a single request's worth of parts (not a passthrough `ModelRequest`/
`ModelResponse`), it's now spliced into the same `ModelRequest` as that tool call's
`ToolReturnPart`, immediately after it. Everything else `when_idle`, enqueues
outside a tool call (hooks between steps, `AgentRun.enqueue`), and passthrough
messages  is delivered exactly as before.

Multiple `enqueue()` calls from the same tool call stay in their own call order
when spliced. Parallel tool calls each splice into their own return, never a
sibling's.

`EnqueuedMessagesEvent` gains a `parts` field alongside `messages`: a spliced
delivery has no standalone message object to report, so the event carries the
inserted parts themselves instead still "the same objects held in the run's
message history, exactly as they landed there," just at the parts level.

Test plan
- [x] Existing enqueue-during-tool tests updated for the new merged shape
- [x] Added a test verifying parallel tool calls each land next to their own return
- [x] Added a test pinning that wire output is byte-identical to the old
      separate-request-plus-merge shape
- [x] `ruff format --check`, `ruff check`, `pyright` all pass
- [x] `pytest tests/test_capabilities.py`: 871 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

