### PR TITLE
Require a label on new PRs and pin the PR-title convention

### DIFF
--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -1,14 +1,26 @@
 ---
 name: pushing-commits-to-the-repo
-description: What to do before and after you push — run a local review, watch CI to green, triage
-  every review comment to a reply and a reaction, and escalate genuine design trade-offs to
-  maintainers. Use whenever you push a commit to a PR.
+description: What to do when you open a PR and every time you push — label the PR, run a local
+  review, watch CI to green, triage every review comment to a reply and a reaction, and escalate
+  genuine design trade-offs to maintainers. Use whenever you open a PR or push a commit to one.
 ---
 
 # pushing-commits-to-the-repo
 
 Pushing starts a loop; it does not end the task. **Work stops only when CI is green AND no comment
 is left unresolved.**
+
+## When you open the PR
+
+Apply a label — the repo triages and filters by them. Fetch the real list first with
+`gh label list --limit 100`, because the set changes and a guessed label silently fails to
+apply. Pick the one naming what the PR *is* (`bug`, `feature`, `docs`, `chore`, `refactor`) and
+add a topic label (`anthropic`, `MCP`, `evals`, …) where one fits:
+`gh pr edit <number> --add-label <label>`.
+
+Labelling needs triage permission on the repo (Pydantic team members and their agents). If it
+fails, quote the actual error rather than concluding you lack permission. Size labels are
+applied automatically — don't set them.
 
 ## Before you push
 - Commit the exact state you intend to push. Leave nothing staged, unstaged or uncommitted unless

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ All changes need to:
 
 When you submit a PR, make sure you include the [PR template](.github/pull_request_template.md) and fill in the issue number that should be closed when the PR is merged. The "AI generated code" checkbox should always be checked manually by the user in the UI, not by the agent.
 
-PR titles feed directly into the release changelog — wrap code identifiers (class names, keyword arguments, module paths, CLI flags, env vars) in backticks, matching the style of recent release notes (e.g. `git log main --oneline -10`).
+PR titles feed directly into the release changelog. Write one as an imperative sentence naming the change — no `fix:` / `docs:` / `chore:` prefix, which belongs on the commit subject and not on the title — and wrap every code identifier (class names, keyword arguments, module paths, CLI flags, env vars, file paths) in backticks. Check the convention against merged PRs rather than commit subjects, which follow a different one: `gh pr list --state merged --limit 20`.
 
 Never add yourself (Claude) as a co-author on commits. Commits should be authored as the user only, with no `Co-Authored-By` trailer referencing Claude.
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David specified this change in conversation and did not read the final prose.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

No issue to close — this is a small, self-contained context-engineering fix.

The `AGENTS.md` PR-title rule pointed agents at `git log main --oneline -10` for style, but
commit subjects in this repo use conventional-commit prefixes (`fix:`, `docs:`, `chore:`) while
merged PR titles don't — so agents following that rule were producing `docs:`-prefixed titles.
The rule now points at merged PR titles instead (`gh pr list --state merged --limit 20`) and
spells out that the prefix belongs on the commit subject, not the title.

Separately, nothing in `pushing-commits-to-the-repo` told an agent to label a new PR at all. Added
a "When you open the PR" section requiring a type label (`bug`/`feature`/`docs`/`chore`/`refactor`)
plus a topic label where one fits, fetched live via `gh label list` rather than guessed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

