### PR TITLE
Close unassigned contributor PRs in `PR Guard`

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -154,6 +154,27 @@ jobs:
           fi
           PR_CREATED_EPOCH=$(date -u -d "$GITHUB_EVENT_PULL_REQUEST_CREATED_AT" +%s)
 
+          DOCS_ONLY_STATUS=""
+          classify_changed_files() {
+            if [ -n "$DOCS_ONLY_STATUS" ]; then
+              return
+            fi
+
+            local changed_files changed_file
+            if ! changed_files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100" --paginate --jq '.[].filename') || [ -z "$changed_files" ]; then
+              DOCS_ONLY_STATUS="unknown"
+              return
+            fi
+
+            DOCS_ONLY_STATUS="docs_only"
+            while IFS= read -r changed_file; do
+              case "$changed_file" in
+                docs/*|*.md|mkdocs.yml) ;;
+                *) DOCS_ONLY_STATUS="not_docs"; return ;;
+              esac
+            done <<< "$changed_files"
+          }
+
           # Helper: close a contributor PR that doesn't link to any existing issue.
           # Only external contributors reach this point (maintainers/collaborators
           # bypass above). Exemptions:
@@ -167,21 +188,12 @@ jobs:
                 ;;
             esac
 
-            # If the changed files can't be determined, err on the side of leaving
-            # the PR open: closing is destructive and the docs-only exemption
-            # can't be ruled out.
-            if ! CHANGED_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100" --paginate --jq '.[].filename') || [ -z "$CHANGED_FILES" ]; then
+            classify_changed_files
+            if [ "$DOCS_ONLY_STATUS" = "unknown" ]; then
               echo "Could not determine changed files; not closing for missing issue link."
               return 0
             fi
-            DOCS_ONLY="true"
-            while IFS= read -r CHANGED_FILE; do
-              case "$CHANGED_FILE" in
-                docs/*|*.md|mkdocs.yml) ;;
-                *) DOCS_ONLY="false"; break ;;
-              esac
-            done <<< "$CHANGED_FILES"
-            if [ "$DOCS_ONLY" = "true" ]; then
+            if [ "$DOCS_ONLY_STATUS" = "docs_only" ]; then
               echo "PR only touches documentation; not closing for missing issue link."
               return 0
             fi
@@ -274,16 +286,27 @@ jobs:
             # Contributors should discuss and be assigned an issue before opening
             # a PR. Issue and bot authors are exempt from this requirement.
             if [ "$PR_AUTHOR" != "$ISSUE_AUTHOR" ] && [[ "$PR_AUTHOR" != *"[bot]" ]]; then
-              ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
-              if ! echo ",$ASSIGNEES," | grep -qF ",${PR_AUTHOR},"; then
-                echo "Closing PR #${PR_NUMBER} — issue #${ISSUE_NUM} is not assigned to ${PR_AUTHOR}."
-                COMMENT=$(printf '%s\n\n%s' \
-                  "Thanks for your interest in this issue! To avoid duplicate effort, please wait to be assigned before opening a PR." \
-                  "This PR has been closed automatically because [issue #${ISSUE_NUM}](https://github.com/${REPO}/issues/${ISSUE_NUM}) is not assigned to you. If you believe this was closed in error, please comment on the issue and a maintainer can reassess.")
-                gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
-                gh pr close "$PR_NUMBER" --repo "$REPO"
-                exit 0
-              fi
+              classify_changed_files
+              case "$DOCS_ONLY_STATUS" in
+                unknown)
+                  echo "Could not determine changed files; not closing for missing issue assignment."
+                  ;;
+                docs_only)
+                  echo "PR only touches documentation; not requiring issue assignment."
+                  ;;
+                not_docs)
+                  ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
+                  if ! echo ",$ASSIGNEES," | grep -qF ",${PR_AUTHOR},"; then
+                    echo "Closing PR #${PR_NUMBER} — issue #${ISSUE_NUM} is not assigned to ${PR_AUTHOR}."
+                    COMMENT=$(printf '%s\n\n%s' \
+                      "Thanks for your interest in this issue! To avoid duplicate effort, please wait to be assigned before opening a PR." \
+                      "This PR has been closed automatically because [issue #${ISSUE_NUM}](https://github.com/${REPO}/issues/${ISSUE_NUM}) is not assigned to you. If you believe this was closed in error, please comment on the issue and a maintainer can reassess.")
+                    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
+                    gh pr close "$PR_NUMBER" --repo "$REPO"
+                    exit 0
+                  fi
+                  ;;
+              esac
             fi
 
             # Check for duplicate/blocking PRs after validating issue ownership.

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -241,22 +241,6 @@ jobs:
 
           echo "Found linked issues: $ISSUE_NUMBERS"
 
-          # Helper: attempt to assign a user to an issue.
-          # GitHub silently ignores assignees who lack push access (returns 201 but doesn't add them).
-          # We check assignability first via GET /repos/{owner}/{repo}/assignees/{user} (204 = yes, 404 = no).
-          try_assign() {
-            local issue_num="$1"
-            local user="$2"
-            if gh api "repos/${REPO}/assignees/${user}" > /dev/null 2>&1; then
-              gh api "repos/${REPO}/issues/${issue_num}/assignees" --method POST -f "assignees[]=${user}" > /dev/null
-              echo "Assigned ${user} to issue #${issue_num}."
-              return 0
-            else
-              echo "Cannot assign ${user} to issue #${issue_num} (user is not assignable to this repo)."
-              return 1
-            fi
-          }
-
           FOUND_OPEN_ISSUE="false"
           FOUND_CLOSED_ISSUE="false"
           for ISSUE_NUM in $ISSUE_NUMBERS; do
@@ -287,7 +271,22 @@ jobs:
             FOUND_OPEN_ISSUE="true"
             ISSUE_AUTHOR=$(echo "$ISSUE_JSON" | jq -r '.user.login')
 
-            # Check for duplicate/blocking PRs first — this must run regardless of assignment outcome.
+            # Contributors should discuss and be assigned an issue before opening
+            # a PR. Issue and bot authors are exempt from this requirement.
+            if [ "$PR_AUTHOR" != "$ISSUE_AUTHOR" ] && [[ "$PR_AUTHOR" != *"[bot]" ]]; then
+              ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
+              if ! echo ",$ASSIGNEES," | grep -qF ",${PR_AUTHOR},"; then
+                echo "Closing PR #${PR_NUMBER} — issue #${ISSUE_NUM} is not assigned to ${PR_AUTHOR}."
+                COMMENT=$(printf '%s\n\n%s' \
+                  "Thanks for your interest in this issue! To avoid duplicate effort, please wait to be assigned before opening a PR." \
+                  "This PR has been closed automatically because [issue #${ISSUE_NUM}](https://github.com/${REPO}/issues/${ISSUE_NUM}) is not assigned to you. If you believe this was closed in error, please comment on the issue and a maintainer can reassess.")
+                gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
+                gh pr close "$PR_NUMBER" --repo "$REPO"
+                exit 0
+              fi
+            fi
+
+            # Check for duplicate/blocking PRs after validating issue ownership.
             # As with the current PR's linked issues, ask GitHub which open PRs
             # would close this issue instead of regex-matching PR bodies, so all
             # closing syntaxes (and manually linked PRs) are recognized. Bot
@@ -391,18 +390,6 @@ jobs:
               echo "All existing PRs for issue #${ISSUE_NUM} are stale. Allowing new PR."
             fi
 
-            # Now handle assignment (best-effort, does not gate duplicate check above)
-            ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
-            echo "Current assignees: ${ASSIGNEES:-none}"
-
-            if [ -z "$ASSIGNEES" ]; then
-              # No assignee — attempt to assign PR author (may fail if user lacks push access)
-              try_assign "$ISSUE_NUM" "$PR_AUTHOR" || true
-            elif echo ",$ASSIGNEES," | grep -qF ",${PR_AUTHOR},"; then
-              echo "Issue #${ISSUE_NUM} is already assigned to ${PR_AUTHOR}."
-            else
-              echo "Issue #${ISSUE_NUM} is assigned to someone else. Leaving assignment as-is for maintainers to review."
-            fi
           done
 
           # If none of the referenced numbers resolved to an actual issue (open or


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

Closes #7090

## Summary

- close external contributor PRs whose linked issue is neither authored by nor assigned to them
- preserve maintainer, issue-author, and bot exemptions
- remove the ineffective post-open assignment attempt

## Verification

- `make format && make lint` — pass
- workflow YAML and embedded Bash syntax — pass
- ownership-policy shell matrix — pass
- independent pre-push review — pass

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

