### PR TITLE
Drop the bound on the Temporal payload `TypeAdapter` cache

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 from typing import Any
 
 from pydantic import TypeAdapter
@@ -13,7 +13,7 @@ from temporalio.contrib.pydantic import (
 from temporalio.converter import CompositePayloadConverter, DefaultPayloadConverter, JSONPlainPayloadConverter
 
 
-@lru_cache(maxsize=None)  # noqa: UP033
+@cache
 def _type_adapter(type_hint: Any) -> TypeAdapter[Any]:
     """Build an adapter once for each type hint.
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
@@ -13,14 +13,14 @@ from temporalio.contrib.pydantic import (
 from temporalio.converter import CompositePayloadConverter, DefaultPayloadConverter, JSONPlainPayloadConverter
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=None)  # noqa: UP033
 def _type_adapter(type_hint: Any) -> TypeAdapter[Any]:
-    """Build an adapter once for each recently used type hint.
+    """Build an adapter once for each type hint.
 
     The cache is replay-safe: a `TypeAdapter` is a pure function of its type hint, so cache hits and
-    misses validate identically and cannot change workflow history. The 128-entry bound comfortably
-    covers the code-defined set of hints used by a worker while preventing accidental growth if an
-    application constructs hints dynamically.
+    misses validate identically and cannot change workflow history. The cache is unbounded because
+    type hints come from annotations on registered workflows and activities, so its key space is
+    fixed by code rather than growing with traffic.
     """
     return TypeAdapter(type_hint)
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_payload_converter.py
@@ -18,9 +18,15 @@ def _type_adapter(type_hint: Any) -> TypeAdapter[Any]:
     """Build an adapter once for each type hint.
 
     The cache is replay-safe: a `TypeAdapter` is a pure function of its type hint, so cache hits and
-    misses validate identically and cannot change workflow history. The cache is unbounded because
-    type hints come from annotations on registered workflows and activities, so its key space is
-    fixed by code rather than growing with traffic.
+    misses validate identically and cannot change workflow history.
+
+    It is deliberately unbounded. Hints reach it from workflow and activity signatures and from
+    explicit `result_type=` arguments, all of which are written in application code, so the key space
+    is fixed by the code rather than growing with traffic. Bounding it is the wrong tool: an LRU
+    smaller than the set of hints a worker cycles through has a 0% hit rate, because each lookup
+    evicts the entry needed next, so it pays the full `TypeAdapter` build on every payload — the
+    problem this cache exists to solve (#7027). An application that builds new type objects per
+    request should reuse them instead, as each distinct hint is retained for the life of the worker.
     """
     return TypeAdapter(type_hint)
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -5596,6 +5596,22 @@ async def test_pydantic_ai_payload_converter_builds_type_adapter_once() -> None:
     assert type_adapter.call_count == 1
 
 
+async def test_pydantic_ai_payload_converter_reuses_more_than_128_type_adapters() -> None:
+    """Cyclic access over 129 distinct hints does not rebuild adapters after warmup."""
+    temporal_payload_converter._type_adapter.cache_clear()  # pyright: ignore[reportPrivateUsage]
+    hints = [type(f'Result{i}', (BaseModel,), {'__annotations__': {'v': int}}) for i in range(129)]
+
+    for hint in hints:
+        temporal_payload_converter._type_adapter(hint)  # pyright: ignore[reportPrivateUsage]
+
+    misses_after_warmup = temporal_payload_converter._type_adapter.cache_info().misses  # pyright: ignore[reportPrivateUsage]
+    for _ in range(3):
+        for hint in hints:
+            temporal_payload_converter._type_adapter(hint)  # pyright: ignore[reportPrivateUsage]
+
+    assert temporal_payload_converter._type_adapter.cache_info().misses == misses_after_warmup  # pyright: ignore[reportPrivateUsage]
+
+
 async def test_pydantic_ai_payload_converter_separates_type_hints() -> None:
     """Different hints use distinct adapters and preserve their respective output types."""
     temporal_payload_converter._type_adapter.cache_clear()  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
- Closes #7027

#7001 memoized the per-payload `TypeAdapter` build behind `lru_cache(maxsize=128)`. An LRU under cyclic access over a working set larger than its bound has a **0% hit rate** — every lookup evicts the entry needed next — so the memo does nothing precisely on the workers large enough to have needed it, while still paying the bookkeeping.

The cliff is at **+1 over the bound**, not gradual:

| distinct type hints | adapter rebuilds over 10 full passes |
|---|---:|
| 120 | 0 |
| 129 | 1290 |
| 153 | 1530 |

On the reporter's worker the key space is 153 hints: 59 from application activities, 53 from workflow run/signal/query/update slots, and 41 from the 188 activities `TemporalDurability` itself generates across 37 agent plugins. Our own generated activities are a third of what overflows the bound, and they are what carry `CallToolResult` — the annotation the memo exists for.

Measured on that annotation (an `Annotated[...]` discriminated union): 2.818 ms to build versus 0.005 ms to validate, 521×. One workflow activation resolving a 792-result tool fan-out spent 11.935 s of 12.089 s in `TypeAdapter.__init__`, exceeded Temporal's deadlock-detection ceiling, had the identical batch redelivered, and failed identically — one run made no progress for 2 h 42 m.

The cache is now unbounded, via `functools.cache`. The key space is closed: type hints come from annotations on registered workflows and activities, so it is fixed by code rather than growing with traffic, and a cache that cannot grow with load does not need a bound. The docstring's previous justification (guarding against dynamically constructed hints) is replaced accordingly; the replay-safety note is unchanged, and remains true — a `TypeAdapter` is a pure function of its type hint, so hits and misses validate identically.

Raising the bound to a larger number was considered and rejected: it only moves an invisible cliff. A configurable `maxsize` was also rejected, as adding public API to fix a bug leaves the default silently broken for anyone who does not know to change it.

The regression test exercises the cyclic-access property specifically: 129 distinct hints, warmed once, then three further full passes asserting zero additional cache misses. Verified to fail against the old bound (387 of 387 post-warmup lookups missed).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

