### PR TITLE
fix: respect explicit timeout=0 in Google ModelSettings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -911,7 +911,7 @@ class GoogleModel(Model[Client]):
             gla_service_tier = _resolve_gla_service_tier(model_settings)
 
         http_options: HttpOptionsDict = {'headers': headers}
-        if timeout := model_settings.get('timeout'):
+        if (timeout := model_settings.get('timeout')) is not None:
             if isinstance(timeout, int | float):
                 http_options['timeout'] = int(1000 * timeout)
             else:


### PR DESCRIPTION
Fixes #7113

`_build_content_and_config()` used a truthiness check (`if timeout := model_settings.get("timeout")`), so an explicit `timeout=0` (requesting no timeout) was silently dropped before reaching `http_options`. This switches to a key-existence check so `0` is forwarded like any other value.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

