### PR TITLE
Honor `include_binary_content=False` in every OTel serialization sink

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -360,6 +360,8 @@ Agent.instrument_all(instrumentation_settings)
 
 ### Excluding binary content
 
+When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry wherever it appears: in user prompts, in tool returns, and in the agent's own output. The media type and other file metadata are still recorded.
+
 ```python {title="excluding_binary_content.py"}
 from pydantic_ai import Agent, InstrumentationSettings
 from pydantic_ai.capabilities import Instrumentation

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -360,7 +360,7 @@ Agent.instrument_all(instrumentation_settings)
 
 ### Excluding binary content
 
-When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry wherever it appears: in user prompts, in tool returns, and in the agent's own output. The media type and other file metadata are still recorded.
+When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry: from user prompts and model responses, from tool returns, and from the agent's own output and the arguments its output function receives. The media type and other file metadata are still recorded.
 
 ```python {title="excluding_binary_content.py"}
 from pydantic_ai import Agent, InstrumentationSettings

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -360,7 +360,9 @@ Agent.instrument_all(instrumentation_settings)
 
 ### Excluding binary content
 
-When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry: from user prompts and model responses, from tool returns, and from the agent's own output and the arguments its output function receives. The media type and other file metadata are still recorded.
+When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry: from user prompts and model responses, from tool returns, from the agent's own output and the arguments its output function receives, and from run and tool deferral metadata. The media type and other file metadata are still recorded.
+
+Binary content is found inside dictionaries, lists and [`ToolReturn`][pydantic_ai.messages.ToolReturn]s, but not inside your own types: a [`BinaryContent`][pydantic_ai.messages.BinaryContent] held as a field of a model or dataclass you define is still recorded in full.
 
 ```python {title="excluding_binary_content.py"}
 from pydantic_ai import Agent, InstrumentationSettings

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -360,7 +360,7 @@ Agent.instrument_all(instrumentation_settings)
 
 ### Excluding binary content
 
-When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry: from user prompts and model responses, from tool returns, from the agent's own output and the arguments its output function receives, and from run and tool deferral metadata. The media type and other file metadata are still recorded.
+When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry: from user prompts and model responses, from tool returns, from the agent's own output and the arguments its output function receives, and from run and tool deferral metadata. The media type is still recorded everywhere; where the value is recorded as the file itself rather than as a message part, so are its vendor metadata and its identifier, which is derived from the content when you don't set one.
 
 Binary content is found inside dictionaries, lists and [`ToolReturn`][pydantic_ai.messages.ToolReturn]s, but not inside your own types: a [`BinaryContent`][pydantic_ai.messages.BinaryContent] held as a field of a model or dataclass you define is still recorded in full.
 

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 import json
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, replace
@@ -61,9 +61,6 @@ MODEL_SETTING_ATTRIBUTES: tuple[
 
 ANY_ADAPTER = TypeAdapter[Any](Any)
 _BASE64_ANY_ADAPTER = TypeAdapter[Any](Any, config=ConfigDict(ser_json_bytes='base64'))
-
-INCLUDE_BINARY_CONTENT_CONTEXT_KEY = 'include_binary_content'
-"""Serialization context key read by `BinaryContent`'s serializer to decide whether to emit `data`."""
 
 # These are in the spec:
 # https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage
@@ -138,20 +135,56 @@ def get_agent_run_baggage_attributes() -> dict[str, Any]:
     return attrs
 
 
-def serialization_context(settings: InstrumentationSettings) -> dict[str, bool] | None:
-    """Pydantic serialization context that makes `BinaryContent` omit its `data` field.
+def redact_binary_content(value: Any, settings: InstrumentationSettings) -> Any:
+    """Strip binary data out of a value that's about to be serialized into a span attribute.
 
-    `None` when binary content is allowed, so the common path serializes without a context at all.
+    The attributes that carry whatever a tool or output function produced serialize arbitrary
+    values, so they can't honor `include_binary_content` the way `_convert_binary_to_otel_part`
+    does for message content: `BinaryContent`'s own serialization is a public contract shared with
+    message history, and making it depend on instrumentation would change how it dumps everywhere.
+    The value is redacted up front instead, keeping the media type and the rest of the file
+    metadata like `_convert_binary_to_otel_part` does, and dropping only the data.
+
+    Containers and `ToolReturn` are walked, matching the depth at which binary content is honored
+    elsewhere (the sequence in a `UserPromptPart`'s content). A `BinaryContent` nested inside a
+    user's own model is left alone: rebuilding that model to redact one field would change how
+    everything else in the attribute is serialized.
     """
-    return None if settings.include_binary_content else {INCLUDE_BINARY_CONTENT_CONTEXT_KEY: False}
+    if settings.include_binary_content:
+        return value
+
+    from pydantic_ai.messages import BinaryContent, ToolReturn
+
+    if isinstance(value, BinaryContent):
+        return {
+            'media_type': value.media_type,
+            'vendor_metadata': value.vendor_metadata,
+            'kind': value.kind,
+            'identifier': value.identifier,
+        }
+    if isinstance(value, ToolReturn):
+        return {
+            'return_value': redact_binary_content(value.return_value, settings),
+            'content': redact_binary_content(value.content, settings),
+            'metadata': redact_binary_content(value.metadata, settings),
+            'kind': value.kind,
+        }
+    if isinstance(value, Mapping):
+        return {  # pyright: ignore[reportUnknownVariableType]
+            key: redact_binary_content(item, settings)
+            for key, item in value.items()  # pyright: ignore[reportUnknownVariableType]
+        }
+    if isinstance(value, (list, tuple)):
+        return [redact_binary_content(item, settings) for item in value]  # pyright: ignore[reportUnknownVariableType]
+    return value
 
 
-def serialize_any(value: Any, *, context: dict[str, bool] | None = None) -> str:
+def serialize_any(value: Any) -> str:
     try:
         try:
-            return ANY_ADAPTER.dump_python(value, mode='json', context=context)
+            return ANY_ADAPTER.dump_python(value, mode='json')
         except UnicodeDecodeError:
-            return _BASE64_ANY_ADAPTER.dump_python(value, mode='json', context=context)
+            return _BASE64_ANY_ADAPTER.dump_python(value, mode='json')
     except Exception:
         try:
             return str(value)
@@ -159,7 +192,7 @@ def serialize_any(value: Any, *, context: dict[str, bool] | None = None) -> str:
             return f'Unable to serialize: {e}'
 
 
-def safe_to_json(value: object, *, context: dict[str, bool] | None = None) -> bytes:
+def safe_to_json(value: object) -> bytes:
     """Serialize `value` to compact JSON bytes, tolerating lone surrogates.
 
     `to_json` raises on unpaired surrogates (e.g. text decoded with `errors='surrogateescape'`),
@@ -167,7 +200,7 @@ def safe_to_json(value: object, *, context: dict[str, bool] | None = None) -> by
     escapes them, matching the lenient behavior callers had before adopting `to_json`.
     """
     try:
-        return to_json(value, context=context)
+        return to_json(value)
     except PydanticSerializationError:
         return json.dumps(value, separators=(',', ':')).encode()
 

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -135,7 +135,10 @@ def get_agent_run_baggage_attributes() -> dict[str, Any]:
     return attrs
 
 
-def redact_binary_content(value: Any, settings: InstrumentationSettings) -> Any:
+CIRCULAR_REFERENCE_PLACEHOLDER = '<circular reference>'
+
+
+def redact_binary_content(value: Any, settings: InstrumentationSettings) -> object:
     """Strip binary data out of a value that's about to be serialized into a span attribute.
 
     The attributes that carry whatever a tool or output function produced serialize arbitrary
@@ -143,7 +146,9 @@ def redact_binary_content(value: Any, settings: InstrumentationSettings) -> Any:
     does for message content: `BinaryContent`'s own serialization is a public contract shared with
     message history, and making it depend on instrumentation would change how it dumps everywhere.
     The value is redacted up front instead, keeping the media type and the rest of the file
-    metadata like `_convert_binary_to_otel_part` does, and dropping only the data.
+    metadata, and dropping only the data. That retained set is `BinaryContent`'s own and is wider
+    than the `mime_type` `_convert_binary_to_otel_part` keeps, because this replaces a value the
+    type itself serialized rather than building a spec-shaped message part.
 
     Containers and `ToolReturn` are walked, matching the depth at which binary content is honored
     elsewhere (the sequence in a `UserPromptPart`'s content). A `BinaryContent` nested inside a
@@ -153,40 +158,51 @@ def redact_binary_content(value: Any, settings: InstrumentationSettings) -> Any:
     if settings.include_binary_content:
         return value
     try:
-        return _redact_binary_content(value)
-    except RecursionError:
-        # A self-referential value (`d = {}; d['self'] = d`) must not crash an otherwise-successful
-        # run from within instrumentation. Handing it back untouched leaves the callers' own
-        # serialization to fall back the way it does for any value it can't represent.
-        return value
+        return _redact_binary_content(value, set())
+    except Exception as e:
+        # Instrumentation must not fail an otherwise-successful run, and the value can't be handed
+        # back to make that happen: the callers fall back to `str(value)`, whose `BinaryContent`
+        # repr prints the very data the flag excludes.
+        return f'Unable to redact binary content: {e}'
 
 
-def _redact_binary_content(value: Any) -> Any:
+def _redact_binary_content(value: Any, active: set[int]) -> object:
     from pydantic_ai.messages import BinaryContent, ToolReturn
 
-    if isinstance(value, BinaryContent):
-        return {
-            'media_type': value.media_type,
-            # Typed `dict[str, Any]`, so it can hold binary content of its own.
-            'vendor_metadata': _redact_binary_content(value.vendor_metadata),
-            'kind': value.kind,
-            'identifier': value.identifier,
-        }
-    if isinstance(value, ToolReturn):
-        return {
-            'return_value': _redact_binary_content(value.return_value),
-            'content': _redact_binary_content(value.content),
-            'metadata': _redact_binary_content(value.metadata),
-            'kind': value.kind,
-        }
-    if isinstance(value, Mapping):
-        return {  # pyright: ignore[reportUnknownVariableType]
-            key: _redact_binary_content(item)
-            for key, item in value.items()  # pyright: ignore[reportUnknownVariableType]
-        }
-    if isinstance(value, (list, tuple)):
-        return [_redact_binary_content(item) for item in value]  # pyright: ignore[reportUnknownVariableType]
-    return value
+    identity = id(value)
+    if not isinstance(value, (BinaryContent, ToolReturn, Mapping, list, tuple)):
+        return value
+    if identity in active:
+        return CIRCULAR_REFERENCE_PLACEHOLDER
+
+    # Tracks the objects on the path currently being walked, not every object seen, so that the
+    # same `BinaryContent` appearing twice side by side is redacted twice rather than the second
+    # occurrence being mistaken for a cycle.
+    active.add(identity)
+    try:
+        if isinstance(value, BinaryContent):
+            return {
+                'media_type': value.media_type,
+                # Typed `dict[str, Any]`, so it can hold binary content of its own.
+                'vendor_metadata': _redact_binary_content(value.vendor_metadata, active),
+                'kind': value.kind,
+                'identifier': value.identifier,
+            }
+        if isinstance(value, ToolReturn):
+            return {
+                'return_value': _redact_binary_content(value.return_value, active),
+                'content': _redact_binary_content(value.content, active),
+                'metadata': _redact_binary_content(value.metadata, active),
+                'kind': value.kind,
+            }
+        if isinstance(value, Mapping):
+            return {  # pyright: ignore[reportUnknownVariableType]
+                key: _redact_binary_content(item, active)
+                for key, item in value.items()  # pyright: ignore[reportUnknownVariableType]
+            }
+        return [_redact_binary_content(item, active) for item in value]  # pyright: ignore[reportUnknownVariableType]
+    finally:
+        active.discard(identity)
 
 
 def serialize_any(value: Any) -> str:

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -152,30 +152,40 @@ def redact_binary_content(value: Any, settings: InstrumentationSettings) -> Any:
     """
     if settings.include_binary_content:
         return value
+    try:
+        return _redact_binary_content(value)
+    except RecursionError:
+        # A self-referential value (`d = {}; d['self'] = d`) must not crash an otherwise-successful
+        # run from within instrumentation. Handing it back untouched leaves the callers' own
+        # serialization to fall back the way it does for any value it can't represent.
+        return value
 
+
+def _redact_binary_content(value: Any) -> Any:
     from pydantic_ai.messages import BinaryContent, ToolReturn
 
     if isinstance(value, BinaryContent):
         return {
             'media_type': value.media_type,
-            'vendor_metadata': value.vendor_metadata,
+            # Typed `dict[str, Any]`, so it can hold binary content of its own.
+            'vendor_metadata': _redact_binary_content(value.vendor_metadata),
             'kind': value.kind,
             'identifier': value.identifier,
         }
     if isinstance(value, ToolReturn):
         return {
-            'return_value': redact_binary_content(value.return_value, settings),
-            'content': redact_binary_content(value.content, settings),
-            'metadata': redact_binary_content(value.metadata, settings),
+            'return_value': _redact_binary_content(value.return_value),
+            'content': _redact_binary_content(value.content),
+            'metadata': _redact_binary_content(value.metadata),
             'kind': value.kind,
         }
     if isinstance(value, Mapping):
         return {  # pyright: ignore[reportUnknownVariableType]
-            key: redact_binary_content(item, settings)
+            key: _redact_binary_content(item)
             for key, item in value.items()  # pyright: ignore[reportUnknownVariableType]
         }
     if isinstance(value, (list, tuple)):
-        return [redact_binary_content(item, settings) for item in value]  # pyright: ignore[reportUnknownVariableType]
+        return [_redact_binary_content(item) for item in value]  # pyright: ignore[reportUnknownVariableType]
     return value
 
 

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -62,6 +62,9 @@ MODEL_SETTING_ATTRIBUTES: tuple[
 ANY_ADAPTER = TypeAdapter[Any](Any)
 _BASE64_ANY_ADAPTER = TypeAdapter[Any](Any, config=ConfigDict(ser_json_bytes='base64'))
 
+INCLUDE_BINARY_CONTENT_CONTEXT_KEY = 'include_binary_content'
+"""Serialization context key read by `BinaryContent`'s serializer to decide whether to emit `data`."""
+
 # These are in the spec:
 # https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage
 TOKEN_HISTOGRAM_BOUNDARIES = (1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864)
@@ -135,12 +138,20 @@ def get_agent_run_baggage_attributes() -> dict[str, Any]:
     return attrs
 
 
-def serialize_any(value: Any) -> str:
+def serialization_context(settings: InstrumentationSettings) -> dict[str, bool] | None:
+    """Pydantic serialization context that makes `BinaryContent` omit its `data` field.
+
+    `None` when binary content is allowed, so the common path serializes without a context at all.
+    """
+    return None if settings.include_binary_content else {INCLUDE_BINARY_CONTENT_CONTEXT_KEY: False}
+
+
+def serialize_any(value: Any, *, context: dict[str, bool] | None = None) -> str:
     try:
         try:
-            return ANY_ADAPTER.dump_python(value, mode='json')
+            return ANY_ADAPTER.dump_python(value, mode='json', context=context)
         except UnicodeDecodeError:
-            return _BASE64_ANY_ADAPTER.dump_python(value, mode='json')
+            return _BASE64_ANY_ADAPTER.dump_python(value, mode='json', context=context)
     except Exception:
         try:
             return str(value)
@@ -148,7 +159,7 @@ def serialize_any(value: Any) -> str:
             return f'Unable to serialize: {e}'
 
 
-def safe_to_json(value: object) -> bytes:
+def safe_to_json(value: object, *, context: dict[str, bool] | None = None) -> bytes:
     """Serialize `value` to compact JSON bytes, tolerating lone surrogates.
 
     `to_json` raises on unpaired surrogates (e.g. text decoded with `errors='surrogateescape'`),
@@ -156,7 +167,7 @@ def safe_to_json(value: object) -> bytes:
     escapes them, matching the lenient behavior callers had before adopting `to_json`.
     """
     try:
-        return to_json(value)
+        return to_json(value, context=context)
     except PydanticSerializationError:
         return json.dumps(value, separators=(',', ':')).encode()
 

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -167,10 +167,11 @@ def redact_binary_content(value: Any, settings: InstrumentationSettings) -> obje
 
 
 def _redact_binary_content(value: Any, active: set[int]) -> object:
+    from pydantic_ai._deferred import DeferredToolRequests
     from pydantic_ai.messages import BinaryContent, ToolReturn
 
     identity = id(value)
-    if not isinstance(value, (BinaryContent, ToolReturn, Mapping, list, tuple)):
+    if not isinstance(value, (BinaryContent, ToolReturn, DeferredToolRequests, Mapping, list, tuple)):
         return value
     if identity in active:
         return CIRCULAR_REFERENCE_PLACEHOLDER
@@ -194,6 +195,14 @@ def _redact_binary_content(value: Any, active: set[int]) -> object:
                 'content': _redact_binary_content(value.content, active),
                 'metadata': _redact_binary_content(value.metadata, active),
                 'kind': value.kind,
+            }
+        if isinstance(value, DeferredToolRequests):
+            # Carries the metadata a deferring tool attached, so the run's own output has to drop
+            # the same binary the tool's span already did.
+            return {
+                'calls': _redact_binary_content(value.calls, active),
+                'approvals': _redact_binary_content(value.approvals, active),
+                'metadata': _redact_binary_content(value.metadata, active),
             }
         if isinstance(value, Mapping):
             return {  # pyright: ignore[reportUnknownVariableType]

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -162,8 +162,9 @@ def redact_binary_content(value: Any, settings: InstrumentationSettings) -> obje
     except Exception as e:
         # Instrumentation must not fail an otherwise-successful run, and the value can't be handed
         # back to make that happen: the callers fall back to `str(value)`, whose `BinaryContent`
-        # repr prints the very data the flag excludes.
-        return f'Unable to redact binary content: {e}'
+        # repr prints the very data the flag excludes. Only the exception's type is reported for
+        # the same reason -- its message is user-controlled and can itself embed a `BinaryContent`.
+        return f'Unable to redact binary content: {type(e).__name__}'
 
 
 def _redact_binary_content(value: Any, active: set[int]) -> object:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -21,6 +21,7 @@ from pydantic_ai._instrumentation import (
     has_stale_message_json,
     open_model_request_span,
     safe_to_json,
+    serialization_context,
     serialize_any,
     time_to_first_chunk_ctx,
 )
@@ -189,7 +190,9 @@ class Instrumentation(AbstractCapability[Any]):
                         (
                             result.output
                             if isinstance(result.output, str)
-                            else safe_to_json(serialize_any(result.output)).decode()
+                            else safe_to_json(
+                                serialize_any(result.output, context=serialization_context(settings))
+                            ).decode()
                         ),
                     )
 
@@ -448,7 +451,9 @@ class Instrumentation(AbstractCapability[Any]):
             span_name=self._instrumentation_names.get_tool_span_name(call.tool_name),
             attributes=self._tool_span_attributes(call),
             action=lambda: handler(args),
-            serialize_result=lambda value: tool_return_ta.dump_json(value).decode(),
+            serialize_result=lambda value: tool_return_ta.dump_json(
+                value, context=serialization_context(self.settings)
+            ).decode(),
             handle_tool_control_flow=True,
         )
 
@@ -492,7 +497,9 @@ class Instrumentation(AbstractCapability[Any]):
         if tool_call is not None and tool_call.tool_call_id:
             attributes['gen_ai.tool.call.id'] = tool_call.tool_call_id
         if include_content:
-            attributes[names.tool_arguments_attr] = safe_to_json(output).decode()
+            attributes[names.tool_arguments_attr] = safe_to_json(
+                output, context=serialization_context(self.settings)
+            ).decode()
 
         attributes['logfire.json_schema'] = to_json(
             {
@@ -516,5 +523,7 @@ class Instrumentation(AbstractCapability[Any]):
             span_name=names.get_output_tool_span_name(span_target),
             attributes=attributes,
             action=lambda: handler(output),
-            serialize_result=lambda value: safe_to_json(serialize_any(value)).decode(),
+            serialize_result=lambda value: safe_to_json(
+                serialize_any(value, context=serialization_context(self.settings))
+            ).decode(),
         )

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -20,8 +20,8 @@ from pydantic_ai._instrumentation import (
     get_instructions,
     has_stale_message_json,
     open_model_request_span,
+    redact_binary_content,
     safe_to_json,
-    serialization_context,
     serialize_any,
     time_to_first_chunk_ctx,
 )
@@ -190,9 +190,7 @@ class Instrumentation(AbstractCapability[Any]):
                         (
                             result.output
                             if isinstance(result.output, str)
-                            else safe_to_json(
-                                serialize_any(result.output, context=serialization_context(settings))
-                            ).decode()
+                            else safe_to_json(serialize_any(redact_binary_content(result.output, settings))).decode()
                         ),
                     )
 
@@ -452,7 +450,7 @@ class Instrumentation(AbstractCapability[Any]):
             attributes=self._tool_span_attributes(call),
             action=lambda: handler(args),
             serialize_result=lambda value: tool_return_ta.dump_json(
-                value, context=serialization_context(self.settings)
+                redact_binary_content(value, self.settings)
             ).decode(),
             handle_tool_control_flow=True,
         )
@@ -497,9 +495,7 @@ class Instrumentation(AbstractCapability[Any]):
         if tool_call is not None and tool_call.tool_call_id:
             attributes['gen_ai.tool.call.id'] = tool_call.tool_call_id
         if include_content:
-            attributes[names.tool_arguments_attr] = safe_to_json(
-                output, context=serialization_context(self.settings)
-            ).decode()
+            attributes[names.tool_arguments_attr] = safe_to_json(redact_binary_content(output, self.settings)).decode()
 
         attributes['logfire.json_schema'] = to_json(
             {
@@ -524,6 +520,6 @@ class Instrumentation(AbstractCapability[Any]):
             attributes=attributes,
             action=lambda: handler(output),
             serialize_result=lambda value: safe_to_json(
-                serialize_any(value, context=serialization_context(self.settings))
+                serialize_any(redact_binary_content(value, self.settings))
             ).decode(),
         )

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -250,7 +250,7 @@ class Instrumentation(AbstractCapability[Any]):
             attrs['pydantic_ai.variable_instructions'] = True
 
         if metadata is not None:
-            attrs['metadata'] = safe_to_json(serialize_any(metadata)).decode()
+            attrs['metadata'] = safe_to_json(serialize_any(redact_binary_content(metadata, settings))).decode()
 
         usage_attrs = (
             {
@@ -400,10 +400,11 @@ class Instrumentation(AbstractCapability[Any]):
                 # ERROR for older instrumentation versions that expected that shape.
                 span.set_attribute(names.tool_deferral_name_attr, type(exc).__name__)
                 if include_content and span.is_recording() and exc.metadata is not None:
+                    redacted_metadata = redact_binary_content(exc.metadata, settings)
                     try:
-                        metadata_str = to_json(exc.metadata).decode()
+                        metadata_str = to_json(redacted_metadata).decode()
                     except (TypeError, ValueError):
-                        metadata_str = repr(exc.metadata)
+                        metadata_str = repr(redacted_metadata)
                     span.set_attribute(names.tool_deferral_metadata_attr, metadata_str)
                 if settings.version < 5:
                     span.record_exception(exc, escaped=True)

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -24,7 +24,7 @@ from typing_extensions import TypeAliasType, TypeVar, assert_never
 from pydantic_ai._cost import calculate_price_for_usage
 
 from . import _otel_messages, _utils
-from ._instrumentation import INCLUDE_BINARY_CONTENT_CONTEXT_KEY, serialization_context, serialize_any
+from ._instrumentation import redact_binary_content, serialize_any
 from ._utils import generate_tool_call_id as _generate_tool_call_id, now_utc as _now_utc
 from .exceptions import UnexpectedModelBehavior
 from .usage import RequestUsage
@@ -685,25 +685,6 @@ class BinaryContent:
                 return _document_format_lookup[self.media_type]
         except KeyError as e:
             raise ValueError(f'Unknown media type: {self.media_type}') from e
-
-    @pydantic.model_serializer(mode='wrap')
-    def _serialize(
-        self, handler: pydantic.SerializerFunctionWrapHandler, info: pydantic.SerializationInfo
-    ) -> dict[str, Any]:
-        """Omit `data` when the serialization context asks for binary content to be excluded.
-
-        Instrumentation passes `{'include_binary_content': False}` so the telemetry sinks that
-        serialize arbitrary values (tool returns, agent output, output-function arguments) don't
-        leak base64. Without that context this is a no-op, so message history round-trips and every
-        other dump are unaffected.
-        """
-        serialized: dict[str, Any] = handler(self)
-        # The annotation is a claim, not a guarantee: a caller can pass any object as the
-        # serialization context, so the `isinstance` is what actually keeps `.get` safe.
-        context: dict[str, Any] | None = info.context
-        if isinstance(context, dict) and context.get(INCLUDE_BINARY_CONTENT_CONTEXT_KEY) is False:
-            del serialized['data']
-        return serialized
 
     __repr__ = _utils.dataclasses_no_defaults_repr
 
@@ -1522,7 +1503,7 @@ class BaseToolReturnPart:
         )
 
         if settings.include_content and self.content is not None:
-            part['result'] = serialize_any(self.content, context=serialization_context(settings))
+            part['result'] = serialize_any(redact_binary_content(self.content, settings))
 
         return [part]
 
@@ -2533,7 +2514,7 @@ class ModelResponse:
                     builtin=True,
                 )
                 if settings.include_content and part.content is not None:  # pragma: no branch
-                    return_part['result'] = serialize_any(part.content, context=serialization_context(settings))
+                    return_part['result'] = serialize_any(redact_binary_content(part.content, settings))
 
                 parts.append(return_part)
             elif isinstance(part, CompactionPart):

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -24,7 +24,7 @@ from typing_extensions import TypeAliasType, TypeVar, assert_never
 from pydantic_ai._cost import calculate_price_for_usage
 
 from . import _otel_messages, _utils
-from ._instrumentation import serialize_any
+from ._instrumentation import INCLUDE_BINARY_CONTENT_CONTEXT_KEY, serialization_context, serialize_any
 from ._utils import generate_tool_call_id as _generate_tool_call_id, now_utc as _now_utc
 from .exceptions import UnexpectedModelBehavior
 from .usage import RequestUsage
@@ -685,6 +685,25 @@ class BinaryContent:
                 return _document_format_lookup[self.media_type]
         except KeyError as e:
             raise ValueError(f'Unknown media type: {self.media_type}') from e
+
+    @pydantic.model_serializer(mode='wrap')
+    def _serialize(
+        self, handler: pydantic.SerializerFunctionWrapHandler, info: pydantic.SerializationInfo
+    ) -> dict[str, Any]:
+        """Omit `data` when the serialization context asks for binary content to be excluded.
+
+        Instrumentation passes `{'include_binary_content': False}` so the telemetry sinks that
+        serialize arbitrary values (tool returns, agent output, output-function arguments) don't
+        leak base64. Without that context this is a no-op, so message history round-trips and every
+        other dump are unaffected.
+        """
+        serialized: dict[str, Any] = handler(self)
+        # The annotation is a claim, not a guarantee: a caller can pass any object as the
+        # serialization context, so the `isinstance` is what actually keeps `.get` safe.
+        context: dict[str, Any] | None = info.context
+        if isinstance(context, dict) and context.get(INCLUDE_BINARY_CONTENT_CONTEXT_KEY) is False:
+            del serialized['data']
+        return serialized
 
     __repr__ = _utils.dataclasses_no_defaults_repr
 
@@ -1503,7 +1522,7 @@ class BaseToolReturnPart:
         )
 
         if settings.include_content and self.content is not None:
-            part['result'] = serialize_any(self.content)
+            part['result'] = serialize_any(self.content, context=serialization_context(settings))
 
         return [part]
 
@@ -2514,7 +2533,7 @@ class ModelResponse:
                     builtin=True,
                 )
                 if settings.include_content and part.content is not None:  # pragma: no branch
-                    return_part['result'] = serialize_any(part.content)
+                    return_part['result'] = serialize_any(part.content, context=serialization_context(settings))
 
                 parts.append(return_part)
             elif isinstance(part, CompactionPart):

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -95,9 +95,12 @@ class InstrumentationSettings:
                 If not provided, the global meter provider is used.
                 Calling `logfire.configure()` sets the global meter provider, so most users don't need this.
             include_binary_content: Whether to include binary file data in the instrumentation events:
-                user prompts and model responses, tool returns, and the agent's output and the
-                arguments its output function receives. The media type and other file metadata are
-                recorded either way.
+                user prompts and model responses, tool returns, the agent's output and the arguments
+                its output function receives, and run and tool deferral metadata. The media type and
+                other file metadata are recorded either way. Binary content is found inside
+                dictionaries, lists and `ToolReturn`s, but not inside your own types: a
+                `BinaryContent` held as a field of a model or dataclass you define is still recorded
+                in full.
             include_content: Whether to include prompts, completions, and tool call arguments and responses
                 in the instrumentation events.
             include_model_request_parameters: Whether to emit the `model_request_parameters` span attribute on

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -96,11 +96,10 @@ class InstrumentationSettings:
                 Calling `logfire.configure()` sets the global meter provider, so most users don't need this.
             include_binary_content: Whether to include binary file data in the instrumentation events:
                 user prompts and model responses, tool returns, the agent's output and the arguments
-                its output function receives, and run and tool deferral metadata. The media type and
-                other file metadata are recorded either way. Binary content is found inside
-                dictionaries, lists and `ToolReturn`s, but not inside your own types: a
-                `BinaryContent` held as a field of a model or dataclass you define is still recorded
-                in full.
+                its output function receives, and run and tool deferral metadata. The media type is
+                recorded either way. Binary content is found inside dictionaries, lists and
+                `ToolReturn`s, but not inside your own types: a `BinaryContent` held as a field of a
+                model or dataclass you define is still recorded in full.
             include_content: Whether to include prompts, completions, and tool call arguments and responses
                 in the instrumentation events.
             include_model_request_parameters: Whether to emit the `model_request_parameters` span attribute on

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -94,7 +94,9 @@ class InstrumentationSettings:
             meter_provider: The OpenTelemetry meter provider to use.
                 If not provided, the global meter provider is used.
                 Calling `logfire.configure()` sets the global meter provider, so most users don't need this.
-            include_binary_content: Whether to include binary content in the instrumentation events.
+            include_binary_content: Whether to include binary file data in the instrumentation events,
+                wherever it appears: user prompts, tool returns, and agent output. The media type and
+                other file metadata are recorded either way.
             include_content: Whether to include prompts, completions, and tool call arguments and responses
                 in the instrumentation events.
             include_model_request_parameters: Whether to emit the `model_request_parameters` span attribute on

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -94,9 +94,10 @@ class InstrumentationSettings:
             meter_provider: The OpenTelemetry meter provider to use.
                 If not provided, the global meter provider is used.
                 Calling `logfire.configure()` sets the global meter provider, so most users don't need this.
-            include_binary_content: Whether to include binary file data in the instrumentation events,
-                wherever it appears: user prompts, tool returns, and agent output. The media type and
-                other file metadata are recorded either way.
+            include_binary_content: Whether to include binary file data in the instrumentation events:
+                user prompts and model responses, tool returns, and the agent's output and the
+                arguments its output function receives. The media type and other file metadata are
+                recorded either way.
             include_content: Whether to include prompts, completions, and tool call arguments and responses
                 in the instrumentation events.
             include_model_request_parameters: Whether to emit the `model_request_parameters` span attribute on

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -74,12 +74,12 @@ class IsSingleEntryDict:
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, dict):
-            return False
+            return False  # pragma: no cover
         entries: dict[str, Any] = other  # pyright: ignore[reportUnknownVariableType]
         return len(entries) == 1 and next(iter(entries.values())) == self.value
 
     def __repr__(self) -> str:
-        return f'IsSingleEntryDict({self.value!r})'
+        return f'IsSingleEntryDict({self.value!r})'  # pragma: no cover
 
 
 def image_returning_tool_agent(settings: InstrumentationSettings) -> Agent[None, str]:

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -24,6 +24,7 @@ from pydantic_ai import (
     NativeToolReturnPart,
     TextPart,
     ToolCallPart,
+    ToolReturn,
     ToolReturnPart,
     UserPromptPart,
 )
@@ -46,8 +47,13 @@ pytestmark = [
 
 IMAGE = BinaryImage(data=b'\x89PNG' + b'kiwi' * 32, media_type='image/png')
 
-REDACTED_IMAGE = snapshot({'media_type': 'image/png', 'vendor_metadata': None, 'kind': 'binary', 'identifier': IsStr()})
-"""The shape a `BinaryImage` serializes to once its data is excluded: everything but `data`."""
+REDACTED_IMAGE: dict[str, Any] = {
+    'media_type': 'image/png',
+    'vendor_metadata': None,
+    'kind': 'binary',
+    'identifier': IsStr(),
+}
+"""The shape a `BinaryImage` is recorded as once its data is excluded: everything but `data`."""
 
 
 def image_returning_tool_agent(settings: InstrumentationSettings) -> Agent[None, str]:
@@ -63,6 +69,23 @@ def image_returning_tool_agent(settings: InstrumentationSettings) -> Agent[None,
     @agent.tool_plain
     def gen_image() -> BinaryImage:
         return IMAGE
+
+    return agent
+
+
+def tool_return_agent(settings: InstrumentationSettings) -> Agent[None, str]:
+    """An agent whose tool wraps the image in a `ToolReturn`, in each of its value fields."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('gen_image', {})])
+        return ModelResponse(parts=[TextPart('a kiwi')])
+
+    agent = Agent(FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], name='agent')
+
+    @agent.tool_plain
+    def gen_image() -> ToolReturn:
+        return ToolReturn(return_value=IMAGE, content=['here it is', IMAGE], metadata={'img': IMAGE})
 
     return agent
 
@@ -155,6 +178,22 @@ CASES = [
         ),
     ),
     Case(
+        # `ToolReturn` is the framework's own wrapper, so it's walked into: a user's own model
+        # holding a `BinaryImage` is not, and would still carry the image here.
+        id='tool_return_result',
+        build=tool_return_agent,
+        span_name='execute_tool gen_image',
+        attribute='gen_ai.tool.call.result',
+        redacted=snapshot(
+            {
+                'return_value': REDACTED_IMAGE,
+                'content': ['here it is', REDACTED_IMAGE],
+                'metadata': {'img': REDACTED_IMAGE},
+                'kind': 'tool-return',
+            }
+        ),
+    ),
+    Case(
         id='final_result',
         build=image_output_agent,
         span_name='invoke_agent agent',
@@ -234,13 +273,21 @@ async def test_binary_content_omitted_from_span_attribute(case: Case, capfire: C
     assert await run_and_read_attribute(case, capfire, include_binary_content=False) == case.redacted
 
 
-@pytest.mark.parametrize('context', [None, {}, {'include_binary_content': True}, {'unrelated': False}, 'not-a-mapping'])
-def test_message_history_round_trip_preserves_binary_content(context: Any) -> None:
-    """Binary data must survive any dump that isn't instrumentation asking for it to be excluded.
+def test_redacted_image_keeps_every_field_but_data() -> None:
+    """A field added to `BinaryContent` has to be added to the redacted shape too.
 
-    `BinaryContent` omits its `data` only for the exact context instrumentation passes, so every
-    other dump — message history above all — is untouched, including one carrying a user's own
-    serialization context of whatever shape.
+    The redaction spells its fields out rather than dumping and dropping `data`, so a new field
+    would otherwise silently stop reaching telemetry. This pins the field set that redaction mirrors.
+    """
+    dumped = ModelMessagesTypeAdapter.dump_python([ModelRequest(parts=[UserPromptPart(content=[IMAGE])])], mode='json')
+    assert set(dumped[0]['parts'][0]['content'][0]) == set(REDACTED_IMAGE) | {'data'}
+
+
+def test_message_history_round_trip_preserves_binary_content() -> None:
+    """Binary data must survive a message history dump: the redaction is instrumentation's alone.
+
+    `BinaryContent` serializes the same way it always did — telemetry redacts the values it's about
+    to record rather than changing how the type dumps — so message history is untouched.
     """
     messages: list[ModelMessage] = [
         ModelRequest(parts=[UserPromptPart(content=['look at this', IMAGE])]),
@@ -248,6 +295,6 @@ def test_message_history_round_trip_preserves_binary_content(context: Any) -> No
         ModelRequest(parts=[ToolReturnPart(tool_name='gen_image', content=IMAGE, tool_call_id='1')]),
     ]
 
-    dumped = ModelMessagesTypeAdapter.dump_json(messages, context=context)
+    dumped = ModelMessagesTypeAdapter.dump_json(messages)
     assert IMAGE.base64 in dumped.decode()
     assert ModelMessagesTypeAdapter.validate_json(dumped) == messages

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -1,0 +1,253 @@
+"""`InstrumentationSettings(include_binary_content=False)` must not leak base64 into any span.
+
+These run against `FunctionModel` rather than a cassette: the leak is in our own OTel serialization
+of `BinaryContent`, which is provider-independent, so a recording would only add a base64 image
+payload to the repo without exercising anything the fake model doesn't.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from pydantic_ai import (
+    Agent,
+    BinaryImage,
+    FilePart,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    NativeToolReturnPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.capabilities.instrumentation import Instrumentation
+from pydantic_ai.messages import ModelMessagesTypeAdapter
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
+from pydantic_ai.profiles import ModelProfile
+
+from ._inline_snapshot import snapshot
+from .conftest import IsStr, try_import
+
+with try_import() as imports_successful:
+    from logfire.testing import CaptureLogfire
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='logfire not installed'),
+    pytest.mark.anyio,
+]
+
+IMAGE = BinaryImage(data=b'\x89PNG' + b'kiwi' * 32, media_type='image/png')
+
+REDACTED_IMAGE = snapshot({'media_type': 'image/png', 'vendor_metadata': None, 'kind': 'binary', 'identifier': IsStr()})
+"""The shape a `BinaryImage` serializes to once its data is excluded: everything but `data`."""
+
+
+def image_returning_tool_agent(settings: InstrumentationSettings) -> Agent[None, str]:
+    """An agent whose tool returns an image, and which then answers with text."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('gen_image', {})])
+        return ModelResponse(parts=[TextPart('a kiwi')])
+
+    agent = Agent(FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], name='agent')
+
+    @agent.tool_plain
+    def gen_image() -> BinaryImage:
+        return IMAGE
+
+    return agent
+
+
+def image_output_agent(settings: InstrumentationSettings) -> Agent[None, BinaryImage]:
+    """An agent whose own output is an image."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[FilePart(content=IMAGE)])
+
+    return Agent(
+        FunctionModel(respond, profile=ModelProfile(supports_image_output=True)),
+        capabilities=[Instrumentation(settings=settings)],
+        output_type=BinaryImage,
+        name='agent',
+    )
+
+
+def image_argument_output_function_agent(settings: InstrumentationSettings) -> Agent[None, str]:
+    """An agent whose output function receives an image as its argument."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart('final_result', {'image': {'data': IMAGE.base64, 'media_type': IMAGE.media_type}})]
+        )
+
+    def describe(image: BinaryImage) -> str:
+        return image.media_type
+
+    return Agent(
+        FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], output_type=describe, name='agent'
+    )
+
+
+def text_agent(settings: InstrumentationSettings) -> Agent[None, str]:
+    """An agent that just answers, for cases where the image enters through message history."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('a kiwi')])
+
+    return Agent(FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], name='agent')
+
+
+@dataclass(frozen=True)
+class Case:
+    """One span attribute that serializes arbitrary values and so could carry binary content."""
+
+    id: str
+    build: Callable[[InstrumentationSettings], Agent[None, Any]]
+    span_name: str
+    attribute: str
+    redacted: Any
+    """The attribute's value once `include_binary_content=False` excludes the image data."""
+    history: list[ModelMessage] = field(default_factory=list[ModelMessage])
+
+
+CASES = [
+    Case(
+        id='tool_result',
+        build=image_returning_tool_agent,
+        span_name='execute_tool gen_image',
+        attribute='gen_ai.tool.call.result',
+        redacted=REDACTED_IMAGE,
+    ),
+    Case(
+        id='tool_return_message',
+        build=image_returning_tool_agent,
+        span_name='invoke_agent agent',
+        attribute='pydantic_ai.all_messages',
+        redacted=snapshot(
+            [
+                {'role': 'user', 'parts': [{'type': 'text', 'content': 'make an image'}]},
+                {
+                    'role': 'assistant',
+                    'parts': [{'type': 'tool_call', 'id': IsStr(), 'name': 'gen_image', 'arguments': {}}],
+                },
+                {
+                    'role': 'user',
+                    'parts': [
+                        {
+                            'type': 'tool_call_response',
+                            'id': IsStr(),
+                            'name': 'gen_image',
+                            'result': REDACTED_IMAGE,
+                        }
+                    ],
+                },
+                {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'a kiwi'}]},
+            ]
+        ),
+    ),
+    Case(
+        id='final_result',
+        build=image_output_agent,
+        span_name='invoke_agent agent',
+        attribute='final_result',
+        redacted=REDACTED_IMAGE,
+    ),
+    Case(
+        id='output_function_arguments',
+        build=image_argument_output_function_agent,
+        span_name='execute_tool final_result',
+        attribute='gen_ai.tool.call.arguments',
+        redacted=REDACTED_IMAGE,
+    ),
+    Case(
+        # Reachable from the UI adapters, which rehydrate a native tool's prior result back into
+        # `BinaryContent` when a client re-sends message history.
+        id='native_tool_return_message',
+        build=text_agent,
+        span_name='invoke_agent agent',
+        attribute='pydantic_ai.all_messages',
+        redacted=snapshot(
+            [
+                {'role': 'user', 'parts': [{'type': 'text', 'content': 'draw a kiwi'}]},
+                {
+                    'role': 'assistant',
+                    'parts': [
+                        {
+                            'type': 'tool_call_response',
+                            'id': 'call-1',
+                            'name': 'image_generation',
+                            'builtin': True,
+                            'result': REDACTED_IMAGE,
+                        }
+                    ],
+                },
+                {'role': 'user', 'parts': [{'type': 'text', 'content': 'make an image'}]},
+                {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'a kiwi'}]},
+            ]
+        ),
+        history=[
+            ModelRequest(parts=[UserPromptPart(content='draw a kiwi')]),
+            ModelResponse(
+                parts=[
+                    NativeToolReturnPart(
+                        tool_name='image_generation',
+                        tool_call_id='call-1',
+                        content=IMAGE,
+                        provider_name='openai',
+                    )
+                ]
+            ),
+        ],
+    ),
+]
+
+
+async def run_and_read_attribute(case: Case, capfire: CaptureLogfire, *, include_binary_content: bool) -> Any:
+    capfire.exporter.clear()
+    agent = case.build(InstrumentationSettings(include_binary_content=include_binary_content))
+    await agent.run('make an image', message_history=case.history)
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    # The last matching span: the run's final model request is the one that has seen the image.
+    attributes = [span['attributes'] for span in spans if span['name'] == case.span_name][-1]
+    return attributes[case.attribute]
+
+
+@pytest.mark.parametrize('case', [pytest.param(case, id=case.id) for case in CASES])
+async def test_binary_content_omitted_from_span_attribute(case: Case, capfire: CaptureLogfire) -> None:
+    """Each attribute carries the image by default, and only its media type once binary is excluded.
+
+    Asserting the default first keeps the case honest: if the attribute stopped carrying binary
+    content altogether, the redaction assertion below would pass without proving anything.
+    """
+    included = await run_and_read_attribute(case, capfire, include_binary_content=True)
+    assert IMAGE.base64 in json.dumps(included)
+
+    assert await run_and_read_attribute(case, capfire, include_binary_content=False) == case.redacted
+
+
+@pytest.mark.parametrize('context', [None, {}, {'include_binary_content': True}, {'unrelated': False}, 'not-a-mapping'])
+def test_message_history_round_trip_preserves_binary_content(context: Any) -> None:
+    """Binary data must survive any dump that isn't instrumentation asking for it to be excluded.
+
+    `BinaryContent` omits its `data` only for the exact context instrumentation passes, so every
+    other dump — message history above all — is untouched, including one carrying a user's own
+    serialization context of whatever shape.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=['look at this', IMAGE])]),
+        ModelResponse(parts=[FilePart(content=IMAGE)]),
+        ModelRequest(parts=[ToolReturnPart(tool_name='gen_image', content=IMAGE, tool_call_id='1')]),
+    ]
+
+    dumped = ModelMessagesTypeAdapter.dump_json(messages, context=context)
+    assert IMAGE.base64 in dumped.decode()
+    assert ModelMessagesTypeAdapter.validate_json(dumped) == messages

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -476,8 +476,37 @@ async def test_output_the_walk_cannot_traverse_does_not_crash_the_run(capfire: C
 
     spans = capfire.exporter.exported_spans_as_dict()
     assert [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent'] == snapshot(
-        ['"Unable to redact binary content: cannot iterate detached rows"']
+        ['"Unable to redact binary content: RuntimeError"']
     )
+
+
+async def test_the_walks_own_failure_does_not_report_a_binary_carrying_message(capfire: CaptureLogfire) -> None:
+    """The fallback names the exception's type, never its message.
+
+    An exception raised out of a user's container carries a user-controlled message, which can embed
+    a `BinaryContent` whose repr prints the data. Interpolating it would have leaked through the very
+    branch that exists to keep the flag honored when the walk can't finish.
+    """
+
+    class Guarded(Mapping[str, Any]):
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError(IMAGE)
+
+        def __getitem__(self, key: str) -> Any:
+            raise KeyError(key)  # pragma: no cover
+
+        def __len__(self) -> int:
+            return 0  # pragma: no cover
+
+    def guarded() -> dict[str, Any]:
+        return {'rows': Guarded()}
+
+    await output_agent(guarded).run('make an image')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    attribute = next(span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent')
+    assert attribute == snapshot('"Unable to redact binary content: RuntimeError"')
+    assert 'kiwi' not in attribute
 
 
 def test_binary_nested_in_a_user_type_is_not_redacted(capfire: CaptureLogfire) -> None:

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -54,9 +54,32 @@ REDACTED_IMAGE: dict[str, Any] = {
     'media_type': 'image/png',
     'vendor_metadata': None,
     'kind': 'binary',
-    'identifier': IsStr(),
+    # Pinned rather than matched: `identifier` defaults to a hash of the data, so it survives as a
+    # fingerprint of the very bytes the flag excludes. `docs/logfire.md` says so; a matcher here
+    # would hide it from anyone reading the cases.
+    'identifier': '734658',
 }
 """The shape a `BinaryImage` is recorded as once its data is excluded: everything but `data`."""
+
+
+class IsSingleEntryDict:
+    """Matches a one-entry dict whose only value equals `value`, without pinning its key.
+
+    `dirty_equals` matchers like `IsStr()` are unhashable, so they can't stand in for a dict key
+    that's a randomly generated `tool_call_id` (e.g. `DeferredToolRequests.metadata`).
+    """
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, dict):
+            return False
+        entries: dict[str, Any] = other  # pyright: ignore[reportUnknownVariableType]
+        return len(entries) == 1 and next(iter(entries.values())) == self.value
+
+    def __repr__(self) -> str:
+        return f'IsSingleEntryDict({self.value!r})'
 
 
 def image_returning_tool_agent(settings: InstrumentationSettings) -> Agent[None, str]:
@@ -123,6 +146,20 @@ def image_argument_output_function_agent(settings: InstrumentationSettings) -> A
 
     return Agent(
         FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], output_type=describe, name='agent'
+    )
+
+
+def image_returning_output_function_agent(settings: InstrumentationSettings) -> Agent[None, BinaryImage]:
+    """An agent whose output function *returns* an image, recorded on its own tool span."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('final_result', {'media_type': 'image/png'})])
+
+    def render(media_type: str) -> BinaryImage:
+        return IMAGE
+
+    return Agent(
+        FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], output_type=render, name='agent'
     )
 
 
@@ -236,6 +273,15 @@ CASES = [
         redacted=REDACTED_IMAGE,
     ),
     Case(
+        # The other attribute on the output function's own span: what it returned, as opposed to
+        # the arguments case above, which reads `gen_ai.tool.call.arguments` on the same span.
+        id='output_function_result',
+        build=image_returning_output_function_agent,
+        span_name='execute_tool final_result',
+        attribute='gen_ai.tool.call.result',
+        redacted=REDACTED_IMAGE,
+    ),
+    Case(
         # Reachable from the UI adapters, which rehydrate a native tool's prior result back into
         # `BinaryContent` when a client re-sends message history.
         id='native_tool_return_message',
@@ -318,6 +364,32 @@ CASES = [
         attribute='pydantic_ai.tool.deferral.metadata',
         redacted=snapshot({'img': REDACTED_IMAGE}),
     ),
+    Case(
+        # The same metadata the deferral span above records, reaching the run's own output through
+        # `DeferredToolRequests`: redacting one span and not its peer would defeat the flag.
+        id='deferred_requests_output',
+        build=deferring_tool_agent,
+        span_name='invoke_agent agent',
+        attribute='final_result',
+        redacted=snapshot(
+            {
+                'calls': [
+                    {
+                        'tool_name': 'defer_image',
+                        'args': {},
+                        'tool_call_id': IsStr(),
+                        'tool_kind': None,
+                        'id': None,
+                        'provider_name': None,
+                        'provider_details': None,
+                        'part_kind': 'tool-call',
+                    }
+                ],
+                'approvals': [],
+                'metadata': IsSingleEntryDict({'img': REDACTED_IMAGE}),
+            }
+        ),
+    ),
 ]
 
 
@@ -344,7 +416,7 @@ async def test_binary_content_omitted_from_span_attribute(case: Case, capfire: C
     assert await run_and_read_attribute(case, capfire, include_binary_content=False) == case.redacted
 
 
-def cyclic_output_agent(output: Callable[[], Any]) -> Agent[None, Any]:
+def output_agent(output: Callable[[], Any]) -> Agent[None, Any]:
     """An agent whose output function returns a value the redaction walk has to survive."""
 
     def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -371,7 +443,7 @@ async def test_self_referential_output_is_recorded_without_its_binary(capfire: C
         output['self'] = output
         return output
 
-    result = await cyclic_output_agent(cycle).run('make an image')
+    result = await output_agent(cycle).run('make an image')
     assert result.output['self'] is result.output
 
     spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
@@ -400,7 +472,7 @@ async def test_output_the_walk_cannot_traverse_does_not_crash_the_run(capfire: C
     def detached() -> dict[str, Any]:
         return {'rows': Detached()}
 
-    await cyclic_output_agent(detached).run('make an image')
+    await output_agent(detached).run('make an image')
 
     spans = capfire.exporter.exported_spans_as_dict()
     assert [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent'] == snapshot(
@@ -438,15 +510,16 @@ def test_binary_nested_in_a_user_type_is_not_redacted(capfire: CaptureLogfire) -
 
 
 def test_redacted_shapes_keep_every_field_but_the_data() -> None:
-    """A field added to `BinaryContent` or `ToolReturn` has to be added to the redacted shape too.
+    """A field added to a redacted type has to be added to its redacted shape too.
 
-    The redaction spells both types' fields out rather than dumping and dropping `data`, so a new
+    The redaction spells each type's fields out rather than dumping and dropping `data`, so a new
     field would otherwise silently stop reaching telemetry. This pins the field sets it mirrors.
     """
     dumped = ModelMessagesTypeAdapter.dump_python([ModelRequest(parts=[UserPromptPart(content=[IMAGE])])], mode='json')
     assert set(dumped[0]['parts'][0]['content'][0]) == set(REDACTED_IMAGE) | {'data'}
 
     assert {f.name for f in fields(ToolReturn)} == {'return_value', 'content', 'metadata', 'kind'}
+    assert {f.name for f in fields(DeferredToolRequests)} == {'calls', 'approvals', 'metadata'}
 
 
 def test_message_history_round_trip_preserves_binary_content() -> None:

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -83,9 +83,12 @@ def tool_return_agent(settings: InstrumentationSettings) -> Agent[None, str]:
 
     agent = Agent(FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], name='agent')
 
+    # `vendor_metadata` is typed `dict[str, Any]`, so it can hold binary content of its own.
+    thumbnailed = BinaryImage(data=IMAGE.data, media_type='image/png', vendor_metadata={'thumbnail': IMAGE})
+
     @agent.tool_plain
     def gen_image() -> ToolReturn:
-        return ToolReturn(return_value=IMAGE, content=['here it is', IMAGE], metadata={'img': IMAGE})
+        return ToolReturn(return_value=thumbnailed, content=['here it is', IMAGE], metadata={'img': IMAGE})
 
     return agent
 
@@ -186,7 +189,7 @@ CASES = [
         attribute='gen_ai.tool.call.result',
         redacted=snapshot(
             {
-                'return_value': REDACTED_IMAGE,
+                'return_value': {**REDACTED_IMAGE, 'vendor_metadata': {'thumbnail': REDACTED_IMAGE}},
                 'content': ['here it is', REDACTED_IMAGE],
                 'metadata': {'img': REDACTED_IMAGE},
                 'kind': 'tool-return',
@@ -271,6 +274,37 @@ async def test_binary_content_omitted_from_span_attribute(case: Case, capfire: C
     assert IMAGE.base64 in json.dumps(included)
 
     assert await run_and_read_attribute(case, capfire, include_binary_content=False) == case.redacted
+
+
+async def test_self_referential_output_does_not_crash_the_run(capfire: CaptureLogfire) -> None:
+    """Walking the value must not turn a survivable pathological output into a failed run.
+
+    Redaction recurses, so a self-referential value would raise `RecursionError` before the span
+    attribute's own serialization gets to fall back to `repr` the way it does without the flag.
+    """
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('final_result', {})])
+
+    def cycle() -> dict[str, Any]:
+        output: dict[str, Any] = {}
+        output['self'] = output
+        return output
+
+    agent = Agent(
+        FunctionModel(respond),
+        capabilities=[Instrumentation(settings=InstrumentationSettings(include_binary_content=False))],
+        output_type=cycle,
+        name='agent',
+    )
+
+    result = await agent.run('make an image')
+    assert result.output['self'] is result.output
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    assert [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent'] == snapshot(
+        ['"{\'self\': {...}}"']
+    )
 
 
 def test_redacted_image_keeps_every_field_but_data() -> None:

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -8,15 +8,18 @@ payload to the repo without exercising anything the fake model doesn't.
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
-from dataclasses import dataclass, field
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field, fields
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 from pydantic_ai import (
     Agent,
     BinaryImage,
+    CallDeferred,
+    DeferredToolRequests,
     FilePart,
     ModelMessage,
     ModelRequest,
@@ -132,6 +135,26 @@ def text_agent(settings: InstrumentationSettings) -> Agent[None, str]:
     return Agent(FunctionModel(respond), capabilities=[Instrumentation(settings=settings)], name='agent')
 
 
+def deferring_tool_agent(settings: InstrumentationSettings) -> Agent[None, Any]:
+    """An agent whose tool defers with an image attached, the way an approval UI would want it."""
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('defer_image', {})])
+
+    agent = Agent(
+        FunctionModel(respond),
+        capabilities=[Instrumentation(settings=settings)],
+        output_type=[str, DeferredToolRequests],
+        name='agent',
+    )
+
+    @agent.tool_plain
+    def defer_image() -> str:
+        raise CallDeferred(metadata={'img': IMAGE})
+
+    return agent
+
+
 @dataclass(frozen=True)
 class Case:
     """One span attribute that serializes arbitrary values and so could carry binary content."""
@@ -143,6 +166,8 @@ class Case:
     redacted: Any
     """The attribute's value once `include_binary_content=False` excludes the image data."""
     history: list[ModelMessage] = field(default_factory=list[ModelMessage])
+    metadata: dict[str, Any] | None = None
+    """Passed to `Agent.run`, for the attribute that records the run's own metadata."""
 
 
 CASES = [
@@ -250,13 +275,56 @@ CASES = [
             ),
         ],
     ),
+    Case(
+        # The OTel-spec attribute the message sinks feed, which travels a different route than
+        # `pydantic_ai.all_messages`: through the per-run message JSON cache rather than one dump.
+        id='input_messages',
+        build=image_returning_tool_agent,
+        span_name='chat function:respond:',
+        attribute='gen_ai.input.messages',
+        redacted=snapshot(
+            [
+                {'role': 'user', 'parts': [{'type': 'text', 'content': 'make an image'}]},
+                {
+                    'role': 'assistant',
+                    'parts': [{'type': 'tool_call', 'id': IsStr(), 'name': 'gen_image', 'arguments': {}}],
+                },
+                {
+                    'role': 'user',
+                    'parts': [
+                        {
+                            'type': 'tool_call_response',
+                            'id': IsStr(),
+                            'name': 'gen_image',
+                            'result': REDACTED_IMAGE,
+                        }
+                    ],
+                },
+            ]
+        ),
+    ),
+    Case(
+        id='run_metadata',
+        build=text_agent,
+        span_name='invoke_agent agent',
+        attribute='metadata',
+        redacted=snapshot({'img': REDACTED_IMAGE}),
+        metadata={'img': IMAGE},
+    ),
+    Case(
+        id='deferral_metadata',
+        build=deferring_tool_agent,
+        span_name='execute_tool defer_image',
+        attribute='pydantic_ai.tool.deferral.metadata',
+        redacted=snapshot({'img': REDACTED_IMAGE}),
+    ),
 ]
 
 
 async def run_and_read_attribute(case: Case, capfire: CaptureLogfire, *, include_binary_content: bool) -> Any:
     capfire.exporter.clear()
     agent = case.build(InstrumentationSettings(include_binary_content=include_binary_content))
-    await agent.run('make an image', message_history=case.history)
+    await agent.run('make an image', message_history=case.history, metadata=case.metadata)
     spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
     # The last matching span: the run's final model request is the one that has seen the image.
     attributes = [span['attributes'] for span in spans if span['name'] == case.span_name][-1]
@@ -276,45 +344,109 @@ async def test_binary_content_omitted_from_span_attribute(case: Case, capfire: C
     assert await run_and_read_attribute(case, capfire, include_binary_content=False) == case.redacted
 
 
-async def test_self_referential_output_does_not_crash_the_run(capfire: CaptureLogfire) -> None:
-    """Walking the value must not turn a survivable pathological output into a failed run.
-
-    Redaction recurses, so a self-referential value would raise `RecursionError` before the span
-    attribute's own serialization gets to fall back to `repr` the way it does without the flag.
-    """
+def cyclic_output_agent(output: Callable[[], Any]) -> Agent[None, Any]:
+    """An agent whose output function returns a value the redaction walk has to survive."""
 
     def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         return ModelResponse(parts=[ToolCallPart('final_result', {})])
 
+    return Agent(
+        FunctionModel(respond),
+        capabilities=[Instrumentation(settings=InstrumentationSettings(include_binary_content=False))],
+        output_type=output,
+        name='agent',
+    )
+
+
+async def test_self_referential_output_is_recorded_without_its_binary(capfire: CaptureLogfire) -> None:
+    """A value that contains itself must neither crash the run nor smuggle the image out.
+
+    The walk marks a repeat visit instead of recursing, so the attribute is still redacted. Handing
+    the value back at that point would have defeated the flag: the caller falls back to `str`, whose
+    `BinaryContent` repr prints the data.
+    """
+
     def cycle() -> dict[str, Any]:
-        output: dict[str, Any] = {}
+        output: dict[str, Any] = {'img': IMAGE}
         output['self'] = output
         return output
+
+    result = await cyclic_output_agent(cycle).run('make an image')
+    assert result.output['self'] is result.output
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    assert [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent'] == snapshot(
+        [{'img': REDACTED_IMAGE, 'self': '<circular reference>'}]
+    )
+
+
+async def test_output_the_walk_cannot_traverse_does_not_crash_the_run(capfire: CaptureLogfire) -> None:
+    """Instrumentation must not fail a run over a container that objects to being walked.
+
+    Without the flag such a value reaches `serialize_any`, which falls back rather than raising, so
+    turning binary exclusion on must not make the same value fatal.
+    """
+
+    class Detached(Mapping[str, Any]):
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError('cannot iterate detached rows')
+
+        def __getitem__(self, key: str) -> Any:
+            raise KeyError(key)  # pragma: no cover
+
+        def __len__(self) -> int:
+            return 0  # pragma: no cover
+
+    def detached() -> dict[str, Any]:
+        return {'rows': Detached()}
+
+    await cyclic_output_agent(detached).run('make an image')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    assert [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent'] == snapshot(
+        ['"Unable to redact binary content: cannot iterate detached rows"']
+    )
+
+
+def test_binary_nested_in_a_user_type_is_not_redacted(capfire: CaptureLogfire) -> None:
+    """The documented boundary: the walk doesn't rebuild types it doesn't own.
+
+    Redacting a field of a user's model would mean reconstructing it, changing how everything else
+    in the attribute serializes. `docs/logfire.md` says so; this pins that the docs stay true.
+    """
+
+    class Wrapper(BaseModel):
+        image: BinaryImage
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart('final_result', {'image': {'data': IMAGE.base64, 'media_type': 'image/png'}})]
+        )
 
     agent = Agent(
         FunctionModel(respond),
         capabilities=[Instrumentation(settings=InstrumentationSettings(include_binary_content=False))],
-        output_type=cycle,
+        output_type=Wrapper,
         name='agent',
     )
 
-    result = await agent.run('make an image')
-    assert result.output['self'] is result.output
+    agent.run_sync('make an image')
 
     spans = capfire.exporter.exported_spans_as_dict()
-    assert [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent'] == snapshot(
-        ['"{\'self\': {...}}"']
-    )
+    final_result = [span['attributes']['final_result'] for span in spans if span['name'] == 'invoke_agent agent']
+    assert IMAGE.base64 in json.dumps(final_result)
 
 
-def test_redacted_image_keeps_every_field_but_data() -> None:
-    """A field added to `BinaryContent` has to be added to the redacted shape too.
+def test_redacted_shapes_keep_every_field_but_the_data() -> None:
+    """A field added to `BinaryContent` or `ToolReturn` has to be added to the redacted shape too.
 
-    The redaction spells its fields out rather than dumping and dropping `data`, so a new field
-    would otherwise silently stop reaching telemetry. This pins the field set that redaction mirrors.
+    The redaction spells both types' fields out rather than dumping and dropping `data`, so a new
+    field would otherwise silently stop reaching telemetry. This pins the field sets it mirrors.
     """
     dumped = ModelMessagesTypeAdapter.dump_python([ModelRequest(parts=[UserPromptPart(content=[IMAGE])])], mode='json')
     assert set(dumped[0]['parts'][0]['content'][0]) == set(REDACTED_IMAGE) | {'data'}
+
+    assert {f.name for f in fields(ToolReturn)} == {'return_value', 'content', 'metadata', 'kind'}
 
 
 def test_message_history_round_trip_preserves_binary_content() -> None:


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David reviewed it lightly.

- Closes #7108

`include_binary_content=False` was honored only by `_convert_binary_to_otel_part`, which covers user-prompt and model-response file parts. Every sink that serializes an *arbitrary* value went through `serialize_any` / `tool_return_ta` / `safe_to_json` / `to_json` and wrote full base64 into traces.

`_instrumentation.redact_binary_content` now walks the value each of those sinks is about to serialize and replaces any `BinaryContent` with its media type and file metadata, dropping only `data` — the same trade `_convert_binary_to_otel_part` makes. `BinaryContent` itself is untouched, so message-history dumps and its serialization contract are unaffected.

### Sinks fixed

| Attribute | Where |
|---|---|
| `result` in `gen_ai.input.messages` / `pydantic_ai.all_messages` | `messages.py::BaseToolReturnPart.otel_message_parts` |
| `result` for native tool returns | `messages.py::ModelResponse.otel_message_parts` |
| `final_result` | `capabilities/instrumentation.py::Instrumentation.wrap_agent_run` |
| `gen_ai.tool.call.arguments` | `capabilities/instrumentation.py::Instrumentation.wrap_output_process` |
| `gen_ai.tool.call.result` | `capabilities/instrumentation.py::Instrumentation._run_tool_span` |
| `metadata` (the run's own) | `capabilities/instrumentation.py::Instrumentation._run_span_end_attributes` |
| `pydantic_ai.tool.deferral.metadata` | `capabilities/instrumentation.py::Instrumentation._run_tool_span` |

The issue named three. The rest were found while reproducing: native tool returns are reachable because the AG-UI and Vercel AI adapters rehydrate a prior native-tool result back into `BinaryContent` when a client re-sends history, and the two `metadata` attributes are the same user-supplied `dict[str, Any]` the walk already covers one layer down in `ToolReturn.metadata`. The run's `metadata` had no `include_content` gate either, so a user who disabled *all* content still got the payload. Every one was reproduced before being included.

### How deep the walk goes

`BinaryContent`, `ToolReturn`, mappings, and lists/tuples. A `BinaryContent` nested inside a *user's own* model is deliberately left alone: rebuilding that model to redact one field would change how everything else in the attribute serializes. That boundary is now stated in `docs/logfire.md` and in the `include_binary_content` docstring, and pinned by a test — an unqualified promise on a flag people make privacy decisions with is worse than a documented gap.

Cycles are tracked by the identity of the objects on the path being walked, so a value containing itself is marked rather than recursed into, and the same image appearing twice as siblings is still redacted twice. Anything the walk can't traverse is reported in place of the value: handing the original back would have defeated the flag, since the callers fall back to `str(value)` and `BinaryContent`'s repr prints the data.

<details><summary>Why not a <code>@model_serializer</code> on <code>BinaryContent</code></summary>

The first iteration (`b5d0de25`) put a context-aware `@model_serializer` on `BinaryContent` and had instrumentation pass a serialization context. Centralized and nesting-proof, but a `@model_serializer`'s return annotation becomes the type's **serialization JSON schema**, so `BinaryImage`'s collapsed to `{'additionalProperties': True, 'type': 'object'}` and `Agent.output_json_schema()` degraded for anyone using `BinaryImage` as structured output. Message-history round-trips were fine; the public schema was not. Rejected: the bug is instrumentation's, not `BinaryContent`'s.

</details>

### Deliberately out of scope

Base64 that a **model** emits as plain JSON — `ToolCallPart.args` containing `{"data": "<base64>"}`, and `models/anthropic.py`'s web-fetch / text-editor results. Those are strings inside a dict, never `BinaryContent` instances, so nothing can recognise them. Both still appear in traces with the flag off; that's a separate problem needing a different mechanism.

### Tests

`tests/test_include_binary_content.py` — one case per sink, each asserting the attribute carries the image by default *before* asserting it's redacted with the flag off, so a case can't silently stop proving anything. Plus a guard that a message-history round-trip still carries the data, one pinning `BinaryContent`'s and `ToolReturn`'s field sets so a new field can't silently stop reaching telemetry, one for a self-referential value carrying an image, one for a container that refuses to be walked, and one pinning the user-type boundary above.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
