### PR TITLE
fix: reject negative Retry-After delays in wait_retry_after

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -361,7 +361,8 @@ def wait_retry_after(
                 try:
                     # Try parsing as seconds first
                     wait_seconds = int(retry_after)
-                    return min(float(wait_seconds), max_wait)
+                    if wait_seconds >= 0:
+                        return min(float(wait_seconds), max_wait)
                 except ValueError:
                     # Try parsing as HTTP date
                     try:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -537,6 +537,27 @@ class TestWaitRetryAfter:
         assert result == 4.0
         fallback.assert_called_once_with(retry_state)
 
+    def test_retry_after_negative_seconds_uses_fallback(self):
+        """Test that negative Retry-After seconds fall back to fallback strategy."""
+        fallback = Mock(return_value=2.0)
+        wait_func = wait_retry_after(fallback_strategy=fallback, max_wait=300)
+
+        # Create HTTP status error with a negative Retry-After (invalid per RFC 9110)
+        request = httpx.Request('GET', 'https://example.com')
+        response = Mock(spec=httpx.Response)
+        response.headers = {'retry-after': '-1'}
+        http_error = httpx.HTTPStatusError('Rate limited', request=request, response=response)
+
+        retry_state = Mock(spec=RetryCallState)
+        retry_state.outcome = Mock()
+        retry_state.outcome.failed = True
+        retry_state.outcome.exception.return_value = http_error
+
+        result = wait_func(retry_state)
+
+        assert result == 2.0
+        fallback.assert_called_once_with(retry_state)
+
     def test_default_fallback_strategy(self):
         """Test that default fallback strategy is used when none is provided."""
         wait_func = wait_retry_after(max_wait=300)


### PR DESCRIPTION
Fixes #7065

## Summary

`wait_retry_after()` now treats a negative integer `Retry-After` header as invalid, per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after) where `delay-seconds` is defined as a non-negative decimal integer.

Previously `Retry-After: -1` parsed successfully and returned `-1.0`, which later crashed in the sleep implementation with `ValueError: sleep length must be non-negative`. Negative values now fall through the existing invalid-value path (date parsing fails) and use the configured fallback strategy, matching the behavior of other invalid header values.

## Tests

- `tests/test_tenacity.py`: new `test_retry_after_negative_seconds_uses_fallback` — asserts `Retry-After: -1` falls back to the provided strategy instead of returning a negative delay.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

