### PR TITLE
fix(mcp): map audio content to sampling messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/_mcp.py
@@ -105,7 +105,15 @@ def map_from_pai_messages(pai_messages: list[messages.ModelMessage]) -> tuple[st
                                         mimeType=chunk.media_type,
                                     ),
                                 )
-                            # TODO(Marcelo): Add support for audio content.
+                            elif isinstance(chunk, messages.BinaryContent) and chunk.is_audio:
+                                add_msg(
+                                    'user',
+                                    mcp_types.AudioContent(
+                                        type='audio',
+                                        data=chunk.base64,
+                                        mimeType=chunk.media_type,
+                                    ),
+                                )
                             else:
                                 raise NotImplementedError(f'Unsupported content type: {type(chunk)}')
         else:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1252,6 +1252,32 @@ class TestSamplingMessageMapping:
     """Cover the mapping helpers in `pydantic_ai._mcp` that translate MCP sampling messages
     to/from PAI message parts. Exercised via the sampling handler that `MCPToolset(sampling_model=...)` installs."""
 
+    async def test_map_pai_audio_content(self):
+        from pydantic_ai import _mcp as _mcp_helpers
+        from pydantic_ai.messages import BinaryContent, ModelRequest, UserPromptPart
+
+        system_prompt, sampling_messages = _mcp_helpers.map_from_pai_messages(
+            [
+                ModelRequest(
+                    parts=[
+                        UserPromptPart(
+                            content=[BinaryContent(data=b'fake-audio', media_type='audio/wav')]
+                        )
+                    ]
+                )
+            ]
+        )
+
+        assert system_prompt == ''
+        assert sampling_messages == [
+            mcp_types.SamplingMessage(
+                role='user',
+                content=mcp_types.AudioContent(
+                    type='audio', data=base64.b64encode(b'fake-audio').decode(), mimeType='audio/wav'
+                ),
+            )
+        ]
+
     async def test_map_handles_image_audio_and_role_transitions(self):
         from pydantic_ai import _mcp as _mcp_helpers
 


### PR DESCRIPTION
## Summary

Adds the missing Pydantic AI `BinaryContent` audio mapping for MCP sampling messages

## Changes

When a user prompt contains audio `BinaryContent`, `map_from_pai_messages()` now emits MCP `AudioContent` with the original base64 payload and MIME type. Added a regression test for the public conversion boundary

## Related issue

Fixes #6932

## Verification

- `python3 -m py_compile pydantic_ai_slim/pydantic_ai/_mcp.py tests/test_mcp.py`
- `git diff --check`
- Focused pytest was attempted but this sparse checkout has no installed pytest environment


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

