### PR TITLE
Block external contributors from modifying `.github/`

### DIFF
--- a/.github/scripts/test_protect_github_dir.py
+++ b/.github/scripts/test_protect_github_dir.py
@@ -1,0 +1,218 @@
+"""Regression tests for the `.github/` protection guard.
+
+`.github/workflows/protect-github-dir.yml` decides whether a pull request may change
+`.github/`. It triggers on `pull_request_target`, and GitHub runs the **base branch's**
+copy of such a workflow, so the guard can never be exercised by the PR that edits it —
+these tests are the only place its logic is checked before it reaches `main`. That
+matters more than for an ordinary workflow: a bug in one direction blocks every
+contributor, and in the other it lets fork-authored changes into a directory that
+executes with repository credentials.
+
+The tests extract the guard's `run:` block straight from the YAML and execute it against
+a stubbed `gh`, so they track the file that Actions actually runs rather than a copy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = 'pydantic/pydantic-ai'
+PR_NUMBER = '1234'
+MARKER = '<!-- protect-github-dir-guard -->'
+WORKFLOW = Path(__file__).parent.parent / 'workflows' / 'protect-github-dir.yml'
+
+# The stub answers the three endpoints the guard reads and records the comment it posts.
+# It pipes the canned payload through the real `jq` so the guard's own `--jq` expressions
+# are under test, not just the shell around them.
+FAKE_GH = '''#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+args = sys.argv[1:]
+
+
+def jq(payload):
+    expr = args[args.index('--jq') + 1]
+    result = subprocess.run(['jq', '-r', expr], input=payload, capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    sys.exit(result.returncode)
+
+
+if args[:1] == ['api']:
+    endpoint = args[1]
+    if endpoint.endswith('/files'):
+        jq(os.environ['FAKE_FILES_JSON'])
+    elif endpoint.endswith('/comments'):
+        jq(os.environ['FAKE_COMMENTS_JSON'])
+    elif endpoint.endswith('/permission'):
+        role = os.environ['FAKE_ROLE_JSON']
+        if role == 'FAIL':
+            sys.stderr.write('gh: HTTP 403: Must have push access\\n')
+            sys.exit(1)
+        jq(role)
+    else:
+        sys.exit('stub gh: unhandled endpoint ' + endpoint)
+elif args[:2] == ['pr', 'comment']:
+    with open(os.environ['FAKE_COMMENT_OUT'], 'w') as handle:
+        handle.write(args[args.index('--body') + 1])
+else:
+    sys.exit('stub gh: unhandled command ' + repr(args))
+'''
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding='utf-8'))
+
+
+@dataclass
+class Case:
+    """One PR the guard has to rule on.
+
+    Defaults describe the case the guard exists for: an outside contributor, on a fork,
+    with no elevated role. Each case overrides only what makes it different.
+    """
+
+    id: str
+    files: list[dict[str, str]]
+    blocked: bool
+    comments: bool
+    author: str = 'outside-contributor'
+    association: str = 'CONTRIBUTOR'
+    head_repo: str = 'outside-contributor/pydantic-ai'
+    role: str = 'read'
+    existing_comments: list[dict[str, object]] = field(default_factory=list)
+
+
+UNRELATED = [{'filename': 'docs/agents.md'}, {'filename': 'pydantic_ai_slim/pydantic_ai/agent.py'}]
+PROTECTED = [{'filename': 'docs/agents.md'}, {'filename': '.github/workflows/ci.yml'}]
+RENAMED_OUT = [{'filename': 'tools/ci.yml', 'previous_filename': '.github/workflows/ci.yml'}]
+
+CASES: list[Case] = [
+    Case(id='external-pr-touching-nothing-protected', files=UNRELATED, blocked=False, comments=False),
+    Case(id='external-pr-touching-dot-github', files=PROTECTED, blocked=True, comments=True),
+    # A rename *out of* `.github/` changes the directory as surely as an edit in place,
+    # and the file only appears under its new path unless `previous_filename` is read.
+    Case(id='external-pr-renaming-a-file-out-of-dot-github', files=RENAMED_OUT, blocked=True, comments=True),
+    # Dependabot owns the action-pin bumps in `.github/workflows/`; blocking it would
+    # freeze them. It is the only allowlisted bot.
+    Case(id='dependabot-bumping-an-action-pin', files=PROTECTED, blocked=False, comments=False, author='dependabot[bot]'),
+    # A branch in the base repository can only exist if its author has push access.
+    Case(id='maintainer-on-a-same-repo-branch', files=PROTECTED, blocked=False, comments=False, head_repo=REPO),
+    # `author_association` can report CONTRIBUTOR for a genuine collaborator (#6359), so
+    # the repo-role lookup is what keeps a maintainer's fork PR from being blocked.
+    Case(id='misreported-collaborator-with-a-write-role', files=PROTECTED, blocked=False, comments=False, role='maintain'),
+    # Fails closed: unlike `pr-guard.yml`'s courtesy gate, an unreadable role blocks.
+    Case(id='unreadable-repo-role', files=PROTECTED, blocked=True, comments=True, role='FAIL'),
+    Case(id='deleted-fork-with-no-head-repo', files=PROTECTED, blocked=True, comments=True, head_repo=''),
+    # `synchronize` re-runs the guard on every push; the explanation is posted once.
+    Case(
+        id='already-explained-on-an-earlier-push',
+        files=PROTECTED,
+        blocked=True,
+        comments=False,
+        existing_comments=[{'id': 9, 'body': f'Thanks for the PR! {MARKER}'}],
+    ),
+] + [
+    Case(id=f'{association.lower()}-editing-dot-github', files=PROTECTED, blocked=False, comments=False, association=association)
+    for association in ('OWNER', 'MEMBER', 'COLLABORATOR')
+]
+
+
+@pytest.mark.skipif(shutil.which('jq') is None, reason='the gh stub filters payloads with jq')
+@pytest.mark.parametrize('case', CASES, ids=lambda case: case.id)
+def test_guard_rules_on_the_pull_request(case: Case, tmp_path: Path):
+    script = tmp_path / 'guard.sh'
+    script.write_text(_workflow()['jobs']['guard']['steps'][0]['run'], encoding='utf-8')
+
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    gh = bin_dir / 'gh'
+    gh.write_text(FAKE_GH, encoding='utf-8')
+    gh.chmod(0o755)
+
+    comment = tmp_path / 'comment.md'
+    role = case.role if case.role == 'FAIL' else json.dumps({'role_name': case.role})
+    result = subprocess.run(
+        ['bash', str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            'PATH': f'{bin_dir}{os.pathsep}{os.environ["PATH"]}',
+            'GH_TOKEN': 'stub-token',
+            'REPO': REPO,
+            'PR_NUMBER': PR_NUMBER,
+            'PR_AUTHOR': case.author,
+            'AUTHOR_ASSOCIATION': case.association,
+            'HEAD_REPO': case.head_repo,
+            'FAKE_FILES_JSON': json.dumps(case.files),
+            'FAKE_COMMENTS_JSON': json.dumps(case.existing_comments),
+            'FAKE_ROLE_JSON': role,
+            'FAKE_COMMENT_OUT': str(comment),
+        },
+    )
+
+    assert result.returncode == (1 if case.blocked else 0), f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}'
+    assert comment.exists() is case.comments
+
+
+@pytest.mark.skipif(shutil.which('jq') is None, reason='the gh stub filters payloads with jq')
+def test_the_comment_names_the_offending_files_and_carries_the_dedup_marker(tmp_path: Path):
+    case = Case(id='external-pr-touching-dot-github', files=PROTECTED, blocked=True, comments=True)
+    test_guard_rules_on_the_pull_request(case, tmp_path)
+
+    body = (tmp_path / 'comment.md').read_text(encoding='utf-8')
+    assert '- `.github/workflows/ci.yml`' in body
+    # The unrelated file is the contributor's actual work — naming it would read as if it
+    # were part of the problem.
+    assert 'docs/agents.md' not in body
+    assert MARKER in body
+
+
+def test_the_guard_never_checks_out_pull_request_code():
+    """`pull_request_target` hands the job a write token in base-repository context.
+
+    Checking out or running the PR's own code under that trigger is precisely the
+    supply-chain hole this workflow exists to close, so the guard reads PR metadata over
+    the API and runs no action at all.
+    """
+    steps = _workflow()['jobs']['guard']['steps']
+    assert [step for step in steps if 'uses' in step] == []
+
+    source = WORKFLOW.read_text(encoding='utf-8')
+    assert 'actions/checkout' not in source
+    # `head.repo.full_name` is read to tell a fork from a same-repo branch; the head
+    # *ref* and *sha* are the handles you'd need to fetch the contributor's code, and
+    # nothing here has any business knowing them.
+    assert 'head.sha' not in source
+    assert 'head.ref' not in source
+
+
+def test_the_trigger_has_no_paths_filter():
+    """A `paths:` filter here would deadlock the repository.
+
+    A `pull_request_target` filtered to `.github/**` does not run at all on the PRs that
+    don't match it, and a *required* check that never runs stays pending forever. The job
+    runs on every PR and exits 0 when nothing protected changed.
+    """
+    # YAML 1.1 resolves the bare `on:` key to the boolean True.
+    trigger = _workflow()[True]['pull_request_target']
+    assert 'paths' not in trigger
+    assert 'paths-ignore' not in trigger
+
+
+def test_the_guard_job_holds_only_the_permission_it_uses():
+    """No `contents:` scope — the job never reads the repository's code."""
+    workflow = _workflow()
+    assert workflow['permissions'] == {}
+    assert workflow['jobs']['guard']['permissions'] == {'pull-requests': 'write'}

--- a/.github/scripts/test_protect_github_dir.py
+++ b/.github/scripts/test_protect_github_dir.py
@@ -1,9 +1,9 @@
 """Regression tests for the `.github/` protection guard.
 
 `.github/workflows/protect-github-dir.yml` decides whether a pull request may change
-`.github/`. It triggers on `pull_request_target`, and GitHub runs the **base branch's**
-copy of such a workflow, so the guard can never be exercised by the PR that edits it —
-these tests are the only place its logic is checked before it reaches `main`. That
+`.github/`. It triggers on `pull_request_target`, and GitHub runs such a workflow from the
+**default branch of the base repository**, so the guard can never be exercised by the PR
+that edits it — these tests are the only place its logic is checked before `main`. That
 matters more than for an ordinary workflow: a bug in one direction blocks every
 contributor, and in the other it lets fork-authored changes into a directory that
 executes with repository credentials.
@@ -27,12 +27,15 @@ import yaml
 REPO = 'pydantic/pydantic-ai'
 PR_NUMBER = '1234'
 MARKER = '<!-- protect-github-dir-guard -->'
+BOT = 'github-actions[bot]'
 WORKFLOW = Path(__file__).parent.parent / 'workflows' / 'protect-github-dir.yml'
 
-# The stub answers the three endpoints the guard reads and records the comment it posts.
-# It pipes the canned payload through the real `jq` so the guard's own `--jq` expressions
-# are under test, not just the shell around them.
-FAKE_GH = '''#!/usr/bin/env python3
+# The stub answers the four endpoints the guard reads and records the comment it posts. It
+# pipes the canned payload through the real `jq` so the guard's own `--jq` expressions are
+# under test, not just the shell around them. It ignores `--paginate` and serves every
+# payload as one page: the guard's page-boundary behaviour is GitHub's to get right, while
+# the truncation case that IS the guard's problem is driven through FAKE_TOTAL_FILES.
+FAKE_GH = """#!/usr/bin/env python3
 import os
 import subprocess
 import sys
@@ -50,16 +53,18 @@ def jq(payload):
 
 if args[:1] == ['api']:
     endpoint = args[1]
-    if endpoint.endswith('/files'):
+    if '/files' in endpoint:
         jq(os.environ['FAKE_FILES_JSON'])
-    elif endpoint.endswith('/comments'):
+    elif '/comments' in endpoint:
         jq(os.environ['FAKE_COMMENTS_JSON'])
-    elif endpoint.endswith('/permission'):
-        role = os.environ['FAKE_ROLE_JSON']
-        if role == 'FAIL':
-            sys.stderr.write('gh: HTTP 403: Must have push access\\n')
+    elif '/permission' in endpoint:
+        permission = os.environ['FAKE_PERMISSION']
+        if permission == 'FAIL':
+            sys.stderr.write('gh: HTTP 403\\n')
             sys.exit(1)
-        jq(role)
+        jq('{"permission": "' + permission + '"}')
+    elif '/pulls/' in endpoint:
+        jq('{"changed_files": ' + os.environ['FAKE_TOTAL_FILES'] + '}')
     else:
         sys.exit('stub gh: unhandled endpoint ' + endpoint)
 elif args[:2] == ['pr', 'comment']:
@@ -67,7 +72,7 @@ elif args[:2] == ['pr', 'comment']:
         handle.write(args[args.index('--body') + 1])
 else:
     sys.exit('stub gh: unhandled command ' + repr(args))
-'''
+"""
 
 
 def _workflow() -> dict:
@@ -78,8 +83,8 @@ def _workflow() -> dict:
 class Case:
     """One PR the guard has to rule on.
 
-    Defaults describe the case the guard exists for: an outside contributor, on a fork,
-    with no elevated role. Each case overrides only what makes it different.
+    Defaults describe the case the guard exists for: an outside contributor with no
+    elevated permission. Each case overrides only what makes it different.
     """
 
     id: str
@@ -87,10 +92,11 @@ class Case:
     blocked: bool
     comments: bool
     author: str = 'outside-contributor'
-    association: str = 'CONTRIBUTOR'
-    head_repo: str = 'outside-contributor/pydantic-ai'
-    role: str = 'read'
+    permission: str = 'read'
+    state: str = 'open'
     existing_comments: list[dict[str, object]] = field(default_factory=list)
+    # Defaults to len(files); set higher to model the PR-files API truncating.
+    total_files: int | None = None
 
 
 UNRELATED = [{'filename': 'docs/agents.md'}, {'filename': 'pydantic_ai_slim/pydantic_ai/agent.py'}]
@@ -100,37 +106,69 @@ RENAMED_OUT = [{'filename': 'tools/ci.yml', 'previous_filename': '.github/workfl
 CASES: list[Case] = [
     Case(id='external-pr-touching-nothing-protected', files=UNRELATED, blocked=False, comments=False),
     Case(id='external-pr-touching-dot-github', files=PROTECTED, blocked=True, comments=True),
-    # A rename *out of* `.github/` changes the directory as surely as an edit in place,
-    # and the file only appears under its new path unless `previous_filename` is read.
+    # A rename *out of* `.github/` changes the directory as surely as an edit in place, and
+    # the file only appears under its new path unless `previous_filename` is read.
     Case(id='external-pr-renaming-a-file-out-of-dot-github', files=RENAMED_OUT, blocked=True, comments=True),
-    # Dependabot owns the action-pin bumps in `.github/workflows/`; blocking it would
-    # freeze them. It is the only allowlisted bot.
-    Case(id='dependabot-bumping-an-action-pin', files=PROTECTED, blocked=False, comments=False, author='dependabot[bot]'),
-    # A branch in the base repository can only exist if its author has push access.
-    Case(id='maintainer-on-a-same-repo-branch', files=PROTECTED, blocked=False, comments=False, head_repo=REPO),
-    # `author_association` can report CONTRIBUTOR for a genuine collaborator (#6359), so
-    # the repo-role lookup is what keeps a maintainer's fork PR from being blocked.
-    Case(id='misreported-collaborator-with-a-write-role', files=PROTECTED, blocked=False, comments=False, role='maintain'),
-    # Fails closed: unlike `pr-guard.yml`'s courtesy gate, an unreadable role blocks.
-    Case(id='unreadable-repo-role', files=PROTECTED, blocked=True, comments=True, role='FAIL'),
-    Case(id='deleted-fork-with-no-head-repo', files=PROTECTED, blocked=True, comments=True, head_repo=''),
+    # Dependabot owns the action-pin bumps in `.github/workflows/`; blocking it would freeze
+    # them. It holds no repo permission, so the allowlist is what lets it through.
+    Case(
+        id='dependabot-bumping-an-action-pin',
+        files=PROTECTED,
+        blocked=False,
+        comments=False,
+        author='dependabot[bot]',
+        permission='none',
+    ),
+    # pydanty builds its branches inside this repo from externally-authored issue text, so a
+    # base-repo head branch must not read as trust. It holds no repo permission and is not
+    # allowlisted, so it is blocked like any other untrusted author.
+    Case(
+        id='pydanty-on-a-base-repo-branch',
+        files=PROTECTED,
+        blocked=True,
+        comments=True,
+        author='pydanty[bot]',
+        permission='none',
+    ),
+    # `.permission` maps `maintain` and custom repo roles onto a stable base level, so a
+    # maintainer clears the check whatever their role is named (#6797).
+    Case(id='maintainer-with-write-permission', files=PROTECTED, blocked=False, comments=False, permission='write'),
+    Case(id='admin-editing-dot-github', files=PROTECTED, blocked=False, comments=False, permission='admin'),
+    # Fails closed: unlike `pr-guard.yml`'s courtesy gate, an unreadable permission blocks.
+    Case(id='unreadable-repo-permission', files=PROTECTED, blocked=True, comments=True, permission='FAIL'),
+    # The PR-files API caps at 3000 and truncates silently, so a padded PR could push a
+    # `.github/` edit out of the response. A short list must never read as "nothing changed".
+    Case(
+        id='truncated-file-list-hiding-a-dot-github-edit',
+        files=UNRELATED,
+        blocked=True,
+        comments=False,
+        total_files=3001,
+    ),
     # `synchronize` re-runs the guard on every push; the explanation is posted once.
     Case(
         id='already-explained-on-an-earlier-push',
         files=PROTECTED,
         blocked=True,
         comments=False,
-        existing_comments=[{'id': 9, 'body': f'Thanks for the PR! {MARKER}'}],
+        existing_comments=[{'id': 9, 'user': {'login': BOT}, 'body': f'Thanks for the PR! {MARKER}'}],
     ),
-] + [
-    Case(id=f'{association.lower()}-editing-dot-github', files=PROTECTED, blocked=False, comments=False, association=association)
-    for association in ('OWNER', 'MEMBER', 'COLLABORATOR')
+    # ...but anyone can paste the marker into a comment, and that must not suppress the
+    # explanation for good.
+    Case(
+        id='marker-forged-by-another-commenter',
+        files=PROTECTED,
+        blocked=True,
+        comments=True,
+        existing_comments=[{'id': 9, 'user': {'login': 'outside-contributor'}, 'body': f'see {MARKER}'}],
+    ),
+    # `edited` fires on closed and merged PRs too, where there is no merge left to guard.
+    Case(id='closed-pr-being-edited', files=PROTECTED, blocked=False, comments=False, state='closed'),
 ]
 
 
-@pytest.mark.skipif(shutil.which('jq') is None, reason='the gh stub filters payloads with jq')
-@pytest.mark.parametrize('case', CASES, ids=lambda case: case.id)
-def test_guard_rules_on_the_pull_request(case: Case, tmp_path: Path):
+def _run_guard(case: Case, tmp_path: Path) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Execute the guard's `run:` block for one case; return the result and the comment path."""
     script = tmp_path / 'guard.sh'
     script.write_text(_workflow()['jobs']['guard']['steps'][0]['run'], encoding='utf-8')
 
@@ -141,7 +179,7 @@ def test_guard_rules_on_the_pull_request(case: Case, tmp_path: Path):
     gh.chmod(0o755)
 
     comment = tmp_path / 'comment.md'
-    role = case.role if case.role == 'FAIL' else json.dumps({'role_name': case.role})
+    total_files = len(case.files) if case.total_files is None else case.total_files
     result = subprocess.run(
         ['bash', str(script)],
         capture_output=True,
@@ -153,14 +191,21 @@ def test_guard_rules_on_the_pull_request(case: Case, tmp_path: Path):
             'REPO': REPO,
             'PR_NUMBER': PR_NUMBER,
             'PR_AUTHOR': case.author,
-            'AUTHOR_ASSOCIATION': case.association,
-            'HEAD_REPO': case.head_repo,
+            'PR_STATE': case.state,
             'FAKE_FILES_JSON': json.dumps(case.files),
             'FAKE_COMMENTS_JSON': json.dumps(case.existing_comments),
-            'FAKE_ROLE_JSON': role,
+            'FAKE_PERMISSION': case.permission,
+            'FAKE_TOTAL_FILES': str(total_files),
             'FAKE_COMMENT_OUT': str(comment),
         },
     )
+    return result, comment
+
+
+@pytest.mark.skipif(shutil.which('jq') is None, reason='the gh stub filters payloads with jq')
+@pytest.mark.parametrize('case', CASES, ids=lambda case: case.id)
+def test_guard_rules_on_the_pull_request(case: Case, tmp_path: Path):
+    result, comment = _run_guard(case, tmp_path)
 
     assert result.returncode == (1 if case.blocked else 0), f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}'
     assert comment.exists() is case.comments
@@ -169,14 +214,30 @@ def test_guard_rules_on_the_pull_request(case: Case, tmp_path: Path):
 @pytest.mark.skipif(shutil.which('jq') is None, reason='the gh stub filters payloads with jq')
 def test_the_comment_names_the_offending_files_and_carries_the_dedup_marker(tmp_path: Path):
     case = Case(id='external-pr-touching-dot-github', files=PROTECTED, blocked=True, comments=True)
-    test_guard_rules_on_the_pull_request(case, tmp_path)
+    _, comment = _run_guard(case, tmp_path)
 
-    body = (tmp_path / 'comment.md').read_text(encoding='utf-8')
+    body = comment.read_text(encoding='utf-8')
     assert '- `.github/workflows/ci.yml`' in body
     # The unrelated file is the contributor's actual work — naming it would read as if it
     # were part of the problem.
     assert 'docs/agents.md' not in body
     assert MARKER in body
+
+
+@pytest.mark.skipif(shutil.which('jq') is None, reason='the gh stub filters payloads with jq')
+def test_a_hostile_filename_cannot_reach_the_shell(tmp_path: Path):
+    """Every PR-controlled value arrives through `env:` and is quoted at each use.
+
+    A filename is attacker-chosen, so if any of it were interpolated into the script it
+    would execute with the write token this trigger hands the job.
+    """
+    hostile = '.github/workflows/$(touch {})`touch {}`.yml'.format(tmp_path / 'pwned-sub', tmp_path / 'pwned-tick')
+    case = Case(id='hostile', files=[{'filename': hostile}], blocked=True, comments=True)
+    _, comment = _run_guard(case, tmp_path)
+
+    assert not (tmp_path / 'pwned-sub').exists()
+    assert not (tmp_path / 'pwned-tick').exists()
+    assert hostile in comment.read_text(encoding='utf-8')
 
 
 def test_the_guard_never_checks_out_pull_request_code():
@@ -191,11 +252,28 @@ def test_the_guard_never_checks_out_pull_request_code():
 
     source = WORKFLOW.read_text(encoding='utf-8')
     assert 'actions/checkout' not in source
-    # `head.repo.full_name` is read to tell a fork from a same-repo branch; the head
-    # *ref* and *sha* are the handles you'd need to fetch the contributor's code, and
+    # The head ref and sha are the handles you'd need to fetch the contributor's code, and
     # nothing here has any business knowing them.
     assert 'head.sha' not in source
     assert 'head.ref' not in source
+
+
+def test_the_guard_does_not_trust_a_base_repo_head_branch():
+    """GitHub Apps push branches straight into this repo, so a same-repo head proves nothing.
+
+    `pydanty[bot]` builds those branches out of externally-authored issue text — the very
+    input this guard exists to keep out of `.github/` — so reading `head.repo` as trust
+    would hand it the bypass. Resolved repo permission is the only signal.
+    """
+    # Match the payload expressions and the jq selector rather than the bare field names,
+    # which also appear in the comments explaining why they aren't used.
+    source = WORKFLOW.read_text(encoding='utf-8')
+    assert 'github.event.pull_request.head.repo' not in source
+    assert 'github.event.pull_request.author_association' not in source
+    # `.role_name` can be an arbitrary custom role name, which fails a hardcoded match and
+    # blocks a genuine maintainer; `.permission` is the stable base access level (#6797).
+    assert "--jq '.role_name'" not in source
+    assert "--jq '.permission'" in source
 
 
 def test_the_trigger_has_no_paths_filter():
@@ -209,10 +287,18 @@ def test_the_trigger_has_no_paths_filter():
     trigger = _workflow()[True]['pull_request_target']
     assert 'paths' not in trigger
     assert 'paths-ignore' not in trigger
+    # `edited` is the only event fired when a PR's base branch changes, and the verdict is a
+    # diff against that base — without it a green check survives a base switch.
+    assert 'edited' in trigger['types']
 
 
 def test_the_guard_job_holds_only_the_permission_it_uses():
-    """No `contents:` scope — the job never reads the repository's code."""
+    """No `contents:` scope — the job never reads the repository's code.
+
+    The collaborator-permission endpoint needs only metadata access, which every token
+    carries and no `permissions:` key can withhold, so `pull-requests: write` covers every
+    call the guard makes.
+    """
     workflow = _workflow()
     assert workflow['permissions'] == {}
     assert workflow['jobs']['guard']['permissions'] == {'pull-requests': 'write'}

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -90,6 +90,32 @@ diff, and expect the first real execution to be on `main`. This is unlike
 `.github/workflows/ci.yml`, which runs on `pull_request` from the PR's own merge
 ref and therefore does test itself.
 
+# `Protect .github` keeps external changes out of this directory
+
+`protect-github-dir.yml` fails a PR that changes anything under `.github/` unless its
+author is trusted. Everything here executes with repository credentials, so an edit from
+outside the org is a supply-chain change rather than an ordinary code review — a
+maintainer carries legitimate ones forward in their own PR (#7024 is the case that
+prompted the guard). **It only blocks merge once it is marked a required check in repo
+settings**; until then it is advisory.
+
+Trust has three paths, because `author_association` alone misreports a genuine
+collaborator as `CONTRIBUTOR` (#6359 — `pr-guard.yml` carries the same fallback): a
+head branch in this repository (which can only exist with push access), a
+maintainer `author_association`, or a `write`-or-higher repo role. Unlike `pr-guard.yml`
+the role lookup fails **closed** — this is a security boundary, not a courtesy gate.
+`dependabot[bot]` is allowlisted because it owns the action-pin bumps here (the
+`github-actions` ecosystem entry in `dependabot.yml`), and is the only bot with a bypass:
+`pydanty[bot]` acts on externally-authored issue text, which is the untrusted input the
+guard exists to keep out, and a blanket `*[bot]` glob would hand the bypass to any bot
+installed later.
+
+**Do not add a `paths:` filter to its trigger.** A `pull_request_target` filtered to
+`.github/**` does not run at all on the PRs that don't touch it, and a required check
+that never runs stays *pending* — blocking every merge. The job runs on every PR and
+exits 0 when nothing protected changed. Being `pull_request_target` it also has the
+`bots.yml` blind spot above: a PR that changes the guard is judged by `main`'s copy of it.
+
 # Agentic workflows (`gh-aw`)
 
 The `pydantic-ai-*` workflows in this directory are [agentic workflows](https://github.com/githubnext/gh-aw) authored as human-editable `<name>.md` sources (frontmatter + prompt) that **compile** to a generated `<name>.lock.yml`. GitHub Actions runs the `.lock.yml`, never the `.md`.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -99,22 +99,48 @@ maintainer carries legitimate ones forward in their own PR (#7024 is the case th
 prompted the guard). **It only blocks merge once it is marked a required check in repo
 settings**; until then it is advisory.
 
-Trust has three paths, because `author_association` alone misreports a genuine
-collaborator as `CONTRIBUTOR` (#6359 — `pr-guard.yml` carries the same fallback): a
-head branch in this repository (which can only exist with push access), a
-maintainer `author_association`, or a `write`-or-higher repo role. Unlike `pr-guard.yml`
-the role lookup fails **closed** — this is a security boundary, not a courtesy gate.
+**The author's resolved repository permission is the only trust signal**, and the two
+shortcuts it replaces are both unsound — the same reasoning `bots.yml`'s agent-config
+guard spells out:
+
+- **A base-repo head branch does not imply push access.** GitHub Apps push branches
+  straight into this repository, so `pydanty[bot]` — which builds those branches out of
+  externally-authored issue text — clears any same-repo check. Trusting the head repo
+  would hand the guard's whole threat model a bypass.
+- **`author_association` misreports** a genuine collaborator as `CONTRIBUTOR` when their
+  org membership is private (#6359).
+
+Read `.permission`, never `.role_name`: the latter can be an arbitrary custom role name
+that fails a hardcoded match and blocks a real maintainer, while `.permission` maps
+`maintain` and custom roles onto their stable base level (#6797, which fixed exactly this
+in `bots.yml` and `at-claude.yml`). The endpoint needs only metadata access, which every
+token carries and no `permissions:` key can withhold — so `pull-requests: write` alone
+reaches it. It fails **closed**: an unreadable permission blocks, because this is a
+security boundary, not `pr-guard.yml`'s courtesy gate.
+
 `dependabot[bot]` is allowlisted because it owns the action-pin bumps here (the
-`github-actions` ecosystem entry in `dependabot.yml`), and is the only bot with a bypass:
-`pydanty[bot]` acts on externally-authored issue text, which is the untrusted input the
-guard exists to keep out, and a blanket `*[bot]` glob would hand the bypass to any bot
-installed later.
+`github-actions` ecosystem entry in `dependabot.yml`) and holds no repo permission of its
+own. It is the only bot with a bypass: a blanket `*[bot]` glob would hand one to any bot
+installed later, and `pydanty[bot]` must not have one for the reason above.
 
 **Do not add a `paths:` filter to its trigger.** A `pull_request_target` filtered to
 `.github/**` does not run at all on the PRs that don't touch it, and a required check
 that never runs stays *pending* — blocking every merge. The job runs on every PR and
-exits 0 when nothing protected changed. Being `pull_request_target` it also has the
-`bots.yml` blind spot above: a PR that changes the guard is judged by `main`'s copy of it.
+exits 0 when nothing protected changed. `edited` is in `types:` because it is the only
+event fired when a PR's **base branch** changes, and the verdict is a diff against that
+base — hence also the `state != open` early exit, since `edited` fires on closed PRs too.
+
+Two consequences of the trigger, both easy to get backwards:
+
+- On github.com `pull_request_target` runs in the context of the **default branch of the
+  base repository** ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target)),
+  *not* the PR's base branch. So `main`'s copy guards PRs targeting **every** branch,
+  `v1` included — a maintenance branch needs no copy of its own. It also means a PR that
+  changes the guard is judged by `main`'s copy, the same blind spot as `bots.yml` above.
+- Branches whose names look like SHAs [may not trigger `pull_request_target` at all](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).
+  While the check is merely advisory such a PR shows no guard run and no failing check, so
+  it reads as clean. Marking the check **required** is what closes that: a check that never
+  ran stays pending and blocks the merge.
 
 # Agentic workflows (`gh-aw`)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           .github/scripts/test_issue_pr_attention_monitor.py
           .github/scripts/test_agentic_workflow_guard.py
           .github/scripts/test_agent_spend_report.py
+          .github/scripts/test_protect_github_dir.py
 
       # Every check except lock freshness reads the tree alone, so run them on `main`
       # too. Two independently-green PRs can still merge into a drifted `main` — the

--- a/.github/workflows/protect-github-dir.yml
+++ b/.github/workflows/protect-github-dir.yml
@@ -13,10 +13,14 @@ name: Protect .github
 
 on:
   # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so the guard runs
-  # from the base branch (a fork can't disable it by editing this file) and can comment on
-  # fork PRs. Nothing here checks out or executes PR code: it reads PR metadata via the API.
+  # from the base repository's default branch (a fork can't disable it by editing this file)
+  # and can comment on fork PRs. Nothing here checks out or executes PR code: it reads PR
+  # metadata via the API.
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # `edited` is in the list because it is the only event fired when a PR's BASE branch
+    # changes, and the verdict is a diff against that base: without it a green check
+    # survives a base switch that changes which files the PR actually touches.
+    types: [opened, synchronize, reopened, edited]
 
 permissions: {}
 
@@ -41,20 +45,41 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_STATE: ${{ github.event.pull_request.state }}
         run: |
           set -euo pipefail
 
-          echo "PR #${PR_NUMBER} by ${PR_AUTHOR} (${AUTHOR_ASSOCIATION}) from ${HEAD_REPO:-<deleted fork>}"
+          echo "PR #${PR_NUMBER} by ${PR_AUTHOR}"
+
+          # `edited` also fires on closed and merged PRs (a bot rewriting the description, an
+          # author tidying the title), where there is no merge left to guard.
+          if [ "$PR_STATE" != "open" ]; then
+            echo "PR is ${PR_STATE}; nothing to guard."
+            exit 0
+          fi
 
           # Changed files first: most PRs touch nothing protected and stop here, so the
-          # trust checks below (and their extra API call) only run when it matters.
+          # permission lookup below only runs when it matters. One JSON object per file, so
+          # the line count below is the file count even though a rename contributes two paths.
+          TOTAL_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files')
+          PR_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100" --paginate \
+            --jq '.[] | {filename, previous_filename} | tojson')
+          RETRIEVED_FILES=$(printf '%s' "$PR_FILES" | grep -c '^{') || true
+
+          # That endpoint hard-caps at 3000 files and truncates rather than erroring, so a PR
+          # padded past the cap could push a `.github/` edit out of the response and be waved
+          # through. Fail closed on a short list instead of deciding on a partial changeset —
+          # the same check, for the same cap, that `ci.yml`'s lock-freshness step makes.
+          if [ "$RETRIEVED_FILES" -lt "$TOTAL_FILES" ]; then
+            echo "::error::Retrieved only ${RETRIEVED_FILES} of ${TOTAL_FILES} changed files (the PR files API caps at 3000)." \
+              "Cannot verify that .github/ is untouched, so failing closed rather than passing blind."
+            exit 1
+          fi
+
           # `previous_filename` catches a rename *out of* `.github/`, which changes the
           # directory just as much as an edit in place.
-          CHANGED_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate \
-            --jq '.[] | .filename, (.previous_filename // empty)')
-          PROTECTED_FILES=$(printf '%s\n' "$CHANGED_FILES" | grep '^\.github/' | sort -u) || true
+          PROTECTED_FILES=$(printf '%s\n' "$PR_FILES" \
+            | jq -r '.filename, (.previous_filename // empty)' | grep '^\.github/' | sort -u) || true
 
           if [ -z "$PROTECTED_FILES" ]; then
             echo "No files under .github/ changed."
@@ -75,34 +100,28 @@ jobs:
             exit 0
           fi
 
-          # A branch in the base repository can only exist if its author has push access,
-          # so a same-repo PR is trusted without asking GitHub anything further. This is
-          # also the reliable half of the check below.
-          if [ -n "${HEAD_REPO}" ] && [ "${HEAD_REPO}" = "${REPO}" ]; then
-            echo "PR head is in ${REPO} itself, so the author has write access; allowed."
-            exit 0
-          fi
-
-          if [[ "$AUTHOR_ASSOCIATION" == "OWNER" || "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" ]]; then
-            echo "Author is a maintainer/collaborator; allowed."
-            exit 0
-          fi
-
-          # The webhook's `author_association` can report CONTRIBUTOR for a genuine
-          # collaborator (observed on #6359, which is why `pr-guard.yml` carries the same
-          # fallback), so confirm the author's actual role on this repo before blocking a
-          # maintainer who opened their PR from a fork. Unlike `pr-guard.yml` this fails
-          # *closed*: an unreadable role blocks, because this is a security boundary rather
-          # than a courtesy gate. That also makes the call free — if the job's token can't
-          # read the endpoint, the outcome is the same as not asking.
-          AUTHOR_ROLE=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
-          case "$AUTHOR_ROLE" in
-            write | maintain | admin)
-              echo "Author ${PR_AUTHOR} has ${AUTHOR_ROLE} access to this repo; allowed."
+          # The author's resolved permission on THIS repository is the only trust signal, and
+          # deliberately the only one — the two shortcuts it replaces are both unsound here,
+          # for the same reasons `bots.yml`'s agent-config guard spells out:
+          #   - a base-repo head branch does NOT imply push access. GitHub Apps push branches
+          #     straight into this repo, so `pydanty[bot]` — which builds those branches from
+          #     externally-authored issue text — would clear a same-repo check and walk the
+          #     untrusted input this guard exists to stop right into `.github/`.
+          #   - `author_association` reports CONTRIBUTOR for maintainers with private org
+          #     membership (#6359), so it wrongly blocks the people it should wave through.
+          # `.permission`, not `.role_name`: the latter can be an arbitrary custom role name,
+          # which fails a hardcoded match and blocks a genuine maintainer, while `.permission`
+          # maps maintain and custom roles onto their stable base access level (#6797).
+          # Fails closed — unlike `pr-guard.yml`'s courtesy gate, an unreadable permission
+          # blocks, because this is a security boundary.
+          AUTHOR_PERMISSION=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "unknown")
+          case "$AUTHOR_PERMISSION" in
+            write | admin)
+              echo "Author ${PR_AUTHOR} has ${AUTHOR_PERMISSION} access to this repo; allowed."
               exit 0
               ;;
             *)
-              echo "Author ${PR_AUTHOR} repo role: ${AUTHOR_ROLE}; not permitted to change .github/."
+              echo "Author ${PR_AUTHOR} repo permission: ${AUTHOR_PERMISSION}; not permitted to change .github/."
               ;;
           esac
 
@@ -110,10 +129,14 @@ jobs:
           # explanation on each one would bury the rest of the review; the failing check is
           # the signal that the branch is still blocked.
           # `--jq` runs once per page under `--paginate`, so this streams one comment id per
-          # match rather than a per-page count that a numeric test would choke on.
+          # match rather than a per-page count that a numeric test would choke on. Matching on
+          # the marker alone would let anyone suppress the explanation for good by pasting it
+          # into a comment (or quote-replying to the guard elsewhere), so the poster has to be
+          # us too — the exit code never depended on this, but a blocked contributor staring at
+          # a red check with no explanation anywhere is the failure worth avoiding.
           MARKER="<!-- protect-github-dir-guard -->"
-          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id")
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${MARKER}\"))) | .id")
 
           if [ -z "$EXISTING" ]; then
             PROTECTED_LIST=$(printf '%s\n' "$PROTECTED_FILES" | awk '{ print "- `" $0 "`" }')

--- a/.github/workflows/protect-github-dir.yml
+++ b/.github/workflows/protect-github-dir.yml
@@ -1,0 +1,132 @@
+name: Protect .github
+
+# Files under `.github/` — workflows, composite actions, and the scripts they run —
+# execute with this repository's credentials, so a change to them from outside the org
+# is a supply-chain boundary, not an ordinary code review. This guard fails the PR when
+# an external contributor touches that directory; a maintainer carries any legitimate
+# change forward in their own PR.
+#
+# Deliberately no `paths:` filter on the trigger. A `pull_request_target` filtered to
+# `.github/**` would not run at all on the PRs that don't touch it, and a required check
+# that never runs stays *pending* forever — blocking every merge. The job runs on every
+# PR and exits 0 when nothing protected changed.
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so the guard runs
+  # from the base branch (a fork can't disable it by editing this file) and can comment on
+  # fork PRs. Nothing here checks out or executes PR code: it reads PR metadata via the API.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: protect-github-dir-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: .github Directory Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # `pull-requests: write` covers both listing and posting the PR comment. No
+    # `contents:` scope: this job never checks out the repository, and granting a
+    # write-token workflow read access to code it doesn't read is how these leak.
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Block external changes to .github/
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          echo "PR #${PR_NUMBER} by ${PR_AUTHOR} (${AUTHOR_ASSOCIATION}) from ${HEAD_REPO:-<deleted fork>}"
+
+          # Changed files first: most PRs touch nothing protected and stop here, so the
+          # trust checks below (and their extra API call) only run when it matters.
+          # `previous_filename` catches a rename *out of* `.github/`, which changes the
+          # directory just as much as an edit in place.
+          CHANGED_FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[] | .filename, (.previous_filename // empty)')
+          PROTECTED_FILES=$(printf '%s\n' "$CHANGED_FILES" | grep '^\.github/' | sort -u) || true
+
+          if [ -z "$PROTECTED_FILES" ]; then
+            echo "No files under .github/ changed."
+            exit 0
+          fi
+
+          echo "Files under .github/ changed:"
+          printf '%s\n' "$PROTECTED_FILES"
+
+          # Dependabot bumps the action pins in `.github/workflows/` — it's configured for
+          # the `github-actions` ecosystem in `.github/dependabot.yml`, so blocking it would
+          # freeze those updates. It is the *only* allowlisted bot: pydanty acts on
+          # externally-authored issue text, which is precisely the untrusted input this
+          # guard exists to keep out of `.github/`, and a blanket `*[bot]` glob would hand
+          # the bypass to any bot installed later.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Author is dependabot; allowed."
+            exit 0
+          fi
+
+          # A branch in the base repository can only exist if its author has push access,
+          # so a same-repo PR is trusted without asking GitHub anything further. This is
+          # also the reliable half of the check below.
+          if [ -n "${HEAD_REPO}" ] && [ "${HEAD_REPO}" = "${REPO}" ]; then
+            echo "PR head is in ${REPO} itself, so the author has write access; allowed."
+            exit 0
+          fi
+
+          if [[ "$AUTHOR_ASSOCIATION" == "OWNER" || "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "Author is a maintainer/collaborator; allowed."
+            exit 0
+          fi
+
+          # The webhook's `author_association` can report CONTRIBUTOR for a genuine
+          # collaborator (observed on #6359, which is why `pr-guard.yml` carries the same
+          # fallback), so confirm the author's actual role on this repo before blocking a
+          # maintainer who opened their PR from a fork. Unlike `pr-guard.yml` this fails
+          # *closed*: an unreadable role blocks, because this is a security boundary rather
+          # than a courtesy gate. That also makes the call free — if the job's token can't
+          # read the endpoint, the outcome is the same as not asking.
+          AUTHOR_ROLE=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
+          case "$AUTHOR_ROLE" in
+            write | maintain | admin)
+              echo "Author ${PR_AUTHOR} has ${AUTHOR_ROLE} access to this repo; allowed."
+              exit 0
+              ;;
+            *)
+              echo "Author ${PR_AUTHOR} repo role: ${AUTHOR_ROLE}; not permitted to change .github/."
+              ;;
+          esac
+
+          # One comment per PR. `synchronize` re-runs this on every push, and repeating the
+          # explanation on each one would bury the rest of the review; the failing check is
+          # the signal that the branch is still blocked.
+          # `--jq` runs once per page under `--paginate`, so this streams one comment id per
+          # match rather than a per-page count that a numeric test would choke on.
+          MARKER="<!-- protect-github-dir-guard -->"
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id")
+
+          if [ -z "$EXISTING" ]; then
+            PROTECTED_LIST=$(printf '%s\n' "$PROTECTED_FILES" | awk '{ print "- `" $0 "`" }')
+            COMMENT=$(printf '%s\n\n%s\n\n%s\n\n%s\n%s\n\n%s\n' \
+              "Thanks for the PR! One thing blocks it: it changes files under \`.github/\`, which we can only accept from maintainers." \
+              "**What to do:** drop those changes from this branch (\`git checkout origin/main -- .github\` and push) — the rest of your work is unaffected and still very welcome. If the \`.github/\` change is needed for the rest to work, say so in a comment and a maintainer will carry it forward in a separate PR." \
+              "**Why:** everything under \`.github/\` runs with this repository's credentials, so changes to it are a supply-chain boundary. This is an automatic rule, not a judgement on your change." \
+              "Files under \`.github/\` changed by this PR:" \
+              "$PROTECTED_LIST" \
+              "$MARKER")
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
+          else
+            echo "Explanatory comment already posted; not repeating it."
+          fi
+
+          exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ include = [
     ".github/scripts/test_agentic_workflow_guard.py",
     ".github/scripts/agent_spend_report.py",
     ".github/scripts/test_agent_spend_report.py",
+    ".github/scripts/test_protect_github_dir.py",
 ]
 
 [tool.ruff.lint]
@@ -286,6 +287,7 @@ quote-style = "single"
 ".github/scripts/test_issue_pr_attention_monitor.py" = ["D"]
 ".github/scripts/test_agentic_workflow_guard.py" = ["D"]
 ".github/scripts/test_agent_spend_report.py" = ["D"]
+".github/scripts/test_protect_github_dir.py" = ["D"]
 
 [tool.pyright]
 pythonVersion = "3.10"


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David requested this change and will review it. He has not reviewed the code line-by-line yet.

---

Fails a PR that changes anything under `.github/` unless its author is trusted. Files there — workflows, composite actions, and the scripts they invoke — execute with this repository's credentials, so an edit from outside the org is a supply-chain change rather than an ordinary code review.

**The incident:** #7024, from an external contributor's fork, modified `.github/scripts/pydantic-ai-runner` and its lock file. Nothing mechanically stopped it — a maintainer noticing was the only gate, and this repo has no `CODEOWNERS` file.

There's no tracking issue; this was requested directly, so no `Closes`.

### ⚠️ Known limitations — this guard does not block until an admin acts

**1. It is advisory until `.github Directory Guard` is marked a required status check** on `main` in branch protection. That is a repo-admin action, which this PR cannot perform and which no code change here can substitute for. Until then the guard reports a failing check that nothing enforces, and a PR modifying `.github/` can still be merged.

**2. Branches whose names look like SHAs [may not trigger `pull_request_target` at all](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target).** Such a PR gets no guard run, no failing check and no comment — it reads as clean. This is stated as a known limitation rather than fixed: it is GitHub's trigger behaviour, not something the workflow can detect from inside. Marking the check required is what closes it, because a required check that never ran stays *pending* and blocks the merge.

Both points resolve to the same action, so until it is taken this guard documents a policy rather than enforcing one.

### How it works

`pull_request_target`, metadata-only. It reads the PR's changed files and author over the API and **never checks out or executes PR code** — under this trigger the job holds a write token in base-repository context, so checking out the PR head would *be* the hole this closes. Tests assert no step has a `uses:`, and that `head.sha` / `head.ref` appear nowhere in the file.

**The author's resolved repository permission is the only trust signal** (`write` or `admin`), plus an allowlist for `dependabot[bot]`, which owns the action-pin bumps here and holds no repo permission of its own.

Two shortcuts were tried first and are both unsound — see the commits:

- **A base-repo head branch does not imply push access.** GitHub Apps push branches straight into this repository (`pydanty[bot]` and `dependabot[bot]` both do — verified), so trusting the head repo would have let `pydanty[bot]` change `.github/`. Since pydanty builds its branches out of externally-authored issue text, that is precisely the untrusted input this guard exists to stop. `bots.yml`'s agent-config guard already states the rule: *"a same-repo branch (e.g. an automated agent's branch built from an untrusted issue) can carry a poisoned instruction file just as a fork can."*
- **`author_association` misreports** a genuine collaborator as `CONTRIBUTOR` when org membership is private (#6359).

Read `.permission`, never `.role_name` — the latter can be an arbitrary custom role name that fails a hardcoded match and blocks a real maintainer. #6797 fixed exactly this in `bots.yml`/`at-claude.yml` last week. The endpoint needs only metadata access, which no `permissions:` key can withhold, so `pull-requests: write` alone reaches it. It fails **closed**: an unreadable permission blocks.

<details><summary>Five footguns the code and tests pin down</summary>

- **No `paths:` filter on the trigger.** A `pull_request_target` filtered to `.github/**` does not run at all on the PRs that don't match it, and a *required* check that never runs stays **pending forever** — deadlocking every merge in the repo. The job runs on every PR and exits 0 when nothing protected changed.
- **`previous_filename` is read alongside `filename`**, so renaming a file *out of* `.github/` is caught. It otherwise shows up only under its new path.
- **The PR-files API caps at 3000 and truncates silently**, so a PR padded past the cap could push a `.github/` edit out of the response. The guard compares the retrieved count against `.changed_files` and fails closed — the same check, for the same cap, that `ci.yml`'s lock-freshness step makes.
- **`edited` is in `types:`** because it is the only event fired when a PR's *base branch* changes, and the verdict is a diff against that base. Hence also the `state != open` early exit, since `edited` fires on closed PRs too.

</details>

<details><summary>What a blocked contributor sees</summary>

> Thanks for the PR! One thing blocks it: it changes files under `.github/`, which we can only accept from maintainers.
>
> **What to do:** drop those changes from this branch (`git checkout origin/main -- .github` and push) — the rest of your work is unaffected and still very welcome. If the `.github/` change is needed for the rest to work, say so in a comment and a maintainer will carry it forward in a separate PR.
>
> **Why:** everything under `.github/` runs with this repository's credentials, so changes to it are a supply-chain boundary. This is an automatic rule, not a judgement on your change.
>
> Files under `.github/` changed by this PR:
> - `.github/workflows/ci.yml`

Posted once per PR — `synchronize` re-runs the guard on every push, and the failing check is the signal that the branch is still blocked.

</details>

### This PR cannot test itself

On github.com `pull_request_target` runs from the **default branch of the base repository** ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target)), so `.github Directory Guard` will not appear on this PR at all — the file isn't on `main` yet. Its first real execution is post-merge. (Same property as `bots.yml`, documented in `.github/workflows/AGENTS.md`.)

The upside of that same rule: `main`'s copy guards PRs targeting **every** base branch, `v1` included, so the security-maintenance branch needs no copy of its own.

So the logic is regression-tested instead: `.github/scripts/test_protect_github_dir.py` extracts the guard's `run:` block from the YAML and executes it against a stubbed `gh`, covering 12 authorization scenarios plus the structural invariants above (including that the guard does *not* read `head.repo`, `author_association`, or `.role_name`) — a bug here either blocks every contributor or silently lets fork-authored changes in, and the workflow can't be exercised any other way before it lands. It's wired into the lint job's existing step alongside `test_agentic_workflow_guard.py`. The workflow is also clean under `zizmor` (the repo's pre-commit hook), `actionlint`, and `shellcheck` on the extracted script.

`.github/workflows/AGENTS.md` gains a section covering the trust model, the bot-allowlist reasoning, and the `paths:` footgun.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

