### PR TITLE
fix: gracefully handle malformed tool call JSON arguments

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2018,11 +2018,24 @@ class BaseToolCallPart:
         """Return the arguments as a JSON string.
 
         This is just for convenience with models that require JSON strings as input.
+
+        Malformed or non-object JSON is handled gracefully by returning
+        `'{"INVALID_JSON": "<raw args>"}'` so that the value can still be sent to any
+        model API (e.g. during a retry flow) without crashing.  This mirrors the
+        behaviour of [`args_as_dict`][pydantic_ai.messages.BaseToolCallPart.args_as_dict].
         """
         if not self.args:
             return '{}'
         if isinstance(self.args, str):
-            return self.args
+            try:
+                parsed = pydantic_core.from_json(self.args)
+            except ValueError:
+                # Malformed JSON — degrade to the same safe wrapper args_as_dict() uses.
+                return pydantic_core.to_json(self.args_as_dict()).decode()
+            if isinstance(parsed, dict):
+                return self.args  # well-formed JSON object — pass through unchanged
+            # Valid JSON but not an object (e.g. a list or scalar) — wrap it.
+            return pydantic_core.to_json(self.args_as_dict()).decode()
         return pydantic_core.to_json(self.args).decode()
 
     def has_content(self) -> bool:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -6213,3 +6213,70 @@ async def test_extra_headers_not_mutated(allow_model_requests: None):
         'X-Custom': 'value',
         'User-Agent': IsStr(regex=r'pydantic-ai/.*'),
     }
+
+
+async def test_openai_malformed_tool_args_no_crash(allow_model_requests: None):
+    """Malformed JSON tool args must not be forwarded verbatim on OpenAI-compatible transports.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/7042.
+
+    args_as_json_str() — used by the Chat Completions _map_tool_call path — previously
+    returned the raw string unchanged, so when the same message history was replayed to a
+    gateway that fronts an object-typed provider (e.g. OpenRouter → Anthropic), the
+    provider rejected the request with "Input should be a valid dictionary".
+
+    After the fix, args_as_json_str() degrades to the INVALID_JSON wrapper exactly as
+    args_as_dict() does, so the value on the wire is always a valid JSON object string.
+    """
+    bad_args = '{"collection": "documents", "filter": {"a": 1}}}, "limit": 20}'
+
+    # The mock returns a simple text response, simulating the model self-correcting.
+    fixed_response = completion_message(
+        ChatCompletionMessage(content='Here is the corrected result.', role='assistant'),
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+    )
+    mock_client = MockOpenAI.create_mock(fixed_response)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    # Construct message history with a malformed tool call + retry prompt,
+    # exactly as would exist after the initial bad tool-call response.
+    message_history = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name='find_documents',
+                    tool_call_id='call_123',
+                    args=bad_args,
+                ),
+            ],
+            timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        ),
+        ModelRequest(
+            parts=[
+                RetryPromptPart(
+                    tool_name='find_documents',
+                    tool_call_id='call_123',
+                    content='Invalid JSON: trailing characters at line 1 column 48',
+                ),
+            ],
+        ),
+    ]
+
+    # Must not raise — the malformed args are degraded to an INVALID_JSON wrapper.
+    result = await agent.run(
+        'Please fix the tool call and try again.',
+        message_history=message_history,
+    )
+    assert result.output == 'Here is the corrected result.'
+
+    # Verify that what reached the OpenAI API was a valid JSON object string,
+    # NOT the raw malformed string.
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assistant_msg = next(m for m in completion_kwargs['messages'] if m['role'] == 'assistant')
+    tool_call_args: str = assistant_msg['tool_calls'][0]['function']['arguments']
+
+    # Must be valid JSON and must be an object.
+    decoded = json.loads(tool_call_args)
+    assert isinstance(decoded, dict), 'function.arguments must be a JSON object'
+    assert decoded == {'INVALID_JSON': bad_args}

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1956,6 +1956,63 @@ def test_args_as_dict_raise_if_invalid_non_dict_json():
         part.args_as_dict(raise_if_invalid=True)
 
 
+def test_args_as_json_str_well_formed_dict_passes_through():
+    """args_as_json_str should return the original string unchanged for a valid JSON object."""
+    valid = '{"key": "value"}'
+    part = ToolCallPart(tool_name='test_tool', args=valid)
+    assert part.args_as_json_str() == valid
+
+
+def test_args_as_json_str_empty_args():
+    """args_as_json_str should return '{}' when args is None/empty."""
+    part = ToolCallPart(tool_name='test_tool', args=None)
+    assert part.args_as_json_str() == '{}'
+
+
+def test_args_as_json_str_dict_args():
+    """args_as_json_str should serialise a dict args value to a JSON string."""
+    part = ToolCallPart(tool_name='test_tool', args={'key': 'value'})
+    assert part.args_as_json_str() == '{"key":"value"}'
+
+
+def test_args_as_json_str_malformed_json_returns_invalid_json_wrapper():
+    """args_as_json_str should return an INVALID_JSON-wrapped JSON object for malformed JSON.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/7042.
+    OpenAI-compatible transports use args_as_json_str(); without this guard a malformed
+    string goes on the wire verbatim and gateways that front object-typed providers reject
+    the request.
+    """
+    malformed = '{"collection": "documents", "filter": {"a": 1}}}, "limit": 20}'
+    part = ToolCallPart(tool_name='find', args=malformed, tool_call_id='toolu_01')
+
+    result = part.args_as_json_str()
+
+    # Must decode as a valid JSON object.
+    import json
+
+    decoded = json.loads(result)
+    assert isinstance(decoded, dict), 'result must be a JSON object'
+    assert decoded == {INVALID_JSON_KEY: malformed}
+
+
+def test_args_as_json_str_non_dict_json_returns_invalid_json_wrapper():
+    """args_as_json_str should return an INVALID_JSON-wrapped JSON object for valid-but-non-dict JSON.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/7042.
+    """
+    json_list = '[1, 2, 3]'
+    part = ToolCallPart(tool_name='test_tool', args=json_list)
+
+    result = part.args_as_json_str()
+
+    import json
+
+    decoded = json.loads(result)
+    assert isinstance(decoded, dict)
+    assert decoded == {INVALID_JSON_KEY: json_list}
+
+
 def test_user_prompt_part_with_text_content():
     part = UserPromptPart(
         content=[


### PR DESCRIPTION
Fixed the handling of malformed tool call JSON arguments in 'args_as_json_str()' by aligning its behavior with the existing graceful-degradation logic used in 'args_as_dict()'. This prevents invalid JSON tool arguments from being forwarded unchanged and ensures they are safely wrapped before being serialized for OpenAI-compatible transports.

Changes Implemented:
- Fixed 'args_as_json_str()' to validate JSON string arguments before serialization.
- Added graceful fallback for malformed and non-dictionary JSON inputs using the existing 'INVALID_JSON' wrapper.
- Preserved the existing behavior for valid JSON object arguments to avoid unnecessary processing.
- Kept the implementation minimal and consistent with the project's current architecture.

Validation:
- Added unit tests covering:
  - Valid JSON object passthrough.
  - Empty arguments.
  - Malformed JSON fallback.
  - Non-dictionary JSON fallback.
  - Dictionary argument serialization.
- Added an integration test for the OpenAI-compatible transport to verify malformed tool call arguments are safely serialized instead of causing request failures.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

