### PR TITLE
Fix broken GitHub Models catalog link in OpenAI docs

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -797,7 +797,7 @@ agent = Agent(model)
 ...
 ```
 
-GitHub Models supports various model families with different prefixes. You can see the full list on the [GitHub Marketplace](https://github.com/marketplace?type=models) or the public [catalog endpoint](https://models.github.ai/catalog/models).
+GitHub Models supports various model families with different prefixes. You can see the full list on the [GitHub Marketplace](https://github.com/marketplace?type=models).
 
 ### Perplexity
 


### PR DESCRIPTION
Fixes #7046

The docs link check flagged two errors:

- `docs/logfire.md` → `https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view`: reported a network connection failure, but the link is live (returns 200) — transient error at scan time, left untouched.
- `docs/models/openai.md` → `https://models.github.ai/catalog/models`: **410 Gone** — the entire `models.github.ai` domain has been retired. Removed the dead "catalog endpoint" clause; the sentence now points only to the GitHub Marketplace listing, which already covers the full model list.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

