### PR TITLE
Close async streams on teardown instead of waiting for the garbage collector

### DIFF
--- a/docs/capabilities/custom.md
+++ b/docs/capabilities/custom.md
@@ -687,6 +687,8 @@ For runs with event streaming ([`run_stream_events`][pydantic_ai.agent.AbstractA
 
 The hook wraps the stream where it's produced, so it fires for every drive mode: [`agent.run()`][pydantic_ai.agent.AbstractAgent.run] (which enables streaming automatically when this hook is registered), [`agent.run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream], and [`agent.iter()`][pydantic_ai.agent.Agent.iter] — whether you advance it with `async for node in agent_run:`, with [`agent_run.next()`][pydantic_ai.run.AgentRun.next], or by [streaming a node yourself](../agent.md#streaming-all-events). Events a capability drops or adds are reflected in what a manual `node.stream()` consumer sees, the same as for any other consumer.
 
+When a consumer closes the event stream before exhausting it, Pydantic AI also closes each wrapper returned by `wrap_run_event_stream` if it provides an `aclose()` method. Custom wrappers should use `try`/`finally` for teardown and may safely await cleanup there, but must not yield events while handling `GeneratorExit` because the consumer has gone away.
+
 !!! warning "A processor shapes the whole stream, not just the handler's view"
     The run has one event stream, so a capability that drops or rewrites events changes what *every*
     consumer sees — including the text an [`agent.run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream]

--- a/docs/capabilities/custom.md
+++ b/docs/capabilities/custom.md
@@ -689,6 +689,8 @@ The hook wraps the stream where it's produced, so it fires for every drive mode:
 
 When a consumer closes the event stream before exhausting it, Pydantic AI also closes each wrapper returned by `wrap_run_event_stream` if it provides an `aclose()` method. Custom wrappers should use `try`/`finally` for teardown and may safely await cleanup there, but must not yield events while handling `GeneratorExit` because the consumer has gone away.
 
+Because a wrapper that closes its own input and a composed capability that closes every wrapper it built can both reach the same stream, `aclose()` may be called more than once. Async generators are idempotent here, so a `try`/`finally` wrapper needs nothing extra; a wrapper implementing `aclose()` by hand should make repeat calls a no-op.
+
 !!! warning "A processor shapes the whole stream, not just the handler's view"
     The run has one event stream, so a capability that drops or rewrites events changes what *every*
     consumer sees — including the text an [`agent.run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream]

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -375,6 +375,13 @@ async def _cleanup_temporal_group(
         await aclose()
 
 
+async def aclose_if_supported(stream: AsyncIterable[Any]) -> None:
+    """Close an async iterable if it exposes an `aclose` method."""
+    aclose: Callable[[], Awaitable[None]] | None = getattr(stream, 'aclose', None)
+    if aclose is not None:
+        await aclose()
+
+
 @asynccontextmanager
 async def group_by_temporal(
     aiterable: AsyncIterable[T], soft_max_interval: float | None
@@ -544,12 +551,12 @@ class PeekableAsyncStream(Generic[T, SourceT]):
         self._source_iter: AsyncIterator[T] | None = None
         self._buffer: T | Unset = UNSET
         self._exhausted = False
-        # Serialize access to the underlying source so `aclose()` waits for any in-flight `__anext__`/
-        # `peek()` to finish before closing it. A debounced consumer (`group_by_temporal`) prefetches the
-        # next item in a background task, so the source generator can be mid-`anext` when the stream is
-        # abandoned (an early `break` or an exception in the consumer body); closing it then would raise
-        # `RuntimeError: aclose(): asynchronous generator is already running`.
+        # Serialize access to the underlying source so cancelling an in-flight pull releases the lock before
+        # `aclose()` closes it. A debounced consumer (`group_by_temporal`) prefetches the next item in a background
+        # task, so the source generator can be mid-`anext` when the stream is abandoned; closing it concurrently
+        # would raise `RuntimeError: aclose(): asynchronous generator is already running`.
         self._source_lock = anyio.Lock()
+        self._pull_scopes: set[anyio.CancelScope] = set()
 
     async def peek(self) -> T | Unset:
         """Returns the next item that would be yielded without consuming it.
@@ -567,14 +574,22 @@ class PeekableAsyncStream(Generic[T, SourceT]):
         if self._source_iter is None:
             self._source_iter = aiter(self.source)
 
-        async with self._source_lock:
+        with anyio.CancelScope() as scope:
+            self._pull_scopes.add(scope)
             try:
-                self._buffer = await anext(self._source_iter)
-            except StopAsyncIteration:
-                self._exhausted = True
-                return UNSET
+                async with self._source_lock:
+                    try:
+                        self._buffer = await anext(self._source_iter)
+                    except StopAsyncIteration:
+                        self._exhausted = True
+                        return UNSET
+                return self._buffer
+            finally:
+                self._pull_scopes.discard(scope)
 
-        return self._buffer
+        # Only reached when `aclose()` cancelled the scope: the stream is closed, so iteration is over.
+        self._exhausted = True
+        return UNSET
 
     async def is_exhausted(self) -> bool:
         """Returns True if the stream is exhausted, False otherwise."""
@@ -602,22 +617,31 @@ class PeekableAsyncStream(Generic[T, SourceT]):
         if self._source_iter is None:
             self._source_iter = aiter(self.source)
 
-        async with self._source_lock:
+        with anyio.CancelScope() as scope:
+            self._pull_scopes.add(scope)
             try:
-                return await anext(self._source_iter)
-            except StopAsyncIteration:
-                self._exhausted = True
-                raise
+                async with self._source_lock:
+                    try:
+                        return await anext(self._source_iter)
+                    except StopAsyncIteration:
+                        self._exhausted = True
+                        raise
+            finally:
+                self._pull_scopes.discard(scope)
+
+        # Only reached when `aclose()` cancelled the scope: the stream is closed, so iteration is over.
+        self._exhausted = True
+        raise StopAsyncIteration
 
     async def aclose(self) -> None:
         self._exhausted = True
+        for scope in self._pull_scopes:
+            scope.cancel()
         value = self._source_iter if self._source_iter is not None else self.source
-        aclose: Callable[[], Awaitable[None]] | None = getattr(value, 'aclose', None)
-        if aclose is not None:
-            # Wait for any in-flight `__anext__`/`peek()` (e.g. a `group_by_temporal` prefetch task) to
-            # release the source before closing it, so we don't close a generator that's still running.
-            async with self._source_lock:
-                await aclose()
+        # Wait for the cancelled pull to release the source before closing it, so we don't close a
+        # generator that's still running.
+        async with self._source_lock:
+            await aclose_if_supported(value)
 
 
 def get_traceparent(x: AgentRun | AgentRunResult | GraphRun[Any, Any, Any]) -> str:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -382,6 +382,21 @@ async def aclose_if_supported(stream: AsyncIterable[Any]) -> None:
         await aclose()
 
 
+async def aclose_all(streams: Iterable[AsyncIterable[Any]]) -> None:
+    """Close every async iterable, then propagate any close failures."""
+    errors: list[BaseException] = []
+    for stream in streams:
+        try:
+            await aclose_if_supported(stream)
+        except BaseException as error:
+            errors.append(error)
+
+    if len(errors) == 1:
+        raise errors[0]
+    if errors:
+        raise BaseExceptionGroup('Errors closing async iterables', errors)
+
+
 @asynccontextmanager
 async def group_by_temporal(
     aiterable: AsyncIterable[T], soft_max_interval: float | None

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeAlias
 from pydantic import ValidationError
 from typing_extensions import deprecated
 
+from pydantic_ai import _utils
 from pydantic_ai._instructions import AgentInstructions
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.exceptions import ModelRetry
@@ -637,8 +638,11 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         `agent.run()` and [`AgentRun.next()`][pydantic_ai.run.AgentRun.next] automatically enable
         streaming mode so this hook fires even without an explicit `event_stream_handler`.
         """
-        async for event in stream:
-            yield event
+        try:
+            async for event in stream:
+                yield event
+        finally:
+            await _utils.aclose_if_supported(stream)
 
     # --- Model request lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions, normalize_instructions
-from pydantic_ai._utils import gather, replace_no_init
+from pydantic_ai._utils import aclose_if_supported, gather, replace_no_init
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.settings import ModelSettings, merge_model_settings
@@ -396,11 +396,17 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         stream: AsyncIterable[AgentStreamEvent],
     ) -> AsyncIterable[AgentStreamEvent]:
+        wrapped_streams = [stream]
         for capability in reversed(self.capabilities):
             if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
                 stream = capability.wrap_run_event_stream(cap_ctx, stream=stream)
-        async for event in stream:
-            yield event
+                wrapped_streams.append(stream)
+        try:
+            async for event in stream:
+                yield event
+        finally:
+            for wrapped_stream in reversed(wrapped_streams):
+                await aclose_if_supported(wrapped_stream)
 
     # --- Model request lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions, normalize_instructions
-from pydantic_ai._utils import aclose_if_supported, gather, replace_no_init
+from pydantic_ai._utils import aclose_all, gather, replace_no_init
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.settings import ModelSettings, merge_model_settings
@@ -405,8 +405,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
             async for event in stream:
                 yield event
         finally:
-            for wrapped_stream in reversed(wrapped_streams):
-                await aclose_if_supported(wrapped_stream)
+            await aclose_all(reversed(wrapped_streams))
 
     # --- Model request lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -943,18 +943,21 @@ class Hooks(AbstractCapability[AgentDepsT]):
     async def wrap_run_event_stream(
         self, ctx: RunContext[AgentDepsT], *, stream: AsyncIterable[AgentStreamEvent]
     ) -> AsyncIterable[AgentStreamEvent]:
+        wrapped_streams = [stream]
         # First, wrap with per-event callbacks (innermost)
         event_entries = self._get('_on_event')
         if event_entries:
             stream = _event_callback_stream(ctx, stream, event_entries)
+            wrapped_streams.append(stream)
         # Then chain explicit stream wrappers (outermost)
         for entry in reversed(self._get('wrap_run_event_stream')):
             stream = entry.func(ctx, stream=stream)
+            wrapped_streams.append(stream)
         try:
             async for event in stream:
                 yield event
         finally:
-            await _utils.aclose_if_supported(stream)
+            await _utils.aclose_all(reversed(wrapped_streams))
 
     async def before_model_request(
         self, ctx: RunContext[AgentDepsT], request_context: ModelRequestContext

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
 import anyio
 from pydantic import ValidationError
 
+from pydantic_ai import _utils
 from pydantic_ai.exceptions import AgentRunError, ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import AgentDepsT, DeferredToolRequests, DeferredToolResults, RunContext, ToolDefinition
@@ -949,8 +950,11 @@ class Hooks(AbstractCapability[AgentDepsT]):
         # Then chain explicit stream wrappers (outermost)
         for entry in reversed(self._get('wrap_run_event_stream')):
             stream = entry.func(ctx, stream=stream)
-        async for event in stream:
-            yield event
+        try:
+            async for event in stream:
+                yield event
+        finally:
+            await _utils.aclose_if_supported(stream)
 
     async def before_model_request(
         self, ctx: RunContext[AgentDepsT], request_context: ModelRequestContext
@@ -1300,7 +1304,10 @@ async def _event_callback_stream(
     entries: list[_HookEntry[Any]],
 ) -> AsyncIterable[AgentStreamEvent]:
     """Wrap a stream with per-event callbacks that can observe or modify events."""
-    async for event in stream:
-        for entry in entries:
-            event = await _call_entry(entry, 'on_event', ctx, event)
-        yield event
+    try:
+        async for event in stream:
+            for entry in entries:
+                event = await _call_entry(entry, 'on_event', ctx, event)
+            yield event
+    finally:
+        await _utils.aclose_if_supported(stream)

--- a/pydantic_ai_slim/pydantic_ai/capabilities/process_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/process_event_stream.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine
+from collections.abc import AsyncIterable, AsyncIterator, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -125,10 +125,10 @@ class ProcessEventStream(AbstractCapability[AgentDepsT]):
         # wrapped, not a latent bug.
         handler_task = asyncio.create_task(run_handler())
         next_task: asyncio.Task[AgentStreamEvent] | None = None
+        stream_iterator = aiter(stream)
         try:
             async with send_stream:
                 handler_alive = True
-                stream_iterator = aiter(stream)
 
                 async def pull_next() -> AgentStreamEvent:
                     return await anext(stream_iterator)
@@ -145,10 +145,8 @@ class ProcessEventStream(AbstractCapability[AgentDepsT]):
                                 handler_alive = False
                             else:
                                 await _utils.cancel_and_drain(next_task)
-                                aclose: Callable[[], Awaitable[None]] | None = getattr(stream_iterator, 'aclose', None)
                                 try:
-                                    if aclose is not None:
-                                        await aclose()
+                                    await _utils.aclose_if_supported(stream_iterator)
                                 finally:
                                     await handler_task
 
@@ -171,6 +169,7 @@ class ProcessEventStream(AbstractCapability[AgentDepsT]):
             # that task, so it would otherwise advance the source one step past our exit and could
             # still be inside `anext()` when someone else closes that same iterator.
             await _utils.cancel_and_drain(handler_task, *filter(None, (next_task,)))
+            await _utils.aclose_if_supported(stream_iterator)
             raise
 
         # Closing `send_stream` ends the handler's iteration; awaiting it surfaces anything it raised.

--- a/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions
-from pydantic_ai._utils import aclose_if_supported, replace_no_init
+from pydantic_ai._utils import aclose_all, replace_no_init
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import (
@@ -256,7 +256,7 @@ class WrapperCapability(AbstractCapability[AgentDepsT]):
             async for event in wrapped_stream:
                 yield event
         finally:
-            await aclose_if_supported(wrapped_stream)
+            await aclose_all((wrapped_stream, stream))
 
     # --- Model request lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions
-from pydantic_ai._utils import replace_no_init
+from pydantic_ai._utils import aclose_if_supported, replace_no_init
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import (
@@ -251,8 +251,12 @@ class WrapperCapability(AbstractCapability[AgentDepsT]):
         *,
         stream: AsyncIterable[AgentStreamEvent],
     ) -> AsyncIterable[AgentStreamEvent]:
-        async for event in self.wrapped.wrap_run_event_stream(ctx, stream=stream):
-            yield event
+        wrapped_stream = self.wrapped.wrap_run_event_stream(ctx, stream=stream)
+        try:
+            async for event in wrapped_stream:
+                yield event
+        finally:
+            await aclose_if_supported(wrapped_stream)
 
     # --- Model request lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar
 from typing_extensions import Self
 
 from pydantic_ai._run_context import set_current_run_context
-from pydantic_ai._utils import get_union_args
+from pydantic_ai._utils import aclose_if_supported, get_union_args
 from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.capabilities import ProcessEventStream
@@ -173,23 +173,24 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         *,
         stream: AsyncIterable[AgentStreamEvent],
     ) -> AsyncIterable[AgentStreamEvent]:
-        if self._effective_event_stream_handler() is None:
-            async for event in stream:
-                yield event
-            return
-        if not self.in_durable_context:
+        event_stream_handler = self._effective_event_stream_handler()
+        dispatch_events = False
+        if event_stream_handler is not None and not self.in_durable_context:
             assert self._process_event_stream is not None
-            async for event in self._process_event_stream.wrap_run_event_stream(ctx, stream=stream):
-                yield event
-            return
+            stream = self._process_event_stream.wrap_run_event_stream(ctx, stream=stream)
+        elif event_stream_handler is not None:
+            dispatch_events = True
 
-        async for event in stream:
-            # `ModelResponseStreamEvent`s were already delivered
-            # live to the handler inside the model-request boundary; workflow-side they're
-            # the replay, so only `HandleResponseEvent`s are dispatched to the handler here.
-            if not isinstance(event, _MODEL_RESPONSE_STREAM_EVENT_TYPES):
-                await self._dispatch_event_stream_event(ctx, event)
-            yield event
+        try:
+            async for event in stream:
+                # `ModelResponseStreamEvent`s were already delivered live to the handler inside the
+                # model-request boundary; workflow-side they're the replay, so only `HandleResponseEvent`s
+                # are dispatched to the handler here.
+                if dispatch_events and not isinstance(event, _MODEL_RESPONSE_STREAM_EVENT_TYPES):
+                    await self._dispatch_event_stream_event(ctx, event)
+                yield event
+        finally:
+            await aclose_if_supported(stream)
 
     @property
     @abstractmethod

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -66,6 +66,7 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
     _cached_output: OutputDataT | None = field(default=None, init=False)
 
     _anext_lock: anyio.Lock = field(default_factory=anyio.Lock, init=False)
+    _pull_scopes: set[anyio.CancelScope] = field(default_factory=lambda: set[anyio.CancelScope](), init=False)
 
     def __post_init__(self):
         self._initial_run_ctx_usage = deepcopy(self._run_ctx.usage)
@@ -398,21 +399,19 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         The event iterator owns the capability chain, which can otherwise stay suspended with
         resources held, like a `ProcessEventStream` handler task parked on its receive stream.
 
+        Any in-flight shared pull is cancelled and drained before the iterator is closed. The
+        close is shielded because graph teardown can run inside an already-cancelled scope.
+
         The closed iterator is kept in place rather than discarded, so a later `__aiter__()` ends
         immediately instead of building a second chain (and a second handler) over a spent stream.
         """
         events_iterator = self._events_iterator
-        if isinstance(events_iterator, AsyncGenerator):
-            try:
-                self._anext_lock.acquire_nowait()
-            except anyio.WouldBlock:
-                # Waiting here would deadlock if another task is parked in `anext()`, while
-                # closing the iterator concurrently would raise because it is already running.
-                return
-            try:
-                await events_iterator.aclose()
-            finally:
-                self._anext_lock.release()
+        if events_iterator is not None:
+            for scope in self._pull_scopes:
+                scope.cancel()
+            with anyio.CancelScope(shield=True):
+                async with self._anext_lock:
+                    await _utils.aclose_if_supported(events_iterator)
 
     async def _pull_shared(self, events_iterator: AsyncIterator[AgentStreamEvent]) -> AsyncIterator[AgentStreamEvent]:
         # Serialize access to the shared iterator. An early break from stream_text() can leave a
@@ -420,10 +419,19 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         # stream.
         while True:
             async with self._anext_lock:
-                try:
-                    event = await anext(events_iterator)
-                except StopAsyncIteration:
+                event: AgentStreamEvent | None = None
+                with anyio.CancelScope() as scope:
+                    self._pull_scopes.add(scope)
+                    try:
+                        try:
+                            event = await anext(events_iterator)
+                        except StopAsyncIteration:
+                            return
+                    finally:
+                        self._pull_scopes.discard(scope)
+                if scope.cancel_called:
                     return
+                assert event is not None
             yield event
 
     async def _model_response_events(self) -> AsyncIterator[ModelResponseStreamEvent]:

--- a/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
@@ -271,11 +271,13 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
             async for e in self.on_error(exc):
                 yield e
         finally:
-            async for e in self._turn_to(None):
-                yield e
+            await _utils.aclose_if_supported(stream)
 
-            async for e in self.after_stream():
-                yield e
+        async for e in self._turn_to(None):
+            yield e
+
+        async for e in self.after_stream():
+            yield e
 
     async def _turn_to(self, to_turn: Literal['request', 'response'] | None) -> AsyncIterator[EventT]:
         """Fire hooks when turning from request to response or vice versa."""

--- a/tests/test_capability_process_event_stream.py
+++ b/tests/test_capability_process_event_stream.py
@@ -277,6 +277,48 @@ class TestProcessEventStream:
             await torn_down.wait()
         assert state == snapshot('cancelled')
 
+    async def test_referenced_inner_wrapper_does_not_pin_observer(self):
+        """Closing the chain must propagate through a wrapper that retains its input stream."""
+        torn_down = anyio.Event()
+        held_streams: list[AsyncIterable[AgentStreamEvent]] = []
+
+        async def observer(_ctx: RunContext[Any], stream: AsyncIterable[AgentStreamEvent]) -> None:
+            try:
+                async for _event in stream:
+                    pass
+            except asyncio.CancelledError:
+                torn_down.set()
+                raise
+
+        @dataclass
+        class Stasher(AbstractCapability[Any]):
+            async def wrap_run_event_stream(
+                self,
+                ctx: RunContext[Any],
+                *,
+                stream: AsyncIterable[AgentStreamEvent],
+            ) -> AsyncIterable[AgentStreamEvent]:
+                held_streams.append(stream)
+                async for event in stream:
+                    yield event
+
+        agent = Agent(
+            FunctionModel(simple_model_function, stream_function=simple_stream_function),
+            capabilities=[Stasher(), ProcessEventStream(handler=observer)],
+        )
+
+        async with agent.iter('hello') as agent_run:
+            node = agent_run.next_node
+            while not Agent.is_model_request_node(node):
+                assert not isinstance(node, End)
+                node = await agent_run.next(node)
+            async with node.stream(agent_run.ctx) as stream:
+                await anext(aiter(stream))
+
+        assert held_streams
+        with anyio.fail_after(5):
+            await torn_down.wait()
+
     @pytest.mark.parametrize('consumer_error', [False, True])
     async def test_abandoned_call_tools_stream_tears_down_the_handler(self, consumer_error: bool):
         """Leaving a response-handling stream closes its memoized capability chain."""

--- a/tests/test_capability_process_event_stream.py
+++ b/tests/test_capability_process_event_stream.py
@@ -299,7 +299,7 @@ class TestProcessEventStream:
                 stream: AsyncIterable[AgentStreamEvent],
             ) -> AsyncIterable[AgentStreamEvent]:
                 held_streams.append(stream)
-                async for event in stream:
+                async for event in stream:  # pragma: no branch
                     yield event
 
         agent = Agent(

--- a/tests/test_capability_stream_teardown.py
+++ b/tests/test_capability_stream_teardown.py
@@ -1,0 +1,292 @@
+"""Regression tests for capability event-stream teardown."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator
+from dataclasses import dataclass
+from typing import Any, cast
+
+import anyio
+import pytest
+
+from pydantic_ai import Agent, RunContext, _utils
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability, Hooks, WrapperCapability
+from pydantic_ai.messages import AgentStreamEvent, ModelMessage, PartStartEvent, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+from pydantic_graph import End
+
+pytestmark = pytest.mark.anyio
+
+
+class _TrackingStream(AsyncIterator[AgentStreamEvent]):
+    def __init__(
+        self,
+        name: str,
+        closed: list[str],
+        stream: AsyncIterable[AgentStreamEvent] | None = None,
+        close_error: BaseException | None = None,
+    ) -> None:
+        self.name = name
+        self.closed = closed
+        self.stream = stream
+        self.close_error = close_error
+        self._iterator = aiter(stream) if stream is not None else None
+
+    def __aiter__(self) -> _TrackingStream:
+        return self
+
+    async def __anext__(self) -> AgentStreamEvent:
+        if self._iterator is not None:
+            return await anext(self._iterator)
+        return PartStartEvent(index=0, part=TextPart(content='event'))
+
+    async def aclose(self) -> None:
+        self.closed.append(self.name)
+        if self.close_error is not None:
+            raise self.close_error
+
+
+@dataclass
+class _TrackingCapability(AbstractCapability[Any]):
+    name: str
+    closed: list[str]
+    close_error: BaseException | None = None
+
+    def wrap_run_event_stream(
+        self,
+        ctx: RunContext[Any],
+        *,
+        stream: AsyncIterable[AgentStreamEvent],
+    ) -> AsyncIterable[AgentStreamEvent]:
+        return _TrackingStream(self.name, self.closed, stream, self.close_error)
+
+
+@dataclass
+class _BlockingCapability(AbstractCapability[Any]):
+    pull_started: anyio.Event
+    torn_down: anyio.Event
+
+    def wrap_run_event_stream(
+        self,
+        ctx: RunContext[Any],
+        *,
+        stream: AsyncIterable[AgentStreamEvent],
+    ) -> AsyncIterable[AgentStreamEvent]:
+        return _BlockingStream(self.pull_started, self.torn_down)
+
+
+@dataclass
+class _BlockingStream(AsyncIterator[AgentStreamEvent]):
+    pull_started: anyio.Event
+    torn_down: anyio.Event
+
+    async def __anext__(self) -> AgentStreamEvent:
+        self.pull_started.set()
+        return cast(AgentStreamEvent, await anyio.sleep_forever())
+
+    async def aclose(self) -> None:
+        self.torn_down.set()
+
+
+@dataclass
+class _CloseTrackingCapability(AbstractCapability[Any]):
+    torn_down: anyio.Event
+    held_streams: list[AsyncIterator[AgentStreamEvent]]
+    checkpoint_on_close: bool = False
+
+    def wrap_run_event_stream(
+        self,
+        ctx: RunContext[Any],
+        *,
+        stream: AsyncIterable[AgentStreamEvent],
+    ) -> AsyncIterable[AgentStreamEvent]:
+        wrapped = _CloseTrackingStream(aiter(stream), self.torn_down, self.checkpoint_on_close)
+        self.held_streams.append(wrapped)
+        return wrapped
+
+
+@dataclass
+class _CloseTrackingStream(AsyncIterator[AgentStreamEvent]):
+    stream: AsyncIterator[AgentStreamEvent]
+    torn_down: anyio.Event
+    checkpoint_on_close: bool
+
+    async def __anext__(self) -> AgentStreamEvent:
+        return await anext(self.stream)
+
+    async def aclose(self) -> None:
+        if self.checkpoint_on_close:
+            await anyio.sleep(0)
+        self.torn_down.set()
+
+
+@dataclass
+class _PlainIteratorRootCapability(CombinedCapability[Any]):
+    torn_down: anyio.Event
+    held_streams: list[AsyncIterator[AgentStreamEvent]]
+
+    def wrap_run_event_stream(
+        self,
+        ctx: RunContext[Any],
+        *,
+        stream: AsyncIterable[AgentStreamEvent],
+    ) -> AsyncIterable[AgentStreamEvent]:
+        wrapped = _CloseTrackingStream(aiter(stream), self.torn_down, checkpoint_on_close=False)
+        self.held_streams.append(wrapped)
+        return wrapped
+
+
+async def _streaming_model(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+    yield 'first'
+    await asyncio.sleep(30)
+
+
+async def _model_request_stream(agent: Agent[Any, Any]):
+    async with agent.iter('hello') as agent_run:
+        node = agent_run.next_node
+        while not Agent.is_model_request_node(node):
+            assert not isinstance(node, End)
+            node = await agent_run.next(node)
+        async with node.stream(agent_run.ctx) as stream:
+            yield stream
+
+
+def _run_context() -> RunContext[None]:
+    return RunContext(deps=None, model=TestModel(), usage=RunUsage())
+
+
+async def test_combined_closes_every_stream_when_wrapper_close_raises() -> None:
+    closed: list[str] = []
+    close_error = RuntimeError('retaining close failed')
+    source = _TrackingStream('source', closed)
+    capability = CombinedCapability(
+        [
+            _TrackingCapability('outer', closed),
+            _TrackingCapability('retaining-raiser', closed, close_error),
+            _TrackingCapability('inner', closed),
+        ]
+    )
+
+    stream = aiter(capability.wrap_run_event_stream(_run_context(), stream=source))
+    await anext(stream)
+    with pytest.raises(RuntimeError, match='retaining close failed') as exc_info:
+        await _utils.aclose_if_supported(stream)
+
+    assert exc_info.value is close_error
+    assert closed == ['outer', 'retaining-raiser', 'inner', 'source']
+
+
+async def test_combined_groups_multiple_close_errors_after_closing_every_stream() -> None:
+    closed: list[str] = []
+    outer_error = RuntimeError('outer close failed')
+    inner_error = ValueError('inner close failed')
+    source = _TrackingStream('source', closed)
+    capability = CombinedCapability(
+        [
+            _TrackingCapability('outer', closed, outer_error),
+            _TrackingCapability('inner', closed, inner_error),
+        ]
+    )
+
+    stream = aiter(capability.wrap_run_event_stream(_run_context(), stream=source))
+    await anext(stream)
+    with pytest.raises(_utils.BaseExceptionGroup) as exc_info:
+        await _utils.aclose_if_supported(stream)
+
+    assert exc_info.value.exceptions == (outer_error, inner_error)
+    assert closed == ['outer', 'inner', 'source']
+
+
+async def test_wrapper_capability_closes_original_stream_when_wrapper_retains_it() -> None:
+    closed: list[str] = []
+    close_error = RuntimeError('wrapped close failed')
+    source = _TrackingStream('source', closed)
+    capability = WrapperCapability(wrapped=_TrackingCapability('wrapped', closed, close_error))
+
+    stream = aiter(capability.wrap_run_event_stream(_run_context(), stream=source))
+    await anext(stream)
+    with pytest.raises(RuntimeError, match='wrapped close failed') as exc_info:
+        await _utils.aclose_if_supported(stream)
+
+    assert exc_info.value is close_error
+    assert closed == ['wrapped', 'source']
+
+
+async def test_hooks_close_every_stream_when_outer_hook_retains_its_input() -> None:
+    closed: list[str] = []
+    close_error = RuntimeError('outer close failed')
+    source = _TrackingStream('source', closed)
+    hooks = Hooks()
+
+    @hooks.on.run_event_stream
+    def outer(ctx: RunContext[Any], *, stream: AsyncIterable[AgentStreamEvent]) -> AsyncIterable[AgentStreamEvent]:
+        return _TrackingStream('outer', closed, stream, close_error)
+
+    @hooks.on.run_event_stream
+    def inner(ctx: RunContext[Any], *, stream: AsyncIterable[AgentStreamEvent]) -> AsyncIterable[AgentStreamEvent]:
+        return _TrackingStream('inner', closed, stream)
+
+    stream = aiter(hooks.wrap_run_event_stream(_run_context(), stream=source))
+    await anext(stream)
+    with pytest.raises(RuntimeError, match='outer close failed') as exc_info:
+        await _utils.aclose_if_supported(stream)
+
+    assert exc_info.value is close_error
+    assert closed == ['outer', 'inner', 'source']
+
+
+async def test_agent_stream_closes_custom_async_iterator() -> None:
+    torn_down = anyio.Event()
+    held_streams: list[AsyncIterator[AgentStreamEvent]] = []
+    agent = Agent(FunctionModel(stream_function=_streaming_model))
+    # `Agent` normally owns a `CombinedCapability`, whose async-generator wrapper would hide the
+    # custom iterator type this regression needs to exercise. Replacing only the root capability
+    # keeps the real `AgentStream` construction and graph teardown path intact.
+    agent._root_capability = _PlainIteratorRootCapability([], torn_down, held_streams)  # pyright: ignore[reportPrivateUsage]
+
+    with anyio.fail_after(5):
+        async for stream in _model_request_stream(agent):
+            async for _event in stream:  # pragma: no branch
+                break
+
+    assert held_streams
+    assert torn_down.is_set()
+
+
+async def test_agent_stream_cancels_parked_pull_and_closes_capability() -> None:
+    pull_started = anyio.Event()
+    torn_down = anyio.Event()
+    capability = _BlockingCapability(pull_started, torn_down)
+    agent = Agent(FunctionModel(stream_function=_streaming_model), capabilities=[capability])
+
+    async def consume(stream: AsyncIterable[AgentStreamEvent]) -> None:
+        async for _ in stream:
+            pass
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as task_group:
+            async for stream in _model_request_stream(agent):
+                task_group.start_soon(consume, stream)
+                await pull_started.wait()
+
+    assert torn_down.is_set()
+
+
+async def test_agent_stream_close_is_shielded_from_cancellation() -> None:
+    torn_down = anyio.Event()
+    held_streams: list[AsyncIterator[AgentStreamEvent]] = []
+    capability = _CloseTrackingCapability(torn_down, held_streams, checkpoint_on_close=True)
+    agent = Agent(FunctionModel(stream_function=_streaming_model), capabilities=[capability])
+
+    with anyio.fail_after(5):
+        with anyio.CancelScope() as scope:
+            async for stream in _model_request_stream(agent):
+                async for _event in stream:  # pragma: no branch
+                    scope.cancel()
+                    break
+
+    assert held_streams
+    assert torn_down.is_set()

--- a/tests/test_capability_stream_teardown.py
+++ b/tests/test_capability_stream_teardown.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
 from typing import Any, cast
@@ -141,7 +140,6 @@ class _PlainIteratorRootCapability(CombinedCapability[Any]):
 
 async def _streaming_model(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
     yield 'first'
-    await asyncio.sleep(30)
 
 
 async def _model_request_stream(agent: Agent[Any, Any]):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -311,7 +311,7 @@ async def test_event_stream_close_finalizes_native_stream_without_protocol_trail
     async def event_generator() -> AsyncIterator[NativeEvent]:
         try:
             yield PartStartEvent(index=0, part=TextPart(content='Hello'))
-            await asyncio.sleep(30)
+            await asyncio.sleep(30)  # pragma: no cover
         finally:
             finalized.set()
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import warnings
 from collections.abc import AsyncIterator, MutableMapping, Sequence
@@ -7,10 +8,11 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any
 
+import anyio
 import pytest
 from pydantic import BaseModel
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, _utils
 from pydantic_ai._run_context import AgentDepsT
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.capabilities import HandleDeferredToolCalls, ReinjectSystemPrompt
@@ -300,6 +302,28 @@ async def test_event_stream_back_to_back_text():
             '</stream>',
         ]
     )
+
+
+async def test_event_stream_close_finalizes_native_stream_without_protocol_trailer():
+    """A disconnected consumer cannot receive protocol trailers, but its native stream must be closed."""
+    finalized = anyio.Event()
+
+    async def event_generator() -> AsyncIterator[NativeEvent]:
+        try:
+            yield PartStartEvent(index=0, part=TextPart(content='Hello'))
+            await asyncio.sleep(30)
+        finally:
+            finalized.set()
+
+    request = DummyUIRunInput(messages=[ModelRequest.user_text_prompt('Hello')])
+    transformed = DummyUIEventStream(run_input=request).transform_stream(event_generator())
+
+    assert await anext(transformed) == '<stream>'
+    assert await anext(transformed) == '<response>'
+    await _utils.aclose_if_supported(transformed)
+
+    with anyio.fail_after(5):
+        await finalized.wait()
 
 
 async def test_event_stream_error_closes_open_text():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from importlib.metadata import distributions
 from typing import Any
 
+import anyio
 import pytest
 
 import pydantic_ai._utils as utils_module
@@ -201,6 +202,44 @@ async def test_peekable_async_stream_aclose_before_iteration():
     await peekable_async_stream.aclose()
 
     assert await peekable_async_stream.is_exhausted()
+
+
+@pytest.mark.parametrize('peek_pull', [False, True])
+async def test_peekable_async_stream_aclose_cancels_in_flight_pull(peek_pull: bool):
+    """Closing independently of a stalled pull must finalize the source without cancelling its consumer."""
+    pull_started = anyio.Event()
+    finalized = anyio.Event()
+    followup_ran = anyio.Event()
+
+    async def source() -> AsyncIterator[int]:
+        try:
+            yield 1
+            pull_started.set()
+            await asyncio.sleep(30)
+        finally:
+            finalized.set()
+
+    stream: PeekableAsyncStream[int, AsyncIterator[int]] = PeekableAsyncStream(source())
+    assert await anext(stream) == 1
+
+    async def consume() -> None:
+        if peek_pull:
+            assert await stream.peek() is UNSET
+        else:
+            with pytest.raises(StopAsyncIteration):
+                await anext(stream)
+        followup_ran.set()
+
+    pull = asyncio.create_task(consume())
+    await pull_started.wait()
+
+    with anyio.fail_after(5):
+        await stream.aclose()
+        await finalized.wait()
+        await pull
+
+    assert followup_ran.is_set()
+    assert not pull.cancelled()
 
 
 def test_run_until_complete_cleans_up_own_task_on_interrupt():


### PR DESCRIPTION
Follows #6871, which fixed capability event-stream and node hooks under `agent.iter()`. Three teardown defects were found while reviewing that PR and split out so they wouldn't delay it. All three are pre-existing on `main`; none was introduced by #6871.

Closes #7013
Closes #7016
Closes #7017

## `wrap_run_event_stream` wrappers now close what they wrap (#7013)

`AgentStream.aclose_events()` closed the *head* of the capability chain. Every pass-through wrapper is `async for event in stream: yield event`, and an `async for` never closes its source — so the inner generators stayed suspended until refcounting dropped the last reference.

Measured from `aclose_events()` returning to a `ProcessEventStream` observer actually being cancelled: 4 event-loop ticks normally, 4 with `gc.disable()` (so cycles aren't involved), and **never** once a capability keeps a reference to the stream it was handed. That last case is the real bug — anything holding the inner generator reachable pins the observer's handler task for the life of the process.

Close now propagates at all five sites (`AbstractCapability`, `CombinedCapability`, `WrapperCapability`, `Hooks`, `_event_callback_stream`) plus the durability capability, through one guarded helper — `contextlib.aclosing` can't be used because the parameter is typed `AsyncIterable` and a custom wrapper may return an iterator with no `aclose()`. `CombinedCapability` closes every composed wrapper rather than relying on the cascade, so a custom wrapper that retains but doesn't close its input can't strand the chain behind it.

**This changes the contract of a public extension point**: a `wrap_run_event_stream` implementation is now closed by its wrapper. Documented in `docs/capabilities/custom.md`.

## `PeekableAsyncStream.aclose()` no longer hangs (#7017)

`__anext__()` and `peek()` held `_source_lock` across `await anext(...)`; `aclose()` re-acquired it. A task parked on a stalled provider blocked `aclose()` indefinitely. The wait was deliberate — it avoids `RuntimeError: aclose(): asynchronous generator is already running` — but unbounded, with nothing cancelling the holder.

Each pull now runs in its own `anyio.CancelScope`. `aclose()` cancels the registered scopes, which unwinds only the pull and releases the lock, then closes the source. A cancelled pull ends iteration cleanly:

```
aclose            = returned
source finalized  = True
iteration ended   = True
followup work ran = True
task cancelled    = False
```

Scoped rather than task-level cancellation is deliberate: cancelling the pulling task kills the consumer's follow-up work too and surfaces a bare `CancelledError`, indistinguishable from its own supervisor cancelling it. `PeekableAsyncStream` backs the streamed responses of Function, OpenAI, Anthropic, Google, Mistral, Groq, Hugging Face and xAI, so the narrower blast radius matters.

This was latent — no caller produces the interleaving today, since `group_by_temporal` cancels its own prefetch before closing. It's fixed because the primitive permits independent pull and close tasks and gave `aclose()` no way to cancel the holder.

## `UIEventStream.transform_stream()` closes cleanly (#7016)

Its `finally` emitted closing protocol events. `aclose()` throws `GeneratorExit` in at the current `yield`, and a generator may `await` while handling `GeneratorExit` but may not `yield` — so closing raised `RuntimeError: async generator ignored GeneratorExit`, and the native stream it forwarded was left suspended.

The trailers moved out of the `finally`, so an uncaught `GeneratorExit` bypasses them — there's no consumer left to receive them — while normal completion and handled errors still emit them. The native input is closed from a guarded `finally`.

A server owning an AG-UI or Vercel-style response that closes the transformer after a client disconnect got the teardown exception and leaked the agent stream behind it.

## Tests

One regression test per issue, each verified to fail with its fix reverted and pass with it restored.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

