### PR TITLE
fix(heroku): route GLM models to the Z.AI profile and match hyphenated ids

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -20,6 +20,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
+from pydantic_ai.profiles.zai import zai_model_profile
 from pydantic_ai.providers import Provider
 
 try:
@@ -29,6 +30,25 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Heroku provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+
+
+def heroku_glm_model_profile(model_name: str) -> ModelProfile | None:
+    """Profile for GLM models served by Heroku under hyphenated ids.
+
+    GLM is Z.AI (Zhipu), not Moonshot, so these models must be routed through
+    `zai_model_profile` rather than the Moonshot profile. Heroku serves GLM ids
+    with a hyphen for the minor version (`glm-4-7`) where Z.AI's own ids use a
+    dot (`glm-4.7`), so normalize the separator before delegating — otherwise
+    `zai_model_profile`'s prefix matching misses them and `supports_thinking`
+    is never set. See the id-scheme note on `zai_model_profile`.
+    """
+    normalized = model_name
+    # 'glm-4-7' -> 'glm-4.7', 'glm-4-7-flash' -> 'glm-4.7-flash'
+    head, sep, tail = normalized.partition('-')
+    if sep and '-' in tail:
+        major, _, rest = tail.partition('-')
+        normalized = f'{head}-{major}.{rest}'
+    return zai_model_profile(normalized)
 
 
 class HerokuProvider(Provider[AsyncOpenAI]):
@@ -59,7 +79,7 @@ class HerokuProvider(Provider[AsyncOpenAI]):
             'qwen': qwen_model_profile,
             'deepseek': deepseek_model_profile,
             'kimi': moonshotai_model_profile,
-            'glm': moonshotai_model_profile,
+            'glm': heroku_glm_model_profile,
             'mistral': mistral_model_profile,
             'nova': amazon_model_profile,
             'llama': meta_model_profile,

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -105,6 +105,33 @@ def test_heroku_model_profile_routes_thinking_capable_families():
     assert fallback.get('supports_thinking') is None
 
 
+def test_heroku_model_profile_glm_routes_to_zai_profile():
+    """Heroku serves GLM models under hyphenated ids; they must get thinking support from the Z.AI profile.
+
+    GLM is Z.AI (Zhipu), not Moonshot — routing it to the Moonshot profile made it inherit a
+    Kimi streaming quirk (`ignore_streamed_leading_whitespace`) and never set `supports_thinking`,
+    so unified `thinking` settings were silently dropped. Heroku's `glm-4-7` id scheme is hyphenated
+    where Z.AI's own ids are dotted (`glm-4.7`), so the normalization must happen here.
+    """
+    provider = HerokuProvider(api_key='api-key')
+
+    # GLM-4.7 and GLM-4.7-Flash both support thinking per the Z.AI docs.
+    for model_name in ('glm-4-7', 'glm-4-7-flash'):
+        profile = provider.model_profile(model_name)
+        assert profile is not None, model_name
+        assert profile.get('supports_thinking') is True, model_name
+        # No Kimi streaming quirk inherited from the Moonshot profile.
+        assert profile.get('ignore_streamed_leading_whitespace') is None, model_name
+        # GLM-4.7 supports thinking on/off only; per-request reasoning effort is GLM-5.2+.
+        assert profile.get('zai_supports_reasoning_effort', False) is False, model_name
+
+    # GLM ids without a minor version (non-thinking models) still route cleanly.
+    fallback = provider.model_profile('glm-4-32b-0414-128k')
+    assert fallback is not None
+    assert fallback.get('supports_thinking') is None
+    assert fallback.get('ignore_streamed_leading_whitespace') is None
+
+
 async def test_heroku_model_provider_claude_3_7_sonnet(allow_model_requests: None, heroku_inference_key: str):
     provider = HerokuProvider(api_key=heroku_inference_key)
     m = OpenAIChatModel('claude-3-7-sonnet', provider=provider)


### PR DESCRIPTION
Fixes #6836

## Summary

Heroku's GLM models were routed to the Moonshot profile, which is wrong on two counts:

1. **Wrong vendor.** GLM is Z.AI (Zhipu), not Moonshot — the Moonshot profile is for the Kimi family. GLM models therefore inherited `ignore_streamed_leading_whitespace=True` and, more importantly, never received `supports_thinking`.
2. **Id-scheme mismatch.** Heroku serves GLM ids with a hyphen for the minor version (`glm-4-7`) while `zai_model_profile` matches dotted ids (`glm-4.7`), so even after routing to the right vendor the prefix match missed and thinking support was silently dropped (`Model.prepare_request` discards `ModelSettings(thinking=...)` when `supports_thinking` is unset).

## Changes

- `pydantic_ai_slim/pydantic_ai/providers/heroku.py`
  - Added a `heroku_glm_model_profile` helper that normalizes the minor-version separator (`glm-4-7` → `glm-4.7`) before delegating to `zai_model_profile`. Dotted ids pass through unchanged; ids that match no thinking-capable prefix (e.g. `glm-4-32b-0414-128k`) fall back to the OpenAI base profile as before.
  - Re-routed `'glm'` from `moonshotai_model_profile` to `heroku_glm_model_profile`. Kimi models still use the Moonshot profile.
- `tests/providers/test_heroku.py`
  - New test asserting GLM ids served by Heroku get `supports_thinking=True`, no `ignore_streamed_leading_whitespace`, and correct `zai_supports_reasoning_effort` — plus the non-thinking long-context id falling back cleanly.

This mirrors the existing precedent of providers that serve GLM under a different id scheme handling routing in their own `model_profile()` (cf. Cerebras).

## Verification

- `pytest tests/providers/test_heroku.py` — 12 passed
- `ruff check` / `ruff format --check` — clean
- `pyright` on both changed files — 0 errors


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

