### PR TITLE
Preserve stream part indexes during `apply_event` replay

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -784,5 +784,6 @@ class ModelResponsePartsManager:
         if isinstance(event, PartStartEvent):
             self.handle_part(vendor_part_id=event.index, part=event.part)
         elif isinstance(event, PartDeltaEvent):
-            part = self.get_parts()[event.index]
+            part = self._parts[event.index]
+            assert not isinstance(part, ToolCallPartDelta)
             self.handle_part(vendor_part_id=event.index, part=event.delta.apply(part))

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -784,6 +784,7 @@ class ModelResponsePartsManager:
         if isinstance(event, PartStartEvent):
             self.handle_part(vendor_part_id=event.index, part=event.part)
         elif isinstance(event, PartDeltaEvent):
-            part = self._parts[event.index]
+            part = self.get_part_by_vendor_id(event.index)
+            assert part is not None
             assert not isinstance(part, ToolCallPartDelta)
             self.handle_part(vendor_part_id=event.index, part=event.delta.apply(part))

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -1156,7 +1156,6 @@ def test_apply_event_preserves_stream_part_indexes():
     assert isinstance(second_delta_event, PartDeltaEvent)
 
     replay_manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
-    assert replay_manager.handle_tool_call_delta(vendor_part_id='tool', args='{"value":') is None
     replay_manager.apply_event(first_start_event)
     replay_manager.apply_event(second_start_event)
     replay_manager.apply_event(first_delta_event)

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -1139,3 +1139,29 @@ def test_get_part_by_vendor_id():
     assert part == snapshot(TextPart(content='hello', part_kind='text'))
 
     assert manager.get_part_by_vendor_id('missing') is None
+
+
+def test_apply_event_preserves_stream_part_indexes():
+    """Incomplete tool calls do not emit events, but still occupy a stream-part index."""
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    assert manager.handle_tool_call_delta(vendor_part_id='tool', args='{"value":') is None
+
+    first_start_event = next(manager.handle_text_delta(vendor_part_id='first', content='hello '))
+    second_start_event = next(manager.handle_text_delta(vendor_part_id='second', content='goodbye '))
+    first_delta_event = next(manager.handle_text_delta(vendor_part_id='first', content='world'))
+    second_delta_event = next(manager.handle_text_delta(vendor_part_id='second', content='everyone'))
+    assert isinstance(first_start_event, PartStartEvent)
+    assert isinstance(second_start_event, PartStartEvent)
+    assert isinstance(first_delta_event, PartDeltaEvent)
+    assert isinstance(second_delta_event, PartDeltaEvent)
+
+    replay_manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    assert replay_manager.handle_tool_call_delta(vendor_part_id='tool', args='{"value":') is None
+    replay_manager.apply_event(first_start_event)
+    replay_manager.apply_event(second_start_event)
+    replay_manager.apply_event(first_delta_event)
+    replay_manager.apply_event(second_delta_event)
+
+    assert replay_manager.get_parts() == snapshot(
+        [TextPart(content='hello world'), TextPart(content='goodbye everyone')]
+    )


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

Closes #6731

### Summary

- Replayed `PartDeltaEvent`s now resolve their source stream index through the replay manager's event-index mapping.
- Invisible incomplete tool-call placeholders emit no event, so replay does not reconstruct them as physical `_parts` slots.
- The regression replays interleaved visible text parts into a fresh manager, covering both wrong-target and index-gap failure modes.

### Replacement context

This focused replacement for [#6732](https://github.com/pydantic/pydantic-ai/pull/6732) and [#6734](https://github.com/pydantic/pydantic-ai/pull/6734) retains the shared intent while matching the emitted-event replay contract. Those PRs remain open and untouched pending maintainer follow-up.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).