### PR TITLE
Document the `GROQ_BASE_URL` environment variable

### DIFF
--- a/docs/models/groq.md
+++ b/docs/models/groq.md
@@ -22,6 +22,12 @@ Once you have the API key, you can set it as an environment variable:
 export GROQ_API_KEY='your-api-key'
 ```
 
+To route requests through a different host, such as a proxy or a gateway, set `GROQ_BASE_URL` as well:
+
+```bash
+export GROQ_BASE_URL='https://your-proxy.example.com'
+```
+
 You can then use `GroqModel` by name:
 
 ```python


### PR DESCRIPTION
`GroqProvider` reads `GROQ_BASE_URL` when `base_url` is not passed, which is documented in the provider docstring but not on the Groq page. The page's Environment variable section only covers `GROQ_API_KEY`, so someone pointing Groq at a proxy or gateway through the environment has no way to find it from the docs.

Added it to that section, following the same shape as the Ollama page, which documents `OLLAMA_BASE_URL` alongside `OLLAMA_API_KEY`.

The behavior is already covered by `test_groq_provider_with_env_base_url` in `tests/providers/test_groq.py`, which sets `GROQ_BASE_URL` and asserts the resulting `provider.base_url`, so this documents what that test already pins. Ran it (passes) plus `uv run mkdocs build --strict`, no new warnings.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. freshman contributor, happy to adjust the wording or drop the proxy example if you would rather keep it to one line.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

