### PR TITLE
Preserve the host's Pydantic AI instrumentation in the Temporal `LogfirePlugin`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
@@ -23,11 +23,15 @@ def _default_setup_logfire() -> Logfire:
     # with a public accessor (e.g. `is_configured()`) if one is added.
     if not instance.config._initialized:  # pyright: ignore[reportPrivateUsage]
         instance = logfire.configure()
-    # `instrument_pydantic_ai()` also replaces rather than merges the process-wide settings, so
-    # calling it unconditionally would discard the host's `include_content`, `include_binary_content`,
-    # and `version` choices. Only instrument if the host hasn't already.
     from pydantic_ai import Agent
 
+    # `instrument_pydantic_ai()` is likewise a replace, not a merge: with no arguments it builds a
+    # default `InstrumentationSettings` and assigns it to the process-wide `Agent._instrument_default`.
+    # Calling it unconditionally would turn a host's deliberate `include_content=False` back on, putting
+    # prompts, completions and tool call results on exported spans. Only instrument if the host hasn't.
+    # `False` is the "never instrumented" sentinel, so a host that explicitly called
+    # `Agent.instrument_all(False)` is indistinguishable from one that never called it and is still
+    # instrumented here; telling those apart would need a separate sentinel.
     if Agent._instrument_default is False:  # pyright: ignore[reportPrivateUsage]
         instance.instrument_pydantic_ai()
     return instance

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
@@ -23,7 +23,13 @@ def _default_setup_logfire() -> Logfire:
     # with a public accessor (e.g. `is_configured()`) if one is added.
     if not instance.config._initialized:  # pyright: ignore[reportPrivateUsage]
         instance = logfire.configure()
-    instance.instrument_pydantic_ai()
+    # `instrument_pydantic_ai()` also replaces rather than merges the process-wide settings, so
+    # calling it unconditionally would discard the host's `include_content`, `include_binary_content`,
+    # and `version` choices. Only instrument if the host hasn't already.
+    from pydantic_ai import Agent
+
+    if Agent._instrument_default is False:  # pyright: ignore[reportPrivateUsage]
+        instance.instrument_pydantic_ai()
     return instance
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -149,6 +149,7 @@ try:
         PydanticAIWorkflow,
         TemporalAgent,  # pyright: ignore[reportDeprecated]
         TemporalDurability,
+        _logfire as temporal_logfire,  # pyright: ignore[reportPrivateUsage]
         _payload_converter as temporal_payload_converter,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.durable_exec.temporal._activity_execution import (
@@ -3325,6 +3326,23 @@ async def test_logfire_plugin_default_setup(client: Client, monkeypatch: pytest.
 
     assert configure_calls == ([] if already_configured else [{}])
     assert instrumented == [instance]
+
+
+def test_logfire_plugin_default_setup_preserves_instrumentation(monkeypatch: pytest.MonkeyPatch):
+    settings = InstrumentationSettings(include_content=False, include_binary_content=False)
+    monkeypatch.setattr(Agent, '_instrument_default', settings)
+
+    temporal_logfire._default_setup_logfire()  # pyright: ignore[reportPrivateUsage]
+
+    assert Agent._instrument_default is settings  # pyright: ignore[reportPrivateUsage]
+
+
+def test_logfire_plugin_default_setup_instruments_by_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(Agent, '_instrument_default', False)
+
+    temporal_logfire._default_setup_logfire()  # pyright: ignore[reportPrivateUsage]
+
+    assert isinstance(Agent._instrument_default, InstrumentationSettings)  # pyright: ignore[reportPrivateUsage]
 
 
 hitl_agent = Agent(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -3328,21 +3328,44 @@ async def test_logfire_plugin_default_setup(client: Client, monkeypatch: pytest.
     assert instrumented == [instance]
 
 
-def test_logfire_plugin_default_setup_preserves_instrumentation(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize('already_instrumented', [True, False])
+def test_logfire_plugin_default_setup_preserves_instrumentation(
+    monkeypatch: pytest.MonkeyPatch, already_instrumented: bool
+):
+    """The default setup leaves a host's own Pydantic AI instrumentation settings alone.
+
+    `instrument_pydantic_ai()` replaces rather than merges `Agent._instrument_default`, so calling it
+    unconditionally turned a deliberate `include_content=False` back on, putting prompts, completions
+    and tool call results on exported spans. A host that hasn't instrumented is still instrumented.
+
+    As in `test_logfire_plugin_default_setup` above, `logfire.DEFAULT_LOGFIRE_INSTANCE`, `configure`
+    and `instrument_pydantic_ai` are swapped for stand-ins so the assertions neither depend on nor
+    disturb whatever configuration the rest of the test session has installed globally.
+    """
+    instance = Logfire(config=LogfireConfig())
+    monkeypatch.setattr(logfire, 'DEFAULT_LOGFIRE_INSTANCE', instance)
+
+    instrumented: list[Logfire] = []
+
+    def configure(**kwargs: Any) -> Logfire:
+        return instance
+
+    def instrument_pydantic_ai(self: Logfire, *args: Any, **kwargs: Any) -> None:
+        instrumented.append(self)
+
+    monkeypatch.setattr(logfire, 'configure', configure)
+    monkeypatch.setattr(Logfire, 'instrument_pydantic_ai', instrument_pydantic_ai)
+
     settings = InstrumentationSettings(include_content=False, include_binary_content=False)
-    monkeypatch.setattr(Agent, '_instrument_default', settings)
+    monkeypatch.setattr(Agent, '_instrument_default', settings if already_instrumented else False)
 
     temporal_logfire._default_setup_logfire()  # pyright: ignore[reportPrivateUsage]
 
-    assert Agent._instrument_default is settings  # pyright: ignore[reportPrivateUsage]
-
-
-def test_logfire_plugin_default_setup_instruments_by_default(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(Agent, '_instrument_default', False)
-
-    temporal_logfire._default_setup_logfire()  # pyright: ignore[reportPrivateUsage]
-
-    assert isinstance(Agent._instrument_default, InstrumentationSettings)  # pyright: ignore[reportPrivateUsage]
+    # With a stand-in in place, whether the plugin instruments at all is the observable: the stand-in
+    # deliberately doesn't assign `_instrument_default`, so asserting on it here would prove nothing.
+    assert instrumented == ([] if already_instrumented else [instance])
+    if already_instrumented:
+        assert Agent._instrument_default is settings  # pyright: ignore[reportPrivateUsage]
 
 
 hitl_agent = Agent(


### PR DESCRIPTION
Follow-up to #6962, reported on #6915 after that fix landed.

#6962 stopped `LogfirePlugin`'s default setup from resetting the host's **Logfire** configuration. The same function still resets the host's **Pydantic AI instrumentation** configuration, which for a privacy-configured host is the more consequential half:

```python
def _default_setup_logfire() -> Logfire:
    ...
    instance.instrument_pydantic_ai()   # unconditional
```

`instrument_pydantic_ai()` with no arguments builds a default `InstrumentationSettings` and assigns it to the process-wide `Agent._instrument_default`. So an application that deliberately turned message-content capture off gets it turned back on the first time it connects a Temporal client with `LogfirePlugin()`:

```
before: False False
after:  True True
```

`include_content=True` puts system prompts, user prompts, model responses and tool call results on exported spans. Applications whose prompts are built from user documents set `include_content=False` on purpose, and a durable-execution plugin is not where anyone looks for it being undone. It is silent, and the host's own explicit call ran earlier and appeared to take effect.

The plugin now only instruments when the host has not. When the host has, its settings are left exactly as they are.

Note that `Agent._instrument_default`'s "never instrumented" sentinel is `False`, not `None` — a guard written against `None` would never fire. One consequence is worth stating: a host that explicitly calls `Agent.instrument_all(False)` is indistinguishable from one that never called it, and is still instrumented here. Distinguishing them needs a separate sentinel on `_instrument_default`, which is public API and out of scope for this fix; the code comment records it.

This does not change the behaviour that motivated the plugin's instrumentation call in the first place: a host that has not configured anything still gets Pydantic AI instrumented on connect. Both directions are covered by tests, which save and restore `Agent._instrument_default` — the suite's own `client_with_logfire` fixture reconfigures Logfire mid-run, which is part of why this stayed invisible.

#7006 carries the same defect on its replay-safe path, where skipping the call is not an option because the spans must reach the replay-safe tracer provider. It is fixed there separately, by preserving the host's settings and overriding only the tracer.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

