### PR TITLE
fix(profiles): match hyphen-spelled kimi reasoning models on Moonshot profile

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/moonshotai.py
@@ -9,7 +9,13 @@ def moonshotai_model_profile(model_name: str) -> ModelProfile | None:
     # reasoning_content; the moonshot-v1/instruct models don't. `thinking_always_enabled` is left
     # to the direct provider, since the `reasoning_effort='none'` quirk is specific to the
     # `api.moonshot.ai` endpoint and this profile is also routed through OpenRouter and Heroku.
-    is_reasoning = model_name.lower().startswith(('kimi-k2.5', 'kimi-k2.6', 'kimi-k2.7', 'kimi-k3', 'kimi-thinking'))
+    #
+    # Model names reach this profile in both dotted and hyphenated spellings depending on the
+    # route (e.g. `kimi-k2.5` on the MoonshotAI endpoint, but `kimi-k2-5`/`kimi-k2-thinking` via
+    # Heroku, Bedrock and OpenRouter). Normalize `-` to `.` so both spellings are recognised.
+    is_reasoning = model_name.lower().replace('-', '.').startswith(
+        ('kimi.k2.5', 'kimi.k2.6', 'kimi.k2.7', 'kimi.k2.thinking', 'kimi.k3', 'kimi.thinking')
+    )
     return ModelProfile(
         ignore_streamed_leading_whitespace=True,
         supports_thinking=is_reasoning,

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -298,6 +298,9 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
         assert kimi_profile.get('supports_json_schema_output', False) is True
         assert kimi_profile.get('bedrock_supports_strict_tool_definition', False) is True
         assert kimi_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
+        # Both spellings (`moonshot.kimi-k2-thinking` hyphenated, `moonshotai.kimi-k2.5` dotted)
+        # must be recognised as reasoning models, or the caller's `thinking` setting is dropped.
+        assert kimi_profile.get('supports_thinking', False) is True
         # Kimi rejects every media kind inside a `toolResult`, so media tool returns are deferred.
         assert kimi_profile.get('bedrock_supported_media_kinds_in_tool_returns') == frozenset()
     moonshotai_model_profile_mock.assert_any_call('kimi-k2-thinking')

--- a/tests/providers/test_moonshotai.py
+++ b/tests/providers/test_moonshotai.py
@@ -77,7 +77,19 @@ def test_moonshotai_model_profile_thinking():
     provider = MoonshotAIProvider(api_key='api-key')
 
     # Reasoning models advertise thinking; it's always-on since Moonshot rejects reasoning_effort='none'.
-    for reasoning_model in ('kimi-k2.5', 'kimi-k2.6', 'kimi-k2.7-code', 'kimi-k2.7-code-highspeed', 'kimi-k3'):
+    # Names reach this profile in both dotted and hyphenated spellings depending on the route:
+    # `kimi-k2.5` on the MoonshotAI endpoint, but `kimi-k2-5`/`kimi-k2-thinking` via Heroku,
+    # Bedrock and OpenRouter.
+    for reasoning_model in (
+        'kimi-k2.5',
+        'kimi-k2.6',
+        'kimi-k2.7-code',
+        'kimi-k2.7-code-highspeed',
+        'kimi-k2-5',
+        'kimi-k2-thinking',
+        'kimi-k3',
+        'kimi-thinking-preview',
+    ):
         profile = provider.model_profile(reasoning_model)
         assert profile is not None
         assert profile.get('supports_thinking') is True
@@ -85,8 +97,16 @@ def test_moonshotai_model_profile_thinking():
         assert profile.get('openai_chat_thinking_field') == 'reasoning_content'
         assert profile.get('openai_chat_send_back_thinking_parts') == 'field'
 
-    # Instruct/base models don't reason, so thinking stays off.
-    for non_reasoning_model in ('moonshot-v1-8k', 'moonshot-v1-auto', 'kimi-k2-0711-preview', 'kimi-latest'):
+    # Instruct/base models don't reason, so thinking stays off. The bare `kimi-k2` and the
+    # `kimi-k2-0905` snapshot must not be swept up by the `-` → `.` normalization.
+    for non_reasoning_model in (
+        'moonshot-v1-8k',
+        'moonshot-v1-auto',
+        'kimi-k2-0711-preview',
+        'kimi-k2',
+        'kimi-k2-0905',
+        'kimi-latest',
+    ):
         profile = provider.model_profile(non_reasoning_model)
         assert profile is not None
         assert profile.get('supports_thinking', False) is False


### PR DESCRIPTION
Fixes #6822

`moonshotai_model_profile` only recognised dotted model ids (`kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7`, `kimi-k3`, `kimi-thinking`), so the hyphenated spellings used by other routes resolved to `supports_thinking=False`:

- `kimi-k2-5` — via Heroku (`heroku:kimi-k2-5` in `_known_model_names.py`)
- `kimi-k2-thinking` — via Heroku, Bedrock (`moonshot.kimi-k2-thinking`, `bedrock:moonshot.kimi-k2-thinking`), Gateway and OpenRouter

Because `prepare_request` in `models/__init__.py` strips `thinking` from `model_settings` unless the profile advertises thinking support, a caller passing `thinking=...` on those models had the setting silently dropped — no error, no `reasoning_effort` on the wire.

## Change

Normalize `-` → `.` before the `startswith` match in `moonshotai_model_profile`, so both spellings are recognised. The tuple gains `kimi.k2.thinking` (needed explicitly, since `kimi.k2.thinking` doesn't start with `kimi.thinking`).

## Verification

- `kimi-k2-5`, `kimi-k2-thinking`, `kimi-k2.5/6/7-code*`, `kimi-k3`, `kimi-thinking-preview` all resolve `supports_thinking=True`
- Bare `kimi-k2` and the `kimi-k2-0905` snapshot stay non-reasoning (no over-match from normalization)
- `moonshot-v1-*`, `kimi-k2-0711-preview`, `kimi-latest` unchanged

## Tests

- Extended `test_moonshotai_model_profile_thinking` with the hyphen-spelled reasoning models plus `kimi-k2`/`kimi-k2-0905` over-match guards
- Added a `supports_thinking` assertion to the Bedrock Kimi loop in `test_bedrock_provider_model_profile`, which previously only asserted the Bedrock-specific fields and so missed this regression

Local: 49 passed (moonshotai/openrouter/nebius/groq/litellm/huggingface/heroku provider suites); bedrock suite runs in CI (requires `mypy_boto3_bedrock_runtime`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

