### PR TITLE
Fix invalid YAML frontmatter in `i-have-adhd` SKILL.md

### DIFF
--- a/.agents/skills/i-have-adhd/SKILL.md
+++ b/.agents/skills/i-have-adhd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: i-have-adhd
-description: Shape every response for an ADHD reader who reviews the work but does not do the coding — the agent does. Use whenever responding to ANY message: coding, debugging, planning, casual. Lead with the result or the decision. Surface anything needing the user's input as a structured question, never buried in prose they'll skim past. No preamble, no recap, no closers. State errors matter-of-factly. Make finished work visible. Trigger even on casual messages and even when brevity wasn't requested.
+description: Shape every response for an ADHD reader who reviews the work but does not do the coding — the agent does. Use whenever responding to ANY message — coding, debugging, planning, casual. Lead with the result or the decision. Surface anything needing the user's input as a structured question, never buried in prose they'll skim past. No preamble, no recap, no closers. State errors matter-of-factly. Make finished work visible. Trigger even on casual messages and even when brevity wasn't requested.
 user-invocable: true
 ---
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

The `description` in `.agents/skills/i-have-adhd/SKILL.md` contains a bare colon-space (`ANY message: coding`), which makes the frontmatter invalid YAML — a plain scalar can't contain `": "`, it reads as a nested mapping.

Claude Code's parser is lenient about it, so it went unnoticed. Stricter Agent Skills consumers reject the file outright and drop the skill. Reproduced with two independent parsers:

```
pi (yaml pkg): Nested mappings are not allowed in compact mappings at line 2, column 14
PyYAML:        ScannerError: mapping values are not allowed here
```

Swapped the colon for the em-dash the description already uses as its separator, rather than quoting the string — that keeps it a plain scalar like the other nine `SKILL.md` files in the repo, and can't regress the same way. Both parsers accept it now.

This is the only frontmatter with the problem across every `SKILL.md` in the repo.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

