### PR TITLE
fix(openai): normalize Harmony tool call names

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -119,6 +119,12 @@ from ._tool_choice import ResolvedToolChoice, resolve_tool_choice
 
 _OPENAI_BACKGROUND_POLL_INTERVAL = 2.0
 
+
+def _strip_harmony_tool_name(name: str) -> str:
+    """Remove a leaked Harmony channel suffix from an inbound tool name."""
+    return name.split('<|channel|>', 1)[0]
+
+
 try:
     from openai import (
         NOT_GIVEN,
@@ -1211,7 +1217,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
                 if isinstance(c, ChatCompletionMessageFunctionToolCall):
-                    part = ToolCallPart(c.function.name, c.function.arguments, tool_call_id=c.id)
+                    part = ToolCallPart(
+                        _strip_harmony_tool_name(c.function.name), c.function.arguments, tool_call_id=c.id
+                    )
                 elif isinstance(c, ChatCompletionMessageCustomToolCall):  # pragma: no cover
                     # NOTE: Custom tool calls are not supported.
                     # See <https://github.com/pydantic/pydantic-ai/issues/2513> for more details.
@@ -2302,7 +2310,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     fn_provider_details = {'namespace': item.namespace}
                 items.append(
                     ToolCallPart(
-                        item.name,
+                        _strip_harmony_tool_name(item.name),
                         item.arguments,
                         tool_call_id=_response_tool_call_id(
                             item.call_id,

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -569,6 +569,34 @@ async def test_request_tool_call(allow_model_requests: None):
     )
 
 
+async def test_request_tool_call_strips_harmony_channel_suffix(allow_model_requests: None):
+    response = completion_message(
+        ChatCompletionMessage(
+            content=None,
+            role='assistant',
+            tool_calls=[
+                ChatCompletionMessageFunctionToolCall(
+                    id='1',
+                    function=Function(arguments='{}', name='get_location<|channel|>commentary'),
+                    type='function',
+                )
+            ],
+        )
+    )
+    mock_client = MockOpenAI.create_mock(
+        [response, completion_message(ChatCompletionMessage(content='done', role='assistant'))]
+    )
+    model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model)
+
+    @agent.tool_plain
+    async def get_location() -> str:
+        return 'located'
+
+    result = await agent.run('find it')
+    assert result.output == 'done'
+
+
 FinishReason = Literal['stop', 'length', 'tool_calls', 'content_filter', 'function_call']
 
 


### PR DESCRIPTION
## Summary

- Strip leaked Harmony channel suffixes from inbound Chat Completions tool calls.
- Strip the same suffixes from inbound Responses API function calls.
- Add a deterministic regression test using mocked Chat Completions.

Fixes #7143

## Validation

- `uv run --frozen pytest tests/models/test_openai.py -k harmony_channel_suffix -q`
- `uv run --frozen ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai.py`
- `uv run --frozen ruff check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

