### PR TITLE
Improve durable leaf-toolset `id` error guidance

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -204,11 +204,16 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
 
     def _wrap_and_register_leaf(self, ts: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
         ts_id = ts.id
+        durable_units_noun = (
+            f'{self._durable_unit_noun[:-1]}ies'
+            if self._durable_unit_noun.endswith('y')
+            else f'{self._durable_unit_noun}s'
+        )
         if ts_id is None and isinstance(ts, DynamicToolset):
             raise UserError(
                 f"Toolsets that are 'leaves' (i.e. those that implement their own tool listing and calling) "
                 f'need to have a unique `id` in order to be used with {self.engine_name}. '
-                f"The ID will be used to identify the toolset's {self._durable_unit_noun}s within the "
+                f"The ID will be used to identify the toolset's {durable_units_noun} within the "
                 f'{self._durable_container_noun}. Set the dynamic toolset ID with `DynamicToolset(id=...)`, '
                 "or, when it is contributed by a capability, set the capability's `id` (for example, "
                 "`DynamicCapability(..., id='user-tools')`). A capability function passed directly to "
@@ -225,7 +230,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             raise UserError(
                 f'Two toolsets have the same `id` {ts_id!r}. Toolset `id`s must be unique among all '
                 f"toolsets registered with the same agent, as they identify the toolset's "
-                f'{self._durable_unit_noun}s within the {self._durable_container_noun}.'
+                f'{durable_units_noun} within the {self._durable_container_noun}.'
             )
         wrapped = self._wrap_leaf_toolset(ts)
         if wrapped is None:
@@ -234,8 +239,10 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             raise UserError(
                 f"Toolsets that are 'leaves' (i.e. those that implement their own tool listing and calling) "
                 f'need to have a unique `id` in order to be used with {self.engine_name}. '
-                f"The ID will be used to identify the toolset's {self._durable_unit_noun}s within the "
-                f'{self._durable_container_noun}.'
+                f"The ID will be used to identify the toolset's {durable_units_noun} within the "
+                f"{self._durable_container_noun}. Set the toolset's `id`, or, when it is contributed by a "
+                "capability, set the capability's `id` (for example, "
+                "`WebSearch(local='duckduckgo', id='search')`)."
             )
         self._toolsets_by_id[ts_id] = wrapped
         return wrapped

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -78,6 +78,7 @@ from pydantic_ai.capabilities import (
     ProcessHistory,
     ResolveModelId,
     Toolset,
+    WebSearch,
     WrapperCapability,
 )
 from pydantic_ai.capabilities.abstract import AbstractCapability
@@ -7451,6 +7452,23 @@ async def test_pydantic_ai_plugin_rejects_bare_agent_without_durability(client: 
 
 
 # --- Toolset without ID raises UserError ---
+
+
+def test_durability_capability_toolset_without_id_error_includes_fix():
+    """The error for a capability-contributed leaf explains where to set its ID."""
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            "The ID will be used to identify the toolset's activities within the workflow. "
+            "Set the toolset's `id`, or, when it is contributed by a capability, set the capability's `id` "
+            "(for example, `WebSearch(local='duckduckgo', id='search')`)."
+        ),
+    ):
+        Agent(
+            _durability_fn_model,
+            name='capability_toolset_without_id',
+            capabilities=[WebSearch(local=get_weather_in_city), TemporalDurability()],
+        )
 
 
 def test_durability_unwrapped_toolset_without_id_is_allowed():


### PR DESCRIPTION
- Closes #7109

## Summary

- explain that capability-contributed leaf toolsets can receive their required `id` from the capability
- include a concrete `WebSearch(local='duckduckgo', id='search')` example in the shared durable-exec error
- pluralize Temporal's durable unit as `activities` instead of `activitys`
- add a public-`Agent` construction regression test for the reported path

## Root cause

`NativeOrLocalTool` capabilities contribute a `FunctionToolset` whose `id` comes from the capability. The generic leaf-toolset error reported the missing `id`, but unlike the `DynamicToolset` branch, it did not tell users that setting the capability's `id` fixes the configuration.

## Verification

- targeted Temporal regression and adjacent tests: 3 passed
- adjacent Prefect tests: 2 passed
- Ruff lint and format checks passed
- Pyright: 0 errors, 0 warnings
- `git diff --check` passed

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

