### PR TITLE
fix(ui): surface invalid client state as a protocol error event

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -441,6 +441,11 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             toolsets: Optional additional toolsets for this run.
             capabilities: Optional additional [capabilities](https://ai.pydantic.dev/capabilities/overview/) for this run, merged with the agent's configured capabilities.
                 Use `capabilities=[NativeTool(...)]` to add provider-side native tools per request.
+
+        A `ValidationError` from resolving the client-supplied `state` against the deps model is
+        re-raised on the first iteration of the returned stream rather than at the call site, so
+        it surfaces as a protocol error event (e.g. AG-UI's `RunError`) instead of escaping the
+        streaming response as an unhandled server error.
         """
         if deferred_tool_results is None:
             deferred_tool_results = self.deferred_tool_results
@@ -455,14 +460,25 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             output_type = [output_type or self.agent.output_type, DeferredToolRequests]
             toolsets = [*(toolsets or []), toolset]
 
+        # `self.state` is client-supplied run input. A state payload that fails the deps model
+        # must reach the client as a protocol error event, not escape from this call site as an
+        # unhandled server error (an HTTP 500 upstream). The validation error is stashed and
+        # re-raised from the stream below, inside `transform_stream`'s error handling, so it
+        # surfaces as a protocol error event (e.g. AG-UI's `RunError`). Only the raising path is
+        # deferred: every request that resolves keeps resolving and assigning `deps.state` here,
+        # so no other error or warning changes when it fires.
+        state_error: Exception | None = None
         if isinstance(deps, StateHandler):
             raw_state = self.state or {}
-            if isinstance(deps.state, BaseModel):
-                state = type(deps.state).model_validate(raw_state)
+            try:
+                if isinstance(deps.state, BaseModel):
+                    state = type(deps.state).model_validate(raw_state)
+                else:
+                    state = raw_state
+            except Exception as e:
+                state_error = e
             else:
-                state = raw_state
-
-            deps.state = state
+                deps.state = state
         elif self.state:
             warnings.warn(
                 f'State was provided but `deps` of type `{type(deps).__name__}` does not implement the `StateHandler` protocol, so the state was ignored. Use `StateDeps[...]` or implement `StateHandler` to receive AG-UI state.',
@@ -477,6 +493,9 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             run_capabilities.extend(capabilities)
 
         async def stream_events() -> AsyncIterator[NativeEvent]:
+            if state_error is not None:
+                raise state_error
+
             async with self.agent.run_stream_events(
                 output_type=output_type,
                 message_history=message_history,

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -512,6 +512,11 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             toolsets: Optional additional toolsets for this run.
             capabilities: Optional additional [capabilities](https://pydantic.dev/docs/ai/capabilities/overview/) for this run, merged with the agent's configured capabilities.
                 Use `capabilities=[NativeTool(...)]` to add provider-side native tools per request.
+
+        A `ValidationError` from resolving the client-supplied `state` against the deps model is
+        re-raised on the first iteration of the returned stream rather than at the call site, so
+        it surfaces as a protocol error event (e.g. AG-UI's `RunError`) instead of escaping the
+        streaming response as an unhandled server error.
         """
         if deferred_tool_results is None:
             deferred_tool_results = self.deferred_tool_results
@@ -530,14 +535,25 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             output_type = [output_type or self.agent.output_type, DeferredToolRequests]
             toolsets = [*(toolsets or []), toolset]
 
+        # `self.state` is client-supplied run input. A state payload that fails the deps model
+        # must reach the client as a protocol error event, not escape from this call site as an
+        # unhandled server error (an HTTP 500 upstream). The validation error is stashed and
+        # re-raised from the stream below, inside `transform_stream`'s error handling, so it
+        # surfaces as a protocol error event (e.g. AG-UI's `RunError`). Only the raising path is
+        # deferred: every request that resolves keeps resolving and assigning `deps.state` here,
+        # so no other error or warning changes when it fires.
+        state_error: Exception | None = None
         if isinstance(deps, StateHandler):
             raw_state = self.state or {}
-            if isinstance(deps.state, BaseModel):
-                state = type(deps.state).model_validate(raw_state)
+            try:
+                if isinstance(deps.state, BaseModel):
+                    state = type(deps.state).model_validate(raw_state)
+                else:
+                    state = raw_state
+            except Exception as e:
+                state_error = e
             else:
-                state = raw_state
-
-            deps.state = state
+                deps.state = state
         elif self.state:
             warnings.warn(
                 f'State was provided but `deps` of type `{type(deps).__name__}` does not implement the `StateHandler` protocol, so the state was ignored. Use `StateDeps[...]` or implement `StateHandler` to receive AG-UI state.',
@@ -557,6 +573,9 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             run_capabilities.extend(capabilities)
 
         async def stream_events() -> AsyncIterator[NativeEvent]:
+            if state_error is not None:
+                raise state_error
+
             async with self.agent.run_stream_events(
                 output_type=output_type,
                 message_history=message_history,

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from pydantic_ai import Agent, RunContext
 from pydantic_ai._run_context import AgentDepsT
@@ -953,6 +953,29 @@ async def test_run_stream_native_metadata_forwarded():
     run_result_event = next(event for event in events if isinstance(event, AgentRunResultEvent))
 
     assert run_result_event.result.metadata == {'ui': 'native'}
+
+
+async def test_run_stream_native_invalid_state_surfaces_on_iteration():
+    """A client-supplied `state` that fails the deps model no longer escapes
+    `run_stream_native` synchronously as a `ValidationError` (which would reach the
+    client as an HTTP 500).
+
+    Regression for #7039: the state payload is resolved inside the returned stream
+    instead, so the error surfaces on the first iteration — where
+    `transform_stream`'s error handling can turn it into a protocol error event
+    (e.g. AG-UI's `RunError`) rather than an unhandled server error at the call site.
+    """
+    agent = Agent(model=TestModel())
+    adapter = DummyUIAdapter(
+        agent,
+        DummyUIRunInput(messages=[ModelRequest.user_text_prompt('Hello')], state={'country': 123}),
+    )
+
+    stream = adapter.run_stream_native(deps=DummyUIDeps(state=DummyUIState(country='US')))
+
+    # Pre-fix, the `ValidationError` escaped here, at the call site.
+    with pytest.raises(ValidationError):
+        [event async for event in stream]
 
 
 async def test_adapter_dispatch_request():

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import anyio
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from pydantic_ai import Agent, RunContext, _utils
 from pydantic_ai._run_context import AgentDepsT
@@ -1333,6 +1333,29 @@ async def test_run_stream_native_metadata_forwarded():
     run_result_event = next(event for event in events if isinstance(event, AgentRunResultEvent))
 
     assert run_result_event.result.metadata == {'ui': 'native'}
+
+
+async def test_run_stream_native_invalid_state_surfaces_on_iteration():
+    """A client-supplied `state` that fails the deps model no longer escapes
+    `run_stream_native` synchronously as a `ValidationError` (which would reach the
+    client as an HTTP 500).
+
+    Regression for #7039: the state payload is resolved inside the returned stream
+    instead, so the error surfaces on the first iteration — where
+    `transform_stream`'s error handling can turn it into a protocol error event
+    (e.g. AG-UI's `RunError`) rather than an unhandled server error at the call site.
+    """
+    agent = Agent(model=TestModel())
+    adapter = DummyUIAdapter(
+        agent,
+        DummyUIRunInput(messages=[ModelRequest.user_text_prompt('Hello')], state={'country': 123}),
+    )
+
+    stream = adapter.run_stream_native(deps=DummyUIDeps(state=DummyUIState(country='US')))
+
+    # Pre-fix, the `ValidationError` escaped here, at the call site.
+    with pytest.raises(ValidationError):
+        [event async for event in stream]
 
 
 async def test_adapter_dispatch_request():


### PR DESCRIPTION
Fixes #7039

## Problem

When a client supplies a `state` payload that fails validation against the deps model (e.g. `state={'count': 'not-an-int'}` with `deps_type=StateDeps[St]` where `St.count: int`), `UIAdapter.run_stream_native` raised the `ValidationError` **eagerly at the call site** — before the streaming response starts. In a server that wraps the adapter in `run_stream`/`transform_stream`, that exception escapes the HTTP handler as an unhandled 500, and the client never receives a proper protocol-level error event (AG-UI's `RunError`).

## Fix

Mirror the stash-and-re-raise pattern already used for `deferred_tool_results` in #7038:

- At the top of `run_stream_native`, wrap the state resolution in `try/except` and stash the exception in `state_error` instead of letting it escape.
- Re-raise `state_error` as the **first statement of `stream_events()`**, i.e. on the first iteration of the returned stream. `transform_stream`'s existing error handling then catches it and routes it through the adapter's `on_error` hook — producing a `RunErrorEvent` on AG-UI and an `ErrorChunk` on the Vercel adapter — instead of an unhandled server error.

Scope is deliberately narrow: only the raising path is deferred. State that validates successfully is still resolved and assigned to `deps.state` eagerly, so no other error or warning changes when it fires, and the block left for #7038 (`deferred_tool_results`) is untouched.

## Test

`test_run_stream_native_invalid_state_surfaces_on_iteration` — asserts that with `state={'country': 123}` against a `DummyUIState` deps model, the `ValidationError` no longer escapes the `run_stream_native(...)` call, but is raised on the first iteration of the stream where it can be converted into a protocol error event.

## Verification

- `pytest tests/test_ui.py` — 54 passed
- `ruff check` — clean
- `pyright` — 0 errors


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

