### PR TITLE
Skip inbound AG-UI content newer than the installed `ag-ui-protocol` instead of returning 422

### DIFF
--- a/docs/ui/ag-ui.md
+++ b/docs/ui/ag-ui.md
@@ -373,6 +373,14 @@ Since `app` is an ASGI application, it can be used with any ASGI server:
 uvicorn ag_ui_tool_events:app --host 0.0.0.0 --port 9000
 ```
 
+### Protocol version compatibility
+
+Pydantic AI supports every `ag-ui-protocol` release from `0.1.10` on, and features added after that floor are gated on the version you have installed rather than requiring an upgrade.
+
+That gate runs in both directions. On the way out, content an older protocol version can't express is downgraded or omitted — see [`AGUIAdapter.ag_ui_version`][pydantic_ai.ui.ag_ui.AGUIAdapter.ag_ui_version] for the negotiated thresholds. On the way in, a message `role` or input content `type` introduced after your installed version is skipped with a `UserWarning` naming the tag, and the rest of the request runs — so a frontend on a newer protocol version than your server keeps working, minus the content your install has no type for. For instance, a gateway that forwards image attachments as typed multimodal content (`ag-ui-protocol >= 0.1.15`) still delivers the accompanying text to an agent running on an older install.
+
+Only content the installed models cannot interpret at all is skipped: a request that is malformed for any other reason is still rejected with `422 Unprocessable Entity`. If you see the warning, upgrading `ag-ui-protocol` is what makes the skipped content reach your agent.
+
 ### Trust model
 
 AG-UI's `RunAgentInput.messages` is fully client-controlled. The [`AGUIAdapter`][pydantic_ai.ui.ag_ui.AGUIAdapter] applies defaults to strip untrusted parts before the agent runs — see [Trust model for client-submitted messages](./overview.md#trust-model-for-client-submitted-messages) in the UI adapter overview, which covers system prompts, file URL schemes, uploaded files ([`allow_uploaded_files`][pydantic_ai.ui.UIAdapter.allow_uploaded_files]), and unresolved tool calls. Those defaults don't make client-submitted history authentic — see [Trust boundary for client-supplied history](../message-history.md#trust-boundary-for-client-supplied-history).

--- a/docs/ui/ag-ui.md
+++ b/docs/ui/ag-ui.md
@@ -377,9 +377,11 @@ uvicorn ag_ui_tool_events:app --host 0.0.0.0 --port 9000
 
 Pydantic AI supports every `ag-ui-protocol` release from `0.1.10` on, and features added after that floor are gated on the version you have installed rather than requiring an upgrade.
 
-That gate runs in both directions. On the way out, content an older protocol version can't express is downgraded or omitted — see [`AGUIAdapter.ag_ui_version`][pydantic_ai.ui.ag_ui.AGUIAdapter.ag_ui_version] for the negotiated thresholds. On the way in, a message `role` or input content `type` introduced after your installed version is skipped with a `UserWarning` naming the tag, and the rest of the request runs — so a frontend on a newer protocol version than your server keeps working, minus the content your install has no type for. For instance, a gateway that forwards image attachments as typed multimodal content (`ag-ui-protocol >= 0.1.15`) still delivers the accompanying text to an agent running on an older install.
+That gate runs in both directions. On the way out, content an older protocol version can't express is downgraded or omitted — see [`AGUIAdapter.ag_ui_version`][pydantic_ai.ui.ag_ui.AGUIAdapter.ag_ui_version] for the negotiated thresholds. On the way in, a message `role` or input content `type` your installed `ag-ui-protocol` has no class for is skipped with a `UserWarning` naming the tag, and the rest of the request runs — so a frontend on a newer protocol version than your server keeps working, minus the content your install has no type for. For instance, a gateway that forwards image attachments as typed multimodal content (`ag-ui-protocol >= 0.1.15`) still delivers the accompanying text to an agent running on an older install.
 
-Only content the installed models cannot interpret at all is skipped: a request that is malformed for any other reason is still rejected with `422 Unprocessable Entity`. If you see the warning, upgrading `ag-ui-protocol` is what makes the skipped content reach your agent.
+What gets skipped is decided by the tag alone: any `role` or `type` string the installed models don't declare qualifies, so a client that misspells `"txet"` is skipped with the same warning as one sending genuinely newer content — the server has no way to tell those apart. The skip is scoped to well-formed items: a message must still carry a string `id`, the field every AG-UI message type requires.
+
+Everything else is still rejected with `422 Unprocessable Entity` — a payload that is malformed under a `role` or `type` the install *does* know, a `role` or `type` that isn't a string at all, and a body that isn't valid JSON. If you see the warning and the content was real, upgrading `ag-ui-protocol` is what makes it reach your agent.
 
 ### Trust model
 

--- a/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md
+++ b/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md
@@ -4,3 +4,7 @@ Since [3971](https://github.com/pydantic/pydantic-ai/pull/3971#discussion_r30110
 - version requirement bumps are disallowed
 - new functionality should be gated behind version checks (including imports)
 - older versions don't error out when they encounter new functionality, but instead skip it
+
+The inbound half of that last rule lives in `ag_ui/_forward_compat.py`: AG-UI's `Message` and `InputContent` are discriminated unions, so a `role` or `type` added after the installed version is a hard validation failure for the whole request unless it's skipped first. Skipping is scoped to exactly that — anything else malformed must still fail.
+
+Tests for version-gated behavior belong behind `requires_ag_ui('<version>')` in `tests/test_ag_ui.py`, never behind the module-level `imports_successful()` gate: a name that only exists above the floor in that import block skips the entire module on CI's `test-lowest-versions` job, which is the only job that exercises the floor these gates exist for.

--- a/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md
+++ b/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md
@@ -5,6 +5,6 @@ Since [3971](https://github.com/pydantic/pydantic-ai/pull/3971#discussion_r30110
 - new functionality should be gated behind version checks (including imports)
 - older versions don't error out when they encounter new functionality, but instead skip it
 
-The inbound half of that last rule lives in `ag_ui/_forward_compat.py`: AG-UI's `Message` and `InputContent` are discriminated unions, so a `role` or `type` added after the installed version is a hard validation failure for the whole request unless it's skipped first. Skipping is scoped to exactly that — anything else malformed must still fail.
+The inbound half of that last rule lives in `ag_ui/_forward_compat.py`: AG-UI's `Message` and `InputContent` are discriminated unions, so a `role` or `type` added after the installed version is a hard validation failure for the whole request unless it's skipped first. Skipping is scoped to exactly that — an unknown tag only counts as new functionality when the item also satisfies the contract every member of its union shares (for `Message`, a string `id`), so anything else malformed must still fail.
 
 Tests for version-gated behavior belong behind `requires_ag_ui('<version>')` in `tests/test_ag_ui.py`, never behind the module-level `imports_successful()` gate: a name that only exists above the floor in that import block skips the entire module on CI's `test-lowest-versions` job, which is the only job that exercises the floor these gates exist for.

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -680,8 +680,15 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 ),
             )
         except ValidationError as e:
+            try:
+                content = e.json()
+            except ValueError:
+                # A body that isn't valid UTF-8 leaves the raw bytes on `input_value`, which
+                # `e.json()` can't serialize — drop the echoed input so the client still gets its
+                # 422 rather than a 500.
+                content = e.json(include_input=False)
             return Response(
-                content=e.json(),
+                content=content,
                 media_type='application/json',
                 status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             )

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -679,7 +679,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                     **kwargs,
                 ),
             )
-        except ValidationError as e:  # pragma: no cover
+        except ValidationError as e:
             return Response(
                 content=e.json(),
                 media_type='application/json',

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -15,6 +15,7 @@ from typing import (
     Literal,
 )
 
+from pydantic import ValidationError
 from typing_extensions import assert_never
 
 from ... import ExternalToolset, ToolDefinition
@@ -77,6 +78,7 @@ try:
 
     from .. import MessagesBuilder, UIAdapter, UIEventStream
     from ._event_stream import AGUIEventStream
+    from ._forward_compat import skip_unknown_tagged_items
     from ._interrupt import (
         HAS_INTERRUPTS,
         ResumeEntry,
@@ -247,7 +249,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
       `VideoInputContent`, `DocumentInputContent`) instead of generic `BinaryInputContent`.
 
     `load_messages` always accepts `ReasoningMessage` and multimodal content types regardless
-    of this setting.
+    of this setting, and `build_run_input` skips inbound content types the installed
+    `ag-ui-protocol` predates rather than rejecting the request.
     """
 
     preserve_file_data: bool = False
@@ -270,8 +273,31 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
 
     @classmethod
     def build_run_input(cls, body: bytes) -> RunAgentInput:
-        """Build an AG-UI run input object from the request body."""
-        return RunAgentInput.model_validate_json(body)
+        """Build an AG-UI run input object from the request body.
+
+        A message `role` or input content `type` introduced by a protocol version newer than the
+        installed `ag-ui-protocol` is skipped with a warning rather than failing the whole request,
+        per the backwards-compatibility policy in `pydantic_ai/ui/AGENTS.md`. Only items the
+        installed models cannot dispatch at all are skipped: a body that is invalid for any other
+        reason still raises, so a client bug isn't converted into silent misbehavior.
+        """
+        try:
+            return RunAgentInput.model_validate_json(body)
+        except ValidationError:
+            payload, skipped = skip_unknown_tagged_items(body)
+            if not skipped:
+                raise
+
+        # Validated outside the `except` block so a body that is *also* malformed reports the
+        # remaining errors on their own rather than chained behind the unknown-tag failure.
+        run_input = RunAgentInput.model_validate(payload)
+        warnings.warn(
+            f'AG-UI content the installed ag-ui-protocol {DEFAULT_AG_UI_VERSION} does not support '
+            f'({", ".join(sorted(skipped))}) was skipped; upgrade `ag-ui-protocol` to accept it.',
+            UserWarning,
+            stacklevel=2,
+        )
+        return run_input
 
     def build_event_stream(self) -> UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, OutputDataT]:
         """Build an AG-UI event stream transformer."""

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_forward_compat.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_forward_compat.py
@@ -83,7 +83,12 @@ def skip_unknown_tagged_items(body: bytes) -> tuple[Any, frozenset[str]]:
     """
     try:
         payload = json.loads(body)
-    except json.JSONDecodeError:
+    except (ValueError, RecursionError):
+        # Re-reading the body is best effort on input that already failed validation, so every way
+        # `json.loads` can reject it means there is nothing to skip and the caller's original
+        # `ValidationError` (and the 422 it maps to) must stand. Invalid JSON and invalid UTF-8 both
+        # arrive as `ValueError` subclasses — `UnicodeDecodeError` is not a `JSONDecodeError` — and
+        # input nested past the interpreter's limit arrives as `RecursionError`.
         return None, frozenset()
     if not is_str_dict(payload):
         return None, frozenset()

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_forward_compat.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_forward_compat.py
@@ -1,0 +1,111 @@
+"""Forward compatibility for inbound AG-UI run input.
+
+Our `ag-ui-protocol` floor is `>=0.1.10` and the policy (see `pydantic_ai/ui/AGENTS.md`) is that an
+older install skips new functionality rather than erroring on it. AG-UI's models set `extra='allow'`,
+so a *field* added to an existing type already parses and is ignored, but `Message` (discriminated on
+`role`) and `InputContent` (discriminated on `type`) are tagged unions: a `role` or `type` the
+installed models don't know is rejected outright, which fails validation for the whole request.
+`ReasoningMessage` (0.1.11) and typed multimodal input content (0.1.15) both sit above the floor, so
+a client that is merely newer than the server trips this.
+
+This module reduces such a body to the items the installed models *can* dispatch, so the rest of the
+run still parses. It deliberately removes nothing else: an item whose tag is known stays untouched
+and keeps failing validation, so a genuinely malformed payload is still rejected rather than silently
+reinterpreted.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TypeGuard, get_args
+
+from ag_ui.core import InputContent, Message
+from pydantic import BaseModel
+
+from ..._utils import is_str_dict
+
+__all__ = ['skip_unknown_tagged_items']
+
+
+def _known_tags(tagged_union: object, discriminator: str) -> frozenset[str]:
+    """Discriminator values declared by the installed `ag-ui-protocol`'s members of a tagged union.
+
+    Read off the union rather than hardcoded, so the known set tracks whatever version is installed —
+    which is the whole point, since what counts as "new functionality" depends on the install.
+    """
+    members: tuple[type[BaseModel], ...] = get_args(get_args(tagged_union)[0])
+    return frozenset(
+        tag
+        for member in members
+        for tag in get_args(member.model_fields[discriminator].annotation)
+        if isinstance(tag, str)
+    )
+
+
+# The discriminator names themselves are AG-UI wire constants, stable across every version in range.
+_KNOWN_MESSAGE_ROLES = _known_tags(Message, 'role')
+_KNOWN_INPUT_CONTENT_TYPES = _known_tags(InputContent, 'type')
+
+
+def _is_any_list(obj: Any) -> TypeGuard[list[Any]]:
+    """Check if obj is a list, narrowing the type to `list[Any]`.
+
+    The counterpart of `is_str_dict` for the arrays in a decoded JSON body: the items are arbitrary
+    client input we only ever inspect through `is_str_dict`, so they type the same way.
+    """
+    return isinstance(obj, list)
+
+
+def _unknown_tag(item: Any, discriminator: str, known: frozenset[str]) -> str | None:
+    """A `"role='reasoning'"`-style label when `item`'s discriminator value is one the installed models don't know.
+
+    `None` for anything else, including an item that isn't an object or carries no string tag: those
+    aren't new functionality, they're malformed, and validation should still report them.
+    """
+    if not is_str_dict(item):
+        return None
+    tag = item.get(discriminator)
+    if isinstance(tag, str) and tag not in known:
+        return f'{discriminator}={tag!r}'
+    return None
+
+
+def skip_unknown_tagged_items(body: bytes) -> tuple[Any, frozenset[str]]:
+    """Re-read a rejected AG-UI request body without the items this install can't dispatch.
+
+    Returns the reduced payload and labels for the tags that were skipped. The payload is only
+    meaningful when the label set is non-empty; an empty set means there was nothing to skip and the
+    caller should let the original validation error stand.
+
+    `messages[]` and a user message's list `content` are the only tagged-union lists in
+    `RunAgentInput`. A body that isn't a JSON object, or whose `messages` isn't a list, is left for
+    validation to reject.
+    """
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None, frozenset()
+    if not is_str_dict(payload):
+        return None, frozenset()
+    messages = payload.get('messages')
+    if not _is_any_list(messages):
+        return None, frozenset()
+
+    skipped: set[str] = set()
+    kept_messages: list[Any] = []
+    for message in messages:
+        if (unknown_role := _unknown_tag(message, 'role', _KNOWN_MESSAGE_ROLES)) is not None:
+            skipped.add(unknown_role)
+            continue
+        if is_str_dict(message) and _is_any_list(content := message.get('content')):
+            kept_content: list[Any] = []
+            for item in content:
+                if (unknown_type := _unknown_tag(item, 'type', _KNOWN_INPUT_CONTENT_TYPES)) is not None:
+                    skipped.add(unknown_type)
+                    continue
+                kept_content.append(item)
+            message['content'] = kept_content
+        kept_messages.append(message)
+
+    payload['messages'] = kept_messages
+    return payload, frozenset(skipped)

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_forward_compat.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_forward_compat.py
@@ -11,18 +11,20 @@ a client that is merely newer than the server trips this.
 This module reduces such a body to the items the installed models *can* dispatch, so the rest of the
 run still parses. It deliberately removes nothing else: an item whose tag is known stays untouched
 and keeps failing validation, so a genuinely malformed payload is still rejected rather than silently
-reinterpreted.
+reinterpreted. An unknown tag alone isn't enough either — an item only qualifies as new functionality
+if it also satisfies the contract every member of its union shares, so a client bug can't ride in
+under a tag we don't recognize.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any, TypeGuard, get_args
+from typing import get_args
 
 from ag_ui.core import InputContent, Message
-from pydantic import BaseModel
+from pydantic import BaseModel, JsonValue
 
-from ..._utils import is_str_dict
+from ..._utils import get_union_args
 
 __all__ = ['skip_unknown_tagged_items']
 
@@ -33,7 +35,7 @@ def _known_tags(tagged_union: object, discriminator: str) -> frozenset[str]:
     Read off the union rather than hardcoded, so the known set tracks whatever version is installed —
     which is the whole point, since what counts as "new functionality" depends on the install.
     """
-    members: tuple[type[BaseModel], ...] = get_args(get_args(tagged_union)[0])
+    members: tuple[type[BaseModel], ...] = get_union_args(tagged_union)
     return frozenset(
         tag
         for member in members
@@ -47,30 +49,19 @@ _KNOWN_MESSAGE_ROLES = _known_tags(Message, 'role')
 _KNOWN_INPUT_CONTENT_TYPES = _known_tags(InputContent, 'type')
 
 
-def _is_any_list(obj: Any) -> TypeGuard[list[Any]]:
-    """Check if obj is a list, narrowing the type to `list[Any]`.
-
-    The counterpart of `is_str_dict` for the arrays in a decoded JSON body: the items are arbitrary
-    client input we only ever inspect through `is_str_dict`, so they type the same way.
-    """
-    return isinstance(obj, list)
-
-
-def _unknown_tag(item: Any, discriminator: str, known: frozenset[str]) -> str | None:
+def _unknown_tag(item: dict[str, JsonValue], discriminator: str, known: frozenset[str]) -> str | None:
     """A `"role='reasoning'"`-style label when `item`'s discriminator value is one the installed models don't know.
 
-    `None` for anything else, including an item that isn't an object or carries no string tag: those
-    aren't new functionality, they're malformed, and validation should still report them.
+    `None` for an item that carries no string tag: that isn't new functionality, it's malformed, and
+    validation should still report it.
     """
-    if not is_str_dict(item):
-        return None
     tag = item.get(discriminator)
     if isinstance(tag, str) and tag not in known:
         return f'{discriminator}={tag!r}'
     return None
 
 
-def skip_unknown_tagged_items(body: bytes) -> tuple[Any, frozenset[str]]:
+def skip_unknown_tagged_items(body: bytes) -> tuple[JsonValue, frozenset[str]]:
     """Re-read a rejected AG-UI request body without the items this install can't dispatch.
 
     Returns the reduced payload and labels for the tags that were skipped. The payload is only
@@ -82,7 +73,7 @@ def skip_unknown_tagged_items(body: bytes) -> tuple[Any, frozenset[str]]:
     validation to reject.
     """
     try:
-        payload = json.loads(body)
+        payload: JsonValue = json.loads(body)
     except (ValueError, RecursionError):
         # Re-reading the body is best effort on input that already failed validation, so every way
         # `json.loads` can reject it means there is nothing to skip and the caller's original
@@ -90,26 +81,38 @@ def skip_unknown_tagged_items(body: bytes) -> tuple[Any, frozenset[str]]:
         # arrive as `ValueError` subclasses — `UnicodeDecodeError` is not a `JSONDecodeError` — and
         # input nested past the interpreter's limit arrives as `RecursionError`.
         return None, frozenset()
-    if not is_str_dict(payload):
+    if not isinstance(payload, dict):
         return None, frozenset()
     messages = payload.get('messages')
-    if not _is_any_list(messages):
+    if not isinstance(messages, list):
         return None, frozenset()
 
     skipped: set[str] = set()
-    kept_messages: list[Any] = []
+    kept_messages: list[JsonValue] = []
     for message in messages:
-        if (unknown_role := _unknown_tag(message, 'role', _KNOWN_MESSAGE_ROLES)) is not None:
-            skipped.add(unknown_role)
-            continue
-        if is_str_dict(message) and _is_any_list(content := message.get('content')):
-            kept_content: list[Any] = []
-            for item in content:
-                if (unknown_type := _unknown_tag(item, 'type', _KNOWN_INPUT_CONTENT_TYPES)) is not None:
-                    skipped.add(unknown_type)
+        if isinstance(message, dict):
+            if (unknown_role := _unknown_tag(message, 'role', _KNOWN_MESSAGE_ROLES)) is not None:
+                # A string `id` is the entire contract the `Message` union shares: it is the only
+                # field every member requires in every version from our floor on, and `BaseMessage`
+                # is not a common base (`ActivityMessage`, `ReasoningMessage` and `ToolMessage` don't
+                # derive from it, and `ActivityMessage.content` is an object where
+                # `BaseMessage.content` is a string). A message that fails it is malformed whatever
+                # its role, so it stays in and keeps failing validation instead of being skipped.
+                if isinstance(message.get('id'), str):
+                    skipped.add(unknown_role)
                     continue
-                kept_content.append(item)
-            message['content'] = kept_content
+            elif isinstance(content := message.get('content'), list):
+                # No such contract exists for content: the `InputContent` members share no field
+                # beyond the discriminator, so a string `type` is all an unknown one can be held to.
+                kept_content: list[JsonValue] = []
+                for item in content:
+                    if isinstance(item, dict) and (
+                        (unknown_type := _unknown_tag(item, 'type', _KNOWN_INPUT_CONTENT_TYPES)) is not None
+                    ):
+                        skipped.add(unknown_type)
+                        continue
+                    kept_content.append(item)
+                message['content'] = kept_content
         kept_messages.append(message)
 
     payload['messages'] = kept_messages

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -24,11 +24,15 @@ carrier (`ReasoningEncryptedValueEvent`) is a separate `REASONING_*` event gated
 REASONING_VERSION = (0, 1, 13)
 """AG-UI version that introduced REASONING_* events (replacing THINKING_*)."""
 
-MULTIMODAL_VERSION = (0, 1, 15)
-"""AG-UI version that introduced typed multimodal input content (Image/Audio/Video/Document).
+REASONING_MESSAGE_ROLE_VERSION = (0, 1, 14)
+"""AG-UI version that changed `ReasoningMessageStartEvent.role` from `'assistant'` to `'reasoning'`.
 
-Also changed `ReasoningMessageStartEvent.role` from `'assistant'` to `'reasoning'`.
+The field is a `Literal`, so the value we emit has to match the *installed* model exactly or
+constructing the event raises — see `REASONING_MESSAGE_ROLE`.
 """
+
+MULTIMODAL_VERSION = (0, 1, 15)
+"""AG-UI version that introduced typed multimodal input content (Image/Audio/Video/Document)."""
 
 INTERRUPTS_VERSION = (0, 1, 19)
 """AG-UI version that introduced the interrupt-aware run lifecycle.
@@ -109,7 +113,7 @@ DEFAULT_AG_UI_VERSION: str = detect_ag_ui_version()
 """The default AG-UI version, auto-detected from the installed `ag-ui-protocol` package."""
 
 REASONING_MESSAGE_ROLE: str = (
-    'reasoning' if parse_ag_ui_version(DEFAULT_AG_UI_VERSION) >= MULTIMODAL_VERSION else 'assistant'
+    'reasoning' if parse_ag_ui_version(DEFAULT_AG_UI_VERSION) >= REASONING_MESSAGE_ROLE_VERSION else 'assistant'
 )
 """The correct `role` value for `ReasoningMessageStartEvent`, based on the installed SDK version."""
 

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from pydantic_ai import (
     AudioUrl,
@@ -90,22 +90,20 @@ from ._inline_snapshot import snapshot
 from .conftest import IsDatetime, IsInt, IsSameStr, IsStr, iter_message_parts, message, message_part, try_import
 
 with try_import() as imports_successful:
+    # Only symbols that exist at our declared floor (`ag-ui-protocol>=0.1.10`) belong here: this gate
+    # controls `pytestmark`, so a name added in a later version would skip the whole module on the
+    # `test-lowest-versions` CI job and leave the floor — the version the compatibility gating in
+    # `pydantic_ai.ui.ag_ui` exists for — completely untested.
     from ag_ui.core import (
         ActivityMessage,
         AssistantMessage,
-        AudioInputContent,
         BaseEvent,
         BinaryInputContent,
         CustomEvent,
         DeveloperMessage,
-        DocumentInputContent,
         EventType,
         FunctionCall,
-        ImageInputContent,
-        InputContentDataSource,
-        InputContentUrlSource,
         Message,
-        ReasoningMessage,
         RunAgentInput,
         StateSnapshotEvent,
         SystemMessage,
@@ -114,7 +112,6 @@ with try_import() as imports_successful:
         ToolCall,
         ToolMessage,
         UserMessage,
-        VideoInputContent,
     )
     from ag_ui.encoder import EventEncoder
     from starlette.requests import Request
@@ -124,6 +121,7 @@ with try_import() as imports_successful:
     from pydantic_ai.ui.ag_ui import AGUIAdapter, AGUIEventStream
     from pydantic_ai.ui.ag_ui._utils import (
         BUILTIN_TOOL_CALL_ID_PREFIX,
+        REASONING_MESSAGE_ROLE,
         detect_ag_ui_version,
         parse_ag_ui_version,
     )
@@ -131,6 +129,22 @@ with try_import() as imports_successful:
 with try_import() as anthropic_imports_successful:
     from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
     from pydantic_ai.providers.anthropic import AnthropicProvider
+
+with try_import():
+    # `ReasoningMessage` was added in ag-ui-protocol 0.1.11 (`ENCRYPTED_VALUE_VERSION`), which also
+    # added the `encrypted_value` field that carries our `tool_kind`/`outcome` claims.
+    from ag_ui.core import ReasoningMessage
+
+with try_import():
+    # Typed multimodal input content was added in ag-ui-protocol 0.1.15 (`MULTIMODAL_VERSION`).
+    from ag_ui.core import (
+        AudioInputContent,
+        DocumentInputContent,
+        ImageInputContent,
+        InputContentDataSource,
+        InputContentUrlSource,
+        VideoInputContent,
+    )
 
 with try_import() as interrupts_imports_successful:
     # `ResumeEntry` and the interrupt-aware run lifecycle were added in ag-ui-protocol 0.1.19
@@ -143,14 +157,40 @@ pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='ag-ui-protocol not installed'),
 ]
 
+_INSTALLED_AG_UI_VERSION = parse_ag_ui_version(detect_ag_ui_version()) if imports_successful() else ()
 
-def simple_result(*, outcome: dict[str, Any] | None = None) -> Any:
+
+def _has_ag_ui(version: str) -> bool:
+    """Whether the installed `ag-ui-protocol` is at least `version`."""
+    return _INSTALLED_AG_UI_VERSION >= parse_ag_ui_version(version)
+
+
+def requires_ag_ui(version: str) -> pytest.MarkDecorator:
+    """Skip a test (or a single `pytest.param`) whose expectations need `ag-ui-protocol >= version`.
+
+    The adapter's compatibility gating keys off the *installed* SDK, so a test that constructs a type
+    or asserts an event introduced later — or that pins `ag_ui_version` above what is installed, which
+    cannot be negotiated up — is only meaningful from that version on. Everything else must stay
+    runnable at our `>=0.1.10` floor, which is the version CI's `test-lowest-versions` job installs.
+    """
+    return pytest.mark.skipif(not _has_ag_ui(version), reason=f'requires ag-ui-protocol >= {version}')
+
+
+def run_finished_outcome() -> dict[str, Any]:
+    """`RunFinishedEvent.outcome` as it appears in an expected event when the adapter emits it.
+
+    Empty below `INTERRUPTS_VERSION` (0.1.19), where the installed `RunFinishedEvent` has no
+    `outcome` field, so an expectation spelled with this stays correct across the supported range.
+    """
+    return {'outcome': {'type': 'success'}} if _has_ag_ui('0.1.19') else {}
+
+
+def simple_result(*, outcome: bool = False) -> Any:
     """Expected event sequence for `simple_stream`.
 
-    Pass `outcome={'type': 'success'}` for callers that run against `ag-ui-protocol >= 0.1.19`
-    (where the adapter emits `RunFinishedEvent.outcome`). Older negotiated versions
-    (e.g. `ag_ui_version='0.1.10'`) suppress the field, so the default `outcome=None`
-    matches a bare `RUN_FINISHED`.
+    Pass `outcome=True` for callers that let the adapter negotiate the installed version, where
+    `RunFinishedEvent.outcome` is emitted from 0.1.19 on. Callers that pin an older negotiated
+    version (e.g. `ag_ui_version='0.1.10'`) suppress the field, and so does the default.
     """
     thread_id = IsSameStr()
     run_id = IsSameStr()
@@ -161,8 +201,8 @@ def simple_result(*, outcome: dict[str, Any] | None = None) -> Any:
         'threadId': thread_id,
         'runId': run_id,
     }
-    if outcome is not None:
-        run_finished['outcome'] = outcome
+    if outcome:
+        run_finished.update(run_finished_outcome())
     return snapshot(
         [
             {
@@ -1388,6 +1428,7 @@ async def test_thinking() -> None:
     )
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_with_signature() -> None:
     """Test that ReasoningEncryptedValueEvent is emitted with thinking metadata."""
 
@@ -1453,6 +1494,7 @@ async def test_thinking_with_signature() -> None:
     )
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_consecutive_signatures() -> None:
     """Test that consecutive ThinkingParts each preserve their own metadata via separate REASONING blocks."""
 
@@ -1553,6 +1595,7 @@ async def test_thinking_consecutive_signatures() -> None:
     )
 
 
+@requires_ag_ui('0.1.11')
 def test_reasoning_message_thinking_roundtrip() -> None:
     """Test that ReasoningMessage converts to ThinkingPart with metadata from encrypted_value."""
     messages = AGUIAdapter.load_messages(
@@ -1592,6 +1635,7 @@ def test_reasoning_message_thinking_roundtrip() -> None:
     )
 
 
+@requires_ag_ui('0.1.13')
 async def test_reasoning_events_with_all_metadata() -> None:
     """Test that REASONING_* events emit encryptedValue with all metadata fields."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -1644,6 +1688,7 @@ def test_activity_message_other_types_ignored() -> None:
     assert messages == snapshot([ModelResponse(parts=[TextPart(content='Response')], timestamp=IsDatetime())])
 
 
+@requires_ag_ui('0.1.11')
 @pytest.mark.parametrize(
     'encrypted_value',
     [
@@ -1725,6 +1770,7 @@ def test_dump_load_roundtrip_basic() -> None:
     assert reloaded == original
 
 
+@requires_ag_ui('0.1.11')
 def test_dump_load_roundtrip_thinking() -> None:
     """Test full round-trip for thinking parts with all metadata."""
     original: list[ModelMessage] = [
@@ -1790,6 +1836,7 @@ def test_dump_load_roundtrip_failed_tool_return() -> None:
     assert reloaded == original
 
 
+@requires_ag_ui('0.1.11')
 def test_dump_load_roundtrip_load_capability() -> None:
     """Typed `load_capability` parts keep their identity through dump/load on >= 0.1.11.
 
@@ -1811,6 +1858,7 @@ def test_dump_load_roundtrip_load_capability() -> None:
     assert parse_loaded_capabilities(reloaded) == {'foobar'}
 
 
+@requires_ag_ui('0.1.11')
 def test_dump_load_roundtrip_load_capability_invalid_args() -> None:
     """Invalid `load_capability` args never count as loaded after a roundtrip.
 
@@ -1889,6 +1937,7 @@ def test_dump_omits_encrypted_value_without_tool_kind() -> None:
     assert 'encrypted_value' not in tool_msg.model_fields_set
 
 
+@requires_ag_ui('0.1.11')
 def test_dump_load_roundtrip_native_tool_search() -> None:
     """Native tool-search parts keep their typed identity through dump/load on >= 0.1.11."""
     original: list[ModelMessage] = [
@@ -1914,7 +1963,13 @@ def test_dump_load_roundtrip_native_tool_search() -> None:
 
 @pytest.mark.parametrize(
     'outcome,old_outcome',
-    [('failed', 'failed'), ('denied', 'failed'), ('interrupted', 'success')],
+    [
+        ('failed', 'failed'),
+        # `'denied'`/`'interrupted'` only survive via the `encrypted_value` carrier, so the
+        # assertion below can only hold from 0.1.11 on; `'failed'` also rides `ToolMessage.error`.
+        pytest.param('denied', 'failed', marks=requires_ag_ui('0.1.11')),
+        pytest.param('interrupted', 'success', marks=requires_ag_ui('0.1.11')),
+    ],
 )
 def test_dump_load_roundtrip_non_success_outcome(
     outcome: Literal['failed', 'denied', 'interrupted'], old_outcome: Literal['success', 'failed']
@@ -2025,6 +2080,7 @@ def test_load_forged_encrypted_outcome_stays_success() -> None:
     assert return_part.outcome == 'success'
 
 
+@requires_ag_ui('0.1.11')
 def test_load_tool_kind_falls_back_to_call_claim() -> None:
     """A ToolMessage without its own `encrypted_value` narrows via the paired call's claim.
 
@@ -2156,7 +2212,7 @@ def test_load_malformed_builtin_tool_call_id_degrades_to_plain() -> None:
     assert type(loaded[1].parts[0]) is ToolReturnPart
 
 
-@pytest.mark.parametrize('ag_ui_version', ['0.1.10', '0.1.13'])
+@pytest.mark.parametrize('ag_ui_version', ['0.1.10', pytest.param('0.1.13', marks=requires_ag_ui('0.1.13'))])
 async def test_run_stream_load_capability_tool_kind_encrypted_value(
     ag_ui_version: Literal['0.1.10', '0.1.13'],
 ) -> None:
@@ -2221,7 +2277,7 @@ async def test_run_stream_load_capability_tool_kind_encrypted_value(
     assert tool_events == expected
 
 
-@pytest.mark.parametrize('ag_ui_version', ['0.1.10', '0.1.13'])
+@pytest.mark.parametrize('ag_ui_version', ['0.1.10', pytest.param('0.1.13', marks=requires_ag_ui('0.1.13'))])
 async def test_run_stream_native_tool_search_tool_kind_encrypted_value(
     ag_ui_version: Literal['0.1.10', '0.1.13'],
 ) -> None:
@@ -2290,6 +2346,7 @@ async def test_run_stream_native_tool_search_tool_kind_encrypted_value(
     assert tool_events == expected
 
 
+@requires_ag_ui('0.1.11')
 def test_dump_load_roundtrip_multiple_thinking_parts() -> None:
     """Test round-trip preserves multiple ThinkingParts with their metadata."""
     original: list[ModelMessage] = [
@@ -2743,6 +2800,7 @@ def test_dump_load_roundtrip_interleaved_text_and_tools() -> None:
     )
 
 
+@requires_ag_ui('0.1.13')
 async def test_reasoning_events_empty_content_with_metadata() -> None:
     """Test REASONING_* events for ThinkingPart with no content but with metadata.
 
@@ -3024,7 +3082,7 @@ async def test_request_with_state() -> None:
         async for event in adapter.encode_stream(adapter.run_stream(deps=deps, on_complete=on_complete)):
             events.append(json.loads(event.removeprefix('data: ')))
 
-        assert events == simple_result(outcome={'type': 'success'})
+        assert events == simple_result(outcome=True)
     assert seen_states == snapshot([41, 0, 0, 42])
     assert seen_deps_states == snapshot([42, 1, 1, 43])
 
@@ -3049,7 +3107,7 @@ async def test_request_with_state_without_handler() -> None:
         async for event in adapter.encode_stream(adapter.run_stream()):
             events.append(json.loads(event.removeprefix('data: ')))
 
-    assert events == simple_result(outcome={'type': 'success'})
+    assert events == simple_result(outcome=True)
 
 
 async def test_request_with_empty_state_without_handler() -> None:
@@ -3068,7 +3126,7 @@ async def test_request_with_empty_state_without_handler() -> None:
     async for event in adapter.encode_stream(adapter.run_stream()):
         events.append(json.loads(event.removeprefix('data: ')))
 
-    assert events == simple_result(outcome={'type': 'success'})
+    assert events == simple_result(outcome=True)
 
 
 async def test_request_with_state_with_custom_handler() -> None:
@@ -3908,7 +3966,7 @@ async def test_event_stream_back_to_back_text():
                 'timestamp': IsInt(),
                 'threadId': thread_id,
                 'runId': run_id,
-                'outcome': {'type': 'success'},
+                **run_finished_outcome(),
             },
         ]
     )
@@ -4134,7 +4192,7 @@ async def test_event_stream_multiple_responses_with_tool_calls():
                 'timestamp': IsInt(),
                 'threadId': thread_id,
                 'runId': run_id,
-                'outcome': {'type': 'success'},
+                **run_finished_outcome(),
             },
         ]
     )
@@ -4307,7 +4365,7 @@ async def test_dispatch_request():
                     'timestamp': IsInt(),
                     'threadId': thread_id,
                     'runId': run_id,
-                    'outcome': {'type': 'success'},
+                    **run_finished_outcome(),
                 },
                 'more_body': True,
             },
@@ -4546,6 +4604,7 @@ def test_load_messages_builtin_tool_return_json_content_rehydrates() -> None:
     )
 
 
+@requires_ag_ui('0.1.11')
 @pytest.mark.parametrize(
     'version,expected_reasoning',
     [
@@ -4716,7 +4775,7 @@ def _client_messages_from_tool_events(events: list[dict[str, Any]]) -> list[Mess
 
 @pytest.mark.parametrize(
     'ag_ui_version,expected_outcome',
-    [('0.1.10', 'success'), ('0.1.13', 'failed')],
+    [('0.1.10', 'success'), pytest.param('0.1.13', 'failed', marks=requires_ag_ui('0.1.13'))],
 )
 async def test_stream_tool_failed_outcome_roundtrip(
     ag_ui_version: Literal['0.1.10', '0.1.13'], expected_outcome: Literal['success', 'failed']
@@ -4756,7 +4815,7 @@ async def test_stream_tool_failed_outcome_roundtrip(
 
 @pytest.mark.parametrize(
     'ag_ui_version,expected_outcome',
-    [('0.1.10', 'success'), ('0.1.13', 'failed')],
+    [('0.1.10', 'success'), pytest.param('0.1.13', 'failed', marks=requires_ag_ui('0.1.13'))],
 )
 async def test_stream_failed_builtin_tool_return_outcome_roundtrip(
     ag_ui_version: Literal['0.1.10', '0.1.13'], expected_outcome: Literal['success', 'failed']
@@ -4841,6 +4900,7 @@ async def test_thinking_events_v010_empty_content() -> None:
     assert events == []
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_delta_v013() -> None:
     """Test v0.1.13 REASONING_* events emitted via handle_thinking_delta."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -4862,6 +4922,7 @@ async def test_thinking_delta_v013() -> None:
     )
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_end_v013_no_content_no_metadata() -> None:
     """Test v0.1.13 early return when ThinkingPart has no content and no encrypted metadata."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -4875,6 +4936,7 @@ async def test_thinking_end_v013_no_content_no_metadata() -> None:
     assert events == []
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_delta_v013_after_content_start() -> None:
     """Test v0.1.13 delta skips START/MESSAGE_START when reasoning already started."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -4934,6 +4996,7 @@ async def test_thinking_end_v010_with_content() -> None:
     )
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_end_v013_no_encrypted_metadata() -> None:
     """Test v0.1.13 end skips encrypted_value event when part has no signature or metadata."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -4959,6 +5022,7 @@ async def test_thinking_end_v013_no_encrypted_metadata() -> None:
 # region: Coverage — encrypted_metadata branch gap
 
 
+@requires_ag_ui('0.1.13')
 async def test_thinking_encrypted_metadata_partial_fields() -> None:
     """Test thinking_encrypted_metadata with signature but no provider_name."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -5348,9 +5412,10 @@ def test_dump_messages_text_content() -> None:
             id='document-url',
         ),
     ]
-    if imports_successful()
+    if _has_ag_ui('0.1.15')
     else [],
 )
+@requires_ag_ui('0.1.15')
 def test_load_multimodal_url_sources(
     input_content: ImageInputContent | AudioInputContent | VideoInputContent | DocumentInputContent,
     expected_type: ImageUrl | AudioUrl | VideoUrl | DocumentUrl,
@@ -5366,6 +5431,7 @@ def test_load_multimodal_url_sources(
     assert part.content[0] == expected_type
 
 
+@requires_ag_ui('0.1.15')
 def test_load_multimodal_data_source() -> None:
     """Test that multimodal data source input content is converted to BinaryContent."""
     messages = AGUIAdapter.load_messages(
@@ -5393,6 +5459,7 @@ def test_load_multimodal_data_source() -> None:
     )
 
 
+@requires_ag_ui('0.1.15')
 def test_dump_messages_multimodal_url() -> None:
     """Test that media URLs are dumped as typed multimodal content with ag_ui_version >= 0.1.15."""
     messages: list[ModelMessage] = [
@@ -5448,6 +5515,7 @@ def test_dump_messages_legacy_binary_content() -> None:
     )
 
 
+@requires_ag_ui('0.1.15')
 def test_multimodal_roundtrip_preserves_file_vendor_metadata() -> None:
     """`vendor_metadata` on `FileUrl`/`BinaryContent` survives a dump -> load round-trip (ag-ui >= 0.1.15).
 
@@ -5579,6 +5647,7 @@ def test_multimodal_roundtrip_preserves_file_vendor_metadata() -> None:
     )
 
 
+@requires_ag_ui('0.1.15')
 @pytest.mark.parametrize(
     'content',
     [
@@ -5645,6 +5714,7 @@ def test_multimodal_roundtrip_drops_file_url_force_download_before_0_1_15() -> N
     assert loaded_content.force_download is False
 
 
+@requires_ag_ui('0.1.15')
 def test_multimodal_roundtrip_file_without_vendor_metadata_stays_none() -> None:
     """A file with no `vendor_metadata` round-trips to `None` (no spurious `metadata`)."""
     messages: list[ModelMessage] = [
@@ -5687,6 +5757,7 @@ def test_multimodal_roundtrip_file_without_vendor_metadata_stays_none() -> None:
         assert getattr(item, 'vendor_metadata', None) is None
 
 
+@requires_ag_ui('0.1.15')
 def test_load_multimodal_rejects_invalid_vendor_metadata() -> None:
     """A malformed `vendor_metadata` on multimodal input content is rejected on load.
 
@@ -5725,6 +5796,223 @@ def test_load_messages_unknown_type_warns() -> None:
         messages = AGUIAdapter.load_messages([UnknownMessage(id='msg-1')])  # pyright: ignore[reportArgumentType]
 
     assert messages == []
+
+
+# endregion
+
+
+# region: Forward compatibility with newer protocol versions
+
+
+def build_run_input_body(*messages: Any) -> bytes:
+    """A raw `RunAgentInput` body carrying arbitrary message dicts.
+
+    The messages go in as dicts rather than `Message` models on purpose: what's under test is content
+    a *newer* client sends that the installed `ag-ui-protocol` has no class for, which by definition
+    can't be constructed from the installed models. The tags below (`hologram`, `telepathy`) are
+    deliberately fictional so the test asserts the same thing on every version in our supported range,
+    including the latest — the real cases (`role='reasoning'` from 0.1.11, `type='image'` from 0.1.15)
+    are the same mechanism seen from an older install.
+    """
+    return json.dumps(
+        {
+            'threadId': uuid_str(),
+            'runId': uuid_str(),
+            'state': {},
+            'messages': list(messages),
+            'tools': [],
+            'context': [],
+            'forwardedProps': None,
+        }
+    ).encode()
+
+
+def test_build_run_input_skips_unknown_content_type() -> None:
+    """An input content type from a newer protocol version is skipped, not 422'd (#7118)."""
+    body = build_run_input_body(
+        {
+            'id': 'msg-1',
+            'role': 'user',
+            'content': [
+                {'type': 'text', 'text': 'what is in this?'},
+                {'type': 'hologram', 'source': {'type': 'data', 'value': 'aGk=', 'mimeType': 'model/gltf+json'}},
+            ],
+        }
+    )
+
+    with pytest.warns(UserWarning, match=r"does not support \(type='hologram'\) was skipped"):
+        run_input = AGUIAdapter.build_run_input(body)
+
+    assert AGUIAdapter.load_messages(run_input.messages) == snapshot(
+        [ModelRequest(parts=[UserPromptPart(content='what is in this?', timestamp=IsDatetime())])]
+    )
+
+
+def test_build_run_input_skips_unknown_message_role() -> None:
+    """A message role from a newer protocol version is skipped while the rest of the history loads."""
+    body = build_run_input_body(
+        {'id': 'msg-1', 'role': 'telepathy', 'content': 'unspoken'},
+        {'id': 'msg-2', 'role': 'user', 'content': 'spoken'},
+    )
+
+    with pytest.warns(UserWarning, match=r"does not support \(role='telepathy'\) was skipped"):
+        run_input = AGUIAdapter.build_run_input(body)
+
+    assert AGUIAdapter.load_messages(run_input.messages) == snapshot(
+        [ModelRequest(parts=[UserPromptPart(content='spoken', timestamp=IsDatetime())])]
+    )
+
+
+def test_build_run_input_skips_only_unknown_content_leaving_empty_message() -> None:
+    """A user message left with no usable content still parses; `load_messages` adds no empty part."""
+    body = build_run_input_body({'id': 'msg-1', 'role': 'user', 'content': [{'type': 'hologram'}]})
+
+    with pytest.warns(UserWarning, match=r"\(type='hologram'\) was skipped"):
+        run_input = AGUIAdapter.build_run_input(body)
+
+    assert run_input.messages[0].content == []
+    assert AGUIAdapter.load_messages(run_input.messages) == []
+
+
+def test_build_run_input_reports_every_unknown_tag_once() -> None:
+    """The warning names each distinct unknown tag, not one warning per occurrence."""
+    body = build_run_input_body(
+        {'id': 'msg-1', 'role': 'telepathy', 'content': 'unspoken'},
+        {
+            'id': 'msg-2',
+            'role': 'user',
+            'content': [{'type': 'hologram'}, {'type': 'hologram'}, {'type': 'aroma'}],
+        },
+    )
+
+    with pytest.warns(UserWarning, match=r"\(role='telepathy', type='aroma', type='hologram'\) was skipped"):
+        AGUIAdapter.build_run_input(body)
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        pytest.param(b'{"messages": [', id='not-json'),
+        pytest.param(b'[]', id='not-an-object'),
+        pytest.param(b'{"threadId": "t", "runId": "r", "messages": "nope"}', id='messages-not-a-list'),
+        pytest.param(build_run_input_body('nope'), id='message-not-an-object'),
+        pytest.param(build_run_input_body({'id': 'msg-1', 'role': 1}), id='role-not-a-string'),
+        pytest.param(
+            build_run_input_body({'id': 'msg-1', 'role': 'user', 'content': [{'type': 'text'}]}),
+            id='known-content-type-missing-field',
+        ),
+        pytest.param(
+            build_run_input_body({'id': 'msg-1', 'role': 'user', 'content': [{'type': 1}]}),
+            id='content-type-not-a-string',
+        ),
+    ],
+)
+def test_build_run_input_still_rejects_malformed_bodies(body: bytes) -> None:
+    """Only an unknown discriminator tag is tolerated; anything else is still a client error.
+
+    Skipping is for functionality this install doesn't have, so a payload that is malformed on its own
+    terms must keep failing rather than being silently reinterpreted.
+    """
+    with pytest.raises(ValidationError):
+        AGUIAdapter.build_run_input(body)
+
+
+def test_build_run_input_reports_remaining_errors_after_skipping() -> None:
+    """A body that is *both* newer and malformed is rejected on the malformed part alone."""
+    body = build_run_input_body(
+        {'id': 'msg-1', 'role': 'user', 'content': [{'type': 'hologram'}, 'not-an-object']},
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        AGUIAdapter.build_run_input(body)
+
+    assert [(error['type'], error['loc'][-1]) for error in exc_info.value.errors()] == snapshot(
+        [('string_type', 'str'), ('model_attributes_type', 0)]
+    )
+
+
+@requires_ag_ui('0.1.13')
+def test_reasoning_message_start_role_matches_installed_model() -> None:
+    """The `role` we put on `ReasoningMessageStartEvent` must be the literal the install accepts.
+
+    The accepted value changed at `REASONING_MESSAGE_ROLE_VERSION`, and getting that threshold wrong
+    raises on every streamed thinking part — invisibly, because CI only installs the floor and the
+    latest. Constructing the event against the installed model catches a wrong threshold on any
+    version rather than only the two CI happens to run.
+    """
+    from ag_ui.core import ReasoningMessageStartEvent
+
+    event = ReasoningMessageStartEvent(message_id='msg-1', role=REASONING_MESSAGE_ROLE)  # pyright: ignore[reportArgumentType]
+
+    assert event.role == REASONING_MESSAGE_ROLE
+
+
+async def test_dispatch_request_returns_422_for_malformed_body() -> None:
+    """A body that isn't a valid `RunAgentInput` is answered with 422 rather than raising."""
+    agent = Agent(model=TestModel())
+
+    async def receive() -> dict[str, Any]:
+        return {'type': 'http.request', 'body': b'{"messages": [{"role": "user"}]}'}
+
+    starlette_request = Request(
+        scope={'type': 'http', 'method': 'POST', 'headers': [(b'content-type', b'application/json')]},
+        receive=receive,
+    )
+
+    response = await AGUIAdapter.dispatch_request(starlette_request, agent=agent)
+
+    assert response.status_code == 422
+    assert response.media_type == 'application/json'
+    # Asserted as a subset rather than a snapshot: the exact field list moves with the installed
+    # `RunAgentInput`, and this test has to hold on every version in our supported range.
+    errors = json.loads(bytes(response.body))
+    assert {error['type'] for error in errors} == {'missing'}
+    assert {'threadId', 'runId', 'content'} <= {error['loc'][-1] for error in errors}
+
+
+async def test_dispatch_request_runs_with_unknown_content_skipped() -> None:
+    """End to end: the request a newer client sends now runs instead of returning 422."""
+    agent = Agent(model=FunctionModel(stream_function=simple_stream))
+    body = build_run_input_body(
+        {
+            'id': 'msg-1',
+            'role': 'user',
+            'content': [{'type': 'text', 'text': 'hello'}, {'type': 'hologram'}],
+        }
+    )
+
+    async def receive() -> dict[str, Any]:
+        return {'type': 'http.request', 'body': body}
+
+    starlette_request = Request(
+        scope={'type': 'http', 'method': 'POST', 'headers': [(b'content-type', b'application/json')]},
+        receive=receive,
+    )
+
+    with pytest.warns(UserWarning, match=r"\(type='hologram'\) was skipped"):
+        response = await AGUIAdapter.dispatch_request(starlette_request, agent=agent)
+
+    assert isinstance(response, StreamingResponse)
+
+    chunks: list[MutableMapping[str, Any]] = []
+
+    async def send(data: MutableMapping[str, Any]) -> None:
+        if chunk_body := data.get('body'):
+            data['body'] = json.loads(chunk_body.decode('utf-8').removeprefix('data: '))
+            chunks.append(data)
+
+    await response.stream_response(send)
+
+    assert [chunk['body']['type'] for chunk in chunks] == snapshot(
+        [
+            'RUN_STARTED',
+            'TEXT_MESSAGE_START',
+            'TEXT_MESSAGE_CONTENT',
+            'TEXT_MESSAGE_CONTENT',
+            'TEXT_MESSAGE_END',
+            'RUN_FINISHED',
+        ]
+    )
 
 
 # endregion

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -2841,6 +2841,7 @@ async def test_reasoning_events_empty_content_with_metadata() -> None:
 
 @pytest.mark.vcr()
 @pytest.mark.skipif(not anthropic_imports_successful(), reason='anthropic not installed')
+@requires_ag_ui('0.1.11')
 async def test_thinking_roundtrip_anthropic(allow_model_requests: None, anthropic_api_key: str) -> None:
     """Test that pydantic -> AG-UI -> pydantic round-trip preserves thinking metadata with real Anthropic responses."""
     m = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key=anthropic_api_key))

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -161,8 +161,13 @@ _INSTALLED_AG_UI_VERSION = parse_ag_ui_version(detect_ag_ui_version()) if import
 
 
 def _has_ag_ui(version: str) -> bool:
-    """Whether the installed `ag-ui-protocol` is at least `version`."""
-    return _INSTALLED_AG_UI_VERSION >= parse_ag_ui_version(version)
+    """Whether the installed `ag-ui-protocol` is at least `version`.
+
+    `version` is parsed here rather than with `parse_ag_ui_version` because `requires_ag_ui` runs at
+    import time, before `pytestmark` can skip anything: reaching for a name from the gated import
+    block makes collection fail outright on the install flavors that have no `ag-ui-protocol`.
+    """
+    return _INSTALLED_AG_UI_VERSION >= tuple(int(part) for part in version.split('.'))
 
 
 def requires_ag_ui(version: str) -> pytest.MarkDecorator:
@@ -5905,6 +5910,10 @@ def test_build_run_input_reports_every_unknown_tag_once() -> None:
             build_run_input_body({'id': 'msg-1', 'role': 'user', 'content': [{'type': 1}]}),
             id='content-type-not-a-string',
         ),
+        # `json.loads` rejects these two where `RunAgentInput.model_validate_json` already did, and
+        # neither failure mode is a `JSONDecodeError`, so an unguarded re-read turns a 422 into a 500.
+        pytest.param(b'{"threadId": "\xff\xfe"}', id='not-utf8'),
+        pytest.param(b'{"messages": ' + b'[' * 100_000 + b']' * 100_000 + b'}', id='nested-past-recursion-limit'),
     ],
 )
 def test_build_run_input_still_rejects_malformed_bodies(body: bytes) -> None:
@@ -5968,6 +5977,29 @@ async def test_dispatch_request_returns_422_for_malformed_body() -> None:
     errors = json.loads(bytes(response.body))
     assert {error['type'] for error in errors} == {'missing'}
     assert {'threadId', 'runId', 'content'} <= {error['loc'][-1] for error in errors}
+
+
+async def test_dispatch_request_returns_422_for_non_utf8_body() -> None:
+    """A body that isn't decodable at all is answered with 422, not an unhandled error.
+
+    Pinned at the HTTP boundary because the skip path re-reads the raw body: `json.loads` raises
+    `UnicodeDecodeError`, which is not a `JSONDecodeError`, so letting it escape would surface as a
+    500 to a client that used to get a 422.
+    """
+    agent = Agent(model=TestModel())
+
+    async def receive() -> dict[str, Any]:
+        return {'type': 'http.request', 'body': b'{"threadId": "\xff\xfe"}'}
+
+    starlette_request = Request(
+        scope={'type': 'http', 'method': 'POST', 'headers': [(b'content-type', b'application/json')]},
+        receive=receive,
+    )
+
+    response = await AGUIAdapter.dispatch_request(starlette_request, agent=agent)
+
+    assert response.status_code == 422
+    assert [error['type'] for error in json.loads(bytes(response.body))] == snapshot(['json_invalid'])
 
 
 async def test_dispatch_request_runs_with_unknown_content_skipped() -> None:

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1464,7 +1464,7 @@ async def test_thinking_with_signature() -> None:
                 'type': 'REASONING_MESSAGE_START',
                 'timestamp': IsInt(),
                 'messageId': reasoning_id,
-                'role': 'reasoning',
+                'role': REASONING_MESSAGE_ROLE,
             },
             {
                 'type': 'REASONING_MESSAGE_CONTENT',
@@ -1533,7 +1533,7 @@ async def test_thinking_consecutive_signatures() -> None:
                 'type': 'REASONING_MESSAGE_START',
                 'timestamp': IsInt(),
                 'messageId': r0,
-                'role': 'reasoning',
+                'role': REASONING_MESSAGE_ROLE,
             },
             {'type': 'REASONING_MESSAGE_CONTENT', 'timestamp': IsInt(), 'messageId': r0, 'delta': 'First thought'},
             {'type': 'REASONING_MESSAGE_END', 'timestamp': IsInt(), 'messageId': r0},
@@ -1551,7 +1551,7 @@ async def test_thinking_consecutive_signatures() -> None:
                 'type': 'REASONING_MESSAGE_START',
                 'timestamp': IsInt(),
                 'messageId': r1,
-                'role': 'reasoning',
+                'role': REASONING_MESSAGE_ROLE,
             },
             {'type': 'REASONING_MESSAGE_CONTENT', 'timestamp': IsInt(), 'messageId': r1, 'delta': 'Second thought'},
             {'type': 'REASONING_MESSAGE_END', 'timestamp': IsInt(), 'messageId': r1},
@@ -1569,7 +1569,7 @@ async def test_thinking_consecutive_signatures() -> None:
                 'type': 'REASONING_MESSAGE_START',
                 'timestamp': IsInt(),
                 'messageId': r2,
-                'role': 'reasoning',
+                'role': REASONING_MESSAGE_ROLE,
             },
             {'type': 'REASONING_MESSAGE_CONTENT', 'timestamp': IsInt(), 'messageId': r2, 'delta': 'Third thought'},
             {'type': 'REASONING_MESSAGE_END', 'timestamp': IsInt(), 'messageId': r2},
@@ -1663,7 +1663,7 @@ async def test_reasoning_events_with_all_metadata() -> None:
     assert [e.model_dump(exclude_none=True) for e in events] == snapshot(
         [
             {'type': 'REASONING_START', 'message_id': IsStr()},
-            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': 'reasoning'},
+            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': REASONING_MESSAGE_ROLE},
             {'type': 'REASONING_MESSAGE_CONTENT', 'message_id': IsStr(), 'delta': 'Thinking content'},
             {'type': 'REASONING_MESSAGE_END', 'message_id': IsStr()},
             {
@@ -4922,7 +4922,7 @@ async def test_thinking_delta_v013() -> None:
     assert [e.model_dump(exclude_none=True) for e in events] == snapshot(
         [
             {'type': 'REASONING_START', 'message_id': IsStr()},
-            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': 'reasoning'},
+            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': REASONING_MESSAGE_ROLE},
             {'type': 'REASONING_MESSAGE_CONTENT', 'message_id': IsStr(), 'delta': 'chunk1'},
         ]
     )
@@ -4957,7 +4957,7 @@ async def test_thinking_delta_v013_after_content_start() -> None:
     assert [e.model_dump(exclude_none=True) for e in events] == snapshot(
         [
             {'type': 'REASONING_START', 'message_id': IsStr()},
-            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': 'reasoning'},
+            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': REASONING_MESSAGE_ROLE},
             {'type': 'REASONING_MESSAGE_CONTENT', 'message_id': IsStr(), 'delta': 'initial'},
             {'type': 'REASONING_MESSAGE_CONTENT', 'message_id': IsStr(), 'delta': 'more'},
         ]
@@ -5015,7 +5015,7 @@ async def test_thinking_end_v013_no_encrypted_metadata() -> None:
     assert [e.model_dump(exclude_none=True) for e in events] == snapshot(
         [
             {'type': 'REASONING_START', 'message_id': IsStr()},
-            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': 'reasoning'},
+            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': REASONING_MESSAGE_ROLE},
             {'type': 'REASONING_MESSAGE_CONTENT', 'message_id': IsStr(), 'delta': 'text'},
             {'type': 'REASONING_MESSAGE_END', 'message_id': IsStr()},
             {'type': 'REASONING_END', 'message_id': IsStr()},
@@ -5045,7 +5045,7 @@ async def test_thinking_encrypted_metadata_partial_fields() -> None:
     assert [e.model_dump(exclude_none=True) for e in events] == snapshot(
         [
             {'type': 'REASONING_START', 'message_id': IsStr()},
-            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': 'reasoning'},
+            {'type': 'REASONING_MESSAGE_START', 'message_id': IsStr(), 'role': REASONING_MESSAGE_ROLE},
             {'type': 'REASONING_MESSAGE_CONTENT', 'message_id': IsStr(), 'delta': 'Thoughts'},
             {'type': 'REASONING_MESSAGE_END', 'message_id': IsStr()},
             {
@@ -5903,6 +5903,21 @@ def test_build_run_input_reports_every_unknown_tag_once() -> None:
         pytest.param(b'{"threadId": "t", "runId": "r", "messages": "nope"}', id='messages-not-a-list'),
         pytest.param(build_run_input_body('nope'), id='message-not-an-object'),
         pytest.param(build_run_input_body({'id': 'msg-1', 'role': 1}), id='role-not-a-string'),
+        # An unknown tag is only new functionality if the item is otherwise well-formed: every
+        # `Message` the installed union knows requires a string `id`, so one without it is a client
+        # bug that happens to carry a role we don't know, and skipping it would swallow the bug.
+        pytest.param(build_run_input_body({'role': 'telepathy', 'content': 'unspoken'}), id='unknown-role-missing-id'),
+        pytest.param(
+            build_run_input_body({'id': 1, 'role': 'telepathy', 'content': 'unspoken'}),
+            id='unknown-role-id-not-a-string',
+        ),
+        pytest.param(
+            build_run_input_body(
+                {'id': 'msg-1', 'role': 'telepathy', 'content': 'unspoken'},
+                {'role': 'telepathy', 'content': 'unspoken'},
+            ),
+            id='unknown-role-missing-id-alongside-a-skippable-one',
+        ),
         pytest.param(
             build_run_input_body({'id': 'msg-1', 'role': 'user', 'content': [{'type': 'text'}]}),
             id='known-content-type-missing-field',


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.
David has not reviewed the diff line-by-line.

- Closes #7118

Inbound AG-UI content newer than the installed `ag-ui-protocol` is now skipped with a warning instead of failing the whole request with `422`, per the policy in [`ui/AGENTS.md`](https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md).

### The tolerance is scoped to unknown discriminator tags only

The crux is not swallowing genuine client bugs. `build_run_input` validates the body first, exactly as before; only when that raises does it re-read the body and drop items whose `role` / `type` the *installed* union has no member for, then validate again. So:

- an unknown tag (`role='reasoning'` on 0.1.10, `type='image'` on 0.1.14) → skipped, warning names each distinct tag, run proceeds
- a known tag with a broken payload, a non-JSON body, a non-list `messages`, a message that isn't an object, a non-string tag → untouched, still `422`
- an unknown tag on an item that is *also* malformed — a message carrying no string `id`, the one field every member of the `Message` union requires → untouched, still `422`: an unrecognized tag alone doesn't make an item new functionality, or a client bug could ride in under one
- **both** at once → the second validation reports the remaining errors on their own, so the malformed part still fails and isn't reinterpreted

Happy-path cost is zero: nothing extra runs unless validation already failed.

Re-reading the body is best effort, so every way `json.loads` can reject it means there is nothing to skip and the original `ValidationError` stands. That covers more than invalid JSON: invalid UTF-8 arrives as `UnicodeDecodeError` (a `ValueError`, **not** a `JSONDecodeError`) and input nested past the interpreter's limit arrives as `RecursionError` — both would otherwise have escaped as a 500. Caught by Macroscope for the first, found by checking for siblings; both are regression-tested.

**Where the tolerance lives** — `ui/ag_ui/_forward_compat.py`, filtering the decoded payload before re-validating. The alternatives were worse: a fallback union member can't be expressed for a Pydantic discriminated union without loosening it for *every* input, and mapping `ValidationError.loc` back onto the payload is unusable because pydantic's union-tag path segments (`messages.0.user.content.list[tagged-union[…]].1`) aren't distinguishable from real keys. The known-tag sets are read off the installed `Message` / `InputContent` unions rather than hardcoded, so they track whatever version is installed — which is the point.

### Two CI blind spots, each of which was hiding a live bug

**1. The AG-UI test module was skipped entirely at the floor.** Its module-level `try_import()` pulled in `ImageInputContent` (0.1.15+), so at `ag-ui-protocol==0.1.10` the import failed and `pytestmark`'s `skipif` skipped all 199 tests — `test-lowest-versions` exercised zero AG-UI code. The import block now only names symbols that exist at the floor; version-dependent tests carry `requires_ag_ui('<version>')` (also usable per-`pytest.param`), which compares against the installed version instead of an import. Verified: **149 pass at 0.1.10** and **179 at 0.1.14**, where previously 0 ran.

**2. `dispatch_request`'s `except ValidationError` → 422 branch carried `# pragma: no cover`** and had no test at any version. Pragma removed, covered — and writing that first test exposed a latent 500 on `main`: the 422 body was built with `e.json()`, which cannot serialize the raw bytes a non-UTF-8 body leaves on `input_value`. Fixed inline by falling back to `e.json(include_input=False)` **only** when serialization fails, so no response that works today changes shape.

<details>
<summary>What blind spot #1 was hiding: <code>ReasoningMessageStartEvent.role</code> is wrong on 0.1.14</summary>

With the module actually running at 0.1.14, five thinking tests failed with a real `ValidationError` from production code:

```
ReasoningMessageStartEvent
role
  Input should be 'reasoning' [type=literal_error, input_value='assistant', input_type=str]
```

`REASONING_MESSAGE_ROLE` gated the `'assistant'` → `'reasoning'` switch on `MULTIMODAL_VERSION` (0.1.15), but the field changed one release earlier. Confirmed by introspecting each release:

| 0.1.11 | 0.1.12 | 0.1.13 | 0.1.14 | 0.1.15 |
|---|---|---|---|---|
| `Literal['assistant']` | `Literal['assistant']` | `Literal['assistant']` | `Literal['reasoning']` | `Literal['reasoning']` |

So on an installed 0.1.14, **every streamed `ThinkingPart` raised**. Fixed with a dedicated `REASONING_MESSAGE_ROLE_VERSION = (0, 1, 14)`, plus `test_reasoning_message_start_role_matches_installed_model`, which constructs the event against the installed model and therefore catches a wrong threshold on *any* version — not just the two CI installs.

Included rather than deferred because it is verified, two lines, and only discoverable through blind spot #1 in this PR; shipping that fix while leaving a known crash on 0.1.14 would be worse.

Un-skipping the module at the floor also exposed seven thinking tests whose event snapshots hard-coded `'role': 'reasoning'`, which is only correct from 0.1.14 on — production was already right. They now assert the version-derived `REASONING_MESSAGE_ROLE`.

The test itself only runs from 0.1.13 on, and `test_thinking_roundtrip_anthropic` needed the same treatment — it dumps at `ag_ui_version=0.1.13`, and being gated on the `anthropic` extra it only runs where CI installs `--all-extras`.

</details>

### Verification

Tests and targeted coverage pass. Run against four real environments — `ag-ui-protocol` 0.1.10, 0.1.13, 0.1.14, and 0.1.19 — all green; `_forward_compat.py` is at 100% coverage, and the tolerance tests use deliberately fictional tags (`role='telepathy'`, `type='hologram'`) so they assert the same behavior on every version including the latest.

### Deliberate scope decisions

- **Outbound (`dump_messages` / `_dump_request_parts`) untouched** — it already gates correctly on `parse_ag_ui_version(ag_ui_version) >= MULTIMODAL_VERSION` and downgrades to `BinaryInputContent`. Only inbound was broken.
- **`ag-ui-protocol>=0.1.10` floor kept** — raising it to `>=0.1.15` would have made this go away, but version bumps are what the policy forbids.
- **No Vercel AI equivalent** — its inbound shape doesn't have the same discriminated-union-with-versioned-members exposure; extending there wasn't reproduced and isn't claimed.
- **The 422 body keeps its echoed `input` wherever it can be serialized** — always dropping it (`include_input=False` unconditionally) would also be defensible as a posture change, but it would alter the response shape of every UI adapter for cases that have no defect, so the fallback is scoped to the failing case only.
- **Skipped content is dropped, not surfaced to the agent** — a placeholder part would put unvalidated client text in the model's context. The `UserWarning` is the signal, matching `warn_tool_kind_not_persisted`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

