### PR TITLE
Flag retired GitHub Models in the models overview list

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -23,7 +23,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 - [Azure AI Foundry](openai.md#azure-ai-foundry)
 - [DeepSeek](openai.md#deepseek)
 - [Fireworks AI](openai.md#fireworks-ai)
-- [GitHub Models](openai.md#github-models)
+- [GitHub Models](openai.md#github-models) (retired, deprecated)
 - [Heroku](openai.md#heroku-ai)
 - [LiteLLM](openai.md#litellm)
 - [Nebius AI Studio](openai.md#nebius-ai-studio)


### PR DESCRIPTION
#7047 deprecated `GitHubProvider` after GitHub Models was retired on July 30, 2026, and added a note to that effect in `docs/models/openai.md`. The models overview still lists GitHub Models in the OpenAI-compatible providers list though, under text that says these providers "can be used with `OpenAIChatModel`", so someone scanning that list to pick a provider gets no signal that this one is gone.

Added a short "(retired, deprecated)" marker to the list entry, keeping the link so the explanation in `docs/models/openai.md#github-models` stays one click away.

I kept the entry rather than deleting it because #7047 chose to keep the openai.md section with an explanatory note instead of removing it, and dropping the list item would leave that section unreachable from the overview. Happy to remove the line entirely instead if you would rather the overview only list currently-usable providers.

Ran `uv run mkdocs build --strict`: no new warnings, and the `#github-models` anchor it points at still exists.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: put this together with Claude Code and checked the diff myself. freshman contributor, so if the wording should match some house convention for retired providers, tell me and I will fix it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

