### PR TITLE
fix(vercel-ai): require a valid approval on approval-responded parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -216,7 +216,7 @@ class ToolApprovalRespondedPart(BaseUIPart):
     input: Any | None = None
     provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
-    approval: ToolApproval | None = None
+    approval: ToolApprovalResponded
 
 
 class ToolOutputDeniedPart(BaseUIPart):
@@ -329,7 +329,7 @@ class DynamicToolApprovalRespondedPart(BaseUIPart):
     input: Any
     provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
-    approval: ToolApproval | None = None
+    approval: ToolApprovalResponded
 
 
 class DynamicToolOutputDeniedPart(BaseUIPart):

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -230,7 +230,7 @@ class ToolApprovalRespondedPart(BaseUIPart):
     input: Any | None = None
     provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
-    approval: ToolApproval | None = None
+    approval: ToolApprovalResponded
 
 
 class ToolOutputDeniedPart(BaseUIPart):
@@ -343,7 +343,7 @@ class DynamicToolApprovalRespondedPart(BaseUIPart):
     input: Any
     provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
-    approval: ToolApproval | None = None
+    approval: ToolApprovalResponded
 
 
 class DynamicToolOutputDeniedPart(BaseUIPart):

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -172,7 +172,9 @@ def test_build_run_input_allows_regenerate_without_message_id():
     ],
 )
 @pytest.mark.parametrize('malformed_approval', [{'id': 'a1'}, None])
-def test_build_run_input_rejects_malformed_approval_responded(approval_part, malformed_approval):
+def test_build_run_input_rejects_malformed_approval_responded(
+    approval_part: dict[str, object], malformed_approval: dict[str, object] | None
+):
     """An `approval-responded` part whose `approval` isn't a `ToolApprovalResponded` fails loudly.
 
     Regression for #7041: `ToolApproval` is an undiscriminated union, so an approval object
@@ -218,7 +220,10 @@ def test_build_run_input_rejects_malformed_approval_responded(approval_part, mal
         ),
     ],
 )
-def test_build_run_input_accepts_valid_approval_responded(approval_part, expected):
+def test_build_run_input_accepts_valid_approval_responded(
+    approval_part: dict[str, object],
+    expected: type[DynamicToolApprovalRespondedPart] | type[ToolApprovalRespondedPart],
+):
     """A well-formed `approval-responded` part keeps its approval through `build_run_input`."""
     data = {
         'trigger': 'submit-message',

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -227,10 +227,8 @@ def test_build_run_input_accepts_valid_approval_responded(approval_part, expecte
             {
                 'id': 'msg_1',
                 'role': 'assistant',
-                'parts': [
-                    {**approval_part, 'approval': {'id': 'a1', 'approved': False, 'reason': 'nope'}}
-                ],
-            }
+                'parts': [{**approval_part, 'approval': {'id': 'a1', 'approved': False, 'reason': 'nope'}}],
+            },
         ],
     }
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -104,6 +104,7 @@ with try_import() as starlette_import_successful:
         TextUIPart,
         ToolApprovalRequested,
         ToolApprovalResponded,
+        ToolApprovalRespondedPart,
         ToolInputAvailablePart,
         ToolInputStreamingPart,
         ToolOutputAvailablePart,
@@ -150,6 +151,95 @@ def test_build_run_input_allows_regenerate_without_message_id():
 
     assert isinstance(run_input, RegenerateMessage)
     assert run_input.message_id is None
+
+
+@pytest.mark.parametrize(
+    'approval_part',
+    [
+        {
+            'type': 'dynamic-tool',
+            'toolName': 'delete_file',
+            'toolCallId': 'delete_1',
+            'state': 'approval-responded',
+            'input': {'path': 'test.txt'},
+        },
+        {
+            'type': 'tool-delete_file',
+            'toolCallId': 'delete_1',
+            'state': 'approval-responded',
+            'input': {'path': 'test.txt'},
+        },
+    ],
+)
+@pytest.mark.parametrize('malformed_approval', [{'id': 'a1'}, None])
+def test_build_run_input_rejects_malformed_approval_responded(approval_part, malformed_approval):
+    """An `approval-responded` part whose `approval` isn't a `ToolApprovalResponded` fails loudly.
+
+    Regression for #7041: `ToolApproval` is an undiscriminated union, so an approval object
+    that omits `approved` parsed as `ToolApprovalRequested` and was silently dropped by
+    `iter_tool_approval_responses` — the client's approval turn vanished, the pending tool
+    call was stripped from history, and the run finished looking like success. An
+    `approval-responded` part now requires a real response, so malformed shapes (missing
+    `approved`, or `null`/omitted) fail validation at `build_run_input` instead.
+    """
+    data = {
+        'trigger': 'submit-message',
+        'id': 'req_123',
+        'messages': [
+            {'id': 'msg_1', 'role': 'assistant', 'parts': [{**approval_part, 'approval': malformed_approval}]}
+        ],
+    }
+
+    with pytest.raises(ValidationError):
+        VercelAIAdapter.build_run_input(json.dumps(data).encode())
+
+
+@pytest.mark.parametrize(
+    'approval_part, expected',
+    [
+        (
+            {
+                'type': 'dynamic-tool',
+                'toolName': 'delete_file',
+                'toolCallId': 'delete_1',
+                'state': 'approval-responded',
+                'input': {'path': 'test.txt'},
+            },
+            DynamicToolApprovalRespondedPart,
+        ),
+        (
+            {
+                'type': 'tool-delete_file',
+                'toolCallId': 'delete_1',
+                'state': 'approval-responded',
+                'input': {'path': 'test.txt'},
+            },
+            ToolApprovalRespondedPart,
+        ),
+    ],
+)
+def test_build_run_input_accepts_valid_approval_responded(approval_part, expected):
+    """A well-formed `approval-responded` part keeps its approval through `build_run_input`."""
+    data = {
+        'trigger': 'submit-message',
+        'id': 'req_123',
+        'messages': [
+            {
+                'id': 'msg_1',
+                'role': 'assistant',
+                'parts': [
+                    {**approval_part, 'approval': {'id': 'a1', 'approved': False, 'reason': 'nope'}}
+                ],
+            }
+        ],
+    }
+
+    run_input = VercelAIAdapter.build_run_input(json.dumps(data).encode())
+
+    assert isinstance(run_input, SubmitMessage)
+    part = run_input.messages[0].parts[0]
+    assert isinstance(part, expected)
+    assert part.approval == ToolApprovalResponded(id='a1', approved=False, reason='nope')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -214,6 +214,95 @@ def test_reasoning_part_id_serialization():
 
 
 @pytest.mark.parametrize(
+    'approval_part',
+    [
+        {
+            'type': 'dynamic-tool',
+            'toolName': 'delete_file',
+            'toolCallId': 'delete_1',
+            'state': 'approval-responded',
+            'input': {'path': 'test.txt'},
+        },
+        {
+            'type': 'tool-delete_file',
+            'toolCallId': 'delete_1',
+            'state': 'approval-responded',
+            'input': {'path': 'test.txt'},
+        },
+    ],
+)
+@pytest.mark.parametrize('malformed_approval', [{'id': 'a1'}, None])
+def test_build_run_input_rejects_malformed_approval_responded(approval_part, malformed_approval):
+    """An `approval-responded` part whose `approval` isn't a `ToolApprovalResponded` fails loudly.
+
+    Regression for #7041: `ToolApproval` is an undiscriminated union, so an approval object
+    that omits `approved` parsed as `ToolApprovalRequested` and was silently dropped by
+    `iter_tool_approval_responses` — the client's approval turn vanished, the pending tool
+    call was stripped from history, and the run finished looking like success. An
+    `approval-responded` part now requires a real response, so malformed shapes (missing
+    `approved`, or `null`/omitted) fail validation at `build_run_input` instead.
+    """
+    data = {
+        'trigger': 'submit-message',
+        'id': 'req_123',
+        'messages': [
+            {'id': 'msg_1', 'role': 'assistant', 'parts': [{**approval_part, 'approval': malformed_approval}]}
+        ],
+    }
+
+    with pytest.raises(ValidationError):
+        VercelAIAdapter.build_run_input(json.dumps(data).encode())
+
+
+@pytest.mark.parametrize(
+    'approval_part, expected',
+    [
+        (
+            {
+                'type': 'dynamic-tool',
+                'toolName': 'delete_file',
+                'toolCallId': 'delete_1',
+                'state': 'approval-responded',
+                'input': {'path': 'test.txt'},
+            },
+            DynamicToolApprovalRespondedPart,
+        ),
+        (
+            {
+                'type': 'tool-delete_file',
+                'toolCallId': 'delete_1',
+                'state': 'approval-responded',
+                'input': {'path': 'test.txt'},
+            },
+            ToolApprovalRespondedPart,
+        ),
+    ],
+)
+def test_build_run_input_accepts_valid_approval_responded(approval_part, expected):
+    """A well-formed `approval-responded` part keeps its approval through `build_run_input`."""
+    data = {
+        'trigger': 'submit-message',
+        'id': 'req_123',
+        'messages': [
+            {
+                'id': 'msg_1',
+                'role': 'assistant',
+                'parts': [
+                    {**approval_part, 'approval': {'id': 'a1', 'approved': False, 'reason': 'nope'}}
+                ],
+            }
+        ],
+    }
+
+    run_input = VercelAIAdapter.build_run_input(json.dumps(data).encode())
+
+    assert isinstance(run_input, SubmitMessage)
+    part = run_input.messages[0].parts[0]
+    assert isinstance(part, expected)
+    assert part.approval == ToolApprovalResponded(id='a1', approved=False, reason='nope')
+
+
+@pytest.mark.parametrize(
     'part',
     [
         {'state': 'input-streaming', 'input': '{"query":'},

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -287,10 +287,8 @@ def test_build_run_input_accepts_valid_approval_responded(approval_part, expecte
             {
                 'id': 'msg_1',
                 'role': 'assistant',
-                'parts': [
-                    {**approval_part, 'approval': {'id': 'a1', 'approved': False, 'reason': 'nope'}}
-                ],
-            }
+                'parts': [{**approval_part, 'approval': {'id': 'a1', 'approved': False, 'reason': 'nope'}}],
+            },
         ],
     }
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -112,6 +112,7 @@ with try_import() as starlette_import_successful:
         TextUIPart,
         ToolApprovalRequested,
         ToolApprovalResponded,
+        ToolApprovalRespondedPart,
         ToolInputAvailablePart,
         ToolInputStreamingPart,
         ToolOutputAvailablePart,
@@ -232,7 +233,9 @@ def test_reasoning_part_id_serialization():
     ],
 )
 @pytest.mark.parametrize('malformed_approval', [{'id': 'a1'}, None])
-def test_build_run_input_rejects_malformed_approval_responded(approval_part, malformed_approval):
+def test_build_run_input_rejects_malformed_approval_responded(
+    approval_part: dict[str, object], malformed_approval: dict[str, object] | None
+):
     """An `approval-responded` part whose `approval` isn't a `ToolApprovalResponded` fails loudly.
 
     Regression for #7041: `ToolApproval` is an undiscriminated union, so an approval object
@@ -278,7 +281,10 @@ def test_build_run_input_rejects_malformed_approval_responded(approval_part, mal
         ),
     ],
 )
-def test_build_run_input_accepts_valid_approval_responded(approval_part, expected):
+def test_build_run_input_accepts_valid_approval_responded(
+    approval_part: dict[str, object],
+    expected: type[DynamicToolApprovalRespondedPart] | type[ToolApprovalRespondedPart],
+):
     """A well-formed `approval-responded` part keeps its approval through `build_run_input`."""
     data = {
         'trigger': 'submit-message',


### PR DESCRIPTION
Fixes #7041

## Problem

A Vercel AI v6 client that sends an `approval-responded` part whose `approval` is missing or malformed (e.g. `{"id": "a1"}` with no `approved` flag) is silently accepted and then dropped:

- `ToolApproval = ToolApprovalRequested | ToolApprovalResponded` is an undiscriminated union, so `{"id": "a1"}` parses as the first member, `ToolApprovalRequested`.
- `iter_tool_approval_responses` skips anything that isn't a `ToolApprovalResponded`, so the pending `ToolCallPart` is stripped and the run looks like a success — the approval just vanishes.

A response that isn't a response should be a loud error, not a silent no-op.

## Change

Make `approval` a required `ToolApprovalResponded` on the two parts that carry an approval response:

- `ToolApprovalRespondedPart`
- `DynamicToolApprovalRespondedPart`

Malformed approvals now produce a 422 `ValidationError` at `build_run_input` parse time instead of being silently dropped:

| Client payload | Before | After |
| --- | --- | --- |
| `{"id": "a1"}` | silently dropped | 422 `ValidationError` |
| `null` / omitted | silently dropped | 422 `ValidationError` (required) |
| `{"id": "a1", "reason": "nope"}` | 422 `ValidationError` | 422 `ValidationError` |
| `{"id": "a1", "approved": false, "reason": "nope"}` | valid, call kept | valid, call kept |

## Tests

Added parametrized tests covering both part shapes (`dynamic-tool` and `tool-<name>`) with malformed approvals (missing `approved`, `null`) asserting a `ValidationError`, plus a positive test asserting a valid `ToolApprovalResponded` parses and round-trips.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

