### PR TITLE
Bound HTTP response body sizes for `web_fetch` and media URL downloads

### DIFF
--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -118,6 +118,9 @@ print(result.output)
     [`WebFetch`][pydantic_ai.capabilities.WebFetch] capability automatically uses it
     as a local fallback when the model doesn't support native URL fetching.
 
+By default the tool caps returned text at 50,000 characters (`max_content_length`) and caps the
+downloaded response body at 50 MiB (`max_download_bytes`). Pass `None` for either to disable that limit.
+
 !!! warning "Credentials in `headers`"
     Headers configured via `web_fetch_tool(headers=...)` are sent to whatever URL the model requests,
     since the model chooses the URL. If you configure a credential like `Authorization`, use

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -21,11 +21,12 @@ from .models import create_async_http_client
 __all__ = ['safe_download']
 
 _DOWNLOAD_EXCEEDS_TEMPLATE = 'Download exceeds the maximum size of {max_bytes} bytes.'
-# Bounded downloads only negotiate encodings we can size-limit during decompression.
+# Bounded downloads only negotiate encodings we can size-limit while streaming.
 # Brotli/Zstandard can expand a few compressed bytes into multi-MiB output in one
-# decoder step, so they are excluded from Accept-Encoding and rejected if a server
-# still returns them.
-_BOUNDED_ACCEPT_ENCODING = 'identity, gzip, deflate'
+# decoder step, and `deflate` has to be buffered whole before its zlib-wrapped vs raw
+# framing can be told apart, so all three are excluded from Accept-Encoding and
+# rejected if a server still returns them.
+_BOUNDED_ACCEPT_ENCODING = 'identity, gzip'
 
 # Private IP ranges that should be blocked by default (i.e. unless allow_local=True).
 # IPv6 transition forms (6to4, NAT64, IPv4-mapped/-compatible, ISATAP) are not listed here;
@@ -624,13 +625,12 @@ async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
     """Read a streamed response body without buffering more than `max_bytes` of decoded data.
 
     Streams the *encoded* body via `aiter_raw` so oversized wire traffic is rejected as it
-    arrives, and applies gzip/deflate with zlib's output `max_length` so a highly compressible
-    payload cannot expand past `max_bytes` mid-decode.
+    arrives, and applies gzip with zlib's output `max_length` so a highly compressible payload
+    cannot expand past `max_bytes` mid-decode.
 
-    Only `identity`, `gzip`/`x-gzip`, and `deflate` are supported on this path. Codings that
-    cannot be size-limited during decompression (notably brotli/zstd) are rejected; callers
-    with `max_bytes` also send `Accept-Encoding: identity, gzip, deflate` so servers are not
-    invited to use them.
+    Only `identity` and `gzip`/`x-gzip` are supported on this path. Codings that cannot be
+    size-limited while streaming are rejected; callers with `max_bytes` also send
+    `Accept-Encoding: identity, gzip` so servers are not invited to use them.
 
     Some transports (e.g. httpx mock responses built from an in-memory `content=` bytes object)
     preload the body and mark the stream consumed; in that case the decoded body is already in
@@ -652,99 +652,39 @@ async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
     if not encodings:
         return await _read_capped_identity(response, max_bytes)
     if encodings in (['gzip'], ['x-gzip']):
-        return await _read_capped_zlib(response, max_bytes, wbits=zlib.MAX_WBITS | 16)
-    if encodings == ['deflate']:
-        return await _read_capped_deflate(response, max_bytes)
+        return await _read_capped_gzip(response, max_bytes)
     raise ValueError(
         f'Unsupported content-encoding for bounded download: {encodings}. '
-        f'Only identity, gzip, and deflate can be size-limited during decompression.'
+        f'Only identity and gzip can be size-limited while streaming.'
     )
 
 
 async def _read_capped_identity(response: httpx.Response, max_bytes: int) -> bytes:
     content = bytearray()
-    encoded_total = 0
     async for raw in response.aiter_raw():
-        encoded_total += len(raw)
-        if encoded_total > max_bytes or len(content) + len(raw) > max_bytes:
+        if len(content) + len(raw) > max_bytes:
             raise _download_exceeds(max_bytes)
         content.extend(raw)
     return bytes(content)
 
 
-async def _read_capped_deflate(response: httpx.Response, max_bytes: int) -> bytes:
-    """Deflate may be zlib-wrapped or raw; match httpx's dual-attempt behaviour.
-
-    The stream can only be read once, so the encoded body is buffered under `max_bytes`
-    first, then both zlib wrappers are tried with a decoded-size cap.
-    """
-    encoded = await _read_capped_identity(response, max_bytes)
-    last_error: zlib.error | None = None
-    for wbits in (zlib.MAX_WBITS, -zlib.MAX_WBITS):
-        try:
-            return _zlib_decompress_capped(encoded, max_bytes, wbits=wbits)
-        except zlib.error as e:
-            last_error = e
-            continue
-    assert last_error is not None
-    raise ValueError(f'Failed to decode deflate response body: {last_error}') from last_error
-
-
-async def _read_capped_zlib(response: httpx.Response, max_bytes: int, *, wbits: int) -> bytes:
+async def _read_capped_gzip(response: httpx.Response, max_bytes: int) -> bytes:
     content = bytearray()
     encoded_total = 0
-    decompressor = zlib.decompressobj(wbits)
+    decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
     async for raw in response.aiter_raw():
         encoded_total += len(raw)
         if encoded_total > max_bytes:
             raise _download_exceeds(max_bytes)
-        _zlib_feed_capped(decompressor, raw, content, max_bytes)
-    tail = decompressor.flush()
-    if len(content) + len(tail) > max_bytes:
-        raise _download_exceeds(max_bytes)
-    content.extend(tail)
-    return bytes(content)
-
-
-def _zlib_decompress_capped(encoded: bytes, max_bytes: int, *, wbits: int) -> bytes:
-    content = bytearray()
-    decompressor = zlib.decompressobj(wbits)
-    _zlib_feed_capped(decompressor, encoded, content, max_bytes)
-    tail = decompressor.flush()
-    if len(content) + len(tail) > max_bytes:
-        raise _download_exceeds(max_bytes)
-    content.extend(tail)
-    return bytes(content)
-
-
-def _zlib_feed_capped(
-    decompressor: zlib._Decompress,  # pyright: ignore[reportPrivateUsage]
-    data: bytes,
-    content: bytearray,
-    max_bytes: int,
-) -> None:
-    """Feed compressed `data` into `decompressor`, extending `content` up to `max_bytes`.
-
-    When decoded content already equals the cap, remaining compressed input is still fed with
-    a one-byte output probe so gzip trailers that produce no further output are accepted.
-    """
-    while data:
-        remaining = max_bytes - len(content)
-        if remaining <= 0:
-            # Cap reached: only allow zero-output consumption (e.g. gzip CRC/ISIZE trailer).
-            previous = data
-            out = decompressor.decompress(data, max_length=1)
-            if out:
+        while raw:
+            # Decompressing one byte past the cap distinguishes an oversized body from one that
+            # exactly fills it, so a gzip CRC/ISIZE trailer arriving in a later chunk is still
+            # consumed (it produces no output) instead of being rejected.
+            content.extend(decompressor.decompress(raw, max_length=max_bytes + 1 - len(content)))
+            if len(content) > max_bytes:
                 raise _download_exceeds(max_bytes)
-            data = decompressor.unconsumed_tail
-            if data == previous:  # pragma: no cover
-                # No progress with a 1-byte probe; finish the stream without allowing output.
-                out = decompressor.decompress(data)
-                if out:
-                    raise _download_exceeds(max_bytes)
-                return
-            continue
-        out = decompressor.decompress(data, max_length=remaining)
-        content.extend(out)
-        data = decompressor.unconsumed_tail
-        # If the cap is full but compressed input remains, loop into the trailer-only path.
+            raw = decompressor.unconsumed_tail
+    content.extend(decompressor.flush())
+    if len(content) > max_bytes:
+        raise _download_exceeds(max_bytes)
+    return bytes(content)

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import zlib
 from dataclasses import dataclass
 from urllib.parse import urlparse, urlunparse
 
@@ -18,6 +19,8 @@ from ._utils import run_in_executor
 from .models import create_async_http_client
 
 __all__ = ['safe_download']
+
+_DOWNLOAD_EXCEEDS_TEMPLATE = 'Download exceeds the maximum size of {max_bytes} bytes.'
 
 # Private IP ranges that should be blocked by default (i.e. unless allow_local=True).
 # IPv6 transition forms (6to4, NAT64, IPv4-mapped/-compatible, ISATAP) are not listed here;
@@ -582,19 +585,11 @@ async def safe_download(
             try:
                 response.raise_for_status()
                 if max_bytes is not None:
-                    content = bytearray()
-                    async for chunk in response.aiter_bytes():
-                        # Bound both decoded body and encoded stream: a body that decodes
-                        # to little can still stream indefinitely, and a compressed one can
-                        # expand past the limit. One decoded chunk is materialized before
-                        # rejection because `aiter_bytes` yields whole network chunks.
-                        if len(content) + len(chunk) > max_bytes or response.num_bytes_downloaded > max_bytes:
-                            raise ValueError(f'Download exceeds the maximum size of {max_bytes} bytes.')
-                        content.extend(chunk)
-                    # `aiter_bytes` yields decoded bytes, so the reconstructed response must not carry
-                    # the content coding, or `httpx.Response` would run the body through the decoder a
-                    # second time and raise `DecodingError`. `content-length` described the encoded
-                    # body and no longer applies either; httpx recomputes it from `content`.
+                    content = await _read_capped_body(response, max_bytes)
+                    # Body is already decoded, so the reconstructed response must not carry
+                    # the content coding, or `httpx.Response` would run it through the decoder
+                    # again. `content-length` described the encoded body and no longer applies;
+                    # httpx recomputes it from `content`.
                     decoded_headers = [
                         (key, value)
                         for key, value in response.headers.multi_items()
@@ -603,7 +598,7 @@ async def safe_download(
                     return httpx.Response(
                         response.status_code,
                         headers=decoded_headers,
-                        content=bytes(content),
+                        content=content,
                         request=response.request,
                         history=response.history,
                         extensions=response.extensions,
@@ -612,3 +607,171 @@ async def safe_download(
                 if max_bytes is not None:
                     await response.aclose()
             return response
+
+
+def _download_exceeds(max_bytes: int) -> ValueError:
+    return ValueError(_DOWNLOAD_EXCEEDS_TEMPLATE.format(max_bytes=max_bytes))
+
+
+def _content_encodings(response: httpx.Response) -> list[str]:
+    """Return content-codings to reverse, excluding no-op `identity`."""
+    encodings: list[str] = []
+    for value in response.headers.get_list('content-encoding'):
+        for part in value.split(','):
+            coding = part.strip().lower()
+            if coding and coding != 'identity':
+                encodings.append(coding)
+    return encodings
+
+
+async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
+    """Read a streamed response body without buffering more than `max_bytes` of decoded data.
+
+    Streams the *encoded* body via `aiter_raw` so oversized wire traffic is rejected as it
+    arrives, and applies content-encoding with an output cap so a highly compressible payload
+    cannot expand past `max_bytes` in a single decoded chunk (the failure mode of `aiter_bytes`).
+
+    Some transports (e.g. httpx mock responses built from an in-memory `content=` bytes object)
+    preload the body and mark the stream consumed; in that case the decoded body is already in
+    `response.content` and we only enforce the size cap on it.
+    """
+    if response.is_stream_consumed:
+        data = response.content
+        if len(data) > max_bytes:
+            raise _download_exceeds(max_bytes)
+        return data
+
+    encodings = _content_encodings(response)
+    if not encodings:
+        return await _read_capped_identity(response, max_bytes)
+    if encodings == ['gzip'] or encodings == ['x-gzip']:
+        return await _read_capped_gzip(response, max_bytes)
+    if encodings == ['deflate']:
+        return await _read_capped_deflate(response, max_bytes)
+    # Other codings (brotli, zstd, multi-layer) are uncommon on this path; still stream with
+    # both bounds via small raw slices so peak decoded growth per step stays limited.
+    return await _read_capped_via_httpx_decoder(response, max_bytes, encodings)
+
+
+async def _read_capped_identity(response: httpx.Response, max_bytes: int) -> bytes:
+    content = bytearray()
+    encoded_total = 0
+    async for raw in response.aiter_raw():
+        encoded_total += len(raw)
+        if encoded_total > max_bytes or len(content) + len(raw) > max_bytes:
+            raise _download_exceeds(max_bytes)
+        content.extend(raw)
+    return bytes(content)
+
+
+async def _read_capped_gzip(response: httpx.Response, max_bytes: int) -> bytes:
+    return await _read_capped_zlib(response, max_bytes, wbits=zlib.MAX_WBITS | 16)
+
+
+async def _read_capped_deflate(response: httpx.Response, max_bytes: int) -> bytes:
+    """Deflate may be zlib-wrapped or raw; match httpx's dual-attempt behaviour.
+
+    The stream can only be read once, so the encoded body is buffered under `max_bytes`
+    first, then both zlib wrappers are tried with a decoded-size cap.
+    """
+    encoded = await _read_capped_identity(response, max_bytes)
+    last_error: zlib.error | None = None
+    for wbits in (zlib.MAX_WBITS, -zlib.MAX_WBITS):
+        try:
+            return _zlib_decompress_capped(encoded, max_bytes, wbits=wbits)
+        except zlib.error as e:
+            last_error = e
+            continue
+    assert last_error is not None
+    raise ValueError(f'Failed to decode deflate response body: {last_error}') from last_error
+
+
+async def _read_capped_zlib(response: httpx.Response, max_bytes: int, *, wbits: int) -> bytes:
+    content = bytearray()
+    encoded_total = 0
+    decompressor = zlib.decompressobj(wbits)
+    async for raw in response.aiter_raw():
+        encoded_total += len(raw)
+        if encoded_total > max_bytes:
+            raise _download_exceeds(max_bytes)
+        _zlib_feed_capped(decompressor, raw, content, max_bytes)
+    tail = decompressor.flush()
+    if len(content) + len(tail) > max_bytes:
+        raise _download_exceeds(max_bytes)
+    content.extend(tail)
+    return bytes(content)
+
+
+def _zlib_decompress_capped(encoded: bytes, max_bytes: int, *, wbits: int) -> bytes:
+    content = bytearray()
+    decompressor = zlib.decompressobj(wbits)
+    _zlib_feed_capped(decompressor, encoded, content, max_bytes)
+    tail = decompressor.flush()
+    if len(content) + len(tail) > max_bytes:
+        raise _download_exceeds(max_bytes)
+    content.extend(tail)
+    return bytes(content)
+
+
+def _zlib_feed_capped(
+    decompressor: zlib._Decompress,  # pyright: ignore[reportPrivateUsage]
+    data: bytes,
+    content: bytearray,
+    max_bytes: int,
+) -> None:
+    """Feed compressed `data` into `decompressor`, extending `content` up to `max_bytes`."""
+    while data:
+        remaining = max_bytes - len(content)
+        if remaining <= 0:
+            raise _download_exceeds(max_bytes)
+        out = decompressor.decompress(data, max_length=remaining)
+        content.extend(out)
+        data = decompressor.unconsumed_tail
+        # `max_length` stopped output with compressed input left → decoded body would exceed.
+        if data and len(content) >= max_bytes:
+            raise _download_exceeds(max_bytes)
+        if data and not out:  # pragma: no cover
+            raise _download_exceeds(max_bytes)
+
+
+async def _read_capped_via_httpx_decoder(response: httpx.Response, max_bytes: int, encodings: list[str]) -> bytes:
+    """Decode less-common content-codings with httpx's decoders, feeding small raw slices.
+
+    Peak decoded growth is limited to one raw slice's expansion; slices are small so a
+    compression bomb cannot materialize gigabytes in a single step.
+    """
+    # Import privately: httpx does not expose a public decoder factory, and we need parity
+    # with the codecs its client already negotiates (brotli/zstd when installed).
+    from httpx._decoders import SUPPORTED_DECODERS, MultiDecoder
+
+    try:
+        children = [SUPPORTED_DECODERS[coding]() for coding in encodings]
+    except KeyError as e:
+        raise ValueError(f'Unsupported content-encoding for bounded download: {encodings}') from e
+    decoder = children[0] if len(children) == 1 else MultiDecoder(children)
+
+    content = bytearray()
+    encoded_total = 0
+    # 4 KiB raw slices keep single-step expansion bounded without thrashing the event loop.
+    slice_size = 4 * 1024
+    async for raw in response.aiter_raw():
+        encoded_total += len(raw)
+        if encoded_total > max_bytes:
+            raise _download_exceeds(max_bytes)
+        for offset in range(0, len(raw), slice_size):
+            piece = raw[offset : offset + slice_size]
+            try:
+                out = decoder.decode(piece)
+            except Exception as e:
+                raise ValueError(f'Failed to decode response body: {e}') from e
+            if len(content) + len(out) > max_bytes:
+                raise _download_exceeds(max_bytes)
+            content.extend(out)
+    try:
+        tail = decoder.flush()
+    except Exception as e:
+        raise ValueError(f'Failed to decode response body: {e}') from e
+    if len(content) + len(tail) > max_bytes:
+        raise _download_exceeds(max_bytes)
+    content.extend(tail)
+    return bytes(content)

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -473,6 +473,7 @@ async def safe_download(
     headers: dict[str, str] | None = None,
     allowed_domains: list[str] | None = None,
     blocked_domains: list[str] | None = None,
+    max_bytes: int | None = None,
 ) -> httpx.Response:
     """Download content from a URL with SSRF protection.
 
@@ -491,6 +492,9 @@ async def safe_download(
                     Cloud metadata endpoints are always blocked regardless.
         max_redirects: Maximum number of redirects to follow (default: 10).
         timeout: Request timeout in seconds (default: 30).
+        max_bytes: Maximum response-body size in bytes. When set, the response body
+            is read as a stream and rejected once either the decoded body or the
+            encoded stream it arrives in exceeds this limit.
         headers: Additional HTTP headers to include in the request.
                 The `Host` header is always set to the original hostname
                 and cannot be overridden. Sensitive headers (`Authorization`,
@@ -510,6 +514,9 @@ async def safe_download(
                 or too many redirects occur.
         httpx.HTTPStatusError: If the response has an error status code.
     """
+    if max_bytes is not None and max_bytes < 0:
+        raise ValueError('max_bytes must be non-negative')
+
     current_url = url
     redirects_followed = 0
     effective_headers: dict[str, str] = dict(headers) if headers else {}
@@ -534,16 +541,22 @@ async def safe_download(
             request_headers: dict[str, str] = {k: v for k, v in effective_headers.items() if k.lower() != 'host'}
             request_headers['Host'] = resolved.hostname
 
-            # Make request with Host header set to original hostname
-            response = await client.get(
-                request_url,
-                headers=request_headers,
-                extensions=extensions,
-                follow_redirects=False,
-            )
+            # Make request with Host header set to original hostname. Keep the existing
+            # buffered path for callers without a body limit.
+            if max_bytes is None:
+                response = await client.get(
+                    request_url,
+                    headers=request_headers,
+                    extensions=extensions,
+                    follow_redirects=False,
+                )
+            else:
+                request = client.build_request('GET', request_url, headers=request_headers, extensions=extensions)
+                response = await client.send(request, follow_redirects=False, stream=True)
 
             # Check if we need to follow a redirect
             if response.is_redirect:
+                await response.aclose()
                 redirects_followed += 1
                 if redirects_followed > max_redirects:
                     raise ValueError(f'Too many redirects ({redirects_followed}). Maximum allowed: {max_redirects}')
@@ -566,5 +579,36 @@ async def safe_download(
                 continue
 
             # Not a redirect, we're done
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+                if max_bytes is not None:
+                    content = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        # Bound both decoded body and encoded stream: a body that decodes
+                        # to little can still stream indefinitely, and a compressed one can
+                        # expand past the limit. One decoded chunk is materialized before
+                        # rejection because `aiter_bytes` yields whole network chunks.
+                        if len(content) + len(chunk) > max_bytes or response.num_bytes_downloaded > max_bytes:
+                            raise ValueError(f'Download exceeds the maximum size of {max_bytes} bytes.')
+                        content.extend(chunk)
+                    # `aiter_bytes` yields decoded bytes, so the reconstructed response must not carry
+                    # the content coding, or `httpx.Response` would run the body through the decoder a
+                    # second time and raise `DecodingError`. `content-length` described the encoded
+                    # body and no longer applies either; httpx recomputes it from `content`.
+                    decoded_headers = [
+                        (key, value)
+                        for key, value in response.headers.multi_items()
+                        if key.lower() not in ('content-encoding', 'content-length')
+                    ]
+                    return httpx.Response(
+                        response.status_code,
+                        headers=decoded_headers,
+                        content=bytes(content),
+                        request=response.request,
+                        history=response.history,
+                        extensions=response.extensions,
+                    )
+            finally:
+                if max_bytes is not None:
+                    await response.aclose()
             return response

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -21,6 +21,11 @@ from .models import create_async_http_client
 __all__ = ['safe_download']
 
 _DOWNLOAD_EXCEEDS_TEMPLATE = 'Download exceeds the maximum size of {max_bytes} bytes.'
+# Bounded downloads only negotiate encodings we can size-limit during decompression.
+# Brotli/Zstandard can expand a few compressed bytes into multi-MiB output in one
+# decoder step, so they are excluded from Accept-Encoding and rejected if a server
+# still returns them.
+_BOUNDED_ACCEPT_ENCODING = 'identity, gzip, deflate'
 
 # Private IP ranges that should be blocked by default (i.e. unless allow_local=True).
 # IPv6 transition forms (6to4, NAT64, IPv4-mapped/-compatible, ISATAP) are not listed here;
@@ -543,6 +548,8 @@ async def safe_download(
 
             request_headers: dict[str, str] = {k: v for k, v in effective_headers.items() if k.lower() != 'host'}
             request_headers['Host'] = resolved.hostname
+            if max_bytes is not None and not any(k.lower() == 'accept-encoding' for k in request_headers):
+                request_headers['Accept-Encoding'] = _BOUNDED_ACCEPT_ENCODING
 
             # Make request with Host header set to original hostname. Keep the existing
             # buffered path for callers without a body limit.
@@ -613,23 +620,17 @@ def _download_exceeds(max_bytes: int) -> ValueError:
     return ValueError(_DOWNLOAD_EXCEEDS_TEMPLATE.format(max_bytes=max_bytes))
 
 
-def _content_encodings(response: httpx.Response) -> list[str]:
-    """Return content-codings to reverse, excluding no-op `identity`."""
-    encodings: list[str] = []
-    for value in response.headers.get_list('content-encoding'):
-        for part in value.split(','):
-            coding = part.strip().lower()
-            if coding and coding != 'identity':
-                encodings.append(coding)
-    return encodings
-
-
 async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
     """Read a streamed response body without buffering more than `max_bytes` of decoded data.
 
     Streams the *encoded* body via `aiter_raw` so oversized wire traffic is rejected as it
-    arrives, and applies content-encoding with an output cap so a highly compressible payload
-    cannot expand past `max_bytes` in a single decoded chunk (the failure mode of `aiter_bytes`).
+    arrives, and applies gzip/deflate with zlib's output `max_length` so a highly compressible
+    payload cannot expand past `max_bytes` mid-decode.
+
+    Only `identity`, `gzip`/`x-gzip`, and `deflate` are supported on this path. Codings that
+    cannot be size-limited during decompression (notably brotli/zstd) are rejected; callers
+    with `max_bytes` also send `Accept-Encoding: identity, gzip, deflate` so servers are not
+    invited to use them.
 
     Some transports (e.g. httpx mock responses built from an in-memory `content=` bytes object)
     preload the body and mark the stream consumed; in that case the decoded body is already in
@@ -641,16 +642,23 @@ async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
             raise _download_exceeds(max_bytes)
         return data
 
-    encodings = _content_encodings(response)
+    encodings: list[str] = []
+    for value in response.headers.get_list('content-encoding'):
+        for part in value.split(','):
+            coding = part.strip().lower()
+            if coding and coding != 'identity':
+                encodings.append(coding)
+
     if not encodings:
         return await _read_capped_identity(response, max_bytes)
-    if encodings == ['gzip'] or encodings == ['x-gzip']:
-        return await _read_capped_gzip(response, max_bytes)
+    if encodings in (['gzip'], ['x-gzip']):
+        return await _read_capped_zlib(response, max_bytes, wbits=zlib.MAX_WBITS | 16)
     if encodings == ['deflate']:
         return await _read_capped_deflate(response, max_bytes)
-    # Other codings (brotli, zstd, multi-layer) are uncommon on this path; still stream with
-    # both bounds via small raw slices so peak decoded growth per step stays limited.
-    return await _read_capped_via_httpx_decoder(response, max_bytes, encodings)
+    raise ValueError(
+        f'Unsupported content-encoding for bounded download: {encodings}. '
+        f'Only identity, gzip, and deflate can be size-limited during decompression.'
+    )
 
 
 async def _read_capped_identity(response: httpx.Response, max_bytes: int) -> bytes:
@@ -662,10 +670,6 @@ async def _read_capped_identity(response: httpx.Response, max_bytes: int) -> byt
             raise _download_exceeds(max_bytes)
         content.extend(raw)
     return bytes(content)
-
-
-async def _read_capped_gzip(response: httpx.Response, max_bytes: int) -> bytes:
-    return await _read_capped_zlib(response, max_bytes, wbits=zlib.MAX_WBITS | 16)
 
 
 async def _read_capped_deflate(response: httpx.Response, max_bytes: int) -> bytes:
@@ -719,59 +723,28 @@ def _zlib_feed_capped(
     content: bytearray,
     max_bytes: int,
 ) -> None:
-    """Feed compressed `data` into `decompressor`, extending `content` up to `max_bytes`."""
+    """Feed compressed `data` into `decompressor`, extending `content` up to `max_bytes`.
+
+    When decoded content already equals the cap, remaining compressed input is still fed with
+    a one-byte output probe so gzip trailers that produce no further output are accepted.
+    """
     while data:
         remaining = max_bytes - len(content)
         if remaining <= 0:
-            raise _download_exceeds(max_bytes)
+            # Cap reached: only allow zero-output consumption (e.g. gzip CRC/ISIZE trailer).
+            previous = data
+            out = decompressor.decompress(data, max_length=1)
+            if out:
+                raise _download_exceeds(max_bytes)
+            data = decompressor.unconsumed_tail
+            if data == previous:  # pragma: no cover
+                # No progress with a 1-byte probe; finish the stream without allowing output.
+                out = decompressor.decompress(data)
+                if out:
+                    raise _download_exceeds(max_bytes)
+                return
+            continue
         out = decompressor.decompress(data, max_length=remaining)
         content.extend(out)
         data = decompressor.unconsumed_tail
-        # `max_length` stopped output with compressed input left → decoded body would exceed.
-        if data and len(content) >= max_bytes:
-            raise _download_exceeds(max_bytes)
-        if data and not out:  # pragma: no cover
-            raise _download_exceeds(max_bytes)
-
-
-async def _read_capped_via_httpx_decoder(response: httpx.Response, max_bytes: int, encodings: list[str]) -> bytes:
-    """Decode less-common content-codings with httpx's decoders, feeding small raw slices.
-
-    Peak decoded growth is limited to one raw slice's expansion; slices are small so a
-    compression bomb cannot materialize gigabytes in a single step.
-    """
-    # Import privately: httpx does not expose a public decoder factory, and we need parity
-    # with the codecs its client already negotiates (brotli/zstd when installed).
-    from httpx._decoders import SUPPORTED_DECODERS, MultiDecoder
-
-    try:
-        children = [SUPPORTED_DECODERS[coding]() for coding in encodings]
-    except KeyError as e:
-        raise ValueError(f'Unsupported content-encoding for bounded download: {encodings}') from e
-    decoder = children[0] if len(children) == 1 else MultiDecoder(children)
-
-    content = bytearray()
-    encoded_total = 0
-    # 4 KiB raw slices keep single-step expansion bounded without thrashing the event loop.
-    slice_size = 4 * 1024
-    async for raw in response.aiter_raw():
-        encoded_total += len(raw)
-        if encoded_total > max_bytes:
-            raise _download_exceeds(max_bytes)
-        for offset in range(0, len(raw), slice_size):
-            piece = raw[offset : offset + slice_size]
-            try:
-                out = decoder.decode(piece)
-            except Exception as e:
-                raise ValueError(f'Failed to decode response body: {e}') from e
-            if len(content) + len(out) > max_bytes:
-                raise _download_exceeds(max_bytes)
-            content.extend(out)
-    try:
-        tail = decoder.flush()
-    except Exception as e:
-        raise ValueError(f'Failed to decode response body: {e}') from e
-    if len(content) + len(tail) > max_bytes:
-        raise _download_exceeds(max_bytes)
-    content.extend(tail)
-    return bytes(content)
+        # If the cap is full but compressed input remains, loop into the trailer-only path.

--- a/pydantic_ai_slim/pydantic_ai/common_tools/web_fetch.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/web_fetch.py
@@ -30,6 +30,7 @@ except ImportError as _import_error:
 __all__ = ('WebFetchResult', 'web_fetch_tool')
 
 _EXCESSIVE_NEWLINES_RE = re.compile(r'\n{3,}')
+_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 
 
 class WebFetchResult(TypedDict):
@@ -57,6 +58,9 @@ class WebFetchLocalTool:
 
     timeout: int
     """Request timeout in seconds."""
+
+    max_download_bytes: int | None = field(default=_MAX_DOWNLOAD_BYTES)
+    """Maximum size in bytes of the response body to download. None for no limit."""
 
     allowed_domains: list[str] | None = field(default=None)
     """Only fetch from these domains (exact hostname match). Raises `ModelRetry` on violation."""
@@ -97,6 +101,7 @@ class WebFetchLocalTool:
                 headers=request_headers,
                 allowed_domains=self.allowed_domains,
                 blocked_domains=self.blocked_domains,
+                max_bytes=self.max_download_bytes,
             )
         except (ValueError, httpx.HTTPStatusError, httpx.RequestError) as e:
             raise ModelRetry(f'Failed to fetch {url}: {e}') from e
@@ -152,6 +157,7 @@ def web_fetch_tool(
     max_content_length: int | None = 50_000,
     allow_local_urls: bool = False,
     timeout: int = 30,
+    max_download_bytes: int | None = _MAX_DOWNLOAD_BYTES,
     allowed_domains: list[str] | None = None,
     blocked_domains: list[str] | None = None,
     headers: dict[str, str] | None = None,
@@ -171,6 +177,9 @@ def web_fetch_tool(
         allow_local_urls: Whether to allow fetching from private/local IP addresses.
             Defaults to `False`.
         timeout: Request timeout in seconds. Defaults to 30.
+        max_download_bytes: Maximum size in bytes of the response body to download, applied
+            before the body is buffered. Defaults to 50 MiB. Use `None` for no limit, which
+            lets a response of any size be read into memory.
         allowed_domains: Only fetch from these domains (exact hostname match). Raises `ModelRetry` on violation.
         blocked_domains: Never fetch from these domains (exact hostname match). Raises `ModelRetry` on violation.
         headers: Additional HTTP headers to include in requests.
@@ -187,6 +196,7 @@ def web_fetch_tool(
             max_content_length=max_content_length,
             allow_local_urls=allow_local_urls,
             timeout=timeout,
+            max_download_bytes=max_download_bytes,
             allowed_domains=allowed_domains,
             blocked_domains=blocked_domains,
             headers=headers,

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -83,6 +83,9 @@ This matches the default timeout used by OpenAI's Python client.
 See https://github.com/openai/openai-python/blob/v1.54.4/src/openai/_constants.py#L9
 """
 
+_MAX_FILE_URL_DOWNLOAD_BYTES = 50 * 1024 * 1024
+"""Default maximum response body size when downloading a [`FileUrl`][pydantic_ai.messages.FileUrl]."""
+
 ModelContextDepsT = TypeVar('ModelContextDepsT')
 
 
@@ -1596,6 +1599,7 @@ async def download_item(
     - Private/internal IP addresses are blocked by default
     - Cloud metadata endpoints (169.254.169.254) are always blocked
     - Hostnames are resolved before requests to prevent DNS rebinding
+    - Response bodies are limited to 50 MiB
 
     Set `item.force_download='allow-local'` to allow private IP addresses.
 
@@ -1613,7 +1617,7 @@ async def download_item(
     Raises:
         UserError: If the URL points to a YouTube video.
         ValueError: If the URL uses an unsupported protocol or targets a private/internal
-            IP address (unless allow-local is set).
+            IP address (unless allow-local is set), or the body exceeds 50 MiB.
     """
     if isinstance(item, VideoUrl) and item.is_youtube:
         raise UserError('Downloading YouTube videos is not supported.')
@@ -1621,7 +1625,7 @@ async def download_item(
     from .._ssrf import safe_download
 
     allow_local = item.force_download == 'allow-local'
-    response = await safe_download(item.url, allow_local=allow_local)
+    response = await safe_download(item.url, allow_local=allow_local, max_bytes=_MAX_FILE_URL_DOWNLOAD_BYTES)
 
     if content_type := response.headers.get('content-type'):
         content_type = content_type.split(';')[0]

--- a/tests/models/test_download_item.py
+++ b/tests/models/test_download_item.py
@@ -1,5 +1,7 @@
 import re
+from unittest.mock import patch
 
+import httpx
 import pytest
 
 from pydantic_ai import AudioUrl, DocumentUrl, ImageUrl, VideoUrl
@@ -44,6 +46,43 @@ async def test_download_item_raises_user_error_with_unsupported_protocol(
 async def test_download_item_raises_user_error_with_youtube_url() -> None:
     with pytest.raises(UserError, match=re.escape('Downloading YouTube videos is not supported.')):
         _ = await download_item(VideoUrl(url='https://youtu.be/lCdaVNyHtjU'), data_format='bytes')
+
+
+@pytest.mark.parametrize(
+    'url',
+    (
+        ImageUrl(url='https://93.184.215.14/image.png', media_type='image/png'),
+        DocumentUrl(url='https://93.184.215.14/doc.pdf', media_type='application/pdf'),
+        VideoUrl(url='https://93.184.215.14/video.mp4', media_type='video/mp4'),
+        AudioUrl(url='https://93.184.215.14/audio.mp3', media_type='audio/mpeg'),
+    ),
+)
+async def test_download_item_rejects_oversized_body(
+    url: AudioUrl | DocumentUrl | ImageUrl | VideoUrl,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """File URL downloads reject response bodies larger than the 50 MiB default limit."""
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b'x' * 1024,
+            headers={'content-type': url.media_type},
+            request=request,
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+    def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+        return http_client
+
+    monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+    with (
+        patch('pydantic_ai.models._MAX_FILE_URL_DOWNLOAD_BYTES', 512),
+        pytest.raises(ValueError, match='maximum size of 512 bytes'),
+    ):
+        await download_item(url, data_format='bytes')
 
 
 @pytest.mark.vcr()

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import gzip
-import zlib
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 
+from pydantic_ai import _ssrf
 from pydantic_ai._ssrf import (
     _DEFAULT_TIMEOUT,  # pyright: ignore[reportPrivateUsage]
     _MAX_REDIRECTS,  # pyright: ignore[reportPrivateUsage]
@@ -592,6 +592,22 @@ class TestValidateAndResolveUrl:
             await validate_and_resolve_url('http://cgnat-host.internal/path', allow_local=False)
 
 
+RequestHandler = Callable[[httpx.Request], httpx.Response]
+
+
+def stream_response(body: bytes, *, content_encoding: str | None = None) -> RequestHandler:
+    """Builds a handler serving `body` as a streamed response, so it is read through `aiter_raw`."""
+    headers = {'content-encoding': content_encoding} if content_encoding else {}
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        async def stream() -> AsyncIterator[bytes]:
+            yield body
+
+        return httpx.Response(200, content=stream(), headers=headers, request=request)
+
+    return handle_request
+
+
 class TestSafeDownload:
     """Tests for safe_download function."""
 
@@ -620,363 +636,155 @@ class TestSafeDownload:
         assert call_args[1]['headers']['Host'] == 'example.com'
         assert call_args[1]['extensions'] == {'sni_hostname': 'example.com'}
 
-    async def test_max_bytes_reads_streamed_body(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.fixture
+    def serve_requests(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> Callable[[RequestHandler], None]:
+        """Serves canned responses to `safe_download` through an `httpx.MockTransport`.
+
+        Also resolves every hostname to a public IP, so the download reaches the handler.
+        """
+
+        def serve(handler: RequestHandler) -> None:
+            mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+            client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+            def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+                return client
+
+            monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        return serve
+
+    async def test_max_bytes_reads_streamed_body(self, serve_requests: Callable[[RequestHandler], None]) -> None:
         """A bounded download buffers a streamed response only after enforcing its limit."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, content=b'streamed content', request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(lambda request: httpx.Response(200, content=b'streamed content', request=request))
 
         response = await safe_download('https://example.com/file.txt', max_bytes=16)
 
         assert response.content == b'streamed content'
 
     async def test_max_bytes_rejects_oversized_streamed_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """A missing or false content-length header cannot bypass the streamed-body limit."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, content=b'content longer than the limit', request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(lambda request: httpx.Response(200, content=b'content longer than the limit', request=request))
 
         with pytest.raises(ValueError, match='maximum size of 16 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=16)
 
     async def test_max_bytes_rejects_body_that_decodes_oversized(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """A small compressed body that expands past the limit is rejected on its decoded size."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
         encoded = gzip.compress(bytes(1_000_000))
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(encoded, content_encoding='gzip'))
 
         assert len(encoded) < 100_000
         with pytest.raises(ValueError, match='maximum size of 100000 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=100_000)
 
     async def test_max_bytes_rejects_gzip_bomb_without_materializing_full_decoded_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """A single highly compressible raw chunk is rejected without buffering the full expansion.
 
         `aiter_bytes` would materialize the entire decoded bomb before any size check; the capped
         path must use `max_length` decompression so peak decoded buffering stays near the limit.
         """
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
         # ~1 MiB of zeros compresses to a tiny gzip payload delivered as one network chunk.
-        decoded_size = 1_000_000
-        encoded = gzip.compress(bytes(decoded_size))
+        encoded = gzip.compress(bytes(1_000_000))
         max_bytes = 10_000
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(encoded, content_encoding='gzip'))
 
         assert len(encoded) < max_bytes
         with pytest.raises(ValueError, match=f'maximum size of {max_bytes} bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=max_bytes)
 
     async def test_max_bytes_rejects_oversized_encoded_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """The limit bounds the encoded stream too, so a body that decodes small can't stream on unchecked."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
         payload = bytes(range(256))
         encoded = gzip.compress(payload)
         max_bytes = (len(payload) + len(encoded)) // 2
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(encoded, content_encoding='gzip'))
 
         with pytest.raises(ValueError, match=f'maximum size of {max_bytes} bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=max_bytes)
 
     async def test_max_bytes_decodes_compressed_body_once(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """A bounded download of a compressed body decodes it exactly once.
 
         The client advertises `gzip` on every request, so the streamed path buffers already-decoded
         bytes; carrying `content-encoding` into the reconstructed response would decode them again.
         """
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
+        serve_requests(
+            lambda request: httpx.Response(
                 200,
                 content=gzip.compress(b'streamed content'),
                 headers={'content-encoding': 'gzip'},
                 request=request,
             )
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        )
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
 
         assert response.content == b'streamed content'
         assert 'content-encoding' not in response.headers
 
-    async def test_max_bytes_follows_redirect(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_max_bytes_follows_redirect(self, serve_requests: Callable[[RequestHandler], None]) -> None:
         """A bounded download closes each streamed redirect hop before re-requesting."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             if request.url.path == '/file.txt':
                 return httpx.Response(302, headers={'location': 'https://example.com/final.txt'}, request=request)
+            return stream_response(b'redirected content')(request)
 
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'redirected content'
-
-            return httpx.Response(200, content=stream(), request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(handle_request)
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
 
         assert response.content == b'redirected content'
 
     async def test_max_bytes_reads_streamed_identity_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """Unencoded bodies are read via `aiter_raw` under the size cap."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'streamed content'
-
-            return httpx.Response(200, content=stream(), request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(b'streamed content'))
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
         assert response.content == b'streamed content'
 
     async def test_max_bytes_rejects_oversized_streamed_identity_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'content longer than the limit'
-
-            return httpx.Response(200, content=stream(), request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(b'content longer than the limit'))
 
         with pytest.raises(ValueError, match='maximum size of 16 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=16)
 
-    async def test_max_bytes_reads_deflate_body(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        payload = b'deflate payload ok'
-        encoded = zlib.compress(payload)
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        response = await safe_download('https://example.com/file.txt', max_bytes=64)
-        assert response.content == payload
-
-    async def test_max_bytes_reads_raw_deflate_body(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Raw deflate (no zlib wrapper) is accepted on the second wbits attempt."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        payload = b'raw deflate payload'
-        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
-        encoded = compressor.compress(payload) + compressor.flush()
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        response = await safe_download('https://example.com/file.txt', max_bytes=64)
-        assert response.content == payload
-
-    async def test_max_bytes_rejects_invalid_deflate_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'not-deflate-at-all'
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        with pytest.raises(ValueError, match='Failed to decode deflate'):
-            await safe_download('https://example.com/file.txt', max_bytes=64)
-
-    async def test_max_bytes_rejects_oversized_deflate_decoded_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        encoded = zlib.compress(bytes(100_000))
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        with pytest.raises(ValueError, match='maximum size of 1000 bytes'):
-            await safe_download('https://example.com/file.txt', max_bytes=1000)
-
-    async def test_max_bytes_x_gzip_alias(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+    async def test_max_bytes_x_gzip_alias(self, serve_requests: Callable[[RequestHandler], None]) -> None:
         payload = b'x-gzip body'
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield gzip.compress(payload)
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'x-gzip'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(gzip.compress(payload), content_encoding='x-gzip'))
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
         assert response.content == payload
 
     async def test_max_bytes_strips_identity_from_content_encoding(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
         payload = b'identity stripped'
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield gzip.compress(payload)
-
-            return httpx.Response(
-                200,
-                content=stream(),
-                headers={'content-encoding': 'identity, gzip'},
-                request=request,
-            )
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(gzip.compress(payload), content_encoding='identity, gzip'))
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
         assert response.content == payload
 
-    @pytest.mark.parametrize('coding', ['br', 'zstd', 'gzip, deflate', 'not-a-real-coding'])
+    @pytest.mark.parametrize('coding', ['br', 'zstd', 'deflate', 'gzip, deflate', 'not-a-real-coding'])
     async def test_max_bytes_rejects_unsupported_content_encoding(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch, coding: str
+        self, serve_requests: Callable[[RequestHandler], None], coding: str
     ) -> None:
-        """Brotli/zstd/stacked/unknown codings are rejected rather than decoded unsafely."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        """Brotli/zstd/deflate/stacked/unknown codings are rejected rather than decoded unsafely."""
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             # Body is never read: unsupported content-coding is rejected before streaming.
@@ -985,155 +793,71 @@ class TestSafeDownload:
 
             return httpx.Response(200, content=stream(), headers={'content-encoding': coding}, request=request)
 
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(handle_request)
 
         with pytest.raises(ValueError, match='Unsupported content-encoding for bounded download'):
             await safe_download('https://example.com/file.txt', max_bytes=64)
 
     async def test_max_bytes_sets_bounded_accept_encoding(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
-        """Bounded downloads negotiate only encodings that can be size-limited mid-decode."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        """Bounded downloads negotiate only encodings that can be size-limited while streaming."""
         seen: dict[str, str] = {}
 
         def handle_request(request: httpx.Request) -> httpx.Response:
-            accept = request.headers.get('accept-encoding', '')
-            seen['accept-encoding'] = accept
+            seen['accept-encoding'] = request.headers.get('accept-encoding', '')
+            return stream_response(b'ok')(request)
 
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'ok'
-
-            return httpx.Response(200, content=stream(), request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(handle_request)
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
         assert response.content == b'ok'
-        assert seen['accept-encoding'] == 'identity, gzip, deflate'
-        assert 'br' not in seen['accept-encoding']
-        assert 'zstd' not in seen['accept-encoding']
+        assert seen['accept-encoding'] == 'identity, gzip'
 
     async def test_max_bytes_rejects_oversized_preloaded_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """Transports that preload `content=` still enforce the decoded size cap."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, content=b'x' * 2000, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(lambda request: httpx.Response(200, content=b'x' * 2000, request=request))
 
         with pytest.raises(ValueError, match='maximum size of 1024 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=1024)
 
     async def test_max_bytes_rejects_oversized_gzip_encoded_stream(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """Encoded gzip wire traffic above the cap is rejected before full decompression."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
         # Incompressible-ish payload so the gzip frame itself exceeds a small cap.
-        payload = bytes(range(256)) * 8
-        encoded = gzip.compress(payload)
+        encoded = gzip.compress(bytes(range(256)) * 8)
         assert len(encoded) > 64
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(encoded, content_encoding='gzip'))
 
         with pytest.raises(ValueError, match='maximum size of 64 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=64)
 
     async def test_max_bytes_accepts_gzip_body_exactly_at_cap_with_split_trailer(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+        self, serve_requests: Callable[[RequestHandler], None]
     ) -> None:
         """A valid gzip body whose size equals the cap must not fail when the trailer is a separate chunk."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
         payload = b'x' * 100
         encoded = gzip.compress(payload)
-        head, trailer = encoded[:-8], encoded[-8:]
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             async def stream() -> AsyncIterator[bytes]:
-                yield head
-                yield trailer
+                yield encoded[:-8]
+                yield encoded[-8:]
 
             return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
 
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(handle_request)
 
         response = await safe_download('https://example.com/file.txt', max_bytes=100)
         assert response.content == payload
 
-    def test_zlib_feed_rejects_when_more_output_would_exceed_cap(self) -> None:
-        from pydantic_ai._ssrf import _zlib_feed_capped  # pyright: ignore[reportPrivateUsage]
-
-        decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
-        content = bytearray(b'x' * 10)
-        with pytest.raises(ValueError, match='maximum size of 10 bytes'):
-            _zlib_feed_capped(decompressor, gzip.compress(b'more'), content, 10)
-
-    def test_zlib_decompress_capped_rejects_flush_overflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """If flush produces bytes past the cap, the helper rejects rather than returning oversized data."""
-        from pydantic_ai import _ssrf
-
-        class _Flushy:
-            def decompress(self, data: bytes, max_length: int = 0) -> bytes:
-                return b''
-
-            @property
-            def unconsumed_tail(self) -> bytes:
-                return b''
-
-            def flush(self) -> bytes:
-                return b'overflow-tail'
-
-        def _make_flushy(wbits: int) -> _Flushy:
-            return _Flushy()
-
-        monkeypatch.setattr(_ssrf.zlib, 'decompressobj', _make_flushy)
-        with pytest.raises(ValueError, match='maximum size of 4 bytes'):
-            _ssrf._zlib_decompress_capped(  # pyright: ignore[reportPrivateUsage]
-                b'anything', 4, wbits=zlib.MAX_WBITS | 16
-            )
-
-    async def test_max_bytes_gzip_flush_overflow_on_stream(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    async def test_max_bytes_rejects_gzip_flush_overflow(
+        self, serve_requests: Callable[[RequestHandler], None], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Streamed gzip rejects when flush would push past the cap after a full feed."""
-        from pydantic_ai import _ssrf
-
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        """Streamed gzip rejects when the final flush would push the decoded body past the cap."""
 
         class _Flushy:
             def decompress(self, data: bytes, max_length: int = 0) -> bytes:
@@ -1150,19 +874,7 @@ class TestSafeDownload:
             return _Flushy()
 
         monkeypatch.setattr(_ssrf.zlib, 'decompressobj', _make_flushy)
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'raw'
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+        serve_requests(stream_response(b'raw', content_encoding='gzip'))
 
         with pytest.raises(ValueError, match='maximum size of 4 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=4)

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -681,6 +681,38 @@ class TestSafeDownload:
         with pytest.raises(ValueError, match='maximum size of 100000 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=100_000)
 
+    async def test_max_bytes_rejects_gzip_bomb_without_materializing_full_decoded_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A single highly compressible raw chunk is rejected without buffering the full expansion.
+
+        `aiter_bytes` would materialize the entire decoded bomb before any size check; the capped
+        path must use `max_length` decompression so peak decoded buffering stays near the limit.
+        """
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        # ~1 MiB of zeros compresses to a tiny gzip payload delivered as one network chunk.
+        decoded_size = 1_000_000
+        encoded = gzip.compress(bytes(decoded_size))
+        max_bytes = 10_000
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        assert len(encoded) < max_bytes
+        with pytest.raises(ValueError, match=f'maximum size of {max_bytes} bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=max_bytes)
+
     async def test_max_bytes_rejects_oversized_encoded_body(
         self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1052,10 +1052,9 @@ class TestSafeDownload:
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
 
         def handle_request(request: httpx.Request) -> httpx.Response:
-            # Empty async generator: the unsupported-encoding path raises before reading body.
-            async def stream() -> AsyncIterator[bytes]:
-                return
-                yield b'x'  # pragma: no cover
+            # Body is never read: unknown content-coding is rejected before streaming.
+            async def stream() -> AsyncIterator[bytes]:  # pragma: no cover
+                yield b'x'
 
             return httpx.Response(
                 200, content=stream(), headers={'content-encoding': 'not-a-real-coding'}, request=request

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import gzip
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -592,6 +594,10 @@ class TestValidateAndResolveUrl:
 class TestSafeDownload:
     """Tests for safe_download function."""
 
+    async def test_negative_max_bytes_rejected(self) -> None:
+        with pytest.raises(ValueError, match='max_bytes must be non-negative'):
+            await safe_download('https://example.com/file.txt', max_bytes=-1)
+
     async def test_successful_download(self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock) -> None:
         mock_response = AsyncMock()
         mock_response.is_redirect = False
@@ -612,6 +618,144 @@ class TestSafeDownload:
         assert '93.184.215.14' in call_args[0][0]
         assert call_args[1]['headers']['Host'] == 'example.com'
         assert call_args[1]['extensions'] == {'sni_hostname': 'example.com'}
+
+    async def test_max_bytes_reads_streamed_body(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bounded download buffers a streamed response only after enforcing its limit."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b'streamed content', request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=16)
+
+        assert response.content == b'streamed content'
+
+    async def test_max_bytes_rejects_oversized_streamed_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing or false content-length header cannot bypass the streamed-body limit."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b'content longer than the limit', request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 16 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=16)
+
+    async def test_max_bytes_rejects_body_that_decodes_oversized(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A small compressed body that expands past the limit is rejected on its decoded size."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        encoded = gzip.compress(bytes(1_000_000))
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        assert len(encoded) < 100_000
+        with pytest.raises(ValueError, match='maximum size of 100000 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=100_000)
+
+    async def test_max_bytes_rejects_oversized_encoded_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The limit bounds the encoded stream too, so a body that decodes small can't stream on unchecked."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        payload = bytes(range(256))
+        encoded = gzip.compress(payload)
+        max_bytes = (len(payload) + len(encoded)) // 2
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match=f'maximum size of {max_bytes} bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=max_bytes)
+
+    async def test_max_bytes_decodes_compressed_body_once(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bounded download of a compressed body decodes it exactly once.
+
+        The client advertises `gzip` on every request, so the streamed path buffers already-decoded
+        bytes; carrying `content-encoding` into the reconstructed response would decode them again.
+        """
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=gzip.compress(b'streamed content'),
+                headers={'content-encoding': 'gzip'},
+                request=request,
+            )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+
+        assert response.content == b'streamed content'
+        assert 'content-encoding' not in response.headers
+
+    async def test_max_bytes_follows_redirect(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bounded download closes each streamed redirect hop before re-requesting."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/file.txt':
+                return httpx.Response(302, headers={'location': 'https://example.com/final.txt'}, request=request)
+            return httpx.Response(200, content=b'redirected content', request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+
+        assert response.content == b'redirected content'
 
     async def test_redirect_followed(self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock) -> None:
         redirect_response = AsyncMock()

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import brotli
 import httpx
 import pytest
 
@@ -28,10 +27,6 @@ from pydantic_ai._ssrf import (
 )
 
 pytestmark = [pytest.mark.anyio]
-
-
-def _brotli_compress(data: bytes) -> bytes:
-    return bytes(brotli.compress(data))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
 
 
 @pytest.fixture
@@ -976,18 +971,45 @@ class TestSafeDownload:
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
         assert response.content == payload
 
-    async def test_max_bytes_reads_brotli_via_httpx_decoder(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize('coding', ['br', 'zstd', 'gzip, deflate', 'not-a-real-coding'])
+    async def test_max_bytes_rejects_unsupported_content_encoding(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch, coding: str
     ) -> None:
+        """Brotli/zstd/stacked/unknown codings are rejected rather than decoded unsafely."""
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        payload = b'brotli payload for capped download'
-        encoded: bytes = _brotli_compress(payload)
 
         def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
+            # Body is never read: unsupported content-coding is rejected before streaming.
+            async def stream() -> AsyncIterator[bytes]:  # pragma: no cover
+                yield b'x'
 
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+            return httpx.Response(200, content=stream(), headers={'content-encoding': coding}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='Unsupported content-encoding for bounded download'):
+            await safe_download('https://example.com/file.txt', max_bytes=64)
+
+    async def test_max_bytes_sets_bounded_accept_encoding(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bounded downloads negotiate only encodings that can be size-limited mid-decode."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        seen: dict[str, str] = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            accept = request.headers.get('accept-encoding', '')
+            seen['accept-encoding'] = accept
+
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'ok'
+
+            return httpx.Response(200, content=stream(), request=request)
 
         http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
 
@@ -997,78 +1019,10 @@ class TestSafeDownload:
         monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
 
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
-        assert response.content == payload
-
-    async def test_max_bytes_rejects_oversized_brotli_decoded_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        encoded: bytes = _brotli_compress(bytes(50_000))
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        with pytest.raises(ValueError, match='maximum size of 1000 bytes'):
-            await safe_download('https://example.com/file.txt', max_bytes=1000)
-
-    async def test_max_bytes_rejects_oversized_brotli_encoded_body(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        # High-entropy payload compresses poorly, so the wire body itself exceeds the limit.
-        payload = bytes(range(256)) * 20
-        encoded: bytes = _brotli_compress(payload)
-        assert len(encoded) > 100
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        with pytest.raises(ValueError, match='maximum size of 100 bytes'):
-            await safe_download('https://example.com/file.txt', max_bytes=100)
-
-    async def test_max_bytes_rejects_unsupported_content_encoding(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            # Body is never read: unknown content-coding is rejected before streaming.
-            async def stream() -> AsyncIterator[bytes]:  # pragma: no cover
-                yield b'x'
-
-            return httpx.Response(
-                200, content=stream(), headers={'content-encoding': 'not-a-real-coding'}, request=request
-            )
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        with pytest.raises(ValueError, match='Unsupported content-encoding'):
-            await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == b'ok'
+        assert seen['accept-encoding'] == 'identity, gzip, deflate'
+        assert 'br' not in seen['accept-encoding']
+        assert 'zstd' not in seen['accept-encoding']
 
     async def test_max_bytes_rejects_oversized_preloaded_body(
         self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
@@ -1115,16 +1069,21 @@ class TestSafeDownload:
         with pytest.raises(ValueError, match='maximum size of 64 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=64)
 
-    async def test_max_bytes_rejects_invalid_brotli_body(
+    async def test_max_bytes_accepts_gzip_body_exactly_at_cap_with_split_trailer(
         self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A valid gzip body whose size equals the cap must not fail when the trailer is a separate chunk."""
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'x' * 100
+        encoded = gzip.compress(payload)
+        head, trailer = encoded[:-8], encoded[-8:]
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             async def stream() -> AsyncIterator[bytes]:
-                yield b'not-valid-brotli'
+                yield head
+                yield trailer
 
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
 
         http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
 
@@ -1133,10 +1092,10 @@ class TestSafeDownload:
 
         monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
 
-        with pytest.raises(ValueError, match='Failed to decode response body'):
-            await safe_download('https://example.com/file.txt', max_bytes=64)
+        response = await safe_download('https://example.com/file.txt', max_bytes=100)
+        assert response.content == payload
 
-    def test_zlib_feed_rejects_when_content_already_at_limit(self) -> None:
+    def test_zlib_feed_rejects_when_more_output_would_exceed_cap(self) -> None:
         from pydantic_ai._ssrf import _zlib_feed_capped  # pyright: ignore[reportPrivateUsage]
 
         decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
@@ -1164,75 +1123,9 @@ class TestSafeDownload:
 
         monkeypatch.setattr(_ssrf.zlib, 'decompressobj', _make_flushy)
         with pytest.raises(ValueError, match='maximum size of 4 bytes'):
-            _ssrf._zlib_decompress_capped(b'anything', 4, wbits=zlib.MAX_WBITS | 16)  # pyright: ignore[reportPrivateUsage]  # pyright: ignore[reportPrivateUsage]
-
-    async def test_max_bytes_rejects_brotli_flush_overflow(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A decoder flush that would push past the cap is rejected."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        payload = b'ok'
-        encoded: bytes = _brotli_compress(payload)
-
-        class _Decoder:
-            def decode(self, data: bytes) -> bytes:
-                return payload
-
-            def flush(self) -> bytes:
-                return b'x' * 100
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield encoded
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        # Patch MultiDecoder/SUPPORTED_DECODERS construction path via monkeypatching the private import site
-        import httpx._decoders as decoders
-
-        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'br', _Decoder)
-
-        with pytest.raises(ValueError, match='maximum size of 10 bytes'):
-            await safe_download('https://example.com/file.txt', max_bytes=10)
-
-    async def test_max_bytes_rejects_brotli_flush_error(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-
-        class _Decoder:
-            def decode(self, data: bytes) -> bytes:
-                return b'ok'
-
-            def flush(self) -> bytes:
-                raise RuntimeError('flush failed')
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield b'x'
-
-            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        import httpx._decoders as decoders
-
-        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'br', _Decoder)
-
-        with pytest.raises(ValueError, match='Failed to decode response body'):
-            await safe_download('https://example.com/file.txt', max_bytes=64)
+            _ssrf._zlib_decompress_capped(  # pyright: ignore[reportPrivateUsage]
+                b'anything', 4, wbits=zlib.MAX_WBITS | 16
+            )
 
     async def test_max_bytes_gzip_flush_overflow_on_stream(
         self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
@@ -1243,9 +1136,6 @@ class TestSafeDownload:
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
 
         class _Flushy:
-            def __init__(self, *args: Any, **kwargs: Any) -> None:
-                pass
-
             def decompress(self, data: bytes, max_length: int = 0) -> bytes:
                 return b'abcd'
 
@@ -1276,51 +1166,6 @@ class TestSafeDownload:
 
         with pytest.raises(ValueError, match='maximum size of 4 bytes'):
             await safe_download('https://example.com/file.txt', max_bytes=4)
-
-    async def test_max_bytes_multi_content_encoding_uses_httpx_decoder(
-        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Stacked content-codings go through the multi-decoder path."""
-        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
-        payload = b'stacked'
-        # gzip then identity is stripped; use gzip+deflate-like via two applications of gzip is invalid.
-        # Instead double-wrap with zlib then gzip is unusual; use br via multi with identity stripped only.
-        # content-encoding "gzip, br" is rare; construct manually with a custom decoder stack.
-        import httpx._decoders as decoders
-
-        class _Pass:
-            def __init__(self) -> None:
-                pass
-
-            def decode(self, data: bytes) -> bytes:
-                return data
-
-            def flush(self) -> bytes:
-                return b''
-
-        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'x-test-a', _Pass)
-        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'x-test-b', _Pass)
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            async def stream() -> AsyncIterator[bytes]:
-                yield payload
-
-            return httpx.Response(
-                200,
-                content=stream(),
-                headers={'content-encoding': 'x-test-a, x-test-b'},
-                request=request,
-            )
-
-        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
-
-        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
-            return http_client
-
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
-
-        response = await safe_download('https://example.com/file.txt', max_bytes=64)
-        assert response.content == payload
 
     async def test_redirect_followed(self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock) -> None:
         redirect_response = AsyncMock()

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import gzip
+import zlib
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import brotli
 import httpx
 import pytest
 
@@ -26,6 +28,10 @@ from pydantic_ai._ssrf import (
 )
 
 pytestmark = [pytest.mark.anyio]
+
+
+def _brotli_compress(data: bytes) -> bytes:
+    return bytes(brotli.compress(data))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
 
 
 @pytest.fixture
@@ -776,7 +782,11 @@ class TestSafeDownload:
         def handle_request(request: httpx.Request) -> httpx.Response:
             if request.url.path == '/file.txt':
                 return httpx.Response(302, headers={'location': 'https://example.com/final.txt'}, request=request)
-            return httpx.Response(200, content=b'redirected content', request=request)
+
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'redirected content'
+
+            return httpx.Response(200, content=stream(), request=request)
 
         http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
 
@@ -788,6 +798,528 @@ class TestSafeDownload:
         response = await safe_download('https://example.com/file.txt', max_bytes=64)
 
         assert response.content == b'redirected content'
+
+    async def test_max_bytes_reads_streamed_identity_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unencoded bodies are read via `aiter_raw` under the size cap."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'streamed content'
+
+            return httpx.Response(200, content=stream(), request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == b'streamed content'
+
+    async def test_max_bytes_rejects_oversized_streamed_identity_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'content longer than the limit'
+
+            return httpx.Response(200, content=stream(), request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 16 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=16)
+
+    async def test_max_bytes_reads_deflate_body(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'deflate payload ok'
+        encoded = zlib.compress(payload)
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == payload
+
+    async def test_max_bytes_reads_raw_deflate_body(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Raw deflate (no zlib wrapper) is accepted on the second wbits attempt."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'raw deflate payload'
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        encoded = compressor.compress(payload) + compressor.flush()
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == payload
+
+    async def test_max_bytes_rejects_invalid_deflate_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'not-deflate-at-all'
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='Failed to decode deflate'):
+            await safe_download('https://example.com/file.txt', max_bytes=64)
+
+    async def test_max_bytes_rejects_oversized_deflate_decoded_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        encoded = zlib.compress(bytes(100_000))
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'deflate'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 1000 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=1000)
+
+    async def test_max_bytes_x_gzip_alias(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'x-gzip body'
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield gzip.compress(payload)
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'x-gzip'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == payload
+
+    async def test_max_bytes_strips_identity_from_content_encoding(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'identity stripped'
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield gzip.compress(payload)
+
+            return httpx.Response(
+                200,
+                content=stream(),
+                headers={'content-encoding': 'identity, gzip'},
+                request=request,
+            )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == payload
+
+    async def test_max_bytes_reads_brotli_via_httpx_decoder(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'brotli payload for capped download'
+        encoded: bytes = _brotli_compress(payload)
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == payload
+
+    async def test_max_bytes_rejects_oversized_brotli_decoded_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        encoded: bytes = _brotli_compress(bytes(50_000))
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 1000 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=1000)
+
+    async def test_max_bytes_rejects_oversized_brotli_encoded_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        # High-entropy payload compresses poorly, so the wire body itself exceeds the limit.
+        payload = bytes(range(256)) * 20
+        encoded: bytes = _brotli_compress(payload)
+        assert len(encoded) > 100
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 100 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=100)
+
+    async def test_max_bytes_rejects_unsupported_content_encoding(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'x'
+
+            return httpx.Response(
+                200, content=stream(), headers={'content-encoding': 'not-a-real-coding'}, request=request
+            )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='Unsupported content-encoding'):
+            await safe_download('https://example.com/file.txt', max_bytes=64)
+
+    async def test_max_bytes_rejects_oversized_preloaded_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transports that preload `content=` still enforce the decoded size cap."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b'x' * 2000, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 1024 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=1024)
+
+    async def test_max_bytes_rejects_oversized_gzip_encoded_stream(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Encoded gzip wire traffic above the cap is rejected before full decompression."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        # Incompressible-ish payload so the gzip frame itself exceeds a small cap.
+        payload = bytes(range(256)) * 8
+        encoded = gzip.compress(payload)
+        assert len(encoded) > 64
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 64 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=64)
+
+    async def test_max_bytes_rejects_invalid_brotli_body(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'not-valid-brotli'
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='Failed to decode response body'):
+            await safe_download('https://example.com/file.txt', max_bytes=64)
+
+    def test_zlib_feed_rejects_when_content_already_at_limit(self) -> None:
+        from pydantic_ai._ssrf import _zlib_feed_capped  # pyright: ignore[reportPrivateUsage]
+
+        decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)
+        content = bytearray(b'x' * 10)
+        with pytest.raises(ValueError, match='maximum size of 10 bytes'):
+            _zlib_feed_capped(decompressor, gzip.compress(b'more'), content, 10)
+
+    def test_zlib_decompress_capped_rejects_flush_overflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If flush produces bytes past the cap, the helper rejects rather than returning oversized data."""
+        from pydantic_ai import _ssrf
+
+        class _Flushy:
+            def decompress(self, data: bytes, max_length: int = 0) -> bytes:
+                return b''
+
+            @property
+            def unconsumed_tail(self) -> bytes:
+                return b''
+
+            def flush(self) -> bytes:
+                return b'overflow-tail'
+
+        def _make_flushy(wbits: int) -> _Flushy:
+            return _Flushy()
+
+        monkeypatch.setattr(_ssrf.zlib, 'decompressobj', _make_flushy)
+        with pytest.raises(ValueError, match='maximum size of 4 bytes'):
+            _ssrf._zlib_decompress_capped(b'anything', 4, wbits=zlib.MAX_WBITS | 16)  # pyright: ignore[reportPrivateUsage]  # pyright: ignore[reportPrivateUsage]
+
+    async def test_max_bytes_rejects_brotli_flush_overflow(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A decoder flush that would push past the cap is rejected."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'ok'
+        encoded: bytes = _brotli_compress(payload)
+
+        class _Decoder:
+            def decode(self, data: bytes) -> bytes:
+                return payload
+
+            def flush(self) -> bytes:
+                return b'x' * 100
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield encoded
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        # Patch MultiDecoder/SUPPORTED_DECODERS construction path via monkeypatching the private import site
+        import httpx._decoders as decoders
+
+        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'br', _Decoder)
+
+        with pytest.raises(ValueError, match='maximum size of 10 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=10)
+
+    async def test_max_bytes_rejects_brotli_flush_error(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        class _Decoder:
+            def decode(self, data: bytes) -> bytes:
+                return b'ok'
+
+            def flush(self) -> bytes:
+                raise RuntimeError('flush failed')
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'x'
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'br'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        import httpx._decoders as decoders
+
+        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'br', _Decoder)
+
+        with pytest.raises(ValueError, match='Failed to decode response body'):
+            await safe_download('https://example.com/file.txt', max_bytes=64)
+
+    async def test_max_bytes_gzip_flush_overflow_on_stream(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Streamed gzip rejects when flush would push past the cap after a full feed."""
+        from pydantic_ai import _ssrf
+
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        class _Flushy:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def decompress(self, data: bytes, max_length: int = 0) -> bytes:
+                return b'abcd'
+
+            @property
+            def unconsumed_tail(self) -> bytes:
+                return b''
+
+            def flush(self) -> bytes:
+                return b'e'
+
+        def _make_flushy(wbits: int) -> _Flushy:
+            return _Flushy()
+
+        monkeypatch.setattr(_ssrf.zlib, 'decompressobj', _make_flushy)
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield b'raw'
+
+            return httpx.Response(200, content=stream(), headers={'content-encoding': 'gzip'}, request=request)
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        with pytest.raises(ValueError, match='maximum size of 4 bytes'):
+            await safe_download('https://example.com/file.txt', max_bytes=4)
+
+    async def test_max_bytes_multi_content_encoding_uses_httpx_decoder(
+        self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stacked content-codings go through the multi-decoder path."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        payload = b'stacked'
+        # gzip then identity is stripped; use gzip+deflate-like via two applications of gzip is invalid.
+        # Instead double-wrap with zlib then gzip is unusual; use br via multi with identity stripped only.
+        # content-encoding "gzip, br" is rare; construct manually with a custom decoder stack.
+        import httpx._decoders as decoders
+
+        class _Pass:
+            def __init__(self) -> None:
+                pass
+
+            def decode(self, data: bytes) -> bytes:
+                return data
+
+            def flush(self) -> bytes:
+                return b''
+
+        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'x-test-a', _Pass)
+        monkeypatch.setitem(decoders.SUPPORTED_DECODERS, 'x-test-b', _Pass)
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            async def stream() -> AsyncIterator[bytes]:
+                yield payload
+
+            return httpx.Response(
+                200,
+                content=stream(),
+                headers={'content-encoding': 'x-test-a, x-test-b'},
+                request=request,
+            )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+
+        def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+            return http_client
+
+        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        response = await safe_download('https://example.com/file.txt', max_bytes=64)
+        assert response.content == payload
 
     async def test_redirect_followed(self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock) -> None:
         redirect_response = AsyncMock()

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1052,8 +1052,10 @@ class TestSafeDownload:
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
 
         def handle_request(request: httpx.Request) -> httpx.Response:
+            # Empty async generator: the unsupported-encoding path raises before reading body.
             async def stream() -> AsyncIterator[bytes]:
-                yield b'x'
+                return
+                yield b'x'  # pragma: no cover
 
             return httpx.Response(
                 200, content=stream(), headers={'content-encoding': 'not-a-real-coding'}, request=request

--- a/tests/test_web_fetch.py
+++ b/tests/test_web_fetch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -297,6 +298,7 @@ class TestWebFetchLocalTool:
             headers={'Accept': 'text/markdown, text/html;q=0.9, */*;q=0.8'},
             allowed_domains=None,
             blocked_domains=None,
+            max_bytes=50 * 1024 * 1024,
         )
 
     async def test_safe_download_error_raises_model_retry(self):
@@ -488,6 +490,50 @@ class TestWebFetchLocalTool:
         call_headers = mock_dl.call_args[1]['headers']
         assert call_headers['Accept'] == 'text/html'
 
+    @pytest.fixture
+    def serve_response(self, monkeypatch: pytest.MonkeyPatch) -> Callable[[httpx.Response], None]:
+        """Serves a canned response through the real `safe_download` so its download bound applies.
+
+        The tests using it request an IP-literal URL, so no DNS resolution is involved.
+        """
+
+        def serve(response: httpx.Response) -> None:
+            client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response))
+
+            def create_http_client(*, timeout: int) -> httpx.AsyncClient:
+                return client
+
+            monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+
+        return serve
+
+    @pytest.mark.parametrize('content_type', ['text/plain', 'application/pdf'])
+    async def test_download_over_max_download_bytes_raises_model_retry(
+        self, serve_response: Callable[[httpx.Response], None], content_type: str
+    ):
+        """A response body larger than `max_download_bytes` is rejected before it is buffered."""
+        from pydantic_ai.exceptions import ModelRetry
+
+        request = httpx.Request('GET', 'https://93.184.215.14/doc')
+        serve_response(
+            httpx.Response(200, content=b'x' * 2000, headers={'content-type': content_type}, request=request)
+        )
+
+        tool = WebFetchLocalTool(max_content_length=None, allow_local_urls=False, timeout=30, max_download_bytes=1024)
+        with pytest.raises(ModelRetry, match='maximum size of 1024 bytes'):
+            await tool('https://93.184.215.14/doc')
+
+    async def test_no_download_limit_when_none(self, serve_response: Callable[[httpx.Response], None]):
+        """`max_download_bytes=None` keeps reading the whole body, however large."""
+        request = httpx.Request('GET', 'https://93.184.215.14/big.txt')
+        serve_response(httpx.Response(200, text='x' * 200_000, headers={'content-type': 'text/plain'}, request=request))
+
+        tool = WebFetchLocalTool(max_content_length=None, allow_local_urls=False, timeout=30, max_download_bytes=None)
+        result = await tool('https://93.184.215.14/big.txt')
+
+        assert isinstance(result, dict)
+        assert len(result['content']) == 200_000
+
 
 class TestWebFetchToolFactory:
     def test_creates_tool(self):
@@ -497,5 +543,7 @@ class TestWebFetchToolFactory:
 
     def test_custom_parameters(self):
         """web_fetch_tool() accepts custom parameters."""
-        tool = web_fetch_tool(max_content_length=10_000, timeout=60, allow_local_urls=True)
+        tool = web_fetch_tool(
+            max_content_length=10_000, timeout=60, allow_local_urls=True, max_download_bytes=1_000_000
+        )
         assert tool.name == 'web_fetch'


### PR DESCRIPTION
This pull request was posted by AICA on behalf of David.

- Closes N/A (maintainer-initiated hardening)

`safe_download` always buffered the full response body. That is fine for small
payloads, but `web_fetch_tool` and `download_item` can pull arbitrary remote
content (the former under model control), so a large response can use unbounded
memory before any text truncation applies.

### Changes

- Add optional `max_bytes` to `safe_download`: stream the body and reject once
  either the decoded body or the encoded stream exceeds the limit
- Default `web_fetch_tool(max_download_bytes=50 MiB)` (alongside existing
  `max_content_length` for returned text)
- Default 50 MiB limit for all `FileUrl` downloads via `download_item`
- Docs note the new `max_download_bytes` knob

Pass `None` for either limit to keep the previous unbounded behavior.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

