### PR TITLE
fix(output): preserve retry guidance for output tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -347,17 +347,13 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         rather than raised inline so the caller can decide whether to re-raise (no other output
         produced a valid result) or absorb it as a skip.
         """
-        max_output_retries = self.ctx.deps.max_output_retries
         try:
             validated = await self.tool_manager.validate_output_tool_call(call, schema=self.schema)
         except exceptions.UnexpectedModelBehavior as e:
-            tool = self.tool_manager.tools.get(call.tool_name) if self.tool_manager.tools else None
-            # Defensive: an output tool is always present in the toolset, so the `None` fallback to
-            # the agent-level budget isn't expected in normal operation.
-            max_retries = tool.max_retries if tool is not None else max_output_retries
-            wrapped = exceptions.UnexpectedModelBehavior(f'Exceeded maximum output retries ({max_retries})')
-            wrapped.__cause__ = e.__cause__ or e
-            return _OutputCallResult(call=call, args_valid=False, raise_exc=wrapped)
+            # `ToolManager._check_max_retries` already built the actionable error, including the
+            # tool name, retry setting, and documentation link. Preserve it instead of replacing
+            # it with the less useful run-level output-retry message.
+            return _OutputCallResult(call=call, args_valid=False, raise_exc=e)
 
         if not validated.args_valid:
             assert validated.validation_error is not None
@@ -372,10 +368,8 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         try:
             result_data: Any = await self.tool_manager.execute_output_tool_call(validated, schema=self.schema)
         except exceptions.UnexpectedModelBehavior as e:
-            max_retries = validated.tool.max_retries if validated.tool else max_output_retries
-            wrapped = exceptions.UnexpectedModelBehavior(f'Exceeded maximum output retries ({max_retries})')
-            wrapped.__cause__ = e.__cause__ or e
-            return _OutputCallResult(call=call, args_valid=True, raise_exc=wrapped)
+            # Keep the per-tool retry guidance produced by `ToolManager` on the execution path too.
+            return _OutputCallResult(call=call, args_valid=True, raise_exc=e)
         except ToolRetryError as e:
             self.output_retries_increment += 1
             return _OutputCallResult(call=call, args_valid=True, retry_part=e.tool_retry)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6460,7 +6460,25 @@ class TestMultipleToolCalls:
             end_strategy='exhaustive',
         )
 
-        with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(1\)'):
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'output_tool' exceeded max retries count of 1"):
+            agent.run_sync('test')
+
+    def test_output_tool_execution_retry_exhaustion_preserves_guidance(self):
+        """Per-tool retry guidance is preserved when an output function exhausts its budget."""
+
+        def process_output(_: str) -> str:
+            raise ModelRetry('try again')
+
+        def return_model(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            assert info.output_tools is not None
+            return ModelResponse(parts=[ToolCallPart('output_tool', {'value': 'value'})])
+
+        agent = Agent(
+            FunctionModel(return_model),
+            output_type=ToolOutput(process_output, name='output_tool', max_retries=0),
+        )
+
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'output_tool' exceeded max retries count of 0"):
             agent.run_sync('test')
 
     def test_exhaustive_skips_output_tool_exceeding_retries_on_validation(self):
@@ -12969,7 +12987,7 @@ def test_output_validator_exceeds_output_retries():
         retries_log.append(ctx.retry)
         raise ModelRetry(f'Retry {ctx.retry}')
 
-    with pytest.raises(UnexpectedModelBehavior, match='Exceeded maximum output retries \\(2\\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'final_result' exceeded max retries count of 2"):
         agent.run_sync('Hello')
 
     assert retries_log == [0, 1, 2]
@@ -13240,7 +13258,7 @@ def test_output_retry_budget_resolution(case: OutputRetryBudgetCase):
         retries_log.append(ctx.retry)
         raise ModelRetry(f'retry {ctx.retry}')
 
-    expected_msg = rf'Exceeded maximum output retries \({case.expected_budget}\)'
+    expected_msg = rf"Tool 'final_result' exceeded max retries count of {case.expected_budget}"
     override_ctx = agent.override(**case.override) if case.override is not None else nullcontext()
 
     with override_ctx:
@@ -13297,7 +13315,7 @@ def test_run_level_output_retry_override_without_validators():
     assert shared_toolset is not None
     assert shared_toolset.max_retries == 10
 
-    with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(2\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'final_result' exceeded max retries count of 2"):
         agent.run_sync('Hello', retries={'output': 2})
 
     # 3 attempts: initial + 2 retries, capped by the run override at 2 (not the agent default 10)
@@ -13321,7 +13339,7 @@ def test_from_spec_preserves_zero_retry_budgets():
         output_type=ToolOutput(Foo),
     )
 
-    with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(0\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'final_result' exceeded max retries count of 0"):
         output_agent.run_sync('Hello')
 
     assert output_call_count == 1
@@ -13590,7 +13608,7 @@ def test_wrapper_override_forwards_retries():
     wrapped = WrapperAgent(agent)
 
     with wrapped.override(retries=0):
-        with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(0\)'):
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'final_result' exceeded max retries count of 0"):
             wrapped.run_sync('Hello')
 
     assert call_count == 1

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3944,7 +3944,7 @@ class TestMultipleToolCalls:
             end_strategy='exhaustive',
         )
 
-        with pytest.raises(UnexpectedModelBehavior, match='Exceeded maximum output retries \\(1\\)'):
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'output_tool' exceeded max retries count of 1"):
             async with agent.run_stream('test') as result:
                 await result.get_output()
 


### PR DESCRIPTION
## Problem

When an output tool exhausts its retry budget, the raised `UnexpectedModelBehavior` message drops the tool name, the configured retry limit, the suggested remediation, and the documentation link. This makes the output-tool failure less actionable than the equivalent function-tool failure.

## Root Cause

`ToolManager._check_max_retries` constructs the detailed per-tool error, but `_ToolCallProcessor._run_output_tool_call` catches it on both the validation and execution paths and replaces it with the generic run-level output retry message.

## Solution

Preserve the `UnexpectedModelBehavior` raised by `ToolManager` so output-tool retry exhaustion keeps the existing per-tool guidance and cause chain.

## Changes

- Return the original retry-exhaustion exception from output-tool validation.
- Return the original retry-exhaustion exception from output-tool execution.
- Update regression expectations and add execution-path coverage for the actionable message.

## Testing

- Baseline focused retry tests: 5 passed.
- Focused post-change retry tests: 6 passed.
- `tests/test_agent.py`: 411 passed, 11 skipped.
- `tests/test_streaming.py`: 180 passed, 3 existing xfailed.
- Ruff format check and Ruff lint: passed.
- Pyright on the changed source file: passed with 0 errors.
- `git diff --check`: passed.
- Full test-file type checking was attempted; unrelated optional `fastmcp` imports are unavailable in this environment, so those test-file checks are not claimed as passed.

## Compatibility/Risk

No API, schema, or retry-count behavior changes. The observable exception text for output-tool retry exhaustion becomes more descriptive and now matches the existing function-tool guidance.

## Notes for Reviewer

The implementation is limited to preserving an exception already produced by `ToolManager`; no retry policy or output processing flow was broadened.

## Linked Issue

Fixes #7203


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

