### PR TITLE
docs(xai): drop xAI from ModelSettings.timeout and extra_headers support lists

### DIFF
--- a/docs/models/xai.md
+++ b/docs/models/xai.md
@@ -74,7 +74,7 @@ agent = Agent(model)
 ...
 ```
 
-`api_host` is the hostname of the xAI API server (the SDK connects over gRPC), and `timeout` is the default timeout in seconds applied to every request the client makes. The provider-level `timeout` is distinct from [`ModelSettings.timeout`][pydantic_ai.settings.ModelSettings.timeout], which overrides the timeout for an individual request. Both options are omitted when left unset, so the SDK's own defaults apply.
+`api_host` is the hostname of the xAI API server (the SDK connects over gRPC), and `timeout` is the default timeout in seconds applied to every request the client makes. The xAI model does not support [`ModelSettings.timeout`][pydantic_ai.settings.ModelSettings.timeout], so this provider-level `timeout` is the only way to set a request timeout. Both options are omitted when left unset, so the SDK's own defaults apply.
 
 Or with a custom `xai_sdk.AsyncClient`:
 

--- a/pydantic_ai_slim/pydantic_ai/providers/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/xai.py
@@ -93,8 +93,8 @@ class XaiProvider(Provider[AsyncClient]):
                 will be used if available.
             api_host: The API host to use for the xAI SDK client.
             timeout: The client-level default timeout for the xAI SDK client, in seconds, applied to all requests
-                made through it. This is distinct from `ModelSettings.timeout`, which overrides the timeout for an
-                individual request.
+                made through it. `ModelSettings.timeout` is not supported by the xAI model, so this provider-level
+                timeout is the only way to set a request timeout for xAI.
             xai_client: An existing `xai_sdk.AsyncClient` to use. This takes precedence over `api_key`, `api_host`,
                 and `timeout`.
         """

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -165,7 +165,6 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI
     * Groq
     * Mistral (numeric seconds only, not `httpx.Timeout`)
-    * xAI
     """
 
     parallel_tool_calls: bool
@@ -286,7 +285,6 @@ class ModelSettings(TypedDict, total=False):
     * Bedrock
     * Gemini
     * Groq
-    * xAI
     """
 
     thinking: ThinkingLevel


### PR DESCRIPTION
Fixes #6843

`ModelSettings.timeout` and `ModelSettings.extra_headers` listed xAI under `Supported by:`, but `XaiModel` reads neither — both are silently dropped (the xAI SDK bakes both into the gRPC channel at `AsyncClient` construction, with no per-request hook). The issue confirms this is a docs fix, not a missing feature.

### Changes

- **`settings.py`** — removed `* xAI` from the `Supported by:` lists of `ModelSettings.timeout` and `ModelSettings.extra_headers`.
- **`providers/xai.py`** — `XaiProvider(timeout=...)` docstring no longer claims `ModelSettings.timeout` "overrides the timeout for an individual request"; it now states that the xAI model does not support `ModelSettings.timeout` and that the provider-level timeout is the only way to set a request timeout.
- **`docs/models/xai.md`** — same correction for the provider-level `timeout` example.

The xAI provider still exposes the equivalents where they do work: `XaiProvider(timeout=30)` for the client-level timeout, and a custom `xai_sdk.AsyncClient` (with `metadata`) passed as `xai_client=` for headers.

### Verification

- `tests/test_settings.py`: 22 passed, 3 skipped (no regressions).
- `tests/providers/test_xai.py`: 9 skipped (the `xai-sdk`/`grpc` extra isn't installed in the test env); none failed.
- `_map_model_settings` behavior is unchanged — this is purely a documentation correction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

