### PR TITLE
fix(tool-search): don't double-wrap when a ToolSearchToolset is already present

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py
@@ -187,9 +187,7 @@ class ToolSearch(AbstractCapability[AgentDepsT]):
             named: ToolSearchNativeStrategy = self.strategy
             return [ToolSearchTool(strategy=named, optional=False)]
 
-    def get_wrapper_toolset(
-        self, toolset: AbstractToolset[AgentDepsT]
-    ) -> AbstractToolset[AgentDepsT] | None:
+    def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT] | None:
         # If the user already supplied a `ToolSearchToolset` themselves (e.g.
         # `Agent(..., toolsets=[ToolSearchToolset(wrapped=inner)])`), their explicit
         # configuration wins — skip the auto-wrap entirely. Wrapping again would stack

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py
@@ -25,6 +25,8 @@ from ..tools import (
 )
 from ..toolsets import AbstractToolset
 from ..toolsets._tool_search import ToolSearchToolset, keywords_search_fn
+from ..toolsets.combined import CombinedToolset
+from ..toolsets.wrapper import WrapperToolset
 from ._deferred_capabilities import record_loaded_capability_tools
 from .abstract import AbstractCapability, CapabilityOrdering
 
@@ -185,7 +187,19 @@ class ToolSearch(AbstractCapability[AgentDepsT]):
             named: ToolSearchNativeStrategy = self.strategy
             return [ToolSearchTool(strategy=named, optional=False)]
 
-    def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+    def get_wrapper_toolset(
+        self, toolset: AbstractToolset[AgentDepsT]
+    ) -> AbstractToolset[AgentDepsT] | None:
+        # If the user already supplied a `ToolSearchToolset` themselves (e.g.
+        # `Agent(..., toolsets=[ToolSearchToolset(wrapped=inner)])`), their explicit
+        # configuration wins — skip the auto-wrap entirely. Wrapping again would stack
+        # a second `search_tools` function inside the combined toolset, and the outer
+        # wrapper's reserved-name guard (in `ToolSearchToolset.get_tools`) would then
+        # blame the inner wrapper's *own* `search_tools` for the conflict — raising a
+        # misleading `UserError` about a nonexistent user tool (see #6921).
+        if _already_wrapped_in_tool_search(toolset):
+            return None
+
         # For explicit named native strategies (`'bm25'` / `'regex'`) the
         # `ToolSearchTool` builtin is registered with `optional=False` (see
         # `get_native_tools` above), so `prepare_request` will raise on a model
@@ -223,3 +237,21 @@ class ToolSearch(AbstractCapability[AgentDepsT]):
 
     function_tool_name: ClassVar[str] = 'search_tools'
     """Reserved name of the local function tool used when tool search runs client-side."""
+
+
+def _already_wrapped_in_tool_search(toolset: AbstractToolset[AgentDepsT]) -> bool:
+    """Return True if `toolset` already contains a `ToolSearchToolset`.
+
+    The agent assembles the user's toolsets into a `CombinedToolset` before capability
+    wrappers run, and the user may have handed in a hand-built `ToolSearchToolset`
+    directly (possibly nested inside a `WrapperToolset` such as `PreparedToolset`).
+    `ToolSearchToolset` must be checked before the generic `WrapperToolset` branch —
+    it is itself a `WrapperToolset` subclass.
+    """
+    if isinstance(toolset, ToolSearchToolset):
+        return True
+    if isinstance(toolset, CombinedToolset):
+        return any(_already_wrapped_in_tool_search(inner) for inner in toolset.toolsets)
+    if isinstance(toolset, WrapperToolset):
+        return _already_wrapped_in_tool_search(toolset.wrapped)
+    return False

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -5742,6 +5742,7 @@ async def test_tool_search_toolset_uses_custom_parameter_description() -> None:
     cap = ToolSearch(parameter_description='custom queries hint')
     base_toolset = _create_function_toolset()
     wrapped = cap.get_wrapper_toolset(base_toolset)
+    assert wrapped is not None
     ctx = _build_run_context(None)
     tools = await wrapped.get_tools(ctx)
     search_tool = tools[_SEARCH_TOOLS_NAME]

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -682,9 +682,8 @@ async def test_search_tools_inherits_agent_tool_retries(tool_retries: int):
 async def test_tool_search_toolset_max_retries_overrides_agent_budget():
     """An explicit `max_retries` on the toolset wins over the agent's tool retry budget.
 
-    Asserted at `get_tools` rather than through an agent run: the capability that owns tool
-    search is auto-injected, so a hand-constructed `ToolSearchToolset` can't be handed to an
-    `Agent` without the outer wrapper tripping the reserved-`search_tools` guard.
+    Asserted at `get_tools` rather than through an agent run: the auto-injected `ToolSearch`
+    capability supplies the agent-level defaults, so this exercises the precedence directly.
     """
     toolset = _create_function_toolset()
     ctx = _build_run_context(None, max_retries=5)
@@ -694,6 +693,40 @@ async def test_tool_search_toolset_max_retries_overrides_agent_budget():
 
     assert inheriting[_SEARCH_TOOLS_NAME].max_retries == 5
     assert overriding[_SEARCH_TOOLS_NAME].max_retries == 2
+
+
+async def test_agent_accepts_pre_wrapped_tool_search_toolset():
+    """A hand-constructed `ToolSearchToolset` in `toolsets=[...]` no longer trips the
+    reserved-`search_tools` guard from the auto-injected `ToolSearch` capability.
+
+    Regression for #6921: the auto-injected `ToolSearch` capability used to wrap the
+    combined toolset *again*, and the outer wrapper's reserved-name guard then fired on
+    the inner wrapper's own `search_tools` function — blaming a nonexistent user tool.
+    The explicit `ToolSearchToolset` should win, and discovery should still work: the
+    model searches, the discovered deferred tool becomes callable, and the run finishes.
+    """
+    calls = 0
+
+    def discover_then_use_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return ModelResponse(parts=[ToolCallPart(_SEARCH_TOOLS_NAME, {'queries': ['mortgage']})])
+        if calls == 2:
+            return ModelResponse(
+                parts=[ToolCallPart('calculate_mortgage', {'principal': 300_000, 'rate': 0.05, 'years': 30})]
+            )
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(
+        NoNativeToolSearchModel(discover_then_use_then_finish),
+        toolsets=[ToolSearchToolset(wrapped=_create_function_toolset())],
+    )
+
+    result = await agent.run('find me a mortgage calculator')
+
+    assert result.output == 'done'
+    assert calls == 3
 
 
 async def test_tool_search_toolset_search_returns_matching_tools():


### PR DESCRIPTION
Fixes #6921

## Problem

A hand-built `ToolSearchToolset` passed to an `Agent` via `toolsets=[ToolSearchToolset(wrapped=inner)]` trips a misleading error at run start:

```
UserError: Tool name 'search_tools' is reserved for tool search. Rename your tool to avoid conflicts.
```

The auto-injected `ToolSearch` capability wraps the assembled (combined) toolset *again* via `get_wrapper_toolset`. The outer wrapper's reserved-name guard then fires on the inner wrapper's **own** `search_tools` function — blaming a nonexistent user tool.

## Fix

`ToolSearch.get_wrapper_toolset` now returns `None` (leaving the toolset unchanged, per the `AbstractCapability` contract) when the incoming toolset already contains a `ToolSearchToolset`. The user's explicit configuration wins; discovery still works exactly as before:

- the model calls `search_tools`,
- the discovered deferred tool becomes callable on the next turn,
- the run completes normally.

The new `_already_wrapped_in_tool_search` helper walks `CombinedToolset.toolsets` and `WrapperToolset.wrapped` (checking `ToolSearchToolset` itself first — it is a `WrapperToolset` subclass), so nested/prepared toolsets are covered too.

Also fixed the override's return annotation to include `| None`, matching the abstract base contract.

## Tests

- New regression test `test_agent_accepts_pre_wrapped_tool_search_toolset`: end-to-end agent run with `toolsets=[ToolSearchToolset(wrapped=...)]` — search, discover, call the deferred tool, finish. No `UserError`.
- Updated the stale docstring on `test_tool_search_toolset_max_retries_overrides_agent_budget`, which previously documented the workaround this fix removes.

`tests/test_tool_search.py` (209 passed), `tests/test_toolsets.py` + `tests/test_agent.py` (524 passed, 2 skipped), ruff and pyright clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

