### PR TITLE
fix(models): validate downloaded image responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -38,6 +38,7 @@ from ..messages import (
     FileUrl,
     FinalResultEvent,
     FinishReason,
+    ImageUrl,
     InstructionPart,
     ModelMessage,
     ModelRequest,
@@ -1571,6 +1572,19 @@ class DownloadedItem(TypedDict, Generic[DataT]):
     """
 
 
+def _image_media_type_from_bytes(data: bytes) -> str | None:
+    """Return a supported image MIME type from common file signatures."""
+    if data.startswith(b'\x89PNG\r\n\x1a\n'):
+        return 'image/png'
+    if data.startswith(b'\xff\xd8\xff'):
+        return 'image/jpeg'
+    if data.startswith((b'GIF87a', b'GIF89a')):
+        return 'image/gif'
+    if data.startswith(b'RIFF') and data[8:12] == b'WEBP':
+        return 'image/webp'
+    return None
+
+
 @overload
 async def download_item(
     item: FileUrl,
@@ -1631,6 +1645,22 @@ async def download_item(
         content_type = content_type.split(';')[0]
         if content_type == 'application/octet-stream':
             content_type = None
+
+    if isinstance(item, ImageUrl):
+        detected_media_type = _image_media_type_from_bytes(response.content)
+        if content_type is None:
+            if detected_media_type is None:
+                raise ValueError('Downloaded image bytes have no recognized image signature')
+            content_type = detected_media_type
+        elif not content_type.startswith('image/'):
+            raise ValueError(
+                f'Downloaded image has non-image content type: {content_type!r}'
+            )
+        elif content_type in {'image/png', 'image/jpeg', 'image/gif', 'image/webp'}:
+            if detected_media_type != content_type:
+                raise ValueError(
+                    f'Downloaded image bytes do not match content type {content_type!r}'
+                )
 
     media_type = content_type or item.media_type
 

--- a/tests/models/test_download_item.py
+++ b/tests/models/test_download_item.py
@@ -115,3 +115,70 @@ async def test_download_item_no_content_type(disable_ssrf_protection_for_vcr: No
     )
     assert downloaded_item['data_type'] == 'text/markdown'
     assert downloaded_item['data'] == IsStr()
+
+
+@pytest.mark.parametrize(
+    ('content_type', 'body'),
+    (
+        ('text/html', b'<html>not an image</html>'),
+        ('image/png', b'<html>not an image</html>'),
+    ),
+)
+async def test_download_item_rejects_mismatched_image_bytes(
+    content_type: str, body: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Image URLs must not forward HTML bytes under an image MIME type."""
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body, headers={'content-type': content_type}, request=request)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+    monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', lambda *, timeout: http_client)
+
+    with pytest.raises(ValueError, match='image'):
+        await download_item(
+            ImageUrl(url='https://example.com/image.png', force_download='allow-local'), data_format='bytes'
+        )
+
+
+async def test_download_item_rejects_unknown_octet_stream_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An octet stream must not fall back to the URL's image extension."""
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b'<html>not an image</html>',
+            headers={'content-type': 'application/octet-stream'},
+            request=request,
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+    monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', lambda *, timeout: http_client)
+
+    with pytest.raises(ValueError, match='signature'):
+        await download_item(
+            ImageUrl(url='https://example.com/image.png', force_download='allow-local'), data_format='bytes'
+        )
+
+
+async def test_download_item_infers_image_type_from_octet_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic response type still preserves a valid image signature."""
+    png = b'\x89PNG\r\n\x1a\n' + b'payload'
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=png, headers={'content-type': 'application/octet-stream'}, request=request
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+    monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', lambda *, timeout: http_client)
+
+    downloaded_item = await download_item(
+        ImageUrl(url='https://example.com/image.png', force_download='allow-local'), data_format='bytes'
+    )
+
+    assert downloaded_item['data_type'] == 'image/png'


### PR DESCRIPTION
## Summary

Validate downloaded ImageUrl responses at the shared download boundary instead of trusting a remote Content-Type header.

- Reject non-image response types for image URLs.
- Verify PNG, JPEG, GIF, and WebP signatures against known image MIME types.
- Require a recognized signature when the response type is missing or application/octet-stream, so HTML cannot fall back to the URL extension.
- Preserve unfamiliar image/* MIME types for provider-specific handling.

## Validation

- uv run --group dev pytest tests/models/test_download_item.py -q (22 passed)
- uv run --group lint ruff check pydantic_ai_slim/pydantic_ai/models/__init__.py tests/models/test_download_item.py
- git diff --check

Fixes #7146

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

