### PR TITLE
fix(agent): record effective instructions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1511,6 +1511,24 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         if not isinstance(messages[-1], _messages.ModelRequest):
             raise exceptions.UserError('Processed history must end with a `ModelRequest`.')
 
+        # History processors and capabilities may replace the request context with new message
+        # objects. Record the instruction parts on the request that is actually sent so history
+        # does not retain the pre-hook rendering. This may not be the last message when a hook has
+        # appended a tool-availability request after the original request.
+        request_to_update = next(
+            (
+                message
+                for message in reversed(messages)
+                if isinstance(message, _messages.ModelRequest)
+                and message.parts == self.request.parts
+                and message.timestamp == self.request.timestamp
+                and message.metadata == self.request.metadata
+            ),
+            None,
+        )
+        if request_to_update is not None and model_request_parameters.instruction_parts is not None:
+            request_to_update.instructions = _messages.InstructionPart.join(model_request_parameters.instruction_parts)
+
         # Fill in framework metadata the history processors may have left unset on a new `ModelRequest`.
         fill_run_metadata(messages[-1], run_id=ctx.state.run_id, conversation_id=ctx.state.conversation_id)
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -82,6 +82,7 @@ from pydantic_ai.messages import (
     FilePart,
     FunctionToolCallEvent,
     ImageUrl,
+    InstructionPart,
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
     ModelMessage,
@@ -5038,6 +5039,40 @@ async def test_for_run_with_different_instructions():
     assert any('per-run' in i for i in instructions_found), (
         f'Expected per-run instructions in messages, got: {captured_messages}'
     )
+
+
+async def test_before_model_request_records_instructions_from_replaced_context():
+    """History records the instructions from the context that the model actually receives."""
+
+    class ReplacingCapability(AbstractCapability[Any]):
+        async def before_model_request(
+            self, ctx: RunContext[Any], request_context: ModelRequestContext
+        ) -> ModelRequestContext:
+            messages = [replace(message) for message in request_context.messages]
+            parameters = replace(
+                request_context.model_request_parameters,
+                instruction_parts=[InstructionPart(content='managed', dynamic=False)],
+            )
+            return replace(request_context, messages=messages, model_request_parameters=parameters)
+
+    seen: list[list[str]] = []
+
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen.append([part.content for part in info.model_request_parameters.instruction_parts or []])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(
+        FunctionModel(respond),
+        instructions='base',
+        capabilities=[ReplacingCapability()],
+    )
+
+    result = await agent.run('Hello')
+
+    assert result.output == 'done'
+    assert seen == [['managed']]
+    requests = [message for message in result.all_messages() if isinstance(message, ModelRequest)]
+    assert requests[-1].instructions == 'managed'
 
 
 async def test_for_run_receives_populated_run_context():


### PR DESCRIPTION
## Problem

When a `before_model_request` hook returns a context with replacement message objects and changes the effective instruction parts, the model receives the new instructions but the recorded `ModelRequest.instructions` can retain the old rendering.

## Root Cause

The request node rendered instructions onto its captured `self.request` before the capability chain. A hook can replace the request context's message objects, leaving that captured object detached from the messages sent to the model.

## Solution

After `before_model_request` returns, locate the request corresponding to the node's request in the returned message history and render the effective `instruction_parts` onto that request. The lookup also handles a tool-availability request appended after the original request.

## Changes

- Synchronize recorded instructions with the request object that remains in the returned context.
- Add a regression test that replaces the message list and instruction parts, then verifies both the model input and `result.all_messages()`.

## Testing

- Baseline focused capability tests: 7 passed.
- Focused regression: 1 passed.
- Full `tests/test_capabilities.py`: 873 passed, 4 skipped.
- Ruff format/check: passed.
- Pyright for the changed source and test file: passed with 0 errors, 0 warnings, 0 informations.
- `git diff --check`: passed.

## Compatibility/Risk

No public API changes. Existing history remains unchanged unless a capability replaces the request context or effective instruction parts; in that case, history now reflects the instructions sent to the model. The full capability suite includes deferred-tool and tool-availability flows.

## Notes for Reviewer

Please review the request matching boundary, especially when a history processor replaces message objects or appends a tool-availability request.

## Linked Issue

Fixes #7194


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

