### PR TITLE
Assert Gemini tool config at the httpx boundary instead of via custom VCR matchers

### DIFF
--- a/tests/models/google/conftest.py
+++ b/tests/models/google/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 from collections.abc import Callable
 
+import httpx
 import pytest
 
 from ...conftest import try_import
@@ -22,10 +23,13 @@ def google_model(gemini_api_key: str) -> GoogleModelFactory:
     def _create_model(
         model_name: str,
         api_key: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
     ) -> GoogleModel:
-        return GoogleModel(
-            model_name,
-            provider=GoogleProvider(api_key=api_key or gemini_api_key),
+        provider = (
+            GoogleProvider(api_key=api_key or gemini_api_key, http_client=http_client)
+            if http_client is not None
+            else GoogleProvider(api_key=api_key or gemini_api_key)
         )
+        return GoogleModel(model_name, provider=provider)
 
     return _create_model

--- a/tests/models/google/conftest.py
+++ b/tests/models/google/conftest.py
@@ -2,69 +2,17 @@
 
 from __future__ import annotations as _annotations
 
-import json
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from ...conftest import try_import
-
-if TYPE_CHECKING:
-    from vcr import VCR
 
 with try_import() as imports_successful:
     from pydantic_ai.models.google import GoogleModel
     from pydantic_ai.providers.google import GoogleProvider
 
     GoogleModelFactory = Callable[..., GoogleModel]
-
-
-def _function_calling_mode(request: Any) -> str | None:
-    """Extract `toolConfig.functionCallingConfig.mode` from a Google request body, or `None`.
-
-    `request` is a VCR `Request` (untyped in practice), so it's typed loosely here.
-    """
-    body: Any = request.body
-    data: dict[str, Any] = json.loads(body) if body else {}
-    tool_config: Any = data.get('toolConfig') or {}
-    fc_config: Any = tool_config.get('functionCallingConfig') or {}
-    mode: Any = fc_config.get('mode')
-    return mode if isinstance(mode, str) else None
-
-
-def _match_function_calling_mode(request1: Any, request2: Any) -> None:
-    assert _function_calling_mode(request1) == _function_calling_mode(request2)
-
-
-def _function_declaration_count(request: Any) -> int:
-    """Count the function declarations across all tools in a Google request body."""
-    body: Any = request.body
-    data: dict[str, Any] = json.loads(body) if body else {}
-    tools: Any = data.get('tools') or []
-    return sum(len(tool.get('functionDeclarations') or []) for tool in tools)
-
-
-def _match_function_declaration_count(request1: Any, request2: Any) -> None:
-    assert _function_declaration_count(request1) == _function_declaration_count(request2)
-
-
-def pytest_recording_configure(config: pytest.Config, vcr: VCR) -> None:
-    """Register custom VCR request matchers that make body assertions drift-safe.
-
-    VCR's default matchers ignore the request body, so a test that asserts on the recorded body
-    (e.g. via `get_first_post_body`) can't detect the live code drifting away from what it asserts —
-    the stale cassette replays regardless. Opt a test in with e.g.
-    `@pytest.mark.vcr(additional_matchers=['function_calling_mode'])` to make the recorded field part
-    of the cassette match: on replay, a request whose value no longer equals the recorded one won't
-    match and the test fails, catching the regression. This is the reusable form of "any field a test
-    explicitly asserts should also gate cassette matching".
-
-    - `function_calling_mode`: gates on `toolConfig.functionCallingConfig.mode`.
-    - `function_declaration_count`: gates on the number of function declarations sent.
-    """
-    vcr.register_matcher('function_calling_mode', _match_function_calling_mode)  # pyright: ignore[reportUnknownMemberType]
-    vcr.register_matcher('function_declaration_count', _match_function_declaration_count)  # pyright: ignore[reportUnknownMemberType]
 
 
 @pytest.fixture

--- a/tests/models/google/test_output.py
+++ b/tests/models/google/test_output.py
@@ -136,10 +136,12 @@ def test_google_strict_tools_upgrade_auto_to_validated(case: dict[str, Any]):
         allow_text_output=True,
     )
 
-    _, tool_config, _ = m._get_tool_config(params, case['settings'])  # pyright: ignore[reportPrivateUsage]
+    tools, tool_config, _ = m._get_tool_config(params, case['settings'])  # pyright: ignore[reportPrivateUsage]
 
     assert tool_config is not None
     assert tool_config['function_calling_config']['mode'].name == case['expected_mode']  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess,reportOptionalSubscript,reportUnknownMemberType]
+    declared = sum(len(tool.get('function_declarations') or []) for tool in tools or [])
+    assert declared == len(case['function_tools']) + len(case.get('output_tools', []))
 
 
 # =============================================================================
@@ -171,7 +173,7 @@ def test_google_strict_resolution_via_transformer():
 # =============================================================================
 
 
-@pytest.mark.vcr(additional_matchers=['function_calling_mode', 'function_declaration_count'])
+@pytest.mark.vcr
 async def test_google_default_tools_use_validated_mode(
     allow_model_requests: None,
     google_model: GoogleModelFactory,
@@ -180,9 +182,9 @@ async def test_google_default_tools_use_validated_mode(
     """On a supported model, function tools default to `VALIDATED` mode with no `strict` flag set, and Gemini
     accepts that enum end-to-end.
 
-    The mode-resolution cases above assert the request shape against a `MagicMock` client; only a live
-    recording proves `VALIDATED` is a wire value the API accepts (rather than 400-ing on it), so this test
-    inspects the recorded request to confirm the mode we sent was `VALIDATED`.
+    The mode-resolution cases above gate what we send against a `MagicMock` client; this test's job is the
+    other half - that `VALIDATED` is a wire value the API accepts rather than 400-ing on it. The assertions
+    below describe the recorded request, which is what makes the recorded 200 evidence of that.
     """
     agent = Agent(google_model('gemini-2.5-flash'))
 
@@ -232,7 +234,7 @@ class HostileToStrict(BaseModel):
     address: Address
 
 
-@pytest.mark.vcr(additional_matchers=['function_calling_mode'])
+@pytest.mark.vcr
 async def test_google_validated_accepts_strict_incompatible_schema(
     allow_model_requests: None,
     google_model: GoogleModelFactory,
@@ -258,9 +260,8 @@ async def test_google_validated_accepts_strict_incompatible_schema(
     )
     assert result.output == snapshot('User John Doe registered successfully with 2 tags.')
 
-    # The `function_calling_mode` matcher (see conftest) makes `mode` part of the cassette match, so
-    # this assertion has teeth on replay: if the code stopped sending `VALIDATED`, no interaction would
-    # match and the test would fail rather than silently reading the stale recorded body.
+    # Describes the request the API accepted, not the one this run built - what we send is gated by
+    # `test_google_strict_tools_upgrade_auto_to_validated`.
     first_request = get_first_post_body(vcr)
     assert first_request['toolConfig']['functionCallingConfig']['mode'] == 'VALIDATED'
 
@@ -321,7 +322,7 @@ class RecursiveAndDeep(BaseModel):
         ),
     ],
 )
-@pytest.mark.vcr(additional_matchers=['function_calling_mode'])
+@pytest.mark.vcr
 async def test_google_validated_accepts_what_auto_accepts(
     allow_model_requests: None,
     google_model: GoogleModelFactory,

--- a/tests/models/google/test_output.py
+++ b/tests/models/google/test_output.py
@@ -11,10 +11,12 @@ Test organization:
 
 from __future__ import annotations as _annotations
 
+import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field
 
@@ -23,7 +25,6 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.tools import ToolDefinition, ToolKind
 
 from ..._inline_snapshot import snapshot
-from ...cassette_utils import get_first_post_body
 from ...conftest import try_import
 
 with try_import() as imports_successful:
@@ -136,12 +137,10 @@ def test_google_strict_tools_upgrade_auto_to_validated(case: dict[str, Any]):
         allow_text_output=True,
     )
 
-    tools, tool_config, _ = m._get_tool_config(params, case['settings'])  # pyright: ignore[reportPrivateUsage]
+    _, tool_config, _ = m._get_tool_config(params, case['settings'])  # pyright: ignore[reportPrivateUsage]
 
     assert tool_config is not None
     assert tool_config['function_calling_config']['mode'].name == case['expected_mode']  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess,reportOptionalSubscript,reportUnknownMemberType]
-    declared = sum(len(tool.get('function_declarations') or []) for tool in tools or [])
-    assert declared == len(case['function_tools']) + len(case.get('output_tools', []))
 
 
 # =============================================================================
@@ -177,16 +176,21 @@ def test_google_strict_resolution_via_transformer():
 async def test_google_default_tools_use_validated_mode(
     allow_model_requests: None,
     google_model: GoogleModelFactory,
-    vcr: Any,
 ):
     """On a supported model, function tools default to `VALIDATED` mode with no `strict` flag set, and Gemini
     accepts that enum end-to-end.
 
-    The mode-resolution cases above gate what we send against a `MagicMock` client; this test's job is the
-    other half - that `VALIDATED` is a wire value the API accepts rather than 400-ing on it. The assertions
-    below describe the recorded request, which is what makes the recorded 200 evidence of that.
+    The mode-resolution cases above gate what `_get_tool_config` returns; the httpx event hook here gates
+    what actually leaves the client, so drift anywhere between the two fails the assertion instead of
+    hiding behind the recording.
     """
-    agent = Agent(google_model('gemini-2.5-flash'))
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def capture_request(request: httpx.Request) -> None:
+        sent_bodies.append(json.loads(request.read()))
+
+    http_client = httpx.AsyncClient(event_hooks={'request': [capture_request]})
+    agent = Agent(google_model('gemini-2.5-flash', http_client=http_client))
 
     @agent.tool_plain
     def get_weather(city: str) -> str:
@@ -199,9 +203,8 @@ async def test_google_default_tools_use_validated_mode(
     result = await agent.run('What is the weather and the time in Paris? Use the tools.')
     assert result.output == snapshot('The weather in Paris is sunny and 24C. The time in Paris is 3pm.')
 
-    first_request = get_first_post_body(vcr)
-    assert first_request['toolConfig']['functionCallingConfig']['mode'] == 'VALIDATED'
-    assert len(first_request['tools'][0]['functionDeclarations']) == 2
+    assert sent_bodies[0]['toolConfig']['functionCallingConfig']['mode'] == 'VALIDATED'
+    assert len(sent_bodies[0]['tools'][0]['functionDeclarations']) == 2
 
 
 class Address(BaseModel):
@@ -238,7 +241,6 @@ class HostileToStrict(BaseModel):
 async def test_google_validated_accepts_strict_incompatible_schema(
     allow_model_requests: None,
     google_model: GoogleModelFactory,
-    vcr: Any,
 ):
     """Gemini `VALIDATED` accepts a schema that OpenAI/Anthropic strict mode would reject or rewrite.
 
@@ -247,7 +249,13 @@ async def test_google_validated_accepts_strict_incompatible_schema(
     under `VALIDATED` and returns a schema-adherent call — the `register` tool only runs if the args
     passed Pydantic validation — so the default doesn't break complex schemas.
     """
-    agent = Agent(google_model('gemini-2.5-flash'))
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def capture_request(request: httpx.Request) -> None:
+        sent_bodies.append(json.loads(request.read()))
+
+    http_client = httpx.AsyncClient(event_hooks={'request': [capture_request]})
+    agent = Agent(google_model('gemini-2.5-flash', http_client=http_client))
 
     @agent.tool_plain
     def register(profile: HostileToStrict) -> str:
@@ -260,10 +268,9 @@ async def test_google_validated_accepts_strict_incompatible_schema(
     )
     assert result.output == snapshot('User John Doe registered successfully with 2 tags.')
 
-    # Describes the request the API accepted, not the one this run built - what we send is gated by
-    # `test_google_strict_tools_upgrade_auto_to_validated`.
-    first_request = get_first_post_body(vcr)
-    assert first_request['toolConfig']['functionCallingConfig']['mode'] == 'VALIDATED'
+    # Read off the hook, not the cassette: if the code stopped sending `VALIDATED` this fails, where an
+    # assertion on the recorded body would keep passing against frozen YAML.
+    assert sent_bodies[0]['toolConfig']['functionCallingConfig']['mode'] == 'VALIDATED'
 
 
 class TreeNode(BaseModel):
@@ -326,7 +333,6 @@ class RecursiveAndDeep(BaseModel):
 async def test_google_validated_accepts_what_auto_accepts(
     allow_model_requests: None,
     google_model: GoogleModelFactory,
-    vcr: Any,
     strict: bool | None,
     expected_mode: str,
     expected_output: str,
@@ -341,7 +347,13 @@ async def test_google_validated_accepts_what_auto_accepts(
     The `strict=False` case doubles as the end-to-end proof of the documented opt-out: one non-strict
     tool puts the whole request back on `AUTO`, because Gemini's mode is request-wide.
     """
-    agent = Agent(google_model('gemini-2.5-flash'))
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def capture_request(request: httpx.Request) -> None:
+        sent_bodies.append(json.loads(request.read()))
+
+    http_client = httpx.AsyncClient(event_hooks={'request': [capture_request]})
+    agent = Agent(google_model('gemini-2.5-flash', http_client=http_client))
 
     @agent.tool_plain(strict=strict)
     def record(payload: RecursiveAndDeep) -> str:
@@ -353,10 +365,9 @@ async def test_google_validated_accepts_what_auto_accepts(
     )
     assert result.output == expected_output
 
-    first_request = get_first_post_body(vcr)
-    assert first_request['toolConfig']['functionCallingConfig']['mode'] == expected_mode
+    assert sent_bodies[0]['toolConfig']['functionCallingConfig']['mode'] == expected_mode
     # Pin both shapes as actually reaching the wire — if the transformer started inlining or
     # flattening them, the mode assertion above would still pass and the test would prove nothing.
-    schema = first_request['tools'][0]['functionDeclarations'][0]['parameters_json_schema']
+    schema = sent_bodies[0]['tools'][0]['functionDeclarations'][0]['parameters_json_schema']
     assert schema['$defs']['TreeNode']['properties']['children']['items'] == {'$ref': '#/$defs/TreeNode'}
     assert schema['$defs']['DeepA']['properties']['b'] == {'$ref': '#/$defs/DeepB'}


### PR DESCRIPTION
Follow-up to [#6353](https://github.com/pydantic/pydantic-ai/pull/6353) - cc @hramezani - ping me if you would rather keep this as is.

### What the matchers were for

The three end-to-end tests in `tests/models/google/test_output.py` assert on `get_first_post_body(vcr)`, which reads the request back out of the cassette being replayed. On its own that is tautological. The `function_calling_mode` / `function_declaration_count` matchers registered in `tests/models/google/conftest.py` are what gave those assertions teeth: making the field part of cassette matching means live code that stops sending `VALIDATED` fails to match its recording.

### What this does instead

`tests/AGENTS.md` calls the per-test matcher the fallback "for when you cannot tap the boundary", and names the httpx event hook as the default for asserting an outbound field. `GoogleProvider` takes an `http_client`, so the boundary is tappable here.

Each of the three tests now builds its model with a client carrying a `request` event hook and asserts on what the hook captured. The matcher registration and the three `additional_matchers` markers are gone, and `google_model` grew an optional `http_client` argument to make it possible.

Event hooks run inside `AsyncClient.send`, above the transport VCR patches, so they fire on replay and observe the request the live code actually built. Cassette matching is untouched.

### Coverage

Two mutations of `models/google.py`, one either side of `_get_tool_config`:

| mutation | `main` | this PR |
|---|---|---|
| `VALIDATED` → `AUTO` inside `_get_tool_config` | 6 failed | 6 failed |
| `tool_config` dropped where the request is built | 4 failed | 4 failed |

Parity on both. `tests/models/google/` is otherwise green - the two `test_code_execution` failures are pre-existing `inline_snapshot` cost drift on `main`. ruff and pyright clean.

### Secondary motivation

`register_matcher` is vcrpy-specific. I'm evaluating [cassetter](https://github.com/Kludex/cassetter) as a replacement for vcrpy/pytest-recording in this suite, and these two matchers were the only thing in the suite with no equivalent - worse, `additional_matchers` would be silently ignored there, leaving the tests passing with the gate gone. That is what surfaced this, but the change stands on its own: a hook is what `tests/AGENTS.md` asks for regardless of which VCR library we end up on.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
