### PR TITLE
fix(mistral): serialize tool call arguments

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -487,7 +487,7 @@ class MistralModel(Model[Mistral]):
         return MistralToolCall(
             id=_utils.guard_tool_call_id(t=t),
             type='function',
-            function=MistralFunctionCall(name=t.tool_name, arguments=t.args or {}),
+            function=MistralFunctionCall(name=t.tool_name, arguments=t.args_as_json_str()),
         )
 
     def _generate_user_output_format(self, schemas: list[dict[str, Any]]) -> MistralUserMessage:

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -214,6 +214,14 @@ def test_init():
     assert m.base_url == 'https://api.mistral.ai'
 
 
+def test_tool_call_arguments_are_json_strings():
+    tool_call = MistralModel._map_tool_call(  # pyright: ignore[reportPrivateUsage]
+        ToolCallPart(tool_name='echo', args='not-json', tool_call_id='call-1')
+    )
+
+    assert tool_call.function.arguments == '{"INVALID_JSON":"not-json"}'
+
+
 #####################
 ## Completion
 #####################


### PR DESCRIPTION
## Problem

`MistralModel` sends `ToolCallPart.args` directly to the Mistral SDK. Malformed JSON arguments can therefore be replayed as a raw string instead of using the SDK's expected JSON-string representation.

## Root Cause

The Mistral request mapper was the only provider path that bypassed `ToolCallPart.args_as_json_str()` / `args_as_dict()` and passed `t.args or {}` unchanged.

## Solution

Serialize tool-call arguments with `args_as_json_str()`, which preserves valid JSON strings and degrades malformed or non-object arguments to the standard `INVALID_JSON` object representation.

## Changes

- Route Mistral tool-call arguments through `ToolCallPart.args_as_json_str()`.
- Add a regression test for malformed tool-call arguments.

## Testing

- Baseline focused Mistral tests: 3 passed after installing the declared optional `mistralai` dependency; before the fix, the new regression failed with raw `not-json` output.
- Focused regression plus related argument tests: 4 passed.
- Full `tests/models/test_mistral.py`: 114 passed.
- Ruff format/check: passed.
- Pyright for the changed source and test file: passed with 0 errors, 0 warnings, 0 informations.
- `git diff --check`: passed.

## Compatibility/Risk

No public API changes. Valid JSON string arguments retain their original bytes; dict arguments and malformed arguments now use the provider-compatible JSON-string form. The local test environment installed `mistralai 2.9.1` and its declared dependencies.

## Notes for Reviewer

Please verify that the Mistral SDK version range continues to accept JSON strings for `FunctionCall.arguments`, including the malformed-argument retry representation.

## Linked Issue

Fixes #7101


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

