### PR TITLE
fix(durable-exec): make the payload type-adapter cache unbounded

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 from typing import Any
 
 from pydantic import TypeAdapter
@@ -13,14 +13,17 @@ from temporalio.contrib.pydantic import (
 from temporalio.converter import CompositePayloadConverter, DefaultPayloadConverter, JSONPlainPayloadConverter
 
 
-@lru_cache(maxsize=128)
+@cache
 def _type_adapter(type_hint: Any) -> TypeAdapter[Any]:
-    """Build an adapter once for each recently used type hint.
+    """Build an adapter once per type hint.
 
     The cache is replay-safe: a `TypeAdapter` is a pure function of its type hint, so cache hits and
-    misses validate identically and cannot change workflow history. The 128-entry bound comfortably
-    covers the code-defined set of hints used by a worker while preventing accidental growth if an
-    application constructs hints dynamically.
+    misses validate identically and cannot change workflow history. It is unbounded because its key
+    space is closed: it is the set of annotations reachable from the registered workflows and
+    activities, which is fixed by the code, not by traffic. A bounded LRU below that working set
+    (the original 128 entries) degrades to a 0% hit rate on large registries — exactly the workers
+    the memo exists for — and every decode then rebuilds its adapter. Unhashable hints, the main
+    dynamic-construction case, bypass the cache entirely.
     """
     return TypeAdapter(type_hint)
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -5612,6 +5612,34 @@ async def test_pydantic_ai_payload_converter_separates_type_hints() -> None:
     assert type_adapter.call_count == 2
 
 
+async def test_pydantic_ai_payload_converter_cache_holds_more_than_128_hints() -> None:
+    """A working set larger than the old 128-entry bound must not thrash the adapter cache.
+
+    Workers that register many activities and agents generate well over 128 distinct payload
+    type hints (the report behind the unbounded cache counted 153). With an LRU sized below
+    the working set every decode misses, so the memo provides no benefit exactly where it is
+    needed most.
+    """
+    temporal_payload_converter._type_adapter.cache_clear()  # pyright: ignore[reportPrivateUsage]
+    converter = DataConverter(payload_converter_class=PydanticAIPayloadConverter)
+
+    models = [type(f'Result{i}', (BaseModel,), {'__annotations__': {'v': int}}) for i in range(200)]
+    values = [m(v=1) for m in models]
+    payloads = await converter.encode(values)
+
+    # Warm every hint once so the cache holds the full working set.
+    assert await converter.decode(payloads, models) == values
+
+    with patch.object(
+        temporal_payload_converter, 'TypeAdapter', wraps=temporal_payload_converter.TypeAdapter
+    ) as type_adapter:
+        for _ in range(5):
+            assert await converter.decode(payloads, models) == values
+
+    # All five passes are served entirely from the cache; nothing is rebuilt.
+    assert type_adapter.call_count == 0
+
+
 async def test_pydantic_ai_payload_converter_accepts_unhashable_type_hint() -> None:
     """Unhashable Pydantic-compatible hints are built uncached rather than rejected."""
     converter = DataConverter(payload_converter_class=PydanticAIPayloadConverter)


### PR DESCRIPTION
Fixes #7027

## Problem

`_type_adapter` is memoized with `lru_cache(maxsize=128)`. Once a worker's distinct payload type-hint count exceeds 128, cyclic access over the working set gives the LRU a **0% hit rate**: every decode misses and rebuilds its `TypeAdapter`, so the memo provides no benefit exactly on the workers large enough to have needed it — it becomes pure overhead on the hottest path.

The count that matters isn't just the application's own activities: `TemporalDurability` generates several activities per agent, and their annotations land in the same key space. The report behind #7027 measured **153 distinct hints** (59 app activities + 53 workflow run/signal/query/update slots + 41 generated activities), with real `CallToolResult` adapter builds taking ~2.8 ms each — a single activation blew the Temporal deadlock ceiling and made zero progress for hours.

## Change

Make the memo unbounded (`functools.cache`). This is safe because the key space is **closed**: it is the set of annotations reachable from the registered workflows and activities, which is fixed by the code, not by traffic. Unhashable hints — the main dynamic-construction case — already bypass the cache entirely (they take the uncached `TypeAdapter(hint)` path in `from_payload`), so the cache cannot grow with load.

Any fixed bound would only relocate the bug; the failure mode (silent 0% hit rate on the largest registries) is invisible until it costs a workflow task.

## Verification

- New test `test_pydantic_ai_payload_converter_cache_holds_more_than_128_hints`: builds 200 distinct dynamically-created hints, warms the cache, then runs 5 full decode passes under a `TypeAdapter` spy — asserts zero rebuilds. Red before the fix (1000 rebuilds, i.e. every decode missed), green after.
- Full `tests/test_temporal.py`: 244 passed, 2 skipped.
- `ruff check` / `ruff format --check` clean on both touched files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

