### PR TITLE
fix(ui): close transform_stream cleanly and release the native stream

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
@@ -175,6 +175,7 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
         async for e in self.before_stream():
             yield e
 
+        closed = False
         try:
             async for event in stream:
                 if isinstance(event, PartStartEvent):
@@ -228,6 +229,13 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
                 ):
                     self._open_part = event.part
                     self._open_part_index = event.index
+        except GeneratorExit:
+            # The consumer closed the stream mid-flight (e.g. a client disconnect). No consumer is
+            # left to receive the closing protocol events, and yielding them while handling
+            # `GeneratorExit` raises `RuntimeError: async generator ignored GeneratorExit`, so skip
+            # them and let the `finally` below release the native input stream instead.
+            closed = True
+            raise
         except Exception as exc:  # `exc` to avoid shadowing by `async for e in` below
             # Close the open message part before emitting the error, so a client that aborts at the
             # error chunk (like the AI SDK) doesn't leave it stuck in a streaming state. This comes
@@ -271,11 +279,20 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
             async for e in self.on_error(exc):
                 yield e
         finally:
-            async for e in self._turn_to(None):
-                yield e
+            if not closed:
+                async for e in self._turn_to(None):
+                    yield e
 
-            async for e in self.after_stream():
-                yield e
+                async for e in self.after_stream():
+                    yield e
+
+            # Release the native input stream. On the normal and error paths this is a no-op for a
+            # generator that already exited; on close it finalizes a native stream that would
+            # otherwise stay suspended (retaining model/node streams) until garbage collection.
+            # A native stream may be any `AsyncIterable`, so guard for the absence of `aclose`.
+            close = getattr(stream, 'aclose', None)
+            if close is not None:
+                await close()
 
     async def _turn_to(self, to_turn: Literal['request', 'response'] | None) -> AsyncIterator[EventT]:
         """Fire hooks when turning from request to response or vice versa."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1020,6 +1020,38 @@ async def test_adapter_dispatch_request():
     assert captured_metadata == [{'ui': 'dispatch'}]
 
 
+async def test_transform_stream_close_mid_stream():
+    """Closing a `transform_stream()` mid-stream must not raise and must close the native input.
+
+    Regression for #7016: `aclose()` raised `RuntimeError: async generator ignored GeneratorExit`
+    because the `finally` yielded closing protocol events while handling `GeneratorExit`, and the
+    forwarding `async for` never closed the native stream, leaving it suspended until GC.
+    """
+    inner_finalized = False
+
+    async def event_generator() -> AsyncIterator[NativeEvent]:
+        try:
+            yield PartStartEvent(index=0, part=TextPart(content='Hello'))
+            yield PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=' world'))
+            yield PartEndEvent(index=0, part=TextPart(content='Hello world'))
+        finally:
+            nonlocal inner_finalized
+            inner_finalized = True
+
+    request = DummyUIRunInput(messages=[ModelRequest.user_text_prompt('Hello')])
+    event_stream = DummyUIEventStream(run_input=request)
+    transformed = event_stream.transform_stream(event_generator())
+
+    events_before_close = [await anext(transformed) for _ in range(3)]
+    assert events_before_close == ['<stream>', '<response>', '<text follows_text=False>Hello']
+
+    # Mid-stream close: must return cleanly instead of raising `RuntimeError`,
+    # and must finalize the native stream rather than leaving it suspended.
+    await transformed.aclose()
+
+    assert inner_finalized
+
+
 def test_manage_system_prompt_visible_in_base_adapter_signatures():
     from_request_parameters = inspect.signature(DummyUIAdapter.from_request).parameters
     dispatch_request_parameters = inspect.signature(DummyUIAdapter.dispatch_request).parameters


### PR DESCRIPTION
Fixes #7016

## Problem

Two defects in `UIEventStream.transform_stream()`:

1. **`aclose()` raised `RuntimeError: async generator ignored GeneratorExit`.** The `finally` block yields closing protocol events (`_turn_to(None)`, `after_stream()`). When a consumer closes the transformer mid-stream, `GeneratorExit` is raised at the current `yield`; CPython forbids yielding while handling `GeneratorExit`, so `aclose()` explodes.
2. **The native input stream leaked.** The forwarding `async for event in stream:` never closes its native input, so the underlying agent stream stays suspended — retaining model/node streams and any capability tasks parked on them — until GC happens to finalize the chain.

A server that closes the protocol transformer after a client disconnect gets a teardown exception and leaves the agent run suspended.

## Fix

- **`except GeneratorExit:`** (before the existing `except Exception`): marks the stream as closed and re-raises. `GeneratorExit` is a `BaseException`, so the error path never handled it before.
- **`finally`**: the closing protocol events are emitted only when the stream is ending normally or on a non-`GeneratorExit` error — there is no consumer left to receive them when the generator is being closed. This keeps the existing error-path behavior (pending tool calls closed, `on_error` emitted, then closing events) intact.
- **Native stream release**: `stream` is closed from the `finally` on every exit path, guarded via `getattr(stream, 'aclose', None)` since a native stream may be any `AsyncIterable`. On the normal and error paths this is a no-op for a generator that already exited; on close it finalizes a suspended native stream.

## Test

`test_transform_stream_close_mid_stream` — feeds the transformer a native generator whose `finally` sets a flag, consumes `<stream>`, `<response>`, and the first text event, then closes the transformer mid-stream. Asserts both that `aclose()` returns cleanly and that the native stream's `finally` ran.

## Verification

- `pytest tests/test_ui.py` — 54 passed (53 baseline + new test)
- `ruff check` — clean
- `pyright` — 0 errors


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

