### PR TITLE
Document `JsonSchemaTransformer` and `InlineDefsJsonSchemaTransformer` in the profiles API reference

### DIFF
--- a/docs/api/profiles.md
+++ b/docs/api/profiles.md
@@ -5,6 +5,8 @@
       members:
         - ModelProfile
         - ModelProfileSpec
+        - JsonSchemaTransformer
+        - InlineDefsJsonSchemaTransformer
         - merge_profile
         - DEFAULT_PROFILE
         - DEFAULT_PROMPTED_OUTPUT_TEMPLATE


### PR DESCRIPTION
`JsonSchemaTransformer` and `InlineDefsJsonSchemaTransformer` are both exported from `pydantic_ai.profiles` (and from `pydantic_ai` itself) but render nowhere in the docs, so neither has an API reference entry to link to.

Two places this shows up:

- `ModelProfile.json_schema_transformer` is typed `type[JsonSchemaTransformer] | None`, so the profile docs describe a field whose type has no reference page.
- The OpenAI docs already show users importing the subclass directly: `from pydantic_ai import Agent, InlineDefsJsonSchemaTransformer`, then passing `json_schema_transformer=InlineDefsJsonSchemaTransformer`.

Added both to the members list in `docs/api/profiles.md`, next to `ModelProfile` and `ModelProfileSpec`. Ran `uv run mkdocs build --strict`: both `id="pydantic_ai.profiles.JsonSchemaTransformer"` and `id="pydantic_ai.profiles.InlineDefsJsonSchemaTransformer"` anchors exist afterwards where there were none before, and no new warnings appear.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built this with Claude Code's help and read the diff myself. freshman still learning the docs setup, so happy to drop the base class and list only the subclass if that fits your intent better.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

