### PR TITLE
docs: fix Pydantic AI spelling in toolsets documentation

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -945,4 +945,4 @@ toolset = EjentumToolset()
 agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 ```
 
-The toolset emits PydanticAI `instructions` that nudge the agent to call the matching `harness_*` tool before generating. Pass `add_instructions=False` to suppress and supply routing guidance from your own system prompt.
+The toolset emits Pydantic AI `instructions` that nudge the agent to call the matching `harness_*` tool before generating. Pass `add_instructions=False` to suppress and supply routing guidance from your own system prompt.


### PR DESCRIPTION
## Summary

Corrects `PydanticAI` to `Pydantic AI` in the third-party toolsets documentation to match the project's documented naming convention.

This is a documentation-only change with no runtime impact.

## Validation

- `git diff --check`
- `uvx --offline codespell docs/toolsets.md --quiet-level=2`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

