### PR TITLE
feat(messages): expose tool_name on ToolCallEvent and ToolResultEvent

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -3448,6 +3448,11 @@ class ToolCallEvent:
         """An ID used for matching details about the call to its result."""
         return self.part.tool_call_id
 
+    @property
+    def tool_name(self) -> str:
+        """The name of the tool that will be called."""
+        return self.part.tool_name
+
     __repr__ = _utils.dataclasses_no_defaults_repr
 
 
@@ -3482,6 +3487,15 @@ class ToolResultEvent:
     def tool_call_id(self) -> str:
         """An ID used to match the result to its original call."""
         return self.part.tool_call_id
+
+    @property
+    def tool_name(self) -> str | None:
+        """The name of the tool that was called, if known.
+
+        `None` only when the underlying part is a [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart]
+        used for an output-validation retry, which carries no tool name.
+        """
+        return self.part.tool_name
 
     __repr__ = _utils.dataclasses_no_defaults_repr
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -23,6 +23,8 @@ from pydantic_ai import (
     DeferredToolResultsEvent,
     DocumentUrl,
     FilePart,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
     ImageUrl,
     InstructionPart,
     InstrumentationSettings,
@@ -34,6 +36,7 @@ from pydantic_ai import (
     MultiModalContent,
     NativeToolCallPart,
     NativeToolReturnPart,
+    OutputToolResultEvent,
     PartDeltaEvent,
     RequestUsage,
     RetryPromptPart,
@@ -2210,3 +2213,36 @@ def test_narrow_message_parts_promotes_valid_claims_and_leaves_plain_parts():
     assert type(narrowed[0].parts[0]) is LoadCapabilityCallPart
     assert narrowed[0].parts[1] is messages[0].parts[1]
     assert type(narrowed[1].parts[0]) is LoadCapabilityReturnPart
+
+
+def test_tool_call_event_exposes_tool_name():
+    """`ToolCallEvent.tool_name` mirrors the call part's required name."""
+    part = ToolCallPart(tool_name='get_weather', args={'city': 'London'}, tool_call_id='call_1')
+    event = FunctionToolCallEvent(part=part)
+    assert event.tool_name == 'get_weather'
+    assert event.tool_call_id == 'call_1'
+
+
+def test_tool_result_event_exposes_tool_name():
+    """`ToolResultEvent.tool_name` mirrors the return part's name."""
+    part = ToolReturnPart(tool_name='get_weather', content='sunny', tool_call_id='call_1')
+    event = FunctionToolResultEvent(part=part)
+    assert event.tool_name == 'get_weather'
+    assert event.tool_call_id == 'call_1'
+
+
+def test_output_tool_result_event_exposes_tool_name():
+    """`OutputToolResultEvent.tool_name` mirrors the output tool's name."""
+    part = ToolReturnPart(tool_name='final_answer', content='42', tool_call_id='call_2')
+    event = OutputToolResultEvent(part=part)
+    assert event.tool_name == 'final_answer'
+    assert event.tool_call_id == 'call_2'
+
+
+def test_tool_result_event_tool_name_none_for_output_validation_retry():
+    """A `RetryPromptPart` used for an output-validation retry carries no tool name, so the
+    mirrored property is `None` rather than reaching into the part."""
+    part = RetryPromptPart(content='must be an int', tool_call_id='call_3')
+    event = FunctionToolResultEvent(part=part)
+    assert event.tool_name is None
+    assert event.tool_call_id == 'call_3'


### PR DESCRIPTION
Fixes #6971

`ToolResultEvent` exposed `tool_call_id` but not `tool_name`, so consumers labeling tool activity on the result side had to carry a `tool_call_id → tool_name` map, reach through `.part`, or ship a placeholder (the Temporal consumer currently hardcodes `"unknown"`).

This adds a `tool_name` property mirroring the underlying part's name:

- `ToolCallEvent.tool_name -> str` — `ToolCallPart.tool_name` is required.
- `ToolResultEvent.tool_name -> str | None` — the mirror of `ToolReturnPart | RetryPromptPart`; `None` only for a `RetryPromptPart` used for an output-validation retry, which carries no tool name. The docstring says so, following the precedent already set by `FinalResultEvent.tool_name: str | None`.

Both events keep their existing `tool_call_id` property untouched; this is purely additive on the event surface (`.part` remains the model-facing part).

### Tests

Added to `tests/test_messages.py`:

- `test_tool_call_event_exposes_tool_name` — `FunctionToolCallEvent`
- `test_tool_result_event_exposes_tool_name` — `FunctionToolResultEvent` over `ToolReturnPart`
- `test_output_tool_result_event_exposes_tool_name` — `OutputToolResultEvent`
- `test_tool_result_event_tool_name_none_for_output_validation_retry` — `FunctionToolResultEvent` over a `RetryPromptPart` with no tool name

`tests/test_messages.py`: 180 passed, 2 failed — both are the pre-existing Windows-only failures (`test_document_url_formats[csv]` mimetype and `test_binary_content_from_path` CRLF), which reproduce on a clean tree and are unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

