### PR TITLE
fix(agent): isolate instruction parts per request

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1474,6 +1474,9 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         # Fetch instructions now that dynamic toolsets have been resolved by for_run_step.
         instruction_parts = await _get_instructions(ctx, run_context)
         if instruction_parts:
+            # Toolsets may reuse `InstructionPart` instances across requests. Clone them before
+            # passing the request context to capabilities so an in-place hook edit is request-local.
+            instruction_parts = [replace(part) for part in instruction_parts]
             instruction_parts = _messages.InstructionPart.sorted(instruction_parts) or None
         self.request.instructions = _messages.InstructionPart.join(instruction_parts) if instruction_parts else None
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -82,6 +82,7 @@ from pydantic_ai.messages import (
     FilePart,
     FunctionToolCallEvent,
     ImageUrl,
+    InstructionPart,
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
     ModelMessage,
@@ -5068,6 +5069,63 @@ async def test_for_run_receives_populated_run_context():
     assert captured['conversation_id'] == 'conv-123'
     assert captured['metadata'] == {'run_id_seen': captured['run_id'], 'conversation_id_seen': 'conv-123'}
     assert captured['instrumentation_version'] is not None
+
+
+async def test_before_model_request_instruction_parts_are_fresh_per_request():
+    """A hook's in-place edit must not leak into the next model request."""
+
+    class ReusableInstructionToolset(AbstractToolset[Any]):
+        def __init__(self) -> None:
+            self.part = InstructionPart(content='shared', dynamic=False)
+
+        @property
+        def id(self) -> str:
+            return 'reusable-instructions'
+
+        async def get_instructions(self, ctx: RunContext[Any]) -> list[InstructionPart]:
+            return [self.part]
+
+        async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+            return {}
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
+        ) -> Any:
+            raise AssertionError('This toolset has no tools')
+
+    class MutatingCapability(AbstractCapability[Any]):
+        async def before_model_request(
+            self, ctx: RunContext[Any], request_context: ModelRequestContext
+        ) -> ModelRequestContext:
+            instruction_parts = request_context.model_request_parameters.instruction_parts
+            assert instruction_parts is not None
+            instruction_parts[0].content += '!'
+            return request_context
+
+    seen: list[list[str]] = []
+
+    def respond(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen.append([part.content for part in info.model_request_parameters.instruction_parts or []])
+        return ModelResponse(parts=[TextPart('done')])
+
+    toolset = ReusableInstructionToolset()
+    agent = Agent(
+        FunctionModel(respond),
+        output_type=str,
+        toolsets=[toolset],
+        capabilities=[MutatingCapability()],
+    )
+
+    @agent.output_validator
+    def retry_once(ctx: RunContext[Any], output: str) -> str:
+        if ctx.retry == 0:
+            raise ModelRetry('retry once')
+        return output
+
+    result = await agent.run('Hello')
+
+    assert result.output == 'done'
+    assert seen == [['shared!'], ['shared!']]
 
 
 async def test_concurrent_runs_capability_isolation():


### PR DESCRIPTION
## Problem

When a `before_model_request` hook mutates an `InstructionPart` in place, the mutation can compound across retries or later model requests if a toolset reuses the same instruction object.

## Root Cause

Toolset instructions are normalized into `InstructionPart` objects and passed directly into the request parameters. A reusable toolset can therefore expose the same mutable instance to multiple requests, allowing a capability hook to modify shared state.

## Solution

Clone each resolved `InstructionPart` before it is sorted, joined, and exposed to the request capability chain. This keeps intentional hook changes local to the current request while preserving instruction content and metadata for that request.

## Changes

- Clone resolved instruction parts in `ModelRequestNode._prepare_request`.
- Add a regression test using a reusable toolset, an in-place mutating capability, and an output retry.

## Testing

- Baseline focused capability tests: 7 passed.
- Focused regression: 1 passed.
- Full `tests/test_capabilities.py`: 873 passed, 4 skipped.
- Ruff format/check: passed.
- Pyright for the changed source and test file: passed with 0 errors, 0 warnings, 0 informations.
- `git diff --check`: passed.

## Compatibility/Risk

No public API changes. Instruction values are unchanged for normal requests; only the object identity is isolated so in-place capability edits cannot leak into later requests. The test suite required the repository's optional `ddgs`, `markdownify`, and `fastmcp` dependencies in this local environment.

## Notes for Reviewer

Please review whether cloning at request preparation is the preferred boundary for protecting toolset-owned instruction objects, especially for retries and other repeated model requests.

## Linked Issue

Fixes #7193


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

