### PR TITLE
Fix Google ModelSettings timeout=0 being silently omitted

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -911,7 +911,7 @@ class GoogleModel(Model[Client]):
             gla_service_tier = _resolve_gla_service_tier(model_settings)
 
         http_options: HttpOptionsDict = {'headers': headers}
-        if timeout := model_settings.get('timeout'):
+        if (timeout := model_settings.get('timeout')) is not None:
             if isinstance(timeout, int | float):
                 http_options['timeout'] = int(1000 * timeout)
             else:

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -7390,3 +7390,40 @@ async def test_google_model_armor_config_is_sent_in_request(
 
     _, kwargs = mock_generate.call_args
     assert kwargs['config']['model_armor_config'] == _MODEL_ARMOR_CONFIG
+
+
+async def test_google_model_timeout_zero(
+    allow_model_requests: None,
+    google_provider: GoogleProvider,
+    mocker: MockerFixture,
+):
+    """Test that setting timeout=0 does not drop the timeout due to falsy check."""
+    model = GoogleModel(
+        model_name='gemini-2.5-flash',
+        provider=google_provider,
+        settings=GoogleModelSettings(timeout=0),
+    )
+
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(parts=[Part(text='Hello!')], role='model'),
+                finish_reason=GoogleFinishReason.STOP,
+            )
+        ],
+        usage_metadata=GenerateContentResponseUsageMetadata(prompt_token_count=1, candidates_token_count=1),
+        response_id='1',
+        model_version='gemini-2.5-flash',
+    )
+    mock_generate = mocker.patch.object(
+        model.client.aio.models,
+        'generate_content',
+        new_callable=mocker.AsyncMock,
+        return_value=response,
+    )
+
+    agent = Agent(model=model, name='test-agent', output_type=str)
+    await agent.run('hello')
+
+    _, kwargs = mock_generate.call_args
+    assert kwargs['config']['http_options']['timeout'] == 0


### PR DESCRIPTION

Fixes #7113
Because `timeout=0` evaluates to falsy, it was being dropped by `if timeout := model_settings.get('timeout'):`. 
This PR updates it to explicitly check for `is not None` and adds a test to verify it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

