### PR TITLE
Use `openai_supports_minimal_reasoning_effort` in OpenAI model profiles

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -479,7 +479,7 @@ def _merge_leading_system_messages(
 
 def _resolve_openai_thinking_effort(thinking: ThinkingLevel, profile: OpenAIModelProfile) -> ReasoningEffort:
     """Map unified thinking to the closest reasoning effort the model supports."""
-    if thinking == 'minimal' and profile.get('openai_requires_minimal_reasoning_effort_fallback', False):
+    if thinking == 'minimal' and not profile.get('openai_supports_minimal_thinking_effort', True):
         return 'low'
     return OPENAI_REASONING_EFFORT_MAP[thinking]  # type: ignore[return-value]
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -479,7 +479,7 @@ def _merge_leading_system_messages(
 
 def _resolve_openai_thinking_effort(thinking: ThinkingLevel, profile: OpenAIModelProfile) -> ReasoningEffort:
     """Map unified thinking to the closest reasoning effort the model supports."""
-    if thinking == 'minimal' and not profile.get('openai_supports_minimal_thinking_effort', True):
+    if thinking == 'minimal' and not profile.get('openai_supports_minimal_reasoning_effort', True):
         return 'low'
     return OPENAI_REASONING_EFFORT_MAP[thinking]  # type: ignore[return-value]
 

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -252,11 +252,11 @@ class OpenAIModelProfile(ModelProfile, total=False):
     accepted in that mode. When reasoning is enabled (low/medium/high/xhigh), sampling params are not supported.
     Whether the model reasons by default is tracked separately by `openai_reasoning_enabled_by_default`."""
 
-    openai_supports_minimal_thinking_effort: bool
-    """Whether unified `thinking='minimal'` can use `reasoning_effort='minimal'`. Default: `True`.
+    openai_supports_minimal_reasoning_effort: bool
+    """Whether the model accepts `reasoning_effort='minimal'`. Default: `True`.
 
-    Disabled for GPT-5.6 models, whose documented reasoning efforts exclude `minimal`; unified `minimal`
-    thinking falls back to `reasoning_effort='low'` instead.
+    Disabled for GPT-5.6 models, whose documented reasoning efforts exclude `minimal`. When disabled,
+    unified `thinking='minimal'` falls back to `reasoning_effort='low'`.
     See https://developers.openai.com/api/docs/guides/latest-model.
     Explicit `openai_reasoning_effort='minimal'` settings are still passed through unchanged."""
 
@@ -389,7 +389,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
         openai_responses_supports_reasoning_context=reasoning.supports_context,
         openai_supports_phase=supports_phase,
         openai_supports_prompt_cache_breakpoints=supports_prompt_cache_breakpoints,
-        openai_supports_minimal_thinking_effort=not model_name.startswith('gpt-5.6'),
+        openai_supports_minimal_reasoning_effort=not model_name.startswith('gpt-5.6'),
         supported_native_tools=supported_native_tools,
         # A Responses request carrying `defer_loading` without `tool_search` is rejected outright:
         # `Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.` Set

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -252,10 +252,11 @@ class OpenAIModelProfile(ModelProfile, total=False):
     accepted in that mode. When reasoning is enabled (low/medium/high/xhigh), sampling params are not supported.
     Whether the model reasons by default is tracked separately by `openai_reasoning_enabled_by_default`."""
 
-    openai_requires_minimal_reasoning_effort_fallback: bool
-    """Whether unified `thinking='minimal'` must fall back to `reasoning_effort='low'`. Default: `False`.
+    openai_supports_minimal_thinking_effort: bool
+    """Whether unified `thinking='minimal'` can use `reasoning_effort='minimal'`. Default: `True`.
 
-    Set for GPT-5.6 models, whose documented reasoning efforts exclude `minimal`.
+    Disabled for GPT-5.6 models, whose documented reasoning efforts exclude `minimal`; unified `minimal`
+    thinking falls back to `reasoning_effort='low'` instead.
     See https://developers.openai.com/api/docs/guides/latest-model.
     Explicit `openai_reasoning_effort='minimal'` settings are still passed through unchanged."""
 
@@ -366,8 +367,6 @@ def openai_model_profile(model_name: str) -> ModelProfile:
     # known versions rather than matching open-endedly.
     # See https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints.
     supports_prompt_cache_breakpoints = model_name.startswith('gpt-5.6')
-    requires_minimal_reasoning_effort_fallback = model_name.startswith('gpt-5.6')
-
     # Structured Outputs (output mode 'native') is only supported with the gpt-4o-mini, gpt-4o-mini-2024-07-18,
     # and gpt-4o-2024-08-06 model snapshots and later. We leave it in here for all models because the
     # `default_structured_output_mode` is `'tool'`, so `native` is only used when the user specifically uses
@@ -390,7 +389,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
         openai_responses_supports_reasoning_context=reasoning.supports_context,
         openai_supports_phase=supports_phase,
         openai_supports_prompt_cache_breakpoints=supports_prompt_cache_breakpoints,
-        openai_requires_minimal_reasoning_effort_fallback=requires_minimal_reasoning_effort_fallback,
+        openai_supports_minimal_thinking_effort=not model_name.startswith('gpt-5.6'),
         supported_native_tools=supported_native_tools,
         # A Responses request carrying `defer_loading` without `tool_search` is rejected outright:
         # `Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.` Set

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -3,7 +3,7 @@
 Tests verify model profile detection for different OpenAI models, particularly the full desired
 reasoning-flag matrix per model version: `openai_supports_reasoning`,
 `openai_reasoning_enabled_by_default`, `openai_supports_reasoning_effort_none`,
-`openai_requires_minimal_reasoning_effort_fallback`, and `openai_responses_supports_reasoning_mode`.
+`openai_supports_minimal_thinking_effort`, and `openai_responses_supports_reasoning_mode`.
 """
 
 from __future__ import annotations as _annotations
@@ -44,8 +44,8 @@ class ReasoningCase:
     supports_mode: bool = False
     """The Responses API accepts `reasoning.mode` ('standard' | 'pro')."""
 
-    requires_minimal_effort_fallback: bool = False
-    """Unified minimal thinking must fall back to `reasoning.effort='low'`."""
+    supports_minimal_thinking_effort: bool = True
+    """Unified minimal thinking can use `reasoning.effort='minimal'`."""
 
     supports_context: bool = False
     """The Responses API accepts `reasoning.context='all_turns'`."""
@@ -100,7 +100,7 @@ REASONING_CASES = [
         enabled_by_default=True,
         can_be_disabled=True,
         supports_mode=True,
-        requires_minimal_effort_fallback=True,
+        supports_minimal_thinking_effort=False,
         supports_context=True,
     ),
     ReasoningCase(
@@ -108,7 +108,7 @@ REASONING_CASES = [
         enabled_by_default=True,
         can_be_disabled=True,
         supports_mode=True,
-        requires_minimal_effort_fallback=True,
+        supports_minimal_thinking_effort=False,
         supports_context=True,
     ),
     ReasoningCase(
@@ -116,7 +116,7 @@ REASONING_CASES = [
         enabled_by_default=True,
         can_be_disabled=True,
         supports_mode=True,
-        requires_minimal_effort_fallback=True,
+        supports_minimal_thinking_effort=False,
         supports_context=True,
     ),
     # no reasoning
@@ -137,9 +137,7 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('openai_supports_reasoning', False) is supports_reasoning
     assert profile.get('openai_reasoning_enabled_by_default', False) is case.enabled_by_default
     assert profile.get('openai_supports_reasoning_effort_none', False) is case.can_be_disabled
-    assert (
-        profile.get('openai_requires_minimal_reasoning_effort_fallback', False) is case.requires_minimal_effort_fallback
-    )
+    assert profile.get('openai_supports_minimal_thinking_effort', True) is case.supports_minimal_thinking_effort
     assert profile.get('openai_responses_supports_reasoning_mode', False) is case.supports_mode
     assert profile.get('openai_responses_supports_reasoning_context', False) is case.supports_context
     assert profile.get('supports_thinking', False) is supports_reasoning

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -3,7 +3,7 @@
 Tests verify model profile detection for different OpenAI models, particularly the full desired
 reasoning-flag matrix per model version: `openai_supports_reasoning`,
 `openai_reasoning_enabled_by_default`, `openai_supports_reasoning_effort_none`,
-`openai_supports_minimal_thinking_effort`, and `openai_responses_supports_reasoning_mode`.
+`openai_supports_minimal_reasoning_effort`, and `openai_responses_supports_reasoning_mode`.
 """
 
 from __future__ import annotations as _annotations
@@ -44,8 +44,8 @@ class ReasoningCase:
     supports_mode: bool = False
     """The Responses API accepts `reasoning.mode` ('standard' | 'pro')."""
 
-    supports_minimal_thinking_effort: bool = True
-    """Unified minimal thinking can use `reasoning.effort='minimal'`."""
+    supports_minimal_reasoning_effort: bool = True
+    """The model accepts `reasoning.effort='minimal'`."""
 
     supports_context: bool = False
     """The Responses API accepts `reasoning.context='all_turns'`."""
@@ -100,7 +100,7 @@ REASONING_CASES = [
         enabled_by_default=True,
         can_be_disabled=True,
         supports_mode=True,
-        supports_minimal_thinking_effort=False,
+        supports_minimal_reasoning_effort=False,
         supports_context=True,
     ),
     ReasoningCase(
@@ -108,7 +108,7 @@ REASONING_CASES = [
         enabled_by_default=True,
         can_be_disabled=True,
         supports_mode=True,
-        supports_minimal_thinking_effort=False,
+        supports_minimal_reasoning_effort=False,
         supports_context=True,
     ),
     ReasoningCase(
@@ -116,7 +116,7 @@ REASONING_CASES = [
         enabled_by_default=True,
         can_be_disabled=True,
         supports_mode=True,
-        supports_minimal_thinking_effort=False,
+        supports_minimal_reasoning_effort=False,
         supports_context=True,
     ),
     # no reasoning
@@ -137,7 +137,7 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('openai_supports_reasoning', False) is supports_reasoning
     assert profile.get('openai_reasoning_enabled_by_default', False) is case.enabled_by_default
     assert profile.get('openai_supports_reasoning_effort_none', False) is case.can_be_disabled
-    assert profile.get('openai_supports_minimal_thinking_effort', True) is case.supports_minimal_thinking_effort
+    assert profile.get('openai_supports_minimal_reasoning_effort', True) is case.supports_minimal_reasoning_effort
     assert profile.get('openai_responses_supports_reasoning_mode', False) is case.supports_mode
     assert profile.get('openai_responses_supports_reasoning_context', False) is case.supports_context
     assert profile.get('supports_thinking', False) is supports_reasoning

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -127,7 +127,7 @@ _CANONICAL_DEFAULTS: dict[str, Any] = {
     'openai_supports_reasoning': False,
     'openai_reasoning_enabled_by_default': False,
     'openai_supports_reasoning_effort_none': False,
-    'openai_requires_minimal_reasoning_effort_fallback': False,
+    'openai_supports_minimal_thinking_effort': True,
     'openai_responses_supports_reasoning_mode': False,
     'openai_responses_supports_reasoning_context': False,
     'openai_responses_requires_function_call_status_none': False,
@@ -330,7 +330,7 @@ def test_openai_gpt_5_6():
             'openai_supports_phase': True,
             'deferred_tools_require_tool_search': True,
             'openai_supports_prompt_cache_breakpoints': True,
-            'openai_requires_minimal_reasoning_effort_fallback': True,
+            'openai_supports_minimal_thinking_effort': False,
         }
     )
 

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -127,7 +127,7 @@ _CANONICAL_DEFAULTS: dict[str, Any] = {
     'openai_supports_reasoning': False,
     'openai_reasoning_enabled_by_default': False,
     'openai_supports_reasoning_effort_none': False,
-    'openai_supports_minimal_thinking_effort': True,
+    'openai_supports_minimal_reasoning_effort': True,
     'openai_responses_supports_reasoning_mode': False,
     'openai_responses_supports_reasoning_context': False,
     'openai_responses_requires_function_call_status_none': False,
@@ -330,7 +330,7 @@ def test_openai_gpt_5_6():
             'openai_supports_phase': True,
             'deferred_tools_require_tool_search': True,
             'openai_supports_prompt_cache_breakpoints': True,
-            'openai_supports_minimal_thinking_effort': False,
+            'openai_supports_minimal_reasoning_effort': False,
         }
     )
 

--- a/tests/providers/test_bedrock_mantle.py
+++ b/tests/providers/test_bedrock_mantle.py
@@ -252,7 +252,7 @@ def test_bedrock_mantle_profiles() -> None:
             'openai_supports_prompt_cache_breakpoints': True,
             'bedrock_mantle_interface': 'openai-responses',
             'deferred_tools_require_tool_search': True,
-            'openai_requires_minimal_reasoning_effort_fallback': True,
+            'openai_supports_minimal_thinking_effort': False,
             'openai_responses_tool_call_ids_are_response_scoped': True,
             'supported_native_tools': frozenset(),
         }

--- a/tests/providers/test_bedrock_mantle.py
+++ b/tests/providers/test_bedrock_mantle.py
@@ -252,7 +252,7 @@ def test_bedrock_mantle_profiles() -> None:
             'openai_supports_prompt_cache_breakpoints': True,
             'bedrock_mantle_interface': 'openai-responses',
             'deferred_tools_require_tool_search': True,
-            'openai_supports_minimal_thinking_effort': False,
+            'openai_supports_minimal_reasoning_effort': False,
             'openai_responses_tool_call_ids_are_response_scoped': True,
             'supported_native_tools': frozenset(),
         }

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -358,11 +358,21 @@ class TestOpenAIChatThinkingTranslation:
 
         assert result == 'low'
 
-    def test_thinking_minimal_passes_through_without_fallback(self):
-        """Not a VCR test: pins the flag-off side using a model that supports minimal effort."""
+    def test_thinking_minimal_passes_through_when_supported(self):
+        """Not a VCR test: pins the capability-on side using a model that supports minimal effort."""
         params = ModelRequestParameters(thinking='minimal')
         settings: ModelSettings = {}
         model = FunctionModel(_echo, profile=openai_model_profile('gpt-5'))
+
+        result = OpenAIChatModel._translate_thinking(model, settings, params)
+
+        assert result == 'minimal'
+
+    def test_thinking_minimal_passes_through_with_sparse_profile(self):
+        """Not a VCR test: pins the default for sparse OpenAI-compatible profiles."""
+        params = ModelRequestParameters(thinking='minimal')
+        settings: ModelSettings = {}
+        model = FunctionModel(_echo, profile=OpenAIModelProfile())
 
         result = OpenAIChatModel._translate_thinking(model, settings, params)
 
@@ -389,7 +399,7 @@ class TestOpenAIChatThinkingTranslation:
         settings = {'openai_reasoning_effort': 'minimal'}
         model = FunctionModel(
             _echo,
-            profile=OpenAIModelProfile(openai_requires_minimal_reasoning_effort_fallback=True),
+            profile=OpenAIModelProfile(openai_supports_minimal_thinking_effort=False),
         )
 
         result = OpenAIChatModel._translate_thinking(model, settings, params)
@@ -438,11 +448,21 @@ class TestOpenAIResponsesThinkingTranslation:
 
         assert result == snapshot({'effort': 'low', 'context': 'all_turns'})
 
-    def test_thinking_minimal_passes_through_without_fallback(self):
-        """Not a VCR test: pins the flag-off side using a model that supports minimal effort."""
+    def test_thinking_minimal_passes_through_when_supported(self):
+        """Not a VCR test: pins the capability-on side using a model that supports minimal effort."""
         params = ModelRequestParameters(thinking='minimal')
         settings: ModelSettings = {}
         model = FunctionModel(_echo, profile=openai_model_profile('gpt-5'))
+
+        result = OpenAIResponsesModel._translate_thinking(model, settings, params)
+
+        assert result == snapshot({'effort': 'minimal'})
+
+    def test_thinking_minimal_passes_through_with_sparse_profile(self):
+        """Not a VCR test: pins the default for sparse OpenAI-compatible profiles."""
+        params = ModelRequestParameters(thinking='minimal')
+        settings: ModelSettings = {}
+        model = FunctionModel(_echo, profile=OpenAIModelProfile())
 
         result = OpenAIResponsesModel._translate_thinking(model, settings, params)
 
@@ -461,7 +481,7 @@ class TestOpenAIResponsesThinkingTranslation:
         settings = {'openai_reasoning_effort': 'minimal'}
         model = FunctionModel(
             _echo,
-            profile=OpenAIModelProfile(openai_requires_minimal_reasoning_effort_fallback=True),
+            profile=OpenAIModelProfile(openai_supports_minimal_thinking_effort=False),
         )
 
         result = OpenAIResponsesModel._translate_thinking(model, settings, params)

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -399,7 +399,7 @@ class TestOpenAIChatThinkingTranslation:
         settings = {'openai_reasoning_effort': 'minimal'}
         model = FunctionModel(
             _echo,
-            profile=OpenAIModelProfile(openai_supports_minimal_thinking_effort=False),
+            profile=OpenAIModelProfile(openai_supports_minimal_reasoning_effort=False),
         )
 
         result = OpenAIChatModel._translate_thinking(model, settings, params)
@@ -481,7 +481,7 @@ class TestOpenAIResponsesThinkingTranslation:
         settings = {'openai_reasoning_effort': 'minimal'}
         model = FunctionModel(
             _echo,
-            profile=OpenAIModelProfile(openai_supports_minimal_thinking_effort=False),
+            profile=OpenAIModelProfile(openai_supports_minimal_reasoning_effort=False),
         )
 
         result = OpenAIResponsesModel._translate_thinking(model, settings, params)


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Follow-up to #7082.

Replace the unreleased negative `openai_requires_minimal_reasoning_effort_fallback` profile flag with the positive `openai_supports_minimal_reasoning_effort` capability. The profile now describes the intrinsic OpenAI API fact—whether the model accepts `reasoning_effort='minimal'`—while the unified `thinking='minimal'` fallback remains derived behavior.

- Default sparse OpenAI-compatible profiles to supporting `minimal`, preserving existing behavior.
- Mark GPT-5.6 profiles as unsupported so unified `thinking='minimal'` falls back to `reasoning_effort='low'`.
- Preserve explicit `openai_reasoning_effort='minimal'` passthrough.
- Pin supported, unsupported, and sparse-profile behavior across Chat and Responses.

No compatibility alias is included because #7082 merged after the latest published release, so the old field has not shipped.

### Test plan

- [x] Targeted profile, translation, resolution-matrix, and Bedrock Mantle tests pass.
- [x] Targeted Pyright passes.
- [x] `make format && make lint` passes.
- [x] Full pre-commit suite passes, including typecheck and cassette validation.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
