### PR TITLE
Forward `model_id` through `WrapperModel` and resolve it against the active model in `TemporalModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -350,6 +350,16 @@ class TemporalModel(WrapperModel):
         return current.system
 
     @property
+    def model_id(self) -> str:
+        """Get the ID of the currently active model, rather than the default one's."""
+        current = self._current_model()
+        if isinstance(current, str):
+            # `system` and `model_name` already parse the raw ID, falling back to the default model's
+            # provider when the string names none, so recombining them is the answer here.
+            return f'{self.system}:{self.model_name}'
+        return current.model_id
+
+    @property
     def profile(self) -> ModelProfile:
         """Get the model profile, inferring from raw strings without provider construction.
 

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -121,6 +121,15 @@ class WrapperModel(Model):
         return self.wrapped.system
 
     @property
+    def model_id(self) -> str:
+        # `Model.model_id` derives from `system` and `model_name`, which are forwarded above, so for
+        # most models this override is redundant. It matters for a wrapped model that computes its own
+        # ID: `FallbackModel` joins its sub-models' `model_id`s, which recombining the two joined
+        # strings can't reproduce. The ID names a Temporal activity and keys a Prefect cache, so a
+        # mangled one isn't only a telemetry concern.
+        return self.wrapped.model_id
+
+    @property
     def profile(self) -> ModelProfile:  # type: ignore[override]
         return self.wrapped.profile
 

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -40,6 +40,7 @@ from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.models.fallback import FallbackModel, ResponseRejected
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
+from pydantic_ai.models.wrapper import WrapperModel
 from pydantic_ai.output import OutputObjectDefinition
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RequestUsage, UsageLimits
@@ -99,6 +100,19 @@ def test_all_fields_are_accessible() -> None:
     fallback_model = FallbackModel(failure_model, success_model)
     for f in dataclasses.fields(fallback_model):
         getattr(fallback_model, f.name)  # must not raise
+
+
+def test_model_id_survives_wrapping() -> None:
+    """A `WrapperModel` around a `FallbackModel` reports the fallback's own ID.
+
+    `Model.model_id` derives from `system` and `model_name`, so without a forward the wrapper
+    recombines the two already-joined fallback strings into an ID naming neither sub-model. Every
+    durability engine, `InstrumentedModel` and `ConcurrencyLimitedModel` interpose a wrapper here,
+    and the ID names a Temporal activity and keys a Prefect cache.
+    """
+    fallback_model = FallbackModel(failure_model, success_model)
+
+    assert WrapperModel(fallback_model).model_id == fallback_model.model_id
 
 
 def test_first_successful() -> None:
@@ -1912,8 +1926,6 @@ async def test_fallback_model_concurrent_entry():
     https://github.com/pydantic/pydantic-ai/pull/4421
     """
     import asyncio
-
-    from pydantic_ai.models.wrapper import WrapperModel
 
     class SlowEnterModel(WrapperModel):
         """Wrapper that yields during __aenter__ to widen the race window."""

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -104,6 +104,7 @@ from pydantic_ai.models import (
     infer_model,
     infer_model_profile,
 )
+from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
@@ -5468,6 +5469,33 @@ def test_temporal_model_base_url_follows_active_model():
 
     with temporal_model.using_model('openai:gpt-5'):
         assert temporal_model.base_url is None
+
+
+def test_temporal_model_model_id_follows_active_model():
+    """`model_id` resolves through `using_model()` rather than reporting the wrapped default's.
+
+    `WrapperModel` forwards `model_id` so a wrapped `FallbackModel` keeps its own composed ID, which
+    would otherwise pin this to the default model. The ID names the activity a request runs under, so
+    a swapped-in model has to be the one it reports.
+    """
+    temporal_model = TemporalModel(
+        TestModel(model_name='default-model'),
+        activity_name_prefix='test__model_id',
+        activity_config={'start_to_close_timeout': timedelta(seconds=60)},
+        deps_type=type(None),
+        models={'alt': FallbackModel(TestModel(model_name='alt-model'), TestModel(model_name='spare-model'))},
+    )
+
+    assert temporal_model.model_id == snapshot('test:default-model')
+
+    with temporal_model.using_model('alt'):
+        assert temporal_model.model_id == snapshot('fallback:test:alt-model,test:spare-model')
+
+    with temporal_model.using_model('openai:gpt-5'):
+        assert temporal_model.model_id == snapshot('openai:gpt-5')
+
+    with temporal_model.using_model('gpt-5'):
+        assert temporal_model.model_id == snapshot('test:gpt-5')
 
 
 async def test_temporal_model_request_outside_workflow():


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Follow-up to #7136, which forwarded `base_url` through `WrapperModel`. `model_id` has the same
problem in a narrower form.

`Model.model_id` derives from `system` and `model_name`, both already forwarded, so for most models
a wrapper already reports the right ID. It breaks for a wrapped model that computes its own:
`FallbackModel` joins its sub-models' `model_id`s, and recombining the two joined strings names
neither sub-model.

```python
inner = FallbackModel(TestModel(), FunctionModel(...))
inner.model_id                # 'fallback:test:test,function:function:<lambda>:'
WrapperModel(inner).model_id  # 'fallback:test,function:fallback:test,function:<lambda>:'
```

Every durability engine, `InstrumentedModel` and `ConcurrencyLimitedModel` interpose a
`WrapperModel` there, and the ID is not only telemetry: it names the Temporal activity a request
runs under (`durable_exec/temporal/_model.py`) and keys the Prefect request cache
(`durable_exec/prefect/_cache_policies.py`).

`TemporalModel` gets its own override for the same reason it needed one for `base_url`: its
`model_name`/`system` follow `_current_model()`, so forwarding to the wrapped default would pin the
ID to the default model while `using_model()` is active.

`label` is deliberately left alone — it derives purely from the already-forwarded `model_name` and
no `Model` subclass overrides it, so a forward would be dead code with no reachable behavior to test.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

