### PR TITLE
Document the `CO_BASE_URL` environment variable

### DIFF
--- a/docs/models/cohere.md
+++ b/docs/models/cohere.md
@@ -22,6 +22,12 @@ Once you have the API key, you can set it as an environment variable:
 export CO_API_KEY='your-api-key'
 ```
 
+To route requests through a different host, such as a proxy or a gateway, set `CO_BASE_URL` as well:
+
+```bash
+export CO_BASE_URL='https://your-proxy.example.com'
+```
+
 You can then use `CohereModel` by name:
 
 ```python


### PR DESCRIPTION
`CohereProvider` reads `CO_BASE_URL` and passes it to both the v1 and v2 Cohere clients, but the Cohere page only documents `CO_API_KEY`, so there is no way to discover it from the docs. Unlike the other providers this one is environment-only: `CohereProvider` takes no `base_url` argument, so the environment variable is the sole way to point it somewhere else.

Added it to the Environment variable section, matching the shape used on the Ollama page for `OLLAMA_BASE_URL`.

The behavior is already covered by `test_cohere_provider_with_env_base_url` in `tests/providers/test_cohere.py`, which sets `CO_BASE_URL` and asserts the resulting `provider.base_url`. Ran it (passes) plus `uv run mkdocs build --strict`, no new warnings.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: put this together with Claude Code and checked the diff myself. companion to the same fix on the Groq page, kept separate so each one is easy to review or drop on its own.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

