### PR TITLE
fix(providers): dispatch mixed-case model names to lowercase family profiles

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -56,7 +56,7 @@ class FireworksProvider(Provider[AsyncOpenAI]):
 
         profile = None
         if model_name.startswith(prefix):
-            model_name = model_name[len(prefix) :]
+            model_name = model_name[len(prefix) :].lower()
             for provider, profile_func in prefix_to_profile.items():
                 if model_name.startswith(provider):
                     profile = profile_func(model_name)

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -70,7 +70,7 @@ class HerokuProvider(Provider[AsyncOpenAI]):
         lower_model_name = model_name.lower()
         for prefix, profile_func in prefix_to_profile.items():
             if lower_model_name.startswith(prefix):
-                profile = profile_func(model_name)
+                profile = profile_func(lower_model_name)
                 break
 
         # As the Heroku API is OpenAI-compatible, we keep the OpenAIJsonSchemaTransformer as the base

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -69,7 +69,7 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
 
         for prefix, profile_func in prefix_to_profile.items():
             if model_name_lower.startswith(prefix):
-                profile = profile_func(model_name)
+                profile = profile_func(model_name_lower)
                 break
 
         # Wrap into OpenAIModelProfile since SambaNova is OpenAI-compatible

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -102,3 +102,17 @@ def test_fireworks_provider_model_profile(mocker: MockerFixture):
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
     assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+
+def test_fireworks_provider_model_profile_mixed_case(mocker: MockerFixture):
+    # Fireworks model IDs can carry mixed case (e.g. `accounts/fireworks/models/DeepSeek-R1`);
+    # the stripped name must be lowercased before both the prefix match and the profile call,
+    # or the model falls through to the bare OpenAI-compatible profile.
+    provider = FireworksProvider(api_key='api-key')
+    ns = 'pydantic_ai.providers.fireworks'
+    deepseek_model_profile_mock = mocker.patch(f'{ns}.deepseek_model_profile', wraps=deepseek_model_profile)
+
+    profile = provider.model_profile('accounts/fireworks/models/DeepSeek-R1')
+    deepseek_model_profile_mock.assert_called_with('deepseek-r1')
+    assert profile is not None
+    assert profile.get('supports_thinking') is True

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -105,6 +105,18 @@ def test_heroku_model_profile_routes_thinking_capable_families():
     assert fallback.get('supports_thinking') is None
 
 
+def test_heroku_model_profile_mixed_case():
+    # The family dispatch lowercases the name for the prefix match but must also hand the
+    # profile function a lowercase name; mixed-case spellings (e.g. `DeepSeek-R1`) would
+    # otherwise resolve the right family and then detect nothing inside it.
+    provider = HerokuProvider(api_key='api-key')
+    mixed = provider.model_profile('DeepSeek-R1')
+    lower = provider.model_profile('deepseek-r1')
+    assert mixed == lower
+    assert mixed is not None
+    assert mixed.get('supports_thinking') is True
+
+
 async def test_heroku_model_provider_claude_3_7_sonnet(allow_model_requests: None, heroku_inference_key: str):
     provider = HerokuProvider(api_key=heroku_inference_key)
     m = OpenAIChatModel('claude-3-7-sonnet', provider=provider)

--- a/tests/providers/test_sambanova_provider.py
+++ b/tests/providers/test_sambanova_provider.py
@@ -8,6 +8,8 @@ from ..conftest import TestEnv, try_import
 with try_import() as imports_successful:
     import openai
 
+    from pydantic_ai.models import ModelRequestParameters
+    from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers import infer_provider
     from pydantic_ai.providers.sambanova import SambaNovaProvider
 
@@ -86,6 +88,28 @@ def test_unknown_model_profile():
     # Unknown model -> should return OpenAI compatibility wrapper with None base profile
     profile = provider.model_profile('unknown-model')
     assert isinstance(profile, dict)
+
+
+def test_deepseek_profile_mixed_case_flags():
+    provider = SambaNovaProvider(api_key='key')
+    # SambaNova serves mixed-case model IDs (e.g. `DeepSeek-R1-0528`); the family profile
+    # dispatch is case-sensitive on lowercase prefixes, so the mixed-case spelling must still
+    # resolve to the full DeepSeek profile rather than silently dropping its capability flags.
+    mixed = provider.model_profile('DeepSeek-R1-0528')
+    lower = provider.model_profile('deepseek-r1-0528')
+    assert mixed == lower
+    assert mixed is not None
+    assert mixed.get('supports_thinking') is True
+    assert mixed.get('thinking_always_enabled') is True
+    assert mixed.get('ignore_streamed_leading_whitespace') is True
+
+
+def test_mixed_case_thinking_reaches_params():
+    # The user-visible symptom: `thinking=True` must reach the request params for the
+    # documented mixed-case spelling instead of being silently consumed and discarded.
+    model = OpenAIChatModel('DeepSeek-R1-0528', provider=SambaNovaProvider(api_key='key'))
+    _, params = model.prepare_request({'thinking': True}, ModelRequestParameters())
+    assert params.thinking is True
 
 
 def test_sambanova_provider_with_openai_client():


### PR DESCRIPTION
Fixes #6816

## Summary

SambaNova, Heroku and Fireworks match their family-profile prefix against a **lowercased** model name but pass the **original casing** to the profile function. Every family profile keys off lowercase prefixes, so a mixed-case model ID selects the right profile function and then detects nothing inside it — `supports_thinking` comes back unset and a `thinking=True` setting is **silently consumed and discarded** (no error, no warning, nothing on the wire). `ignore_streamed_leading_whitespace` is lost the same way.

SambaNova's model IDs are mixed case in ordinary use — `docs/models/openai.md` uses `sambanova:Meta-Llama-3.1-8B-Instruct`, and `DeepSeek-R1-0528` / `Qwen3-32B` are real IDs:

```
DeepSeek-R1-0528   supports_thinking=False  always=False  ignore_ws=False  -> params.thinking=None
deepseek-r1-0528   supports_thinking=True   always=True   ignore_ws=True   -> params.thinking=True
```

Fireworks is worse: it never lowercases the stripped name at all, so a mixed-case ID matches no prefix and gets the bare OpenAI-compatible profile (`None` flags). Heroku documents lowercase IDs, so it's latent — same one-line defect.

## Fix

Pass the lowercased name to the profile function in all three providers, which is what the four correct providers already do (`cerebras.py` passes `model_name_lower`; `azure.py`/`ollama.py`/`ovhcloud.py`/`together.py` rebind `model_name = model_name.lower()`). Fireworks now lowercases the name after stripping the `accounts/fireworks/models/` prefix.

## Tests

- **sambanova** — `DeepSeek-R1-0528` (mixed case) must resolve the same profile as `deepseek-r1-0528`, with `supports_thinking`/`thinking_always_enabled`/`ignore_streamed_leading_whitespace` all `True`.
- **sambanova** — the user-visible symptom: `prepare_request({'thinking': True})` on the documented mixed-case spelling must yield `params.thinking is True`.
- **heroku** — mixed-case `DeepSeek-R1` resolves the same profile as `deepseek-r1`, with `supports_thinking=True`.
- **fireworks** — mocked `deepseek_model_profile` must be called with `'deepseek-r1'` for `accounts/fireworks/models/DeepSeek-R1`, and the merged profile advertises `supports_thinking=True`.

## Validation

- `tests/providers/` + `tests/profiles/`: **483 passed, 68 skipped**, 0 failed.
- New tests fail on unmodified `main` (confirmed red→green).
- `ruff check`, `ruff format --check`, and `pyright` all clean on the changed files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

