### PR TITLE
Resolve the gh-aw runner's `pydantic-ai-slim` from the workspace instead of PyPI

### DIFF
--- a/.github/scripts/pydantic-ai-runner
+++ b/.github/scripts/pydantic-ai-runner
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#   "pydantic-ai-slim[anthropic,mcp]>=1.105.0",
+#   "pydantic-ai-slim[anthropic,mcp]",
 #   # The file/shell tools (Bash/Read/Write/Edit/Grep/Glob/LS) are backed by
 #   # harness FileSystem/Shell, which ship as stable top-level modules from 0.4.0
 #   # onwards. Keep these in sync with the out-of-band installs in CI and the Makefile;

--- a/.github/scripts/pydantic-ai-runner
+++ b/.github/scripts/pydantic-ai-runner
@@ -11,6 +11,13 @@
 #   "logfire",
 #   "opentelemetry-instrumentation-httpx",
 # ]
+#
+# # The shim's code is this checkout, so its library must be too: resolving
+# # `pydantic-ai-slim` from PyPI pinned the runner to the last *release*, and any
+# # PR adding a `pydantic_ai` symbol the shim uses died at import until that
+# # symbol shipped (#6998, #7103). The path is relative to this script.
+# [tool.uv.sources]
+# pydantic-ai-slim = { path = "../../pydantic_ai_slim" }
 # ///
 """Pydantic AI gh-aw shim launcher.
 

--- a/.github/scripts/pydantic-ai-runner.lock
+++ b/.github/scripts/pydantic-ai-runner.lock
@@ -8,12 +8,26 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+logfire = false
+pydantic-settings = false
+pydantic-handlebars = false
+genai-prices = false
+pydantic-extra-types = false
+pydantic-core = false
+pydantic = false
+logfire-api = false
+
 [manifest]
 requirements = [
     { name = "logfire" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "pydantic-ai-harness", specifier = "==0.7.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "mcp"], specifier = ">=1.105.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "mcp"], directory = "../../pydantic_ai_slim" },
 ]
 
 [[package]]
@@ -492,15 +506,15 @@ client = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.71"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/5072862613fba039da2b7c981a8649c6c6bbcb2863bd8bc81617c09ce5ee/genai_prices-0.0.71.tar.gz", hash = "sha256:de4db34ec38404f9ef383cb1ab29e204d16ccf27071af0b16d5747ee7affe36b", size = 82105, upload-time = "2026-07-10T00:38:30.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/9b/85e646305a90a2da18f1edf055498668391e71f9849d3e1754d66559a311/genai_prices-0.1.1.tar.gz", hash = "sha256:54a2237691e0aaefb057d10a0c3c20160accc9fc09521c64c03fcdb7a4a69f68", size = 91182, upload-time = "2026-08-01T09:02:49.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/98/c06c1318f6834a26268a2d4280e4183f60c5ea92152aea841feff29826ff/genai_prices-0.0.71-py3-none-any.whl", hash = "sha256:1d13111563af2b1ce43ccfacf77b7ac3216ad704c644408a56e11b181fe0d128", size = 84586, upload-time = "2026-07-10T00:38:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/cfe36dff790ffad6aeff8a069b6f36743987ac17053579035ee0a67635dd/genai_prices-0.1.1-py3-none-any.whl", hash = "sha256:de2e3d8ea3ca1d0d292025995c598da447a74e94f22cd3342df46941aeb5416b", size = 95300, upload-time = "2026-08-01T09:02:48.308Z" },
 ]
 
 [[package]]
@@ -1113,9 +1127,9 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { directory = "../../pydantic_ai_slim" }
 dependencies = [
+    { name = "anyio" },
     { name = "genai-prices" },
     { name = "griffelib" },
     { name = "httpx" },
@@ -1123,10 +1137,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/c2/c399c833d88c48a3f5c3dc8a2d9f92644d22efc33bd8345605ae87fa373b/pydantic_ai_slim-2.11.0.tar.gz", hash = "sha256:d174372ee7e70e763b92aaac841d0f1728aa5e80c6373dd3704eee1c799a1194", size = 824048, upload-time = "2026-07-16T02:59:33.085Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/d9/edcc186a9f10bd0f73e2ee4dec8130aa0f9b5428f9e7bd2bc2b27a7b96cd/pydantic_ai_slim-2.11.0-py3-none-any.whl", hash = "sha256:1a797a9c1c6d192f3b2e19f7d833aa9ab92ec1de000693a139a2320a6863581b", size = 1001962, upload-time = "2026-07-16T02:59:25.256Z" },
 ]
 
 [package.optional-dependencies]
@@ -1136,6 +1146,61 @@ anthropic = [
 mcp = [
     { name = "fastmcp-slim", extra = ["client"] },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.108.0" },
+    { name = "anyio", specifier = ">=4.7.0" },
+    { name = "argcomplete", marker = "extra == 'cli'", specifier = ">=3.5.0" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.63" },
+    { name = "botocore", marker = "extra == 'bedrock-mantle'", specifier = ">=1.42.63" },
+    { name = "cohere", marker = "sys_platform != 'emscripten' and extra == 'cohere'", specifier = ">=5.20.6" },
+    { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0" },
+    { name = "ddgs", marker = "extra == 'duckduckgo'", specifier = ">=9.0.0" },
+    { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.0.0" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },
+    { name = "fastmcp-slim", extras = ["client"], marker = "extra == 'mcp'", specifier = ">=3.3.0,<4" },
+    { name = "genai-prices", specifier = ">=0.1.0" },
+    { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.70.0" },
+    { name = "griffelib", specifier = ">=2.0" },
+    { name = "groq", marker = "extra == 'groq'", specifier = ">=0.25.0" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and extra == 'huggingface') or (platform_machine == 'aarch64' and extra == 'huggingface') or (platform_machine == 'amd64' and extra == 'huggingface') or (platform_machine == 'arm64' and extra == 'huggingface') or (platform_machine == 'x86_64' and extra == 'huggingface')", specifier = "<1.5.0" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27.0" },
+    { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=1.3.4,<2.0.0" },
+    { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.16.0" },
+    { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
+    { name = "openai", marker = "extra == 'bedrock-mantle'", specifier = ">=2.45.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0" },
+    { name = "openai", marker = "extra == 'openrouter'", specifier = ">=2.45.0" },
+    { name = "openai", marker = "extra == 'zai'", specifier = ">=2.45.0" },
+    { name = "opentelemetry-api", specifier = ">=1.28.0" },
+    { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.7.5" },
+    { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3" },
+    { name = "pydantic", specifier = ">=2.12" },
+    { name = "pydantic-evals", marker = "extra == 'evals'", editable = "../../pydantic_evals" },
+    { name = "pydantic-graph", editable = "../../pydantic_graph" },
+    { name = "pydantic-handlebars", marker = "extra == 'spec'", specifier = ">=0.1.0" },
+    { name = "pyperclip", marker = "extra == 'cli'", specifier = ">=1.9.0" },
+    { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
+    { name = "pyyaml", marker = "extra == 'spec'", specifier = ">=6.0.2" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=13" },
+    { name = "sentence-transformers", marker = "python_full_version < '3.14' and extra == 'sentence-transformers'", specifier = ">=5.2.0" },
+    { name = "starlette", marker = "extra == 'ag-ui'", specifier = ">=0.46.2" },
+    { name = "starlette", marker = "extra == 'ui'", specifier = ">=0.46.2" },
+    { name = "starlette", marker = "extra == 'web'", specifier = ">=0.46.2" },
+    { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.5.0" },
+    { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.24.0" },
+    { name = "tenacity", marker = "extra == 'retries'", specifier = ">=8.2.3" },
+    { name = "tiktoken", marker = "extra == 'openai'", specifier = ">=0.12.0" },
+    { name = "typing-inspection", specifier = ">=0.4.0" },
+    { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.38.0" },
+    { name = "voyageai", marker = "python_full_version < '3.14' and extra == 'voyageai'", specifier = ">=0.3.7" },
+    { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.14.0" },
+]
+provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
 
 [[package]]
 name = "pydantic-core"
@@ -1241,17 +1306,22 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../../pydantic_graph" }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/4f/1b10ff0e166a346a3967fca1f7c5cd7d7d9f8209848c9bd5d89ed9b85eef/pydantic_graph-2.11.0.tar.gz", hash = "sha256:25a40a815ef1dcf6e08bad4264c4c09d6426b34126570e72a356d50e358520fd", size = 43937, upload-time = "2026-07-16T02:59:35.355Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/5e/7e51421f9a70e24907768556e21aa0272cae429bf78d79b5eae8175bd151/pydantic_graph-2.11.0-py3-none-any.whl", hash = "sha256:e40dbf2dd51a0c7a7fb306b41c0af7f3acdc892cb5a60324733ad8eb51f441f3", size = 51655, upload-time = "2026-07-16T02:59:28.721Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.7.0" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "logfire-api", specifier = ">=3.14.1" },
+    { name = "pydantic", specifier = ">=2.12" },
+    { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 
 [[package]]

--- a/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
@@ -65,6 +65,7 @@ from pydantic_ai.messages import (
     NativeToolCallPart,
     NativeToolSearchCallPart,
     RetryPromptPart,
+    ToolAvailabilityDeltaPart,
     ToolCallEvent,
     ToolCallPart,
     ToolResultEvent,
@@ -79,17 +80,6 @@ from pydantic_ai.providers.anthropic import AnthropicProvider
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, PrefixedToolset
 from pydantic_ai.usage import RunUsage, UsageLimits
-
-# The shim runs against the *released* Pydantic AI resolved by
-# `pydantic-ai-runner.lock`, not the checked-out tree, so importing a message
-# part that hasn't shipped in a release yet breaks every gh-aw workflow at
-# startup. Keep such parts behind a tolerant import until a release carries
-# them: the empty-tuple fallback makes `isinstance` against it always false,
-# so the rendering branch below simply never fires on an older runtime.
-try:
-    from pydantic_ai.messages import ToolAvailabilityDeltaPart
-except ImportError:
-    ToolAvailabilityDeltaPart = ()
 
 from . import (
     CLAUDE_CODE_TOOL_NAMES,

--- a/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
@@ -65,7 +65,6 @@ from pydantic_ai.messages import (
     NativeToolCallPart,
     NativeToolSearchCallPart,
     RetryPromptPart,
-    ToolAvailabilityDeltaPart,
     ToolCallEvent,
     ToolCallPart,
     ToolResultEvent,
@@ -80,6 +79,17 @@ from pydantic_ai.providers.anthropic import AnthropicProvider
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, PrefixedToolset
 from pydantic_ai.usage import RunUsage, UsageLimits
+
+# The shim runs against the *released* Pydantic AI resolved by
+# `pydantic-ai-runner.lock`, not the checked-out tree, so importing a message
+# part that hasn't shipped in a release yet breaks every gh-aw workflow at
+# startup. Keep such parts behind a tolerant import until a release carries
+# them: the empty-tuple fallback makes `isinstance` against it always false,
+# so the rendering branch below simply never fires on an older runtime.
+try:
+    from pydantic_ai.messages import ToolAvailabilityDeltaPart
+except ImportError:
+    ToolAvailabilityDeltaPart = ()
 
 from . import (
     CLAUDE_CODE_TOOL_NAMES,

--- a/.github/scripts/test_pydantic_ai_runner.py
+++ b/.github/scripts/test_pydantic_ai_runner.py
@@ -943,7 +943,7 @@ def test_runner_drops_dynamic_workflow_dependencies():
 
 
 def test_runner_resolves_pydantic_ai_from_the_workspace():
-    """The shim's code is this checkout, so its library must be too — see #6998."""
+    """The shim's code is this checkout, so its library must be too — see #6998, #7103."""
     runner = (Path(__file__).parent / 'pydantic-ai-runner').read_text(encoding='utf-8')
     assert '# [tool.uv.sources]' in runner
     assert '# pydantic-ai-slim = { path = "../../pydantic_ai_slim" }' in runner

--- a/.github/scripts/test_pydantic_ai_runner.py
+++ b/.github/scripts/test_pydantic_ai_runner.py
@@ -942,6 +942,16 @@ def test_runner_drops_dynamic_workflow_dependencies():
     assert 'pydantic-monty' not in runner
 
 
+def test_runner_resolves_pydantic_ai_from_the_workspace():
+    """The shim's code is this checkout, so its library must be too — see #6998."""
+    runner = (Path(__file__).parent / 'pydantic-ai-runner').read_text(encoding='utf-8')
+    assert '# [tool.uv.sources]' in runner
+    assert '# pydantic-ai-slim = { path = "../../pydantic_ai_slim" }' in runner
+
+    lock = (Path(__file__).parent / 'pydantic-ai-runner.lock').read_text(encoding='utf-8')
+    assert 'directory = "../../pydantic_ai_slim"' in lock
+
+
 def test_compiled_workflows_pin_retry_policy():
     workflow_dir = Path(__file__).parent.parent / 'workflows'
     for compiled_workflow in workflow_dir.glob('pydantic-ai-*.lock.yml'):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,19 @@ jobs:
           .github/scripts/test_agentic_workflow_guard.py
           .github/scripts/test_agent_spend_report.py
 
+      # The tests above import the shim inside this job's workspace venv, which is not
+      # the environment it runs in: gh-aw executes it via `uv run --script` against the
+      # runner's own locked dependency set. Run it there, with no argv, so it reaches
+      # the empty-prompt short-circuit without touching the network. This catches
+      # general shim breakage — a syntax error, a bad import, a module the runner lock
+      # doesn't carry. It is not what guards against importing an unreleased
+      # `pydantic_ai` symbol: the runner's workspace source (#6998) does that, by making
+      # the shim's library the same checkout as its code.
+      - name: Smoke-test the gh-aw shim against the runner's own dependencies
+        run: |
+          uv run --script .github/scripts/pydantic-ai-runner 2>&1 | tee /tmp/shim-smoke.log
+          grep -q 'empty prompt' /tmp/shim-smoke.log
+
       # Every check except lock freshness reads the tree alone, so run them on `main`
       # too. Two independently-green PRs can still merge into a drifted `main` — the
       # classic case being one that bumps the gh-aw compiler while another adds a lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,13 @@ jobs:
       # general shim breakage — a syntax error, a bad import, a module the runner lock
       # doesn't carry. It is not what guards against importing an unreleased
       # `pydantic_ai` symbol: the runner's workspace source (#6998) does that, by making
-      # the shim's library the same checkout as its code.
+      # the shim's library the same checkout as its code. The shim exits non-zero on
+      # that path, so the assertion is on its output, never its status: `|| true` holds
+      # whether or not the shell has `pipefail` (the default `run` shell here is
+      # `bash -e`, but `shell: bash` would add it).
       - name: Smoke-test the gh-aw shim against the runner's own dependencies
         run: |
-          uv run --script .github/scripts/pydantic-ai-runner 2>&1 | tee /tmp/shim-smoke.log
+          uv run --script .github/scripts/pydantic-ai-runner 2>&1 | tee /tmp/shim-smoke.log || true
           grep -q 'empty prompt' /tmp/shim-smoke.log
 
       # Every check except lock freshness reads the tree alone, so run them on `main`


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David chose this approach and directed the pivot to it; he did not review the code line-by-line.

- Closes #6998
- Closes #7103

The shim's *code* is the checkout, but the library it imports came from the last PyPI release — so any PR adding a `pydantic_ai` symbol the shim uses died at import until that symbol shipped. Most recently #6793 added `ToolAvailabilityDeltaPart`, and all 11 `pydantic-ai-runner` agentic workflows failed at startup with `ImportError` on every branch containing it.

This points the runner's PEP 723 block at the workspace instead:

```
# [tool.uv.sources]
# pydantic-ai-slim = { path = "../../pydantic_ai_slim" }
```

The runner now always matches the checked-out source, so the shim can never import a symbol its runtime lacks — for `ToolAvailabilityDeltaPart` or any future one. That also means the agentic workflows exercise the branch's own library, which is what you want from a check running on a PR.

The lock was regenerated (`uv lock --script`), which resolves `pydantic-graph` and `pydantic-evals` to the workspace too, since `pydantic-ai-slim` pins `pydantic-graph` to its own version. `pydantic-ai-harness==0.7.0` stays on PyPI — it is genuinely external.

Two guards come with it:

- `test_runner_resolves_pydantic_ai_from_the_workspace` pins the source block and the lock's `directory =` entry, so the runner can't silently drift back to PyPI.
- A `lint`-job CI step runs the shim through `uv run --script` with no argv, against the runner's *own* locked dependency set, and asserts it reaches the empty-prompt short-circuit. The existing tests import the shim inside the workspace venv, which is not the environment it runs in. To be clear about what this catches: general shim breakage — a syntax error, a bad import, a module the runner lock doesn't carry. It is *not* the guard against importing an unreleased `pydantic_ai` symbol; the workspace source above is, by construction.

The runner's `>=1.105.0` floor is dropped — a v1-era pin that the workspace source made inert (the regenerated lock carries no specifier for `pydantic-ai-slim`), and which now contradicted the file it sits in.

**Credit to @hxaxd**, who diagnosed this and wrote the same fix in #7024. We're carrying their approach forward here rather than merging theirs — `.github/` is a supply-chain boundary we keep to maintainer-authored changes. That's a policy call about the path, not about the fix, which was right.

<details><summary>Verification of #6998's two open questions</summary>

#6998 flagged two things to confirm rather than assume. Both hold, read from the compiled `.lock.yml` workflows (not from a live run):

1. **Schedule-triggered workflows resolve the relative path.** The agent job in every `pydantic-ai-*.lock.yml` — including the scheduled ones (`bug-hunter`, `stale-issues-finder`) — checks the repo out before `Setup uv` and the prewarm step. The path is relative to the script at `$GITHUB_WORKSPACE/.github/scripts/pydantic-ai-runner`, so it resolves to `$GITHUB_WORKSPACE/pydantic_ai_slim`. The sandbox runs with `--container-workdir "${GITHUB_WORKSPACE}"` and the workspace mounted, so it resolves inside the firewall too.

    Worth stating precisely, because a shallow checkout has no tags and `pydantic-ai-slim`'s version comes from `uv-dynamic-versioning` off git: 10 of the 11 agent jobs use `fetch-depth: 0`; `pydantic-ai-attention-triage` does not. That turns out not to matter. Verified on a `--depth 1 --no-tags` clone: the build succeeds and yields `0.0.1.dev1+<sha>`, `uv sync --script` installs from the lock without re-checking a floor, and the shim imports with `ToolAvailabilityDeltaPart` present. The cost is a cosmetic version string in that one workflow's telemetry, not a failure. (The new CI smoke step runs on a shallow checkout too, so this path is exercised on every PR.)

2. **Prewarm builds the path dependency before the firewall closes.** `prewarm-pydantic-ai-runner.sh` runs `uv sync --script "${GITHUB_WORKSPACE}/.github/scripts/pydantic-ai-runner"` in `pre-agent-steps` — after checkout, before the firewalled agent container — into `UV_CACHE_DIR=/tmp/gh-aw/uv/cache`, the same cache the in-sandbox launcher uses. Building a path dependency reads the (read-only) workspace mount and writes only to that cache, and `*.pythonhosted.org` is in the firewall allowlist, so even a cache miss in-sandbox can still fetch the build backend.

Locally: `uv lock --script` + `uv sync --script` succeed, and the resulting environment imports `ToolAvailabilityDeltaPart` and the shim cleanly — the exact failure from #7103, gone.

</details>

<details><summary>Why not a defensive import in the shim</summary>

The first version of this PR wrapped the one import in `try/except ImportError`. #6998 argues against that shape directly: _"The alternative — defensive imports in the shim — is worse: it would hide real incompatibilities between the shim and the library, which is the one thing this check ought to catch."_ It also only ever covers the symbol someone remembered to wrap. That commit is superseded by the root fix and the guard is gone from `cli.py`, which is now byte-identical to `main`.

</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
