### PR TITLE
fix(messages): degrade malformed tool-call args in `args_as_json_str` like `args_as_dict`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2018,10 +2018,22 @@ class BaseToolCallPart:
         """Return the arguments as a JSON string.
 
         This is just for convenience with models that require JSON strings as input.
+
+        Malformed or non-object JSON is handled gracefully by returning
+        `'{"INVALID_JSON": "<raw args>"}'` so that the value can still be sent to a
+        model API (e.g. during a retry flow) without crashing — the same degradation
+        `args_as_dict()` applies for dict-based transports. Without it, OpenAI-compatible
+        transports forward the raw string into object-typed backends (e.g. Anthropic via
+        a gateway), which reject the entire request.
         """
         if not self.args:
             return '{}'
         if isinstance(self.args, str):
+            try:
+                parsed = pydantic_core.from_json(self.args)
+                assert isinstance(parsed, dict), 'args should be a dict'
+            except (ValueError, AssertionError):
+                return pydantic_core.to_json({INVALID_JSON_KEY: self.args}).decode()
             return self.args
         return pydantic_core.to_json(self.args).decode()
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1956,6 +1956,46 @@ def test_args_as_dict_raise_if_invalid_non_dict_json():
         part.args_as_dict(raise_if_invalid=True)
 
 
+def test_args_as_json_str_valid_json_verbatim():
+    """args_as_json_str should return valid object JSON strings verbatim."""
+    part = ToolCallPart(tool_name='test_tool', args='{"key": "value"}')
+    assert part.args_as_json_str() == '{"key": "value"}'
+
+
+def test_args_as_json_str_dict_args():
+    """args_as_json_str should serialize dict args to a JSON string."""
+    part = ToolCallPart(tool_name='test_tool', args={'key': 'value'})
+    assert json.loads(part.args_as_json_str()) == {'key': 'value'}
+
+
+def test_args_as_json_str_empty_args():
+    """args_as_json_str should return '{}' when args is None/empty."""
+    part = ToolCallPart(tool_name='test_tool', args=None)
+    assert part.args_as_json_str() == '{}'
+
+
+def test_args_as_json_str_malformed_json_returns_invalid_json_wrapper():
+    """args_as_json_str should degrade malformed JSON to INVALID_JSON, like args_as_dict.
+
+    Without this, OpenAI-compatible transports forward the raw malformed string into
+    object-typed backends (e.g. Anthropic via a gateway), which reject the entire
+    request — and since the part stays in history, every retry replays the failure.
+    """
+    malformed = '{"query": "bad", "ids":[4556]</parameter>\n<parameter name="limit": 8}'
+    part = ToolCallPart(tool_name='test_tool', args=malformed)
+    assert json.loads(part.args_as_json_str()) == {INVALID_JSON_KEY: malformed}
+
+
+def test_args_as_json_str_non_dict_json_returns_invalid_json_wrapper():
+    """args_as_json_str should degrade valid non-object JSON to INVALID_JSON, like args_as_dict.
+
+    An object-typed backend also rejects a non-dict `tool_use.input` (e.g. a JSON array),
+    so the same degradation applies for parity between the two transports.
+    """
+    part = ToolCallPart(tool_name='test_tool', args='[1, 2, 3]')
+    assert json.loads(part.args_as_json_str()) == {INVALID_JSON_KEY: '[1, 2, 3]'}
+
+
 def test_user_prompt_part_with_text_content():
     part = UserPromptPart(
         content=[


### PR DESCRIPTION
Fixes #7042

## Problem

`ToolCallPart.args_as_json_str()` — used by every OpenAI-compatible transport (`openai.py` Chat Completions + Responses, `groq.py`, `huggingface.py`, plus `anthropic.py` gateway paths and `cohere.py`) — returns a malformed `args` string verbatim, while `args_as_dict()` deliberately degrades it to `{'INVALID_JSON': '<raw>'}` (the Anthropic-documented pattern referenced in `messages.py:33-37`).

When the OpenAI-compatible endpoint fronts an **object-typed** provider (e.g. Anthropic via OpenRouter → Vertex/Bedrock), the raw string is forwarded into `tool_use.input` and the provider rejects the entire request:

```
messages.N.content.M.tool_use.input: Input should be a valid dictionary
```

Because the malformed `ToolCallPart` stays in message history, **every subsequent request in the run replays it** — the run cannot recover, including the retry the malformed args themselves triggered.

| helper | used by | malformed args (before) |
|---|---|---|
| `args_as_dict()` | dict transports | `{'INVALID_JSON': <raw>}` — provider accepts |
| `args_as_json_str()` | JSON-string transports | raw string, verbatim — object-typed backend rejects the whole request |

## Fix

`args_as_json_str()` now applies the same graceful degradation as `args_as_dict()`: if the args string doesn't parse, or parses to something that isn't an object, it returns `'{"INVALID_JSON": "<raw args>"}'` (JSON-encoded). Valid object JSON strings and dict args are unchanged — the wire format is identical for every well-formed tool call.

## Tests

Added five tests in `tests/test_messages.py` mirroring the existing `args_as_dict` block:

- valid object JSON string → verbatim (unchanged)
- dict args → serialized JSON (unchanged)
- empty args → `'{}'` (unchanged)
- malformed JSON string → `{"INVALID_JSON": <raw>}` (new)
- valid non-object JSON (e.g. `'[1, 2, 3]'`) → `{"INVALID_JSON": <raw>}` (new; an object-typed backend also rejects a non-dict `tool_use.input`)

Full `tests/test_messages.py` + `tests/models/test_openai.py`, `test_groq.py`, `test_huggingface.py`, `test_cohere.py`: 405 passed, 0 regressions. (Two pre-existing Windows-only failures in `test_messages.py` — `.csv` mimetype via the Windows registry and CRLF in `Path.write_text` — reproduce on a clean tree and are unrelated.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

