### PR TITLE
Add `DurableRunCancellation` for externally cancelling a durable agent run first-party

### DIFF
--- a/docs/api/durable_exec.md
+++ b/docs/api/durable_exec.md
@@ -1,5 +1,7 @@
 # `pydantic_ai.durable_exec`
 
+::: pydantic_ai.durable_exec.DurableRunCancellation
+
 ::: pydantic_ai.durable_exec.temporal
 
 ::: pydantic_ai.durable_exec.dbos

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -245,10 +245,13 @@ Because the model stream is consumed inside the activity, cancelling it from the
 
 Whole-run cancellation (see [Cancelling a Run](../agent.md#cancelling-a-run)) follows the same split, with Temporal-specific consequences:
 
-- Calling [`AgentRun.cancel()`][pydantic_ai.run.AgentRun.cancel] from workflow code raises [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] as an ordinary application outcome: a workflow that catches it completes normally rather than ending as *Cancelled*, and the run remains replay-deterministic. An uncaught `RunCancelled` fails the workflow as a typed application error, and the run state does not cross the failure boundary -- catch it inside the workflow if you need [`all_messages()`][pydantic_ai.exceptions.RunCancelled.all_messages].
+- Calling [`AgentRun.cancel()`][pydantic_ai.run.AgentRun.cancel] from workflow code raises [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] as an ordinary application outcome that you should **catch inside the workflow** and turn into a normal completion; the caught run remains replay-deterministic and its state is available via [`all_messages()`][pydantic_ai.exceptions.RunCancelled.all_messages]. Letting `RunCancelled` escape the workflow uncaught is not supported: see the warning below.
 - [`RunContext.cancel()`][pydantic_ai.tools.RunContext.cancel] requires being in the same process as the run, so calling it from a tool running inside an activity raises a clear [`UserError`][pydantic_ai.exceptions.UserError] instead of hanging.
 - [`CancellationToken`][pydantic_ai.CancellationToken] is also same-process state and cannot be passed to a Temporal durable run; use [`DurableRunCancellation`][pydantic_ai.durable_exec.DurableRunCancellation] (below) or cancel the Temporal workflow instead.
 - Cancelling the Temporal workflow itself remains an external cancellation: `CancelledError` keeps propagating and the workflow still ends as *Cancelled*.
+
+!!! warning "Always catch `RunCancelled` inside a durable workflow"
+    First-party cancellation is delivered by cancelling the run's asyncio task, so an *uncaught* `RunCancelled` that fails the workflow is **not replay-safe**: Temporal rejects the replayed activation (`Workflow activation completion failed`), which can wedge the workflow. Catch `RunCancelled` in your `@workflow.run` method and complete normally (or convert it to a separate application error you raise yourself) rather than letting it propagate.
 
 To let an **external** actor (a user hitting "stop") cancel a durable run first-party without tearing down the whole workflow, pass a [`DurableRunCancellation`][pydantic_ai.durable_exec.DurableRunCancellation] capability to the run and trigger it from a [`@workflow.signal`](https://docs.temporal.io/develop/python/message-passing#signals) handler. A signal runs on the workflow event loop and is recorded in history, so the resulting cancellation is deterministic on replay:
 
@@ -281,7 +284,7 @@ class MyAgentWorkflow:
         self.cancellation.cancel()
 ```
 
-An external actor then cancels the run by signalling the workflow: `await handle.signal(MyAgentWorkflow.cancel)`. As with [`AgentRun.cancel()`][pydantic_ai.run.AgentRun.cancel] above, catch [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] inside the workflow if you want it to complete normally rather than fail as a typed application error.
+An external actor then cancels the run by signalling the workflow: `await handle.signal(MyAgentWorkflow.cancel)`. As the example shows, catch [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] inside the workflow and complete normally — the same replay requirement as [`AgentRun.cancel()`][pydantic_ai.run.AgentRun.cancel] above applies.
 
 `DurableRunCancellation` is engine-agnostic: it captures the run's cancellation controller and exposes a `cancel()` method that each durable engine wires to its own external-cancellation mechanism.
 

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -247,8 +247,43 @@ Whole-run cancellation (see [Cancelling a Run](../agent.md#cancelling-a-run)) fo
 
 - Calling [`AgentRun.cancel()`][pydantic_ai.run.AgentRun.cancel] from workflow code raises [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] as an ordinary application outcome: a workflow that catches it completes normally rather than ending as *Cancelled*, and the run remains replay-deterministic. An uncaught `RunCancelled` fails the workflow as a typed application error, and the run state does not cross the failure boundary -- catch it inside the workflow if you need [`all_messages()`][pydantic_ai.exceptions.RunCancelled.all_messages].
 - [`RunContext.cancel()`][pydantic_ai.tools.RunContext.cancel] requires being in the same process as the run, so calling it from a tool running inside an activity raises a clear [`UserError`][pydantic_ai.exceptions.UserError] instead of hanging.
-- [`CancellationToken`][pydantic_ai.CancellationToken] is also same-process state and cannot be passed to a Temporal durable run; cancel the Temporal workflow instead.
+- [`CancellationToken`][pydantic_ai.CancellationToken] is also same-process state and cannot be passed to a Temporal durable run; use [`DurableRunCancellation`][pydantic_ai.durable_exec.DurableRunCancellation] (below) or cancel the Temporal workflow instead.
 - Cancelling the Temporal workflow itself remains an external cancellation: `CancelledError` keeps propagating and the workflow still ends as *Cancelled*.
+
+To let an **external** actor (a user hitting "stop") cancel a durable run first-party without tearing down the whole workflow, pass a [`DurableRunCancellation`][pydantic_ai.durable_exec.DurableRunCancellation] capability to the run and trigger it from a [`@workflow.signal`](https://docs.temporal.io/develop/python/message-passing#signals) handler. A signal runs on the workflow event loop and is recorded in history, so the resulting cancellation is deterministic on replay:
+
+```python {title="temporal_signal_cancellation.py" test="skip"}
+from temporalio import workflow
+
+from pydantic_ai import RunCancelled
+from pydantic_ai.durable_exec import DurableRunCancellation
+
+with workflow.unsafe.imports_passed_through():
+    from temporal_durability import temporal_agent
+
+
+@workflow.defn
+class MyAgentWorkflow:
+    def __init__(self) -> None:
+        # A fresh handle per workflow execution; it binds to this run's cancellation only.
+        self.cancellation = DurableRunCancellation()
+
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        try:
+            result = await temporal_agent.run(prompt, capabilities=[self.cancellation])
+            return result.output
+        except RunCancelled:
+            return 'The run was cancelled.'
+
+    @workflow.signal
+    def cancel(self) -> None:
+        self.cancellation.cancel()
+```
+
+An external actor then cancels the run by signalling the workflow: `await handle.signal(MyAgentWorkflow.cancel)`. As with [`AgentRun.cancel()`][pydantic_ai.run.AgentRun.cancel] above, catch [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] inside the workflow if you want it to complete normally rather than fail as a typed application error.
+
+`DurableRunCancellation` is engine-agnostic: it captures the run's cancellation controller and exposes a `cancel()` method that each durable engine wires to its own external-cancellation mechanism.
 
 [`Agent.run_stream_sync()`][pydantic_ai.agent.Agent.run_stream_sync] is not for workflow code: it requires no running event loop and wraps `run_stream()`. Under [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability], use the buffered async streaming APIs above or [`Agent.run()`][pydantic_ai.agent.Agent.run] with an event stream handler. Outside a workflow, an agent with `TemporalDurability` behaves like a normal agent, so `run_stream_sync()` works as usual. (Wrapper `TemporalAgent` forbids `run_stream` inside workflows — use `run` + event stream handler there.)
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/__init__.py
@@ -9,4 +9,12 @@ capability you attach to an [`Agent`][pydantic_ai.Agent]:
   [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability]
 - [`pydantic_ai.durable_exec.prefect`][pydantic_ai.durable_exec.prefect] —
   [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability]
+
+Cancelling a durable run from outside it is engine-agnostic and lives here:
+
+- [`DurableRunCancellation`][pydantic_ai.durable_exec.DurableRunCancellation]
 """
+
+from ._cancellation import DurableRunCancellation
+
+__all__ = ('DurableRunCancellation',)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
@@ -47,6 +47,9 @@ class DurableRunCancellation(AbstractCapability[AgentDepsT]):
 
     from pydantic_ai.durable_exec import DurableRunCancellation
 
+    with workflow.unsafe.imports_passed_through():
+        from my_agent import my_temporal_agent
+
 
     @workflow.defn
     class MyAgentWorkflow:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
@@ -1,6 +1,6 @@
 """Portable, engine-agnostic seam for externally cancelling a durable agent run.
 
-First-party run cancellation (`AgentRun.cancel()`, `RunContext.cancel_run()`,
+First-party run cancellation (`AgentRun.cancel()`, `RunContext.cancel()`,
 [`CancellationToken`][pydantic_ai.CancellationToken]) has no story across a durable-execution
 boundary: a `CancellationToken` is a same-process, cross-thread handle that can't be serialized
 into a workflow/flow, and a durable run exposes no `AgentRun` for an external actor (a user hitting

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
@@ -1,0 +1,115 @@
+"""Portable, engine-agnostic seam for externally cancelling a durable agent run.
+
+First-party run cancellation (`AgentRun.cancel()`, `RunContext.cancel_run()`,
+[`CancellationToken`][pydantic_ai.CancellationToken]) has no story across a durable-execution
+boundary: a `CancellationToken` is a same-process, cross-thread handle that can't be serialized
+into a workflow/flow, and a durable run exposes no `AgentRun` for an external actor (a user hitting
+"stop") to reach. Cancelling the whole workflow works but is all-or-nothing and doesn't produce a
+first-party "the run was cancelled" outcome.
+
+[`DurableRunCancellation`][pydantic_ai.durable_exec.DurableRunCancellation] bridges that gap with a
+per-run capability. It captures the run's [`RunCancellation`][pydantic_ai._cancel.RunCancellation]
+controller in `before_run`, and its [`cancel`][pydantic_ai.durable_exec.DurableRunCancellation.cancel]
+method triggers it. Each durable engine wires its own external-cancellation mechanism to that one
+method — for Temporal a `@workflow.signal` handler (a signal runs on the workflow event loop and is
+recorded in history, so the resulting cancellation is deterministic on replay) — while the binding
+between the trigger and the run stays engine-agnostic here.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
+
+from ..capabilities.abstract import AbstractCapability
+from ..tools import AgentDepsT, RunContext
+
+if TYPE_CHECKING:
+    from .._cancel import RunCancellation
+
+
+@dataclass
+class DurableRunCancellation(AbstractCapability[AgentDepsT]):
+    """A per-run handle for cancelling a durable agent run from outside the run.
+
+    Pass a single instance to one durable `run(capabilities=[...])` call, then call
+    [`cancel`][pydantic_ai.durable_exec.DurableRunCancellation.cancel] from the engine's
+    external-cancellation handler to cancel *that* run first-party: it ends with
+    [`RunCancelled`][pydantic_ai.exceptions.RunCancelled] rather than by tearing down the
+    whole workflow or flow.
+
+    For Temporal, wire `cancel()` to a [`@workflow.signal`](https://docs.temporal.io/develop/python/message-passing#signals)
+    handler:
+
+    ```python {test="skip"}
+    from temporalio import workflow
+
+    from pydantic_ai.durable_exec import DurableRunCancellation
+
+
+    @workflow.defn
+    class MyAgentWorkflow:
+        def __init__(self) -> None:
+            # A fresh handle per workflow execution; it binds to this run only.
+            self.cancellation = DurableRunCancellation()
+
+        @workflow.run
+        async def run(self, prompt: str) -> str:
+            result = await my_temporal_agent.run(prompt, capabilities=[self.cancellation])
+            return result.output
+
+        @workflow.signal
+        def cancel(self) -> None:
+            self.cancellation.cancel()
+    ```
+
+    An external actor then cancels the run by signalling the workflow
+    (`await handle.signal(MyAgentWorkflow.cancel)`). DBOS and Prefect bind their own
+    external-cancellation mechanisms to the same `cancel()` method.
+
+    A single instance binds to a single run; create a fresh one per durable execution (e.g. in the
+    workflow's `__init__`), not a module-level singleton shared across concurrent runs.
+    """
+
+    _safe_at_runtime: ClassVar[bool] = True
+    """Workflow-side only — introduces no toolsets, native tools, or model wrapping — so it is safe
+    to attach per-run even when a durability capability is bound. Internal flag read by the bundled
+    durable-execution integrations."""
+
+    _cancellation: RunCancellation | None = field(default=None, init=False, repr=False)
+    _cancel_requested: bool = field(default=False, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        # Holds a live, run-scoped controller reference, so it is not spec-constructible.
+        return None
+
+    async def before_run(self, ctx: RunContext[AgentDepsT]) -> None:
+        # Capture the run's cancellation controller so `cancel()` can trigger it. Read via
+        # `__dict__` so a restricted run-context subclass (e.g. `TemporalRunContext`) whose
+        # `__getattribute__` rejects absent fields returns `None` instead of raising. `before_run`
+        # has no `await`, so it completes before any engine handler (e.g. a Temporal signal) can run
+        # on the same loop: the controller is always captured before a `cancel()` can reach it.
+        cancellation: RunCancellation | None = ctx.__dict__.get('_cancellation')
+        with self._lock:
+            self._cancellation = cancellation
+            already_requested = self._cancel_requested
+        if already_requested and cancellation is not None:
+            # A `cancel()` that arrived before the run bound its controller is applied now.
+            cancellation.cancel()
+
+    def cancel(self) -> None:
+        """Request first-party cancellation of the bound run.
+
+        Idempotent, and safe to call before the run has started (the request is applied once the run
+        binds its controller) or after it has finished (a no-op). `RunCancellation.cancel()` marshals
+        the request onto the run's own event loop, so this is safe to call from the engine's
+        external-cancellation handler.
+        """
+        with self._lock:
+            self._cancel_requested = True
+            cancellation = self._cancellation
+        if cancellation is not None:
+            cancellation.cancel()

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_cancellation.py
@@ -45,6 +45,7 @@ class DurableRunCancellation(AbstractCapability[AgentDepsT]):
     ```python {test="skip"}
     from temporalio import workflow
 
+    from pydantic_ai import RunCancelled
     from pydantic_ai.durable_exec import DurableRunCancellation
 
     with workflow.unsafe.imports_passed_through():
@@ -59,8 +60,13 @@ class DurableRunCancellation(AbstractCapability[AgentDepsT]):
 
         @workflow.run
         async def run(self, prompt: str) -> str:
-            result = await my_temporal_agent.run(prompt, capabilities=[self.cancellation])
-            return result.output
+            try:
+                result = await my_temporal_agent.run(prompt, capabilities=[self.cancellation])
+                return result.output
+            except RunCancelled:
+                # Catch `RunCancelled` and complete normally: letting it escape the workflow
+                # uncaught is not replay-safe and can wedge the workflow.
+                return 'The run was cancelled.'
 
         @workflow.signal
         def cancel(self) -> None:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_runtime_toolsets.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_runtime_toolsets.py
@@ -41,7 +41,7 @@ def cancellation_token_unsupported_error(engine: str) -> UserError:
         f'`cancellation_token` cannot be used with {engine} durable execution because it is a same-process '
         'handle and cannot cross the durable execution boundary. To cancel a durable run from outside it, '
         "pass a `DurableRunCancellation` capability to the run and trigger it from the engine's "
-        'external-cancellation handler (a `@workflow.signal` for Temporal); or cancel the whole workflow or flow.'
+        'external-cancellation handler; or cancel the whole workflow or flow.'
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_runtime_toolsets.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_runtime_toolsets.py
@@ -39,7 +39,9 @@ def cancellation_token_unsupported_error(engine: str) -> UserError:
     """The error raised when a same-process cancellation token meets a durable execution boundary."""
     return UserError(
         f'`cancellation_token` cannot be used with {engine} durable execution because it is a same-process '
-        'handle and cannot cross the durable execution boundary. Cancel the durable workflow or flow instead.'
+        'handle and cannot cross the durable execution boundary. To cancel a durable run from outside it, '
+        "pass a `DurableRunCancellation` capability to the run and trigger it from the engine's "
+        'external-cancellation handler (a `@workflow.signal` for Temporal); or cancel the whole workflow or flow.'
     )
 
 

--- a/tests/test_durable_run_cancellation.py
+++ b/tests/test_durable_run_cancellation.py
@@ -1,0 +1,82 @@
+"""Tests for `DurableRunCancellation`, the engine-agnostic seam for externally cancelling a
+durable agent run.
+
+The capability captures the run's cancellation controller in `before_run` and triggers it from
+`cancel()`. Each durable engine wires its own external-cancellation mechanism (a Temporal
+`@workflow.signal`, a DBOS/Prefect equivalent) to that one method; the engine-agnostic binding is
+exercised here without any durable runtime, since the behavior under test is pure control flow
+around injected `asyncio` cancellation that no recorded provider response can trigger. The Temporal
+signal wiring itself is covered end-to-end in `test_temporal.py`.
+"""
+
+from __future__ import annotations as _annotations
+
+import asyncio
+
+import pytest
+
+from pydantic_ai import Agent, RunCancelled
+from pydantic_ai.durable_exec import DurableRunCancellation
+from pydantic_ai.messages import ModelMessage, ModelResponse
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_cancel_from_sibling_task_surfaces_run_cancelled():
+    """`cancel()` from another task cancels the bound run and surfaces as `RunCancelled`, standing
+    in for an engine's external-cancellation handler reaching a run in flight."""
+    started = asyncio.Event()
+
+    async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError  # pragma: no cover
+
+    cancellation = DurableRunCancellation()
+    task = asyncio.create_task(Agent(FunctionModel(model_function)).run('hello', capabilities=[cancellation]))
+    await started.wait()
+    cancellation.cancel()
+
+    with pytest.raises(RunCancelled) as exc_info:
+        await task
+    assert [type(message).__name__ for message in exc_info.value.all_messages()] == ['ModelRequest']
+
+
+async def test_cancel_before_run_binds_controller_still_cancels():
+    """A `cancel()` that arrives before the run binds its controller is buffered and applied in
+    `before_run`, so the run is cancelled before any model request goes out."""
+    called = False
+
+    async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
+        nonlocal called
+        called = True
+        raise AssertionError
+
+    cancellation = DurableRunCancellation()
+    cancellation.cancel()
+
+    with pytest.raises(RunCancelled) as exc_info:
+        await Agent(FunctionModel(model_function)).run('hello', capabilities=[cancellation])
+    assert exc_info.value.all_messages() == []
+    assert not called
+
+
+async def test_cancel_after_run_finishes_is_a_no_op():
+    """Once the run has finished, `cancel()` is a no-op and doesn't disturb the event loop."""
+    cancellation = DurableRunCancellation()
+    result = await Agent(TestModel()).run('hello', capabilities=[cancellation])
+    assert result.output
+
+    cancellation.cancel()
+    await asyncio.sleep(0)
+    assert await asyncio.sleep(0, result='unrelated') == 'unrelated'
+
+
+def test_capability_is_safe_at_runtime_and_not_spec_constructible():
+    """The capability introduces no durable units, so it may be added per-run inside a durable
+    container (`_safe_at_runtime`), and it holds a live controller reference, so it opts out of
+    spec construction."""
+    assert DurableRunCancellation._safe_at_runtime is True  # pyright: ignore[reportPrivateUsage]
+    assert DurableRunCancellation.get_serialization_name() is None

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -673,7 +673,7 @@ async def _signal_cancellation_stream_model(messages: list[ModelMessage], info: 
     _signal_cancellation_activity_started.set()
     yield 'thinking'
     # Block until the model activity is cancelled by the run's first-party cancellation.
-    while True:  # pragma: no cover
+    while True:
         activity.heartbeat()
         await asyncio.sleep(0.01)
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -140,6 +140,7 @@ try:
     from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
     from temporalio.workflow import ActivityCancellationType, ActivityConfig
 
+    from pydantic_ai.durable_exec import DurableRunCancellation
     from pydantic_ai.durable_exec._toolset import (
         CallToolResult,
         unwrap_tool_call_result,
@@ -659,6 +660,98 @@ async def test_temporal_cancellation_backstop_survives_absorbed_activity_cancel(
 
     await Replayer(
         workflows=[CancellationBackstopWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        data_converter=pydantic_data_converter,
+    ).replay_workflow(history)
+
+
+_signal_cancellation_activity_started: asyncio.Event | None = None
+
+
+async def _signal_cancellation_stream_model(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+    assert _signal_cancellation_activity_started is not None
+    _signal_cancellation_activity_started.set()
+    yield 'thinking'
+    # Block until the model activity is cancelled by the run's first-party cancellation.
+    while True:  # pragma: no cover
+        activity.heartbeat()
+        await asyncio.sleep(0.01)
+
+
+async def _signal_cancellation_event_stream_handler(
+    ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]
+) -> None:
+    async for _ in stream:
+        pass
+
+
+_signal_cancellation_agent = Agent(
+    FunctionModel(stream_function=_signal_cancellation_stream_model),
+    name='signal_cancellation_agent',
+    deps_type=type(None),
+    capabilities=[
+        TemporalDurability(
+            event_stream_handler=_signal_cancellation_event_stream_handler,
+            model_activity_config=ActivityConfig(
+                cancellation_type=ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+                heartbeat_timeout=timedelta(seconds=1),
+            ),
+        )
+    ],
+)
+
+
+@workflow.defn
+class SignalCancellationWorkflow:
+    def __init__(self) -> None:
+        # A fresh handle per workflow execution; it binds to this run's cancellation only.
+        self._cancellation = DurableRunCancellation[None]()
+
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        try:
+            return (await _signal_cancellation_agent.run(prompt, capabilities=[self._cancellation])).output
+        except RunCancelled:
+            # Catching `RunCancelled` lets the workflow complete normally on a first-party cancel
+            # rather than ending *Cancelled*, and keeps the run replay-deterministic.
+            return 'run cancelled'
+
+    @workflow.signal
+    def cancel(self) -> None:
+        self._cancellation.cancel()
+
+
+async def test_temporal_run_cancelled_by_workflow_signal(client: Client) -> None:
+    """An external `@workflow.signal` wired to `DurableRunCancellation.cancel()` cancels the
+    in-flight durable run first-party: the run raises `RunCancelled`, which the workflow catches to
+    complete normally rather than ending as a *Cancelled* workflow. The recorded history replays
+    deterministically."""
+    global _signal_cancellation_activity_started
+
+    _signal_cancellation_activity_started = asyncio.Event()
+    workflow_id = f'{SignalCancellationWorkflow.__name__}-{uuid.uuid4()}'
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[SignalCancellationWorkflow],
+        plugins=[AgentPlugin(_signal_cancellation_agent)],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        handle = await client.start_workflow(
+            SignalCancellationWorkflow.run,
+            args=['cancel me'],
+            id=workflow_id,
+            task_queue=TASK_QUEUE,
+        )
+        await _signal_cancellation_activity_started.wait()
+        await handle.signal(SignalCancellationWorkflow.cancel)
+
+        assert await handle.result() == 'run cancelled'
+
+        history = await handle.fetch_history()
+
+    await Replayer(
+        workflows=[SignalCancellationWorkflow],
         workflow_runner=UnsandboxedWorkflowRunner(),
         data_converter=pydantic_data_converter,
     ).replay_workflow(history)


### PR DESCRIPTION

Advances #7197. Builds on first-party cancellation (#6497, now merged); targets `main`.

### What & why

First-party cancellation (#6497: `CancellationToken`, `RunContext.cancel()`, `AgentRun.cancel()`) has no story for an **external** actor cancelling a **capability-style durable run**: a `CancellationToken` is a same-process, cross-thread handle that can't cross the durable boundary (and #6497 rejects it there), and a durable run exposes no `AgentRun` for a user hitting "stop" to reach. Today the only external option is to cancel the whole workflow, which ends it *Cancelled* rather than producing a first-party "the run was cancelled" outcome.

This adds a small, portable seam: `DurableRunCancellation`, an engine-agnostic capability you pass to a single durable `run(capabilities=[...])`. It captures the run's `RunCancellation` controller in `before_run` and exposes a `cancel()` method that each durable engine wires to its own external-cancellation mechanism.

### Temporal wiring

`cancel()` is triggered from a `@workflow.signal` handler — a signal runs on the workflow event loop and is recorded in history, so the resulting cancellation is deterministic on replay:

```python
@workflow.defn
class MyAgentWorkflow:
    def __init__(self) -> None:
        self.cancellation = DurableRunCancellation()

    @workflow.run
    async def run(self, prompt: str) -> str:
        try:
            result = await my_temporal_agent.run(prompt, capabilities=[self.cancellation])
            return result.output
        except RunCancelled:
            return 'The run was cancelled.'

    @workflow.signal
    def cancel(self) -> None:
        self.cancellation.cancel()
```

An external actor cancels the run with `await handle.signal(MyAgentWorkflow.cancel)`.

### Replay determinism (important finding)

Verified against the Temporal dev server, including `Replayer`:

- **Catching `RunCancelled`** inside the workflow (so it completes *normally*) replays cleanly. This is the supported pattern, and matches the existing docs for `AgentRun.cancel()`.
- **An uncaught `RunCancelled`** (which fails the workflow) currently does **not** replay: Temporal rejects the completion with `Workflow activation completion failed`, because first-party cancellation is implemented via `asyncio.Task.cancel()` and Temporal's replay validation doesn't sanction a workflow cancelling one of its own tasks *and then failing*. The live run still surfaces `RunCancelled` correctly; only replay of the failed-workflow variant breaks. The integration test therefore uses the catch-and-complete pattern (with the `Replayer` assertion). Worth a maintainer eye — the existing `AgentRun.cancel()` docs claim replay-determinism, which holds only for the caught case.

### Design notes

- **Portable seam / not painting DBOS/Prefect into a corner**: the capability is engine-agnostic and lives in `durable_exec/`. `cancel()` delegates to `RunCancellation.cancel()`, which already marshals cross-loop/thread, so a DBOS/Prefect trigger binds to the same method. Only the *trigger* is engine-specific.
- `_safe_at_runtime = True` so it may be attached per-run under a bound durability capability (it introduces no toolsets/native tools/model wrapping); `get_serialization_name()` returns `None` (holds a live controller reference).
- The `cancellation_token`-unsupported error now points at `DurableRunCancellation` as the supported alternative.

### Deliberately deferred

- **DBOS / Prefect trigger equivalents** — the portable capability works with them, but this PR does not build/test their external-cancellation trigger. Follow-up under #7197.
- **Replay-safe uncaught cancellation** — see above; likely needs a cooperative (non-`Task.cancel`) cancellation path in durable contexts. Needs maintainer input.

### Tests

- `tests/test_durable_run_cancellation.py` — engine-agnostic coverage of the seam (sibling-task cancel, pre-bind cancel buffering, post-finish no-op, `_safe_at_runtime`/serialization opt-out).
- `tests/test_temporal.py::test_temporal_run_cancelled_by_workflow_signal` — end-to-end signal → first-party cancel with a `Replayer` determinism check.

### Docs

- `docs/durable_execution/temporal.md` — the signal pattern and the catch-`RunCancelled` guidance.
- `docs/api/durable_exec.md` — API reference entry.

- Advances #7197

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


