### PR TITLE
Cover and document DeepSeek V4 Flash via `OpenAIResponsesModel` + `DeepSeekProvider`

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -416,7 +416,7 @@ async def main():
 
 _(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
 
-On models that don't label their output, per [`OpenAIModelProfile.openai_supports_phase`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_supports_phase], `provider_details` has no `'phase'` key and nothing is sent back.
+A `'phase'` key appears in `provider_details` whenever the model labels its output, but it is only sent back on models that [`OpenAIModelProfile.openai_supports_phase`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_supports_phase] marks as accepting it. On every other model the label is surfaced to you and dropped from follow-up requests.
 
 ### Background mode
 
@@ -568,7 +568,7 @@ agent = Agent(model)
 ...
 ```
 
-As an alternative to the Chat Completions API shown above, DeepSeek also serves an OpenAI-compatible [Responses API](#responses-api-features), currently for the `deepseek-v4-flash` model only. Use it by pairing [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] with `DeepSeekProvider`:
+As an alternative to the Chat Completions API shown above, DeepSeek also serves an OpenAI-compatible [Responses API](#responses-api-features), [currently for the `deepseek-v4-flash` model only](https://api-docs.deepseek.com/guides/responses_api). Use it by pairing [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] with [`DeepSeekProvider`][pydantic_ai.providers.deepseek.DeepSeekProvider]:
 
 ```python
 from pydantic_ai import Agent
@@ -583,7 +583,11 @@ agent = Agent(model)
 ...
 ```
 
-DeepSeek's Responses API is stateless, so [`openai_previous_response_id`](#referencing-earlier-responses) and [`openai_conversation_id`](#using-durable-conversations) are not available: pass [message history](../message-history.md) back on each run instead.
+DeepSeek [documents](https://api-docs.deepseek.com/guides/responses_api) which parts of the Responses API it implements, and unsupported fields are silently ignored rather than rejected, so it's worth knowing what does nothing:
+
+- The API is stateless, so [`openai_previous_response_id`](#referencing-earlier-responses), [`openai_conversation_id`](#using-durable-conversations), [background mode](#background-mode) and [message compaction](#message-compaction) are unavailable. Pass [message history](../message-history.md) back on each run instead.
+- Of the [native tools](../native-tools.md), only [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool] is executed; the others are ignored rather than refused.
+- Reasoning is configured with `openai_reasoning_effort` (or the unified [`thinking`](../capabilities/thinking.md) setting); `openai_reasoning_summary` is accepted but produces no summary.
 
 ### Alibaba Cloud Model Studio (DashScope)
 

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -568,6 +568,23 @@ agent = Agent(model)
 ...
 ```
 
+As an alternative to the Chat Completions API shown above, DeepSeek also serves an OpenAI-compatible [Responses API](#responses-api-features), currently for the `deepseek-v4-flash` model only. Use it by pairing [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] with `DeepSeekProvider`:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.deepseek import DeepSeekProvider
+
+model = OpenAIResponsesModel(
+    'deepseek-v4-flash',
+    provider=DeepSeekProvider(api_key='your-deepseek-api-key'),
+)
+agent = Agent(model)
+...
+```
+
+DeepSeek's Responses API is stateless, so [`openai_previous_response_id`](#referencing-earlier-responses) and [`openai_conversation_id`](#using-durable-conversations) are not available: pass [message history](../message-history.md) back on each run instead.
+
 ### Alibaba Cloud Model Studio (DashScope)
 
 To use Qwen models via [Alibaba Cloud Model Studio (DashScope)](https://www.alibabacloud.com/en/product/modelstudio), you can set the `ALIBABA_API_KEY` (or `DASHSCOPE_API_KEY`) environment variable and use [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider] by name:

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -386,7 +386,7 @@ For lower-level use cases, you can call [`compact_messages`][pydantic_ai.models.
 
 ### Text phases
 
-Models that support it label each assistant message with a `phase`: `commentary` for the preamble the model writes while it works, and `final_answer` for the answer itself. Pydantic AI surfaces it as `'phase'` in [`TextPart.provider_details`][pydantic_ai.messages.TextPart.provider_details], and sends it back on the next request so the model keeps the distinction across turns.
+Models that support it label each assistant message with a `phase`: `commentary` for the preamble the model writes while it works, and `final_answer` for the answer itself. Pydantic AI surfaces it as `'phase'` in [`TextPart.provider_details`][pydantic_ai.messages.TextPart.provider_details], and on models known to accept the field it also sends it back on the next request so the model keeps the distinction across turns.
 
 When [streaming](../agent.md#streaming-all-events), the phase is set on the [`PartStartEvent`][pydantic_ai.messages.PartStartEvent] that opens each text part (including its first content chunk), so you can route commentary and the final answer differently as they're generated. Prefer [`run_stream_events`][pydantic_ai.agent.AbstractAgent.run_stream_events] for this: [`run_stream`][pydantic_ai.agent.AbstractAgent.run_stream] treats the first text part as the final output, which is often `commentary` on models that emit a preamble.
 
@@ -585,8 +585,10 @@ agent = Agent(model)
 
 DeepSeek [documents](https://api-docs.deepseek.com/guides/responses_api) which parts of the Responses API it implements, and unsupported fields are silently ignored rather than rejected, so it's worth knowing what does nothing:
 
-- The API is stateless, so [`openai_previous_response_id`](#referencing-earlier-responses), [`openai_conversation_id`](#using-durable-conversations), [background mode](#background-mode) and [message compaction](#message-compaction) are unavailable. Pass [message history](../message-history.md) back on each run instead.
-- Of the [native tools](../native-tools.md), only [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool] is executed; the others are ignored rather than refused.
+- The API is stateless, so [`openai_conversation_id`](#using-durable-conversations), [background mode](#background-mode) and [message compaction](#message-compaction) are unavailable. Pass [message history](../message-history.md) back on each run instead.
+- Leave [`openai_previous_response_id`](#referencing-earlier-responses) unset. Setting it makes Pydantic AI drop the earlier turns it assumes the server already holds, and DeepSeek stores nothing, so the model silently loses the conversation instead of erroring.
+- Of the [native tools](../native-tools.md), DeepSeek runs only [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool]; it ignores the other built-in tool types instead of reporting an error.
+- Image and document inputs are replaced with placeholder text rather than rejected.
 - Reasoning is configured with `openai_reasoning_effort` (or the unified [`thinking`](../capabilities/thinking.md) setting); `openai_reasoning_summary` is accepted but produces no summary.
 
 ### Alibaba Cloud Model Studio (DashScope)

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -45,7 +45,7 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
     def model_profile(model_name: str) -> ModelProfile | None:
         profile = deepseek_model_profile(model_name)
 
-        # As DeepSeekProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
+        # As DeepSeekProvider is most often used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
         # we need to maintain that behavior unless json_schema_transformer is set explicitly.
         # This was not the case when using a DeepSeek model with another model class (e.g. BedrockConverseModel or GroqModel),
         # so we won't do this in `deepseek_model_profile` unless we learn it's always needed.
@@ -62,6 +62,12 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
                 openai_supports_tool_choice_required=(
                     model_name != 'deepseek-reasoner' and not model_name.startswith('deepseek-v4-')
                 ),
+                # `openai_supports_phase` is deliberately left at its `False` default even though
+                # DeepSeek labels its Responses API output with `phase`: the field is absent from
+                # DeepSeek's documented input items, and its API silently ignores what it doesn't
+                # support, so a request carrying `phase` returns 200 without that proving the model
+                # reads it. Sending it back would add an undocumented field for no observable gain.
+                # See https://api-docs.deepseek.com/guides/responses_api.
             ),
         )
 

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[function_tool].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[function_tool].yaml
@@ -1,0 +1,269 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '411'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the temperature in Tokyo?
+        role: user
+      model: deepseek-v4-flash
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: Get the current temperature in a city.
+        name: get_temperature
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+          required:
+          - city
+          type: object
+        strict: true
+        type: function
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1732'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785967718
+      content_filters: null
+      created_at: 1785967717
+      error: null
+      frequency_penalty: 0.0
+      id: 92471b7c-94ad-452f-a3f5-c29aa74a95e1
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - text: The user asks for the temperature in Tokyo. I should call the get_temperature tool.
+          type: reasoning_text
+        id: 76f8b89e-4a41-46fb-86ae-546cc1e4ba6c
+        status: completed
+        summary: []
+        type: reasoning
+      - arguments: '{"city": "Tokyo"}'
+        call_id: call_00_iD0U8IMtyIljI0ET7GLz1318
+        id: 8fc1af85-3010-42b2-bcb8-1a6d5003ad3b
+        name: get_temperature
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: null
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools:
+      - description: Get the current temperature in a city.
+        name: get_temperature
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+          required:
+          - city
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 366
+        input_tokens_details:
+          cached_tokens: 256
+        output_tokens: 63
+        output_tokens_details:
+          reasoning_tokens: 18
+        total_tokens: 429
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '896'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the temperature in Tokyo?
+        role: user
+      - content:
+        - text: The user asks for the temperature in Tokyo. I should call the get_temperature tool.
+          type: reasoning_text
+        encrypted_content: null
+        id: 76f8b89e-4a41-46fb-86ae-546cc1e4ba6c
+        summary: []
+        type: reasoning
+      - arguments: '{"city": "Tokyo"}'
+        call_id: call_00_iD0U8IMtyIljI0ET7GLz1318
+        name: get_temperature
+        type: function_call
+      - call_id: call_00_iD0U8IMtyIljI0ET7GLz1318
+        output: '21.0'
+        type: function_call_output
+      model: deepseek-v4-flash
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: Get the current temperature in a city.
+        name: get_temperature
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+          required:
+          - city
+          type: object
+        strict: true
+        type: function
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1549'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785967719
+      content_filters: null
+      created_at: 1785967718
+      error: null
+      frequency_penalty: 0.0
+      id: 7f3d6c65-b8c2-410e-87ce-987bc467aef6
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - annotations: []
+          logprobs: []
+          text: The current temperature in Tokyo is 21.0°C.
+          type: output_text
+        id: f00869b9-665c-4653-b2ee-3857ef1413fd
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: null
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools:
+      - description: Get the current temperature in a city.
+        name: get_temperature
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+          required:
+          - city
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 444
+        input_tokens_details:
+          cached_tokens: 384
+        output_tokens: 14
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 458
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[function_tool_stream].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[function_tool_stream].yaml
@@ -1,0 +1,296 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '410'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the temperature in Tokyo?
+        role: user
+      model: deepseek-v4-flash
+      stream: true
+      tool_choice: auto
+      tools:
+      - description: Get the current temperature in a city.
+        name: get_temperature
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+          required:
+          - city
+          type: object
+        strict: true
+        type: function
+    uri: https://api.deepseek.com/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"1235b7ba-fdc9-4a1c-bfe4-6137c207baf3","object":"response","created_at":1785983456,"status":"in_progress","background":false,"completed_at":null,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[{"type":"function","name":"get_temperature","description":"Get the current temperature in a city.","parameters":{"additionalProperties":false,"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"1235b7ba-fdc9-4a1c-bfe4-6137c207baf3","object":"response","created_at":1785983456,"status":"in_progress","background":false,"completed_at":null,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[{"type":"function","name":"get_temperature","description":"Get the current temperature in a city.","parameters":{"additionalProperties":false,"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"type":"reasoning","id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","status":"in_progress","content":[],"summary":[]},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"part":{"type":"reasoning_text","text":""},"sequence_number":3}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":"The","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":4}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" user","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":5}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" asks","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":6}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" about","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":7}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" temperature","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":8}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" in","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":9}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" Tokyo","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":10}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":".","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":11}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" I","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":12}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":"'ll","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":13}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" call","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":14}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" the","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":15}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" tool","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":16}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":".","item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":17}
+
+        event: response.reasoning_text.done
+        data: {"type":"response.reasoning_text.done","content_index":0,"item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"sequence_number":18,"text":"The user asks about temperature in Tokyo. I'll call the tool."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","output_index":0,"part":{"type":"reasoning_text","text":"The user asks about temperature in Tokyo. I'll call the tool."},"sequence_number":19}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","status":"completed","content":[{"type":"reasoning_text","text":"The user asks about temperature in Tokyo. I'll call the tool."}],"summary":[]},"output_index":0,"sequence_number":20}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"type":"function_call","id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","status":"in_progress","arguments":"","call_id":"call_00_xjY8Z2BvSlzgEmmw0DtH0464","name":"get_temperature"},"output_index":1,"sequence_number":21}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"{","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":22}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"\"","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":23}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"city","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":24}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"\"","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":25}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":": ","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":26}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"\"","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":27}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"Tokyo","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":28}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"\"","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":29}
+
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","delta":"}","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":30}
+
+        event: response.function_call_arguments.done
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"city\": \"Tokyo\"}","item_id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","output_index":1,"sequence_number":31}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"function_call","id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","status":"completed","arguments":"{\"city\": \"Tokyo\"}","call_id":"call_00_xjY8Z2BvSlzgEmmw0DtH0464","name":"get_temperature"},"output_index":1,"sequence_number":32}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"1235b7ba-fdc9-4a1c-bfe4-6137c207baf3","object":"response","created_at":1785983456,"status":"completed","background":false,"completed_at":1785983456,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[{"type":"reasoning","id":"fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba","status":"completed","content":[{"type":"reasoning_text","text":"The user asks about temperature in Tokyo. I'll call the tool."}],"summary":[]},{"type":"function_call","id":"62bf2bb7-56af-4e3a-883b-83d4aad54da1","status":"completed","arguments":"{\"city\": \"Tokyo\"}","call_id":"call_00_xjY8Z2BvSlzgEmmw0DtH0464","name":"get_temperature"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[{"type":"function","name":"get_temperature","description":"Get the current temperature in a city.","parameters":{"additionalProperties":false,"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":366,"input_tokens_details":{"cached_tokens":256},"output_tokens":59,"output_tokens_details":{"reasoning_tokens":14},"total_tokens":425},"user":null,"metadata":{}},"sequence_number":33}
+
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      cache-control:
+      - no-cache
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '873'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the temperature in Tokyo?
+        role: user
+      - content:
+        - text: The user asks about temperature in Tokyo. I'll call the tool.
+          type: reasoning_text
+        encrypted_content: null
+        id: fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba
+        summary: []
+        type: reasoning
+      - arguments: '{"city": "Tokyo"}'
+        call_id: call_00_xjY8Z2BvSlzgEmmw0DtH0464
+        name: get_temperature
+        type: function_call
+      - call_id: call_00_xjY8Z2BvSlzgEmmw0DtH0464
+        output: '21.0'
+        type: function_call_output
+      model: deepseek-v4-flash
+      stream: true
+      tool_choice: auto
+      tools:
+      - description: Get the current temperature in a city.
+        name: get_temperature
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+          required:
+          - city
+          type: object
+        strict: true
+        type: function
+    uri: https://api.deepseek.com/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"33df88f0-9f36-4616-95b0-ead91a37f7f1","object":"response","created_at":1785983457,"status":"in_progress","background":false,"completed_at":null,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[{"type":"function","name":"get_temperature","description":"Get the current temperature in a city.","parameters":{"additionalProperties":false,"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"33df88f0-9f36-4616-95b0-ead91a37f7f1","object":"response","created_at":1785983457,"status":"in_progress","background":false,"completed_at":null,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[{"type":"function","name":"get_temperature","description":"Get the current temperature in a city.","parameters":{"additionalProperties":false,"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"type":"message","id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" current","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" temperature","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" in","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Tokyo","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"21","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":11}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":12}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"0","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":13}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"°","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":14}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"C","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":15}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"**.","item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":16}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","logprobs":[],"output_index":0,"sequence_number":17,"text":"The current temperature in Tokyo is **21.0°C**."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The current temperature in Tokyo is **21.0°C**."},"sequence_number":18}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"message","id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The current temperature in Tokyo is **21.0°C**."}],"phase":"final_answer","role":"assistant"},"output_index":0,"sequence_number":19}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"33df88f0-9f36-4616-95b0-ead91a37f7f1","object":"response","created_at":1785983457,"status":"completed","background":false,"completed_at":1785983457,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[{"type":"message","id":"305ae5c3-aed7-4986-88b5-4bcbb950ca6b","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The current temperature in Tokyo is **21.0°C**."}],"phase":"final_answer","role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[{"type":"function","name":"get_temperature","description":"Get the current temperature in a city.","parameters":{"additionalProperties":false,"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":440,"input_tokens_details":{"cached_tokens":384},"output_tokens":14,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":454},"user":null,"metadata":{}},"sequence_number":20}
+
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      cache-control:
+      - no-cache
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[reasoning_effort].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[reasoning_effort].yaml
@@ -1,0 +1,110 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '140'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 17 * 23?
+        role: user
+      model: deepseek-v4-flash
+      reasoning:
+        effort: high
+      stream: false
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1468'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785967721
+      content_filters: null
+      created_at: 1785967721
+      error: null
+      frequency_penalty: 0.0
+      id: 7a293ad0-b030-4055-a857-894eec88f488
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - text: We need answer simple. Need comply. 17*23 = 391. final.
+          type: reasoning_text
+        id: 99b90f85-3f3e-400c-b826-147f81c4672f
+        status: completed
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: '391'
+          type: output_text
+        id: d7c69e03-b418-418f-98ab-fe09ad528cc0
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: high
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools: []
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 91
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 20
+        output_tokens_details:
+          reasoning_tokens: 18
+        total_tokens: 111
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[structured_output].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[structured_output].yaml
@@ -1,0 +1,136 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '455'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the capital of Japan?
+        role: user
+      model: deepseek-v4-flash
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: The final response which ends this conversation
+        name: final_result
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+            country:
+              type: string
+          required:
+          - city
+          - country
+          type: object
+        strict: true
+        type: function
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1810'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785967720
+      content_filters: null
+      created_at: 1785967719
+      error: null
+      frequency_penalty: 0.0
+      id: 4333ebf8-e16c-4969-b5ac-fde1294e642a
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - text: The user asked for the capital of Japan, which is Tokyo. I should use the final_result tool.
+          type: reasoning_text
+        id: eaa32d41-e515-4399-adf5-9ef8c58fc62d
+        status: completed
+        summary: []
+        type: reasoning
+      - arguments: '{"city": "Tokyo", "country": "Japan"}'
+        call_id: call_00_fHeIT46fj9tK0YhyHu7Q9878
+        id: c830d5e3-c87c-4e9c-9150-b157d70e5f9f
+        name: final_result
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: null
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools:
+      - description: The final response which ends this conversation
+        name: final_result
+        parameters:
+          additionalProperties: false
+          properties:
+            city:
+              type: string
+            country:
+              type: string
+          required:
+          - city
+          - country
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 376
+        input_tokens_details:
+          cached_tokens: 256
+        output_tokens: 81
+        output_tokens_details:
+          reasoning_tokens: 21
+        total_tokens: 457
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[text].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[text].yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '121'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the capital of France?
+        role: user
+      model: deepseek-v4-flash
+      stream: false
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1471'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785967715
+      content_filters: null
+      created_at: 1785967714
+      error: null
+      frequency_penalty: 0.0
+      id: 2e532992-cac2-41fd-80b5-c98ad79215f3
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - text: We need answer capital of France.
+          type: reasoning_text
+        id: 1dfb7474-dbd9-4b8d-a852-ebe49345dd32
+        status: completed
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: The capital of France is Paris.
+          type: output_text
+        id: 8050c022-c55f-4377-b009-1d6341eacc57
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: null
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools: []
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 90
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 15
+        output_tokens_details:
+          reasoning_tokens: 7
+        total_tokens: 105
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[text_multi_turn].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[text_multi_turn].yaml
@@ -1,0 +1,227 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '109'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: 'Say exactly: hello'
+        role: user
+      model: deepseek-v4-flash
+      stream: false
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1439'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785983454
+      content_filters: null
+      created_at: 1785983453
+      error: null
+      frequency_penalty: 0.0
+      id: 49d254fd-deb4-4207-a85a-038a3893db25
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - text: We need answer exactly hello.
+          type: reasoning_text
+        id: 1e97d346-aa16-46e5-866d-b34e91c5d499
+        status: completed
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: hello
+          type: output_text
+        id: c431c0bc-edd8-4d1d-9bab-46ddd59d15e1
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: null
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools: []
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 87
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 8
+        output_tokens_details:
+          reasoning_tokens: 6
+        total_tokens: 95
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '402'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: 'Say exactly: hello'
+        role: user
+      - content:
+        - text: We need answer exactly hello.
+          type: reasoning_text
+        encrypted_content: null
+        id: 1e97d346-aa16-46e5-866d-b34e91c5d499
+        summary: []
+        type: reasoning
+      - content: hello
+        role: assistant
+      - content: 'Now say exactly: goodbye'
+        role: user
+      model: deepseek-v4-flash
+      stream: false
+    uri: https://api.deepseek.com/responses
+  response:
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      connection:
+      - keep-alive
+      content-length:
+      - '1662'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    parsed_body:
+      background: false
+      completed_at: 1785983455
+      content_filters: null
+      created_at: 1785983454
+      error: null
+      frequency_penalty: 0.0
+      id: cad18dc8-ce7a-4247-8cd7-d9574926a924
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: deepseek-v4-flash
+      moderation: null
+      object: response
+      output:
+      - content:
+        - text: 'We need to respond to the user. The user said "Now say exactly: goodbye". The instruction is to say exactly
+            "goodbye". We already responded "hello" to the previous "Say exactly: hello". Now we just output "goodbye". Ensure
+            no extra text.'
+          type: reasoning_text
+        id: 3e320fb9-da94-4b4f-8ef8-08d750d3cdf9
+        status: completed
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: goodbye
+          type: output_text
+        id: 2d999a8e-8086-4e87-bf7e-051cab5b9181
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: null
+      reasoning:
+        effort: null
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: false
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: null
+      tool_choice: auto
+      tools: []
+      top_logprobs: 0
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 97
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 59
+        output_tokens_details:
+          reasoning_tokens: 56
+        total_tokens: 156
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[text_stream].yaml
+++ b/tests/models/cassettes/test_deepseek_responses/test_deepseek_responses[text_stream].yaml
@@ -1,0 +1,127 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '120'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is the capital of France?
+        role: user
+      model: deepseek-v4-flash
+      stream: true
+    uri: https://api.deepseek.com/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"bf5e7791-6c05-44ca-b7e0-56aa217150b1","object":"response","created_at":1785967715,"status":"in_progress","background":false,"completed_at":null,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"bf5e7791-6c05-44ca-b7e0-56aa217150b1","object":"response","created_at":1785967715,"status":"in_progress","background":false,"completed_at":null,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"type":"reasoning","id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","status":"in_progress","content":[],"summary":[]},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"part":{"type":"reasoning_text","text":""},"sequence_number":3}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":"We","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":4}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" need","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":5}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" answer","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":6}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" capital","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":7}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" of","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":8}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":" France","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":9}
+
+        event: response.reasoning_text.delta
+        data: {"type":"response.reasoning_text.delta","content_index":0,"delta":".","item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":10}
+
+        event: response.reasoning_text.done
+        data: {"type":"response.reasoning_text.done","content_index":0,"item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"sequence_number":11,"text":"We need answer capital of France."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","output_index":0,"part":{"type":"reasoning_text","text":"We need answer capital of France."},"sequence_number":12}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","status":"completed","content":[{"type":"reasoning_text","text":"We need answer capital of France."}],"summary":[]},"output_index":0,"sequence_number":13}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"type":"message","id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":14}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":15}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":16}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" capital","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":17}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":18}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" France","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":19}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":20}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Paris","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":21}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":22}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","logprobs":[],"output_index":1,"sequence_number":23,"text":"The capital of France is Paris."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of France is Paris."},"sequence_number":24}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"message","id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of France is Paris."}],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":25}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"bf5e7791-6c05-44ca-b7e0-56aa217150b1","object":"response","created_at":1785967715,"status":"completed","background":false,"completed_at":1785967716,"content_filters":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"deepseek-v4-flash","moderation":null,"output":[{"type":"reasoning","id":"b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80","status":"completed","content":[{"type":"reasoning_text","text":"We need answer capital of France."}],"summary":[]},{"type":"message","id":"f9be6778-cb0b-4264-8d37-24af0349d7ef","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of France is Paris."}],"phase":"final_answer","role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":null},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":90,"input_tokens_details":{"cached_tokens":0},"output_tokens":15,"output_tokens_details":{"reasoning_tokens":7},"total_tokens":105},"user":null,"metadata":{}},"sequence_number":26}
+
+    headers:
+      access-control-allow-credentials:
+      - 'true'
+      cache-control:
+      - no-cache
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -1,8 +1,8 @@
 """DeepSeek's OpenAI-compatible Responses API, driven by `OpenAIResponsesModel` + `DeepSeekProvider`.
 
 DeepSeek exposes a Responses endpoint at `https://api.deepseek.com/responses`, currently for
-`deepseek-v4-flash` only (the V4-Flash-0731 backend). It is stateless — requests are recorded with
-`store: false` and there is no server-side conversation to resume — so `previous_response_id`
+`deepseek-v4-flash` only (the V4-Flash-0731 backend). It is stateless — every response reports
+`store: false`, and there is no server-side conversation to resume — so `previous_response_id`
 continuation is not available and is not exercised here.
 
 Each case snapshots both the resulting messages and the bodies that actually went out, captured by an
@@ -193,6 +193,10 @@ CASES = [
             ]
         ),
     ),
+    # The follow-up request body is where the `openai_supports_phase` off side is pinned: DeepSeek
+    # labels its answer `final_answer` on the way in, and the assistant turn goes back out as a
+    # bare `{'role': 'assistant', 'content': ...}` with no `phase` key. Flipping the flag on would
+    # add one and fail this snapshot.
     Case(
         id='text_multi_turn',
         prompt='Say exactly: hello',

--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -1,0 +1,534 @@
+"""DeepSeek's OpenAI-compatible Responses API, driven by `OpenAIResponsesModel` + `DeepSeekProvider`.
+
+DeepSeek exposes a Responses endpoint at `https://api.deepseek.com/responses`, currently for
+`deepseek-v4-flash` only (the V4-Flash-0731 backend). It is stateless — requests are recorded with
+`store: false` and there is no server-side conversation to resume — so `previous_response_id`
+continuation is not available and is not exercised here.
+
+Each case snapshots both the resulting messages and the bodies that actually went out, captured by an
+httpx event hook so the wire assertions run against what the client built rather than what the
+cassette happens to hold. The request bodies are what pin the two facts this pairing rests on: the
+`openai_reasoning_effort` setting reaching DeepSeek as `reasoning.effort`, and DeepSeek's raw
+chain-of-thought being sent back as `reasoning_text` content on the follow-up request of a tool call.
+"""
+
+from __future__ import annotations as _annotations
+
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai import (
+    Agent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ThinkingPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.usage import RequestUsage
+
+from .._inline_snapshot import snapshot
+from ..conftest import IsDatetime, IsStr, try_import
+
+with try_import() as imports_successful:
+    from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
+    from pydantic_ai.providers.deepseek import DeepSeekProvider
+
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
+    pytest.mark.anyio,
+    pytest.mark.vcr,
+]
+
+
+class City(BaseModel):
+    city: str
+    country: str
+
+
+def get_temperature(city: str) -> float:
+    """Get the current temperature in a city."""
+    return 21.0
+
+
+@dataclass
+class Case:
+    id: str
+    prompt: str
+    stream: bool = False
+    output_type: type[str] | type[City] = str
+    tools: Sequence[Callable[..., Any]] = ()
+    model_settings: OpenAIResponsesModelSettings | None = None
+    expected_output: str | City = ''
+    expected_messages: list[ModelMessage] = field(default_factory=list[ModelMessage])
+    expected_request_bodies: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
+
+
+CASES = [
+    Case(
+        id='text',
+        prompt='What is the capital of France?',
+        expected_output=snapshot('The capital of France is Paris.'),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='What is the capital of France?', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='1dfb7474-dbd9-4b8d-a852-ebe49345dd32',
+                            provider_name='deepseek',
+                            provider_details={'raw_content': ['We need answer capital of France.']},
+                        ),
+                        TextPart(
+                            content='The capital of France is Paris.',
+                            id='8050c022-c55f-4377-b009-1d6341eacc57',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 7},
+                        input_tokens=90,
+                        output_reasoning_tokens=7,
+                        output_tokens=15,
+                        cost=Decimal('0.0000168'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='2e532992-cac2-41fd-80b5-c98ad79215f3',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'What is the capital of France?'}],
+                    'model': 'deepseek-v4-flash',
+                    'stream': False,
+                }
+            ]
+        ),
+    ),
+    Case(
+        id='text_stream',
+        prompt='What is the capital of France?',
+        stream=True,
+        expected_output=snapshot('The capital of France is Paris.'),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='What is the capital of France?', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='b594b7e1-3dbb-4b65-b8c2-f4f5aae4ee80',
+                            provider_name='deepseek',
+                            provider_details={'raw_content': ['We need answer capital of France.']},
+                        ),
+                        TextPart(
+                            content='The capital of France is Paris.',
+                            id='f9be6778-cb0b-4264-8d37-24af0349d7ef',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 7},
+                        output_tokens=15,
+                        output_reasoning_tokens=7,
+                        input_tokens=90,
+                        cost=Decimal('0.0000168'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'timestamp': IsDatetime(), 'finish_reason': 'completed'},
+                    provider_response_id='bf5e7791-6c05-44ca-b7e0-56aa217150b1',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'What is the capital of France?'}],
+                    'model': 'deepseek-v4-flash',
+                    'stream': True,
+                }
+            ]
+        ),
+    ),
+    Case(
+        id='function_tool',
+        prompt='What is the temperature in Tokyo?',
+        tools=[get_temperature],
+        expected_output=snapshot('The current temperature in Tokyo is 21.0°C.'),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='What is the temperature in Tokyo?', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='76f8b89e-4a41-46fb-86ae-546cc1e4ba6c',
+                            provider_name='deepseek',
+                            provider_details={
+                                'raw_content': [
+                                    'The user asks for the temperature in Tokyo. I should call the get_temperature tool.'
+                                ]
+                            },
+                        ),
+                        ToolCallPart(
+                            tool_name=get_temperature.__qualname__,
+                            args='{"city": "Tokyo"}',
+                            tool_call_id='call_00_iD0U8IMtyIljI0ET7GLz1318',
+                            id='8fc1af85-3010-42b2-bcb8-1a6d5003ad3b',
+                            provider_name='deepseek',
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 18},
+                        input_tokens=366,
+                        cache_read_tokens=256,
+                        output_reasoning_tokens=18,
+                        output_tokens=63,
+                        cost=Decimal('0.0000337568'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='92471b7c-94ad-452f-a3f5-c29aa74a95e1',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name=get_temperature.__qualname__,
+                            content=21.0,
+                            tool_call_id='call_00_iD0U8IMtyIljI0ET7GLz1318',
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        TextPart(
+                            content='The current temperature in Tokyo is 21.0°C.',
+                            id='f00869b9-665c-4653-b2ee-3857ef1413fd',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        )
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 0},
+                        input_tokens=444,
+                        cache_read_tokens=384,
+                        output_reasoning_tokens=0,
+                        output_tokens=14,
+                        cost=Decimal('0.0000133952'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='7f3d6c65-b8c2-410e-87ce-987bc467aef6',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'What is the temperature in Tokyo?'}],
+                    'model': 'deepseek-v4-flash',
+                    'stream': False,
+                    'tool_choice': 'auto',
+                    'tools': [
+                        {
+                            'name': get_temperature.__qualname__,
+                            'parameters': {
+                                'additionalProperties': False,
+                                'properties': {'city': {'type': 'string'}},
+                                'required': ['city'],
+                                'type': 'object',
+                            },
+                            'type': 'function',
+                            'description': 'Get the current temperature in a city.',
+                            'strict': True,
+                        }
+                    ],
+                },
+                {
+                    'input': [
+                        {'role': 'user', 'content': 'What is the temperature in Tokyo?'},
+                        {
+                            'id': '76f8b89e-4a41-46fb-86ae-546cc1e4ba6c',
+                            'summary': [],
+                            'encrypted_content': None,
+                            'type': 'reasoning',
+                            'content': [
+                                {
+                                    'text': 'The user asks for the temperature in Tokyo. I should call the get_temperature tool.',
+                                    'type': 'reasoning_text',
+                                }
+                            ],
+                        },
+                        {
+                            'name': get_temperature.__qualname__,
+                            'arguments': '{"city": "Tokyo"}',
+                            'call_id': 'call_00_iD0U8IMtyIljI0ET7GLz1318',
+                            'type': 'function_call',
+                        },
+                        {
+                            'type': 'function_call_output',
+                            'call_id': 'call_00_iD0U8IMtyIljI0ET7GLz1318',
+                            'output': '21.0',
+                        },
+                    ],
+                    'model': 'deepseek-v4-flash',
+                    'stream': False,
+                    'tool_choice': 'auto',
+                    'tools': [
+                        {
+                            'name': get_temperature.__qualname__,
+                            'parameters': {
+                                'additionalProperties': False,
+                                'properties': {'city': {'type': 'string'}},
+                                'required': ['city'],
+                                'type': 'object',
+                            },
+                            'type': 'function',
+                            'description': 'Get the current temperature in a city.',
+                            'strict': True,
+                        }
+                    ],
+                },
+            ]
+        ),
+    ),
+    Case(
+        id='structured_output',
+        prompt='What is the capital of Japan?',
+        output_type=City,
+        expected_output=snapshot(City(city='Tokyo', country='Japan')),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='What is the capital of Japan?', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='eaa32d41-e515-4399-adf5-9ef8c58fc62d',
+                            provider_name='deepseek',
+                            provider_details={
+                                'raw_content': [
+                                    'The user asked for the capital of Japan, which is Tokyo. I should use the final_result tool.'
+                                ]
+                            },
+                        ),
+                        ToolCallPart(
+                            tool_name='final_result',
+                            args='{"city": "Tokyo", "country": "Japan"}',
+                            tool_call_id='call_00_fHeIT46fj9tK0YhyHu7Q9878',
+                            id='c830d5e3-c87c-4e9c-9150-b157d70e5f9f',
+                            provider_name='deepseek',
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 21},
+                        input_tokens=376,
+                        cache_read_tokens=256,
+                        output_reasoning_tokens=21,
+                        output_tokens=81,
+                        cost=Decimal('0.0000401968'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='4333ebf8-e16c-4969-b5ac-fde1294e642a',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name='final_result',
+                            content='Final result processed.',
+                            tool_call_id='call_00_fHeIT46fj9tK0YhyHu7Q9878',
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'What is the capital of Japan?'}],
+                    'model': 'deepseek-v4-flash',
+                    'stream': False,
+                    'tool_choice': 'auto',
+                    'tools': [
+                        {
+                            'name': 'final_result',
+                            'parameters': {
+                                'properties': {'city': {'type': 'string'}, 'country': {'type': 'string'}},
+                                'required': ['city', 'country'],
+                                'type': 'object',
+                                'additionalProperties': False,
+                            },
+                            'type': 'function',
+                            'description': 'The final response which ends this conversation',
+                            'strict': True,
+                        }
+                    ],
+                }
+            ]
+        ),
+    ),
+    Case(
+        id='reasoning_effort',
+        prompt='What is 17 * 23?',
+        model_settings=OpenAIResponsesModelSettings(openai_reasoning_effort='high'),
+        expected_output=snapshot('391'),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='What is 17 * 23?', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='99b90f85-3f3e-400c-b826-147f81c4672f',
+                            provider_name='deepseek',
+                            provider_details={
+                                'raw_content': ['We need answer simple. Need comply. 17*23 = 391. final.']
+                            },
+                        ),
+                        TextPart(
+                            content='391',
+                            id='d7c69e03-b418-418f-98ab-fe09ad528cc0',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 18},
+                        input_tokens=91,
+                        output_reasoning_tokens=18,
+                        output_tokens=20,
+                        cost=Decimal('0.00001834'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='7a293ad0-b030-4055-a857-894eec88f488',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'What is 17 * 23?'}],
+                    'model': 'deepseek-v4-flash',
+                    'reasoning': {'effort': 'high'},
+                    'stream': False,
+                }
+            ]
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize('case', [pytest.param(c, id=c.id) for c in CASES])
+async def test_deepseek_responses(case: Case, allow_model_requests: None, deepseek_api_key: str):
+    """`OpenAIResponsesModel('deepseek-v4-flash', provider=DeepSeekProvider())` against the live API."""
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def capture_request(request: httpx.Request) -> None:
+        sent_bodies.append(json.loads(request.read()))
+
+    http_client = httpx.AsyncClient(event_hooks={'request': [capture_request]})
+    model = OpenAIResponsesModel(
+        'deepseek-v4-flash', provider=DeepSeekProvider(api_key=deepseek_api_key, http_client=http_client)
+    )
+    agent = Agent(model, output_type=case.output_type, tools=case.tools, model_settings=case.model_settings)
+
+    if case.stream:
+        async with agent.run_stream(case.prompt) as streamed:
+            output = await streamed.get_output()
+        messages = streamed.all_messages()
+    else:
+        result = await agent.run(case.prompt)
+        output = result.output
+        messages = result.all_messages()
+
+    assert output == case.expected_output
+    assert messages == case.expected_messages
+    assert sent_bodies == case.expected_request_bodies

--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -7,9 +7,12 @@ continuation is not available and is not exercised here.
 
 Each case snapshots both the resulting messages and the bodies that actually went out, captured by an
 httpx event hook so the wire assertions run against what the client built rather than what the
-cassette happens to hold. The request bodies are what pin the two facts this pairing rests on: the
-`openai_reasoning_effort` setting reaching DeepSeek as `reasoning.effort`, and DeepSeek's raw
-chain-of-thought being sent back as `reasoning_text` content on the follow-up request of a tool call.
+cassette happens to hold. The request bodies are what pin the facts this pairing rests on:
+
+- the `openai_reasoning_effort` setting reaching DeepSeek as `reasoning.effort`
+- DeepSeek's raw chain-of-thought going back as `reasoning_text` content on a follow-up request
+- the `phase` DeepSeek labels its output with being surfaced in `provider_details` but never sent
+  back, since `openai_supports_phase` stays off for a provider that doesn't document accepting it
 """
 
 from __future__ import annotations as _annotations
@@ -62,10 +65,11 @@ def get_temperature(city: str) -> float:
     return 21.0
 
 
-@dataclass
+@dataclass(frozen=True)
 class Case:
     id: str
     prompt: str
+    follow_up_prompt: str | None = None
     stream: bool = False
     output_type: type[str] | type[City] = str
     tools: Sequence[Callable[..., Any]] = ()
@@ -186,6 +190,121 @@ CASES = [
                     'model': 'deepseek-v4-flash',
                     'stream': True,
                 }
+            ]
+        ),
+    ),
+    Case(
+        id='text_multi_turn',
+        prompt='Say exactly: hello',
+        follow_up_prompt='Now say exactly: goodbye',
+        expected_output=snapshot('goodbye'),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='Say exactly: hello', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='1e97d346-aa16-46e5-866d-b34e91c5d499',
+                            provider_name='deepseek',
+                            provider_details={'raw_content': ['We need answer exactly hello.']},
+                        ),
+                        TextPart(
+                            content='hello',
+                            id='c431c0bc-edd8-4d1d-9bab-46ddd59d15e1',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 6},
+                        input_tokens=87,
+                        output_reasoning_tokens=6,
+                        output_tokens=8,
+                        cost=Decimal('0.00001442'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='49d254fd-deb4-4207-a85a-038a3893db25',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[UserPromptPart(content='Now say exactly: goodbye', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='3e320fb9-da94-4b4f-8ef8-08d750d3cdf9',
+                            provider_name='deepseek',
+                            provider_details={
+                                'raw_content': [
+                                    'We need to respond to the user. The user said "Now say exactly: goodbye". The instruction is to say exactly "goodbye". We already responded "hello" to the previous "Say exactly: hello". Now we just output "goodbye". Ensure no extra text.'
+                                ]
+                            },
+                        ),
+                        TextPart(
+                            content='goodbye',
+                            id='2d999a8e-8086-4e87-bf7e-051cab5b9181',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 56},
+                        input_tokens=97,
+                        output_reasoning_tokens=56,
+                        output_tokens=59,
+                        cost=Decimal('0.00003010'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'finish_reason': 'completed', 'timestamp': IsDatetime()},
+                    provider_response_id='cad18dc8-ce7a-4247-8cd7-d9574926a924',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'Say exactly: hello'}],
+                    'model': 'deepseek-v4-flash',
+                    'stream': False,
+                },
+                {
+                    'input': [
+                        {'role': 'user', 'content': 'Say exactly: hello'},
+                        {
+                            'id': '1e97d346-aa16-46e5-866d-b34e91c5d499',
+                            'summary': [],
+                            'encrypted_content': None,
+                            'type': 'reasoning',
+                            'content': [{'text': 'We need answer exactly hello.', 'type': 'reasoning_text'}],
+                        },
+                        {'role': 'assistant', 'content': 'hello'},
+                        {'role': 'user', 'content': 'Now say exactly: goodbye'},
+                    ],
+                    'model': 'deepseek-v4-flash',
+                    'stream': False,
+                },
             ]
         ),
     ),
@@ -333,6 +452,168 @@ CASES = [
                     ],
                     'model': 'deepseek-v4-flash',
                     'stream': False,
+                    'tool_choice': 'auto',
+                    'tools': [
+                        {
+                            'name': get_temperature.__qualname__,
+                            'parameters': {
+                                'additionalProperties': False,
+                                'properties': {'city': {'type': 'string'}},
+                                'required': ['city'],
+                                'type': 'object',
+                            },
+                            'type': 'function',
+                            'description': 'Get the current temperature in a city.',
+                            'strict': True,
+                        }
+                    ],
+                },
+            ]
+        ),
+    ),
+    Case(
+        id='function_tool_stream',
+        prompt='What is the temperature in Tokyo?',
+        stream=True,
+        tools=[get_temperature],
+        expected_output=snapshot('The current temperature in Tokyo is **21.0°C**.'),
+        expected_messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='What is the temperature in Tokyo?', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ThinkingPart(
+                            content='',
+                            id='fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba',
+                            provider_name='deepseek',
+                            provider_details={
+                                'raw_content': ["The user asks about temperature in Tokyo. I'll call the tool."]
+                            },
+                        ),
+                        ToolCallPart(
+                            tool_name=get_temperature.__qualname__,
+                            args='{"city": "Tokyo"}',
+                            tool_call_id='call_00_xjY8Z2BvSlzgEmmw0DtH0464',
+                            id='62bf2bb7-56af-4e3a-883b-83d4aad54da1',
+                            provider_name='deepseek',
+                        ),
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 14},
+                        output_tokens=59,
+                        output_reasoning_tokens=14,
+                        cache_read_tokens=256,
+                        input_tokens=366,
+                        cost=Decimal('0.0000326368'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'timestamp': IsDatetime(), 'finish_reason': 'completed'},
+                    provider_response_id='1235b7ba-fdc9-4a1c-bfe4-6137c207baf3',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name=get_temperature.__qualname__,
+                            content=21.0,
+                            tool_call_id='call_00_xjY8Z2BvSlzgEmmw0DtH0464',
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        TextPart(
+                            content='The current temperature in Tokyo is **21.0°C**.',
+                            id='305ae5c3-aed7-4986-88b5-4bcbb950ca6b',
+                            provider_name='deepseek',
+                            provider_details={'phase': 'final_answer'},
+                        )
+                    ],
+                    usage=RequestUsage(
+                        details={'reasoning_tokens': 0},
+                        output_tokens=14,
+                        output_reasoning_tokens=0,
+                        cache_read_tokens=384,
+                        input_tokens=440,
+                        cost=Decimal('0.0000128352'),
+                    ),
+                    model_name='deepseek-v4-flash',
+                    timestamp=IsDatetime(),
+                    provider_name='deepseek',
+                    provider_url='https://api.deepseek.com',
+                    provider_details={'timestamp': IsDatetime(), 'finish_reason': 'completed'},
+                    provider_response_id='33df88f0-9f36-4616-95b0-ead91a37f7f1',
+                    finish_reason='stop',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        expected_request_bodies=snapshot(
+            [
+                {
+                    'input': [{'role': 'user', 'content': 'What is the temperature in Tokyo?'}],
+                    'model': 'deepseek-v4-flash',
+                    'stream': True,
+                    'tool_choice': 'auto',
+                    'tools': [
+                        {
+                            'name': get_temperature.__qualname__,
+                            'parameters': {
+                                'additionalProperties': False,
+                                'properties': {'city': {'type': 'string'}},
+                                'required': ['city'],
+                                'type': 'object',
+                            },
+                            'type': 'function',
+                            'description': 'Get the current temperature in a city.',
+                            'strict': True,
+                        }
+                    ],
+                },
+                {
+                    'input': [
+                        {'role': 'user', 'content': 'What is the temperature in Tokyo?'},
+                        {
+                            'id': 'fa6f3a83-5d25-46e8-9d03-1a89ce5cf2ba',
+                            'summary': [],
+                            'encrypted_content': None,
+                            'type': 'reasoning',
+                            'content': [
+                                {
+                                    'text': "The user asks about temperature in Tokyo. I'll call the tool.",
+                                    'type': 'reasoning_text',
+                                }
+                            ],
+                        },
+                        {
+                            'name': get_temperature.__qualname__,
+                            'arguments': '{"city": "Tokyo"}',
+                            'call_id': 'call_00_xjY8Z2BvSlzgEmmw0DtH0464',
+                            'type': 'function_call',
+                        },
+                        {
+                            'type': 'function_call_output',
+                            'call_id': 'call_00_xjY8Z2BvSlzgEmmw0DtH0464',
+                            'output': '21.0',
+                        },
+                    ],
+                    'model': 'deepseek-v4-flash',
+                    'stream': True,
                     'tool_choice': 'auto',
                     'tools': [
                         {
@@ -508,7 +789,15 @@ CASES = [
 
 @pytest.mark.parametrize('case', [pytest.param(c, id=c.id) for c in CASES])
 async def test_deepseek_responses(case: Case, allow_model_requests: None, deepseek_api_key: str):
-    """`OpenAIResponsesModel('deepseek-v4-flash', provider=DeepSeekProvider())` against the live API."""
+    """`OpenAIResponsesModel('deepseek-v4-flash', provider=DeepSeekProvider())` against the live API.
+
+    Every case snapshots the request bodies as the httpx hook saw them, so the two recorded facts
+    the pairing depends on stay pinned to what the client builds rather than to the cassette: the
+    `tool_choice: 'auto'` that DeepSeek's `openai_supports_tool_choice_required=False` profile
+    forces even where the run would otherwise force a tool, and the `phase` label DeepSeek puts on
+    its output being surfaced in `provider_details` while never going back out (the off side of
+    `openai_supports_phase`, which stays off because DeepSeek doesn't document accepting it).
+    """
     sent_bodies: list[dict[str, Any]] = []
 
     async def capture_request(request: httpx.Request) -> None:
@@ -520,14 +809,19 @@ async def test_deepseek_responses(case: Case, allow_model_requests: None, deepse
     )
     agent = Agent(model, output_type=case.output_type, tools=case.tools, model_settings=case.model_settings)
 
-    if case.stream:
-        async with agent.run_stream(case.prompt) as streamed:
-            output = await streamed.get_output()
-        messages = streamed.all_messages()
-    else:
-        result = await agent.run(case.prompt)
-        output = result.output
-        messages = result.all_messages()
+    async def run(
+        prompt: str, message_history: list[ModelMessage] | None = None
+    ) -> tuple[str | City, list[ModelMessage]]:
+        if case.stream:
+            async with agent.run_stream(prompt, message_history=message_history) as streamed:
+                output = await streamed.get_output()
+            return output, streamed.all_messages()
+        result = await agent.run(prompt, message_history=message_history)
+        return result.output, result.all_messages()
+
+    output, messages = await run(case.prompt)
+    if case.follow_up_prompt is not None:
+        output, messages = await run(case.follow_up_prompt, message_history=messages)
 
     assert output == case.expected_output
     assert messages == case.expected_messages


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David has not reviewed it yet.

- Closes #7169

DeepSeek's OpenAI-compatible Responses API (`deepseek-v4-flash`, the V4-Flash-0731 backend) already works through `OpenAIResponsesModel` + `DeepSeekProvider`, but it was undocumented and untested, so nothing stopped it from silently breaking. This PR pins it and documents it. Every claim here was verified live against `api.deepseek.com` before it was written down; **no runtime logic changes** (the one production edit is a comment).

### Tests

New `tests/models/test_deepseek_responses.py`: one case-based parametrized VCR test, recorded live, covering non-streamed, streamed, multi-turn, function tools (non-streamed and streamed), structured output, and `openai_reasoning_effort`. Each case snapshots the resulting messages *and* the request bodies that actually went out, captured via an httpx event hook so the wire assertions run against what the client builds rather than what the cassette holds.

Three facts the request-body snapshots pin, each of which a refactor could otherwise break silently:

- `openai_reasoning_effort` reaches DeepSeek as `reasoning.effort`
- DeepSeek's raw chain-of-thought is sent back as `reasoning_text` content on a follow-up request
- the `phase` DeepSeek labels its output with is surfaced in `provider_details` but never sent back

### Docs

A Responses example in the DeepSeek subsection, plus the list of things DeepSeek accepts and then ignores — the failure mode worth documenting, since its API silently drops what it doesn't support instead of erroring.

### Scope decisions

<details><summary>Why no <code>openai_supports_reasoning</code> on the DeepSeek profile</summary>

The issue and its follow-up comment both suggest adding `openai_responses_*` profile fields. Verified live that this isn't needed and would be a regression:

1. `_translate_thinking` sets `reasoning.effort` from `openai_reasoning_effort` (and from the unified `thinking` setting) **without** gating on `openai_supports_reasoning`, so effort already forwards — the `reasoning_effort` case's recorded request body shows `{'reasoning': {'effort': 'high'}}`.
2. `openai_supports_reasoning` is *not* Responses-scoped. Setting it `True` would make `_drop_sampling_params_for_reasoning` strip `temperature`/`top_p` with a `UserWarning` on the **Chat Completions** path too, for `deepseek-reasoner` and every `deepseek-v4-*` model. DeepSeek accepts `temperature` today (verified live), so that's a behavior regression for existing users, not a fix.

`openai_supports_minimal_reasoning_effort` also stays at its default: `minimal`, `none` and `xhigh` were each verified live to return 200.
</details>

<details><summary>Why <code>openai_supports_phase</code> stays off</summary>

DeepSeek stamps `phase: final_answer` on every response, which we ingest unconditionally but only send back when this flag is set — so the field looked like a candidate to flip. Sending it back does return 200. But DeepSeek's [compatibility table](https://api-docs.deepseek.com/guides/responses_api) states that unsupported fields are *silently ignored rather than rejected*, and `phase` is absent from its documented input items, so the 200 proves acceptance, not that the model reads it. Flipping the flag would add an undocumented field to every request for no observable gain. The reasoning is recorded as a comment in `providers/deepseek.py`, and the `text_multi_turn` case pins the current behavior: the replayed assistant turn carries no `phase` key.
</details>

`previous_response_id` continuation is **out of scope by design** — DeepSeek's Responses API is stateless. It's worse than merely unavailable, so the docs say to leave `openai_previous_response_id` unset: setting it makes Pydantic AI trim the turns it assumes are server-side while DeepSeek stores nothing, and a two-turn run then answered `'Unknown'` to a fact stated one turn earlier, on a 200.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
