### PR TITLE
fix(retries): reject negative `Retry-After` delays

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -361,7 +361,8 @@ def wait_retry_after(
                 try:
                     # Try parsing as seconds first
                     wait_seconds = int(retry_after)
-                    return min(float(wait_seconds), max_wait)
+                    if wait_seconds >= 0:
+                        return min(float(wait_seconds), max_wait)
                 except ValueError:
                     # Try parsing as HTTP date
                     try:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -440,6 +440,26 @@ class TestWaitRetryAfter:
         assert result == 60.0  # Capped at max_wait
         fallback.assert_not_called()
 
+    def test_retry_after_negative_seconds_uses_fallback(self):
+        """Test that an invalid negative delay uses the fallback strategy."""
+        fallback = Mock(return_value=2.0)
+        wait_func = wait_retry_after(fallback_strategy=fallback, max_wait=300)
+
+        request = httpx.Request('GET', 'https://example.com')
+        response = Mock(spec=httpx.Response)
+        response.headers = {'retry-after': '-1'}
+        http_error = httpx.HTTPStatusError('Rate limited', request=request, response=response)
+
+        retry_state = Mock(spec=RetryCallState)
+        retry_state.outcome = Mock()
+        retry_state.outcome.failed = True
+        retry_state.outcome.exception.return_value = http_error
+
+        result = wait_func(retry_state)
+
+        assert result == 2.0
+        fallback.assert_called_once_with(retry_state)
+
     def test_retry_after_http_date_format(self):
         """Test parsing Retry-After header in HTTP date format."""
         fallback = Mock()


### PR DESCRIPTION
## Summary

- reject negative delay-seconds in `Retry-After`
- use the configured fallback strategy instead of returning a value that can make `time.sleep()` raise
- add a regression test for the invalid negative value

No linked issue; this is a trivial one-line bug fix.

## Tests

- focused helper and transport regressions: 2 passed
- `git diff --check`
- `python3 -m py_compile pydantic_ai_slim/pydantic_ai/retries.py tests/test_tenacity.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

