### PR TITLE
Record `FileSearchTool` options against the live xAI API instead of an empty-result search

### DIFF
--- a/tests/models/xai/cassettes/test_search_tools/test_xai_builtin_file_search_tool.xai.yaml
+++ b/tests/models/xai/cassettes/test_search_tools/test_xai_builtin_file_search_tool.xai.yaml
@@ -3,10 +3,16 @@ interactions:
 - collections_method:
     method: create
     response_proto_type: CollectionMetadata
+    request_json:
+      name: pydantic-ai-test-8a7e057d
+      chunk_configuration:
+        chars_configuration:
+          max_chunk_size_chars: 256
+          chunk_overlap_chars: 32
     response_json:
-      collection_id: collection_545f66c9-0270-488e-bcb0-ab7cc4108e81
-      collection_name: pydantic-ai-test-31c56c35
-      created_at: '2026-04-15T01:47:51.643557Z'
+      collection_id: collection_744aab7b-44f2-41ab-a982-9c49d1690c2f
+      collection_name: pydantic-ai-test-8a7e057d
+      created_at: '2026-08-05T15:28:20.222795Z'
       index_configuration:
         model_name: grok-embedding-small
       chunk_configuration:
@@ -14,27 +20,38 @@ interactions:
           max_chunk_size_chars: 256
           chunk_overlap_chars: 32
     response_raw: !!binary |
-      Ci9jb2xsZWN0aW9uXzU0NWY2NmM5LTAyNzAtNDg4ZS1iY2IwLWFiN2NjNDEwOGU4MRIZcHlkYW50
-      aWMtYWktdGVzdC0zMWM1NmMzNRoMCMfc+84GEIjN77ICIhYKFGdyb2stZW1iZWRkaW5nLXNtYWxs
-      KgcKBQiAAhAg
+      Ci9jb2xsZWN0aW9uXzc0NGFhYjdiLTQ0ZjItNDFhYi1hOTgyLTljNDlkMTY5MGMyZhIZcHlkYW50
+      aWMtYWktdGVzdC04YTdlMDU3ZBoLCJStzdMGEPipnmoiFgoUZ3Jvay1lbWJlZGRpbmctc21hbGwq
+      BwoFCIACECCSASQyODk4YTFhMy1iY2IxLTQ5M2MtOWNjMS1mYTYwOGI4YWU1ZjI=
 - collections_method:
     method: upload_document
     response_proto_type: DocumentMetadata
+    request_json:
+      collection_id: collection_744aab7b-44f2-41ab-a982-9c49d1690c2f
+      name: zorblax-memo-7742.txt
+      data: <bytes len=4739>
+      wait_for_indexing: true
+      timeout: datetime.timedelta(seconds=180)
     response_json:
       file_metadata:
-        file_id: file_b8886af2-6251-47e9-9ee3-5a4f7320824b
+        file_id: file_e9ef3a06-160e-4a51-a3e2-762cd070cc32
         name: zorblax-memo-7742.txt
         size_bytes: '4739'
         content_type: text/plain
-        created_at: '2026-04-15T01:47:51.965877Z'
+        created_at: '2026-08-05T15:28:20.614Z'
         hash: 39538abcab8556581a7d2358ccdb533a65c1ec8dfc1b8300be17bc02cbc8961d
         upload_status: Complete
+        processing_status: Processing
+        file_path: ''
       status: DOCUMENT_STATUS_PROCESSED
+      last_indexed_at: '2026-08-05T15:28:27.436354Z'
+      chunk_count: 6
+      chunks_processed_count: '6'
     response_raw: !!binary |
-      CrkBCilmaWxlX2I4ODg2YWYyLTYyNTEtNDdlOS05ZWUzLTVhNGY3MzIwODI0YhIVem9yYmxheC1t
-      ZW1vLTc3NDIudHh0GIMlIgp0ZXh0L3BsYWluKgwIx9z7zgYQiLrIzAM6QDM5NTM4YWJjYWI4NTU2
+      CrkBCilmaWxlX2U5ZWYzYTA2LTE2MGUtNGE1MS1hM2UyLTc2MmNkMDcwY2MzMhIVem9yYmxheC1t
+      ZW1vLTc3NDIudHh0GIMlIgp0ZXh0L3BsYWluKgwIlK3N0wYQgMvjpAI6QDM5NTM4YWJjYWI4NTU2
       NTgxYTdkMjM1OGNjZGI1MzNhNjVjMWVjOGRmYzFiODMwMGJlMTdiYzAyY2JjODk2MWRCCENvbXBs
-      ZXRlUgpQcm9jZXNzaW5nWgAYAioMCM7c+84GEPD6stACMAY4Bg==
+      ZXRlUgpQcm9jZXNzaW5nWgAYAioMCJutzdMGEND3iNABMAY4Bg==
 - request_sample:
     json:
       messages:
@@ -46,7 +63,11 @@ interactions:
       tools:
       - collections_search:
           collection_ids:
-          - collection_545f66c9-0270-488e-bcb0-ab7cc4108e81
+          - collection_744aab7b-44f2-41ab-a982-9c49d1690c2f
+          limit: 1
+          instructions: Prioritize exact factual matches from the uploaded research
+            memo.
+          semantic_retrieval: {}
       tool_choice:
         mode: TOOL_MODE_AUTO
       include:
@@ -55,54 +76,85 @@ interactions:
       CosBCoYBCoMBVXNpbmcgdGhlIHVwbG9hZGVkIFpvcmJsYXggUmVzZWFyY2ggTWVtbywgaW4gd2hh
       dCB5ZWFyIHdhcyB0aGUgWm9yYmxheCBQcm90b2NvbCBpbnZlbnRlZCBhbmQgd2hvIGFyZSBpdHMg
       dGhyZWUgcHJpbmNpcGFsIGludmVudG9ycz8QARIZZ3Jvay00LWZhc3Qtbm9uLXJlYXNvbmluZ4oB
-      MzIxCi9jb2xsZWN0aW9uXzU0NWY2NmM5LTAyNzAtNDg4ZS1iY2IwLWFiN2NjNDEwOGU4MZIBAggB
-      0gEBBA==
+      ejJ4Ci9jb2xsZWN0aW9uXzc0NGFhYjdiLTQ0ZjItNDFhYi1hOTgyLTljNDlkMTY5MGMyZhABGkFQ
+      cmlvcml0aXplIGV4YWN0IGZhY3R1YWwgbWF0Y2hlcyBmcm9tIHRoZSB1cGxvYWRlZCByZXNlYXJj
+      aCBtZW1vLioAkgECCAHSAQEE
   response_sample:
     json:
-      id: ffedb888-1d0b-92b9-ac70-6663c3a32d2e
+      id: 9695bb6d-c521-90fc-925b-c4ed0f7798db
       outputs:
-      - finish_reason: REASON_TOOL_CALLS
-        message:
+      - message:
           role: ROLE_ASSISTANT
           tool_calls:
-          - id: call_06614169
+          - id: call-ea6364ef-fc09-4f73-b49a-a869a33604a2-0
             type: TOOL_CALL_TYPE_COLLECTIONS_SEARCH_TOOL
             status: TOOL_CALL_STATUS_COMPLETED
             function:
               name: collections_search
-              arguments: '{"query":"Zorblax Protocol invention year and principal
-                inventors","limit":10}'
+              arguments: '{"search_request":"{\"query\": \"Zorblax Protocol invented
+                year principal inventors\", \"limit\": 10, \"retrieval_mode\": \"semantic\"}"}'
       - index: 1
         message:
-          content: "{\n  \"search_matches\": [],\n  \"info\": \"No results found.\"\
-            \n}"
+          content: '{"search_matches":[{"file_id":"file_e9ef3a06-160e-4a51-a3e2-762cd070cc32","chunk_id":"file_e9ef3a06-160e-4a51-a3e2-762cd070cc32_5","chunk_content":"ary
+            substrate. The Zorblax Protocol was adopted as the galactic standard by
+            the Outer Rim Treaty of 2193. Researchers cite three principal inventors:
+            Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas Rhen. \\n\\nSection 10. Zorblax
+            Research Memo 7742. The Zorblax Protocol is a fictional encryption scheme
+            invented by the Zorblax Research Collective in the year 2187. Its defining
+            property is the use of heptapod-prime key rotation, which cycles every
+            7919 milliseconds across the primary substrate. The Zorblax Protocol was
+            adopted as the galactic standard by the Outer Rim Treaty of 2193. Researchers
+            cite three principal inventors: Dr. Mira Calyx, Dr. Taren Ko, and Dr.
+            Silas Rhen. \"}]","score":0.7739996314048767,"collection_ids":["collection_744aab7b-44f2-41ab-a982-9c49d1690c2f"]}]}'
           role: ROLE_TOOL
           tool_calls:
-          - id: call_06614169
+          - id: call-ea6364ef-fc09-4f73-b49a-a869a33604a2-0
             type: TOOL_CALL_TYPE_COLLECTIONS_SEARCH_TOOL
             status: TOOL_CALL_STATUS_COMPLETED
             function:
               name: collections_search
-              arguments: '{"query":"Zorblax Protocol invention year and principal
-                inventors","limit":10}'
+              arguments: '{"search_request":"{\"query\": \"Zorblax Protocol invented
+                year principal inventors\", \"limit\": 10, \"retrieval_mode\": \"semantic\"}"}'
+          citations:
+          - collections_citation:
+              file_id: file_e9ef3a06-160e-4a51-a3e2-762cd070cc32
+              chunk_id: file_e9ef3a06-160e-4a51-a3e2-762cd070cc32_5
+              chunk_content: 'ary substrate. The Zorblax Protocol was adopted as the
+                galactic standard by the Outer Rim Treaty of 2193. Researchers cite
+                three principal inventors: Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas
+                Rhen. \n\nSection 10. Zorblax Research Memo 7742. The Zorblax Protocol
+                is a fictional encryption scheme invented by the Zorblax Research
+                Collective in the year 2187. Its defining property is the use of heptapod-prime
+                key rotation, which cycles every 7919 milliseconds across the primary
+                substrate. The Zorblax Protocol was adopted as the galactic standard
+                by the Outer Rim Treaty of 2193. Researchers cite three principal
+                inventors: Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas Rhen. "}]'
+              score: 0.77399963
+              collection_ids:
+              - collection_744aab7b-44f2-41ab-a982-9c49d1690c2f
       - finish_reason: REASON_STOP
         index: 2
         message:
-          content: I'm sorry, but I don't have access to any "Zorblax Research Memo"
-            or related information in my knowledge base. If you can provide the content
-            or more details, I may be able to assist further.
+          content: "**2187**, by **Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas Rhen**.\
+            \ \n\nThis is stated directly in the uploaded Zorblax Research Memo (Section\
+            \ 10), which describes the Zorblax Protocol as a fictional encryption\
+            \ scheme invented by the Zorblax Research Collective in 2187, with those\
+            \ three researchers cited as the principal inventors."
           role: ROLE_ASSISTANT
-      created: '2026-04-15T01:48:08.773309304Z'
-      model: grok-4-fast-non-reasoning
-      system_fingerprint: fp_391eaea9fb
+      created: '2026-08-05T15:28:38.489578359Z'
+      model: grok-4.3
+      system_fingerprint: fp_eb3c003fc66c14ed
       usage:
-        completion_tokens: 88
-        prompt_tokens: 980
-        total_tokens: 1068
-        prompt_text_tokens: 980
-        cached_prompt_text_tokens: 920
+        completion_tokens: 120
+        prompt_tokens: 2417
+        total_tokens: 2537
+        prompt_text_tokens: 2417
+        cached_prompt_text_tokens: 1152
         server_side_tools_used:
         - SERVER_SIDE_TOOL_COLLECTIONS_SEARCH
+        cost_in_usd_ticks: '46116500'
+      citations:
+      - collections://collection_744aab7b-44f2-41ab-a982-9c49d1690c2f/files/file_e9ef3a06-160e-4a51-a3e2-762cd070cc32
       settings:
         parallel_tool_calls: true
         temperature: 0.7
@@ -111,25 +163,71 @@ interactions:
         tools:
         - collections_search:
             collection_ids:
-            - collection_545f66c9-0270-488e-bcb0-ab7cc4108e81
+            - collection_744aab7b-44f2-41ab-a982-9c49d1690c2f
+            limit: 1
+            instructions: Prioritize exact factual matches from the uploaded research
+              memo.
+            semantic_retrieval: {}
         top_p: 0.95
         include:
         - INCLUDE_OPTION_COLLECTIONS_SEARCH_CALL_OUTPUT
     raw: !!binary |
-      CiRmZmVkYjg4OC0xZDBiLTkyYjktYWM3MC02NjYzYzNhMzJkMmUSgQEIBBp9EAIaeQoNY2FsbF8w
-      NjYxNDE2ORAFGAFSZAoSY29sbGVjdGlvbnNfc2VhcmNoEk57InF1ZXJ5IjoiWm9yYmxheCBQcm90
-      b2NvbCBpbnZlbnRpb24geWVhciBhbmQgcHJpbmNpcGFsIGludmVudG9ycyIsImxpbWl0IjoxMH0S
-      vQEQARq4AQo5ewogICJzZWFyY2hfbWF0Y2hlcyI6IFtdLAogICJpbmZvIjogIk5vIHJlc3VsdHMg
-      Zm91bmQuIgp9EAUaeQoNY2FsbF8wNjYxNDE2ORAFGAFSZAoSY29sbGVjdGlvbnNfc2VhcmNoEk57
-      InF1ZXJ5IjoiWm9yYmxheCBQcm90b2NvbCBpbnZlbnRpb24geWVhciBhbmQgcHJpbmNpcGFsIGlu
-      dmVudG9ycyIsImxpbWl0IjoxMH0SywEIAxACGsQBCr8BSSdtIHNvcnJ5LCBidXQgSSBkb24ndCBo
-      YXZlIGFjY2VzcyB0byBhbnkgIlpvcmJsYXggUmVzZWFyY2ggTWVtbyIgb3IgcmVsYXRlZCBpbmZv
-      cm1hdGlvbiBpbiBteSBrbm93bGVkZ2UgYmFzZS4gSWYgeW91IGNhbiBwcm92aWRlIHRoZSBjb250
-      ZW50IG9yIG1vcmUgZGV0YWlscywgSSBtYXkgYmUgYWJsZSB0byBhc3Npc3QgZnVydGhlci4QAioM
-      CNjc+84GEPiG3/ACMhlncm9rLTQtZmFzdC1ub24tcmVhc29uaW5nOg1mcF8zOTFlYWVhOWZiShYI
-      WBDUBxisCCDUBziYB0oBBligkbQMWkgQAS0zMzM/OgIIAUIzMjEKL2NvbGxlY3Rpb25fNTQ1ZjY2
-      YzktMDI3MC00ODhlLWJjYjAtYWI3Y2M0MTA4ZTgxTTMzcz9yAQQ=
+      CiQ5Njk1YmI2ZC1jNTIxLTkwZmMtOTI1Yi1jNGVkMGY3Nzk4ZGIS3gEa2wEQAhrUAQorY2FsbC1l
+      YTYzNjRlZi1mYzA5LTRmNzMtYjQ5YS1hODY5YTMzNjA0YTItMBAFGAFSoAEKEmNvbGxlY3Rpb25z
+      X3NlYXJjaBKJAXsic2VhcmNoX3JlcXVlc3QiOiJ7XCJxdWVyeVwiOiBcIlpvcmJsYXggUHJvdG9j
+      b2wgaW52ZW50ZWQgeWVhciBwcmluY2lwYWwgaW52ZW50b3JzXCIsIFwibGltaXRcIjogMTAsIFwi
+      cmV0cmlldmFsX21vZGVcIjogXCJzZW1hbnRpY1wifSJ9OAESxQ8QARrADwqjB3sic2VhcmNoX21h
+      dGNoZXMiOlt7ImZpbGVfaWQiOiJmaWxlX2U5ZWYzYTA2LTE2MGUtNGE1MS1hM2UyLTc2MmNkMDcw
+      Y2MzMiIsImNodW5rX2lkIjoiZmlsZV9lOWVmM2EwNi0xNjBlLTRhNTEtYTNlMi03NjJjZDA3MGNj
+      MzJfNSIsImNodW5rX2NvbnRlbnQiOiJhcnkgc3Vic3RyYXRlLiBUaGUgWm9yYmxheCBQcm90b2Nv
+      bCB3YXMgYWRvcHRlZCBhcyB0aGUgZ2FsYWN0aWMgc3RhbmRhcmQgYnkgdGhlIE91dGVyIFJpbSBU
+      cmVhdHkgb2YgMjE5My4gUmVzZWFyY2hlcnMgY2l0ZSB0aHJlZSBwcmluY2lwYWwgaW52ZW50b3Jz
+      OiBEci4gTWlyYSBDYWx5eCwgRHIuIFRhcmVuIEtvLCBhbmQgRHIuIFNpbGFzIFJoZW4uIFxcblxc
+      blNlY3Rpb24gMTAuIFpvcmJsYXggUmVzZWFyY2ggTWVtbyA3NzQyLiBUaGUgWm9yYmxheCBQcm90
+      b2NvbCBpcyBhIGZpY3Rpb25hbCBlbmNyeXB0aW9uIHNjaGVtZSBpbnZlbnRlZCBieSB0aGUgWm9y
+      YmxheCBSZXNlYXJjaCBDb2xsZWN0aXZlIGluIHRoZSB5ZWFyIDIxODcuIEl0cyBkZWZpbmluZyBw
+      cm9wZXJ0eSBpcyB0aGUgdXNlIG9mIGhlcHRhcG9kLXByaW1lIGtleSByb3RhdGlvbiwgd2hpY2gg
+      Y3ljbGVzIGV2ZXJ5IDc5MTkgbWlsbGlzZWNvbmRzIGFjcm9zcyB0aGUgcHJpbWFyeSBzdWJzdHJh
+      dGUuIFRoZSBab3JibGF4IFByb3RvY29sIHdhcyBhZG9wdGVkIGFzIHRoZSBnYWxhY3RpYyBzdGFu
+      ZGFyZCBieSB0aGUgT3V0ZXIgUmltIFRyZWF0eSBvZiAyMTkzLiBSZXNlYXJjaGVycyBjaXRlIHRo
+      cmVlIHByaW5jaXBhbCBpbnZlbnRvcnM6IERyLiBNaXJhIENhbHl4LCBEci4gVGFyZW4gS28sIGFu
+      ZCBEci4gU2lsYXMgUmhlbi4gXCJ9XSIsInNjb3JlIjowLjc3Mzk5OTYzMTQwNDg3NjcsImNvbGxl
+      Y3Rpb25faWRzIjpbImNvbGxlY3Rpb25fNzQ0YWFiN2ItNDRmMi00MWFiLWE5ODItOWM0OWQxNjkw
+      YzJmIl19XX0QBRrUAQorY2FsbC1lYTYzNjRlZi1mYzA5LTRmNzMtYjQ5YS1hODY5YTMzNjA0YTIt
+      MBAFGAFSoAEKEmNvbGxlY3Rpb25zX3NlYXJjaBKJAXsic2VhcmNoX3JlcXVlc3QiOiJ7XCJxdWVy
+      eVwiOiBcIlpvcmJsYXggUHJvdG9jb2wgaW52ZW50ZWQgeWVhciBwcmluY2lwYWwgaW52ZW50b3Jz
+      XCIsIFwibGltaXRcIjogMTAsIFwicmV0cmlldmFsX21vZGVcIjogXCJzZW1hbnRpY1wifSJ9MrwG
+      KrkGCilmaWxlX2U5ZWYzYTA2LTE2MGUtNGE1MS1hM2UyLTc2MmNkMDcwY2MzMhIrZmlsZV9lOWVm
+      M2EwNi0xNjBlLTRhNTEtYTNlMi03NjJjZDA3MGNjMzJfNRqoBWFyeSBzdWJzdHJhdGUuIFRoZSBa
+      b3JibGF4IFByb3RvY29sIHdhcyBhZG9wdGVkIGFzIHRoZSBnYWxhY3RpYyBzdGFuZGFyZCBieSB0
+      aGUgT3V0ZXIgUmltIFRyZWF0eSBvZiAyMTkzLiBSZXNlYXJjaGVycyBjaXRlIHRocmVlIHByaW5j
+      aXBhbCBpbnZlbnRvcnM6IERyLiBNaXJhIENhbHl4LCBEci4gVGFyZW4gS28sIGFuZCBEci4gU2ls
+      YXMgUmhlbi4gXG5cblNlY3Rpb24gMTAuIFpvcmJsYXggUmVzZWFyY2ggTWVtbyA3NzQyLiBUaGUg
+      Wm9yYmxheCBQcm90b2NvbCBpcyBhIGZpY3Rpb25hbCBlbmNyeXB0aW9uIHNjaGVtZSBpbnZlbnRl
+      ZCBieSB0aGUgWm9yYmxheCBSZXNlYXJjaCBDb2xsZWN0aXZlIGluIHRoZSB5ZWFyIDIxODcuIEl0
+      cyBkZWZpbmluZyBwcm9wZXJ0eSBpcyB0aGUgdXNlIG9mIGhlcHRhcG9kLXByaW1lIGtleSByb3Rh
+      dGlvbiwgd2hpY2ggY3ljbGVzIGV2ZXJ5IDc5MTkgbWlsbGlzZWNvbmRzIGFjcm9zcyB0aGUgcHJp
+      bWFyeSBzdWJzdHJhdGUuIFRoZSBab3JibGF4IFByb3RvY29sIHdhcyBhZG9wdGVkIGFzIHRoZSBn
+      YWxhY3RpYyBzdGFuZGFyZCBieSB0aGUgT3V0ZXIgUmltIFRyZWF0eSBvZiAyMTkzLiBSZXNlYXJj
+      aGVycyBjaXRlIHRocmVlIHByaW5jaXBhbCBpbnZlbnRvcnM6IERyLiBNaXJhIENhbHl4LCBEci4g
+      VGFyZW4gS28sIGFuZCBEci4gU2lsYXMgUmhlbi4gIn1dJdckRj8qL2NvbGxlY3Rpb25fNzQ0YWFi
+      N2ItNDRmMi00MWFiLWE5ODItOWM0OWQxNjkwYzJmOAES2AIIAxACGtECCsoCKioyMTg3KiosIGJ5
+      ICoqRHIuIE1pcmEgQ2FseXgsIERyLiBUYXJlbiBLbywgYW5kIERyLiBTaWxhcyBSaGVuKiouIAoK
+      VGhpcyBpcyBzdGF0ZWQgZGlyZWN0bHkgaW4gdGhlIHVwbG9hZGVkIFpvcmJsYXggUmVzZWFyY2gg
+      TWVtbyAoU2VjdGlvbiAxMCksIHdoaWNoIGRlc2NyaWJlcyB0aGUgWm9yYmxheCBQcm90b2NvbCBh
+      cyBhIGZpY3Rpb25hbCBlbmNyeXB0aW9uIHNjaGVtZSBpbnZlbnRlZCBieSB0aGUgWm9yYmxheCBS
+      ZXNlYXJjaCBDb2xsZWN0aXZlIGluIDIxODcsIHdpdGggdGhvc2UgdGhyZWUgcmVzZWFyY2hlcnMg
+      Y2l0ZWQgYXMgdGhlIHByaW5jaXBhbCBpbnZlbnRvcnMuEAI4ASoMCKatzdMGEPe+uekBMghncm9r
+      LTQuMzoTZnBfZWIzYzAwM2ZjNjZjMTRlZEodCHgQ8RIY6RMg8RI4gAlKAQZYlN3+FZAB1gqYAVJS
+      bWNvbGxlY3Rpb25zOi8vY29sbGVjdGlvbl83NDRhYWI3Yi00NGYyLTQxYWItYTk4Mi05YzQ5ZDE2
+      OTBjMmYvZmlsZXMvZmlsZV9lOWVmM2EwNi0xNjBlLTRhNTEtYTNlMi03NjJjZDA3MGNjMzJajwEQ
+      AS0zMzM/OgIIAUJ6MngKL2NvbGxlY3Rpb25fNzQ0YWFiN2ItNDRmMi00MWFiLWE5ODItOWM0OWQx
+      NjkwYzJmEAEaQVByaW9yaXRpemUgZXhhY3QgZmFjdHVhbCBtYXRjaGVzIGZyb20gdGhlIHVwbG9h
+      ZGVkIHJlc2VhcmNoIG1lbW8uKgBNMzNzP3IBBA==
 - collections_method:
     method: delete
     response_proto_type: ''
+    request_json:
+      _args:
+      - '''collection_744aab7b-44f2-41ab-a982-9c49d1690c2f'''
     response_raw: !!binary ""

--- a/tests/models/xai/test_search_tools.py
+++ b/tests/models/xai/test_search_tools.py
@@ -881,7 +881,16 @@ async def test_xai_builtin_file_search_tool(
         m = XaiModel(XAI_NON_REASONING_MODEL, provider=xai_provider)
         agent = Agent(
             m,
-            capabilities=[NativeTool(FileSearchTool(file_store_ids=[collection.collection_id]))],
+            capabilities=[
+                NativeTool(
+                    FileSearchTool(
+                        file_store_ids=[collection.collection_id],
+                        max_num_results=1,
+                        instructions='Prioritize exact factual matches from the uploaded research memo.',
+                        retrieval_mode='semantic',
+                    )
+                )
+            ],
             model_settings=XaiModelSettings(xai_include_collections_search_output=True),
         )
 
@@ -906,28 +915,44 @@ async def test_xai_builtin_file_search_tool(
                     parts=[
                         NativeToolCallPart(
                             tool_name='file_search',
-                            args={'query': 'Zorblax Protocol invention year and principal inventors', 'limit': 10},
+                            args={
+                                'search_request': '{"query": "Zorblax Protocol invented year principal inventors", "limit": 10, "retrieval_mode": "semantic"}'
+                            },
                             tool_call_id=IsStr(),
                             provider_name='xai',
                             provider_details={'function_name': 'collections_search'},
                         ),
                         NativeToolReturnPart(
                             tool_name='file_search',
-                            content={'search_matches': [], 'info': 'No results found.'},
+                            content={
+                                'search_matches': [
+                                    {
+                                        'file_id': 'file_e9ef3a06-160e-4a51-a3e2-762cd070cc32',
+                                        'chunk_id': 'file_e9ef3a06-160e-4a51-a3e2-762cd070cc32_5',
+                                        'chunk_content': 'ary substrate. The Zorblax Protocol was adopted as the galactic standard by the Outer Rim Treaty of 2193. Researchers cite three principal inventors: Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas Rhen. \\n\\nSection 10. Zorblax Research Memo 7742. The Zorblax Protocol is a fictional encryption scheme invented by the Zorblax Research Collective in the year 2187. Its defining property is the use of heptapod-prime key rotation, which cycles every 7919 milliseconds across the primary substrate. The Zorblax Protocol was adopted as the galactic standard by the Outer Rim Treaty of 2193. Researchers cite three principal inventors: Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas Rhen. "}]',
+                                        'score': 0.7739996314048767,
+                                        'collection_ids': ['collection_744aab7b-44f2-41ab-a982-9c49d1690c2f'],
+                                    }
+                                ]
+                            },
                             tool_call_id=IsStr(),
                             timestamp=IsDatetime(),
                             provider_name='xai',
                         ),
                         TextPart(
-                            content='I\'m sorry, but I don\'t have access to any "Zorblax Research Memo" or related information in my knowledge base. If you can provide the content or more details, I may be able to assist further.'
+                            content="""\
+**2187**, by **Dr. Mira Calyx, Dr. Taren Ko, and Dr. Silas Rhen**. \n\
+
+This is stated directly in the uploaded Zorblax Research Memo (Section 10), which describes the Zorblax Protocol as a fictional encryption scheme invented by the Zorblax Research Collective in 2187, with those three researchers cited as the principal inventors.\
+"""
                         ),
                     ],
                     usage=RequestUsage(
-                        input_tokens=980,
-                        cache_read_tokens=920,
-                        output_tokens=88,
+                        input_tokens=2417,
+                        cache_read_tokens=1152,
+                        output_tokens=120,
                         details={'server_side_tools_file_search': 1},
-                        cost=Decimal('0.000102'),
+                        cost=Decimal('0.0003706'),
                     ),
                     model_name='grok-4-fast-non-reasoning',
                     timestamp=IsDatetime(),


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David asked for this PR to be opened from a commit recorded during #7154; he has not reviewed the diff.

<!-- No issue: recovers a live recording made while #7154 was in flight. -->

`test_xai_builtin_file_search_tool` currently asserts a **failed** search. Its cassette on `main` has `collections_search` return `{'search_matches': [], 'info': 'No results found.'}`, and the snapshot pins the model's answer as:

> I'm sorry, but I don't have access to any "Zorblax Research Memo" or related information in my knowledge base.

So the test proves the tool is *wired up*, but never that it *works* — and it passes just as well if retrieval is broken.

This re-records it against the live xAI API with the `FileSearchTool` options actually set:

```python
FileSearchTool(
    file_store_ids=[collection.collection_id],
    max_num_results=1,
    instructions='Prioritize exact factual matches from the uploaded research memo.',
    retrieval_mode='semantic',
)
```

Three things the new recording pins that the old one could not:

1. **The options reach the provider.** `retrieval_mode` comes back inside the serialized `search_request` argument xAI echoes on the `NativeToolCallPart` — `'{"query": ..., "limit": 10, "retrieval_mode": "semantic"}'`. The old snapshot had a bare `{'query': ..., 'limit': 10}`, so the shape of that argument was itself unverified.
2. **Retrieval returns a real match**, with the `file_id` / `chunk_id` / `chunk_content` / `score` / `collection_ids` fields — the `NativeToolReturnPart` content shape was previously only ever exercised on the empty path.
3. **The model answers from the retrieved chunk** (`2187`, and the three inventors), which is the behavior the test is named for.

`max_num_results=1` also keeps the payload to a single chunk, so the cassette stays small.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

