### PR TITLE
Expose finalized execution counts in Pydantic Evals telemetry

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -1046,7 +1046,11 @@ def _set_experiment_span_attributes(
     n_cases: int,
     repeat: int,
 ) -> None:
-    full_experiment_metadata: dict[str, Any] = {'n_cases': n_cases}
+    full_experiment_metadata: dict[str, Any] = {
+        'n_cases': n_cases,
+        'completed_case_count': len(report.cases),
+        'errored_case_count': len(report.failures),
+    }
     if repeat > 1:
         full_experiment_metadata['repeat'] = repeat
     if metadata is not None:

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -32,6 +32,7 @@ with try_import() as imports_successful:
         LLMJudge,
     )
     from pydantic_evals.evaluators.context import EvaluatorContext
+    from pydantic_evals.lifecycle import CaseLifecycle
     from pydantic_evals.reporting import EvaluationReport, ReportCase, ReportCaseAdapter, ReportCaseFailure
 
     @dataclass
@@ -1772,6 +1773,8 @@ async def test_evaluate_async_logfire(
                     'n_cases': 2,
                     'logfire.experiment.metadata': {
                         'n_cases': 2,
+                        'completed_case_count': 2,
+                        'errored_case_count': 0,
                         'metadata': {'key': 'value'},
                         'averages': {
                             'name': 'Averages',
@@ -1957,6 +1960,75 @@ async def test_evaluate_async_logfire(
             ),
         ]
     )
+
+
+@needs_logfire
+@pytest.mark.parametrize(
+    ('case_inputs', 'repeat', 'evaluator_fails', 'expected_completed', 'expected_errored'),
+    [
+        pytest.param([1, 2], 1, False, 2, 0, id='healthy-single-run'),
+        pytest.param([1], 1, True, 1, 0, id='evaluator-failure'),
+        pytest.param([1, -1], 1, False, 1, 1, id='partial-task-failure'),
+        pytest.param([1, -1], 3, False, 3, 3, id='repeated-mixed-results'),
+        pytest.param([], 1, False, 0, 0, id='empty-dataset'),
+    ],
+)
+async def test_evaluate_logfire_finalized_execution_counts(
+    capfire: CaptureLogfire,
+    case_inputs: list[int],
+    repeat: int,
+    evaluator_fails: bool,
+    expected_completed: int,
+    expected_errored: int,
+):
+    """Final experiment metadata distinguishes logical cases from execution outcomes."""
+
+    @dataclass
+    class FailingEvaluator(Evaluator[int, int, None]):
+        def evaluate(self, ctx: EvaluatorContext[int, int, None]) -> EvaluatorOutput:
+            raise ValueError('evaluation failed')
+
+    async def task(value: int) -> int:
+        if value < 0:
+            raise ValueError('negative input')
+        return value
+
+    dataset = Dataset[int, int, None](
+        name='execution-counts',
+        cases=[Case(name=f'case-{index}', inputs=value) for index, value in enumerate(case_inputs)],
+        evaluators=[FailingEvaluator()] if evaluator_fails else [],
+    )
+    report = await dataset.evaluate(task, progress=False, repeat=repeat)
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    eval_span = next(span for span in spans if span['name'] == 'evaluate {name}')
+    experiment_metadata = eval_span['attributes']['logfire.experiment.metadata']
+
+    assert experiment_metadata['n_cases'] == len(case_inputs)
+    assert experiment_metadata.get('repeat') == (repeat if repeat > 1 else None)
+    assert experiment_metadata['completed_case_count'] == expected_completed
+    assert experiment_metadata['errored_case_count'] == expected_errored
+    assert expected_completed + expected_errored == len(case_inputs) * repeat
+    if evaluator_fails:
+        assert all(case.evaluator_failures for case in report.cases)
+
+
+@needs_logfire
+async def test_evaluate_logfire_execution_counts_require_final_report(capfire: CaptureLogfire):
+    """An interrupted evaluation must not be presented as having finalized execution counts."""
+
+    class BrokenTeardown(CaseLifecycle[str, str, None]):
+        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None] | None) -> None:
+            raise RuntimeError('teardown exploded')
+
+    dataset = Dataset[str, str, None](name='interrupted', cases=[Case(name='case', inputs='input')])
+
+    with pytest.raises(ExceptionGroup, match='unhandled errors in a TaskGroup'):
+        await dataset.evaluate(lambda value: value, progress=False, lifecycle=BrokenTeardown)
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    eval_span = next(span for span in spans if span['name'] == 'evaluate {name}')
+    assert 'logfire.experiment.metadata' not in eval_span['attributes']
 
 
 async def test_evaluate_with_experiment_metadata(example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata]):


### PR DESCRIPTION
- Closes #6842

## Summary

- add `completed_case_count` and `errored_case_count` to finalized `logfire.experiment.metadata`
- derive the counts from `report.cases` and `report.failures`, preserving the distinction between logical cases and repeated execution outcomes
- keep evaluator failures in the completed count while treating task and lifecycle failures as errored outcomes
- leave interrupted experiments without finalized execution-count metadata

This lets telemetry consumers summarize evaluation completeness without loading and aggregating every child case span, especially when `repeat > 1`.

## Tests

Coverage includes healthy single runs, evaluator failures, partial task failures, repeated mixed outcomes, empty datasets, and interruption before report finalization.

- `uv run pytest tests/evals/test_dataset.py tests/evals/test_multi_run.py -q` — 93 passed
- `uv run ruff check pydantic_evals/pydantic_evals/dataset.py tests/evals/test_dataset.py`
- `uv run ruff format --check pydantic_evals/pydantic_evals/dataset.py tests/evals/test_dataset.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_evals/pydantic_evals/dataset.py tests/evals/test_dataset.py` — 0 errors

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

