### PR TITLE
docs: add API-design rule against changing shared defaults for one new feature

### DIFF
--- a/agent_docs/api-design.md
+++ b/agent_docs/api-design.md
@@ -22,6 +22,7 @@
 - Don't access or modify private attributes (`_prefixed`) — use public APIs, properties, or constructor parameters — Prevents breakage when internal implementation changes and ensures compatibility with library updates
 <!-- rule:72 -->
 - Promote settings to base classes (`ModelSettings`, embedding settings) when 2-3+ providers support them; maintain backward compatibility with automatic mapping from new common fields to legacy provider-prefixed fields — Prevents API duplication across provider-specific subclasses (e.g., `OpenAIEmbeddingSettings`, `CohereEmbeddingSettings`) while preserving backward compatibility when refactoring provider-prefixed parameters (e.g., `cohere_`, `openai_`) to shared fields
+- Never change a shared default, public signature, or abstraction to accommodate one new feature — if a new type only behaves correctly once an existing public default is rewritten, the new type's design is wrong — Fix the new code instead, or split the shared change into its own PR with maintainer sign-off, so one caller's needs don't silently change behavior for every existing user
 <!-- rule:302 -->
 - Keep `NativeToolReturnPart.content` flat and non-redundant — avoid duplicating part fields, repeating `return_value` data, single-key wrappers, or unnecessary lists — Reduces API surface area, prevents inconsistencies between duplicate fields, and simplifies consumption for both users and AI assistants
 <!-- rule:265 -->


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Adds one rule to `agent_docs/api-design.md`, immediately after `rule:72`.

### Why

`rule:72` says to promote settings to base classes *when 2-3+ providers support them*. That gives the threshold at which changing a shared thing is right — but on its own it reads as permission, with nothing stating the guard below the threshold. One new caller is not a threshold.

The gap is not hypothetical. While working on #4221 (adding a `ContextWindowExceeded` exception), the natural-looking way to make the new exception behave correctly was to rewrite `FallbackModel`'s public `fallback_on` default so it would exclude the new type. That's a shared, public default being reshaped to accommodate a single new class — the tail wagging the dog. Nothing in the guidelines pushed back on it.

The closest existing text is in the root `AGENTS.md`:

> Do not refactor a shared protocol, helper, or abstraction to fix one caller unless the narrow fix is unavailable or the refactor is itself the confirmed fix

but it's the tail of a bullet that opens *"for a bug fix, make the narrowest change that resolves the reported, reproduced behavior"*, so it reads as bug-fix-scoped and doesn't fire on a feature PR. This states it as its own rule, in the guide agents are told to read when designing public APIs.

Worth noting the rule permits the change once it stands on its own: #4221 does end up changing that default, but as a deliberate behavior change with its own tests, docs, and follow-up issue (#7139) — not as a prop for a class hierarchy. That distinction is the point.

### One question for a maintainer

`agent_docs/` looks generated — `index.md` opens with `<!-- braindump: rules extracted from PR review patterns -->`, and the directory was created wholesale in #4501. Every other bullet carries a `<!-- rule:NNN -->` id from that corpus.

I deliberately did **not** invent an id, so this is visibly hand-added rather than masquerading as extracted. Two things I can't tell from outside:

1. Will a hand-added rule survive the next braindump run, or get dropped?
2. Is there a source-of-truth upstream of the generated markdown that this should be added to instead?

Happy to move it wherever it actually belongs — including closing this and feeding the rule into the corpus, if that's the right path.

- [ ] Review AI generated code


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

