### PR TITLE
Map streamed OpenRouter reasoning details by their index

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1314,12 +1314,12 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
         if reasoning_details := choice.delta.reasoning_details:
             for i, detail in enumerate(reasoning_details):
                 thinking_part = _from_reasoning_detail(detail)
-                # Use unique vendor_part_id for each reasoning detail type to prevent
-                # different detail types (e.g., reasoning.text, reasoning.encrypted)
-                # from being incorrectly merged into a single ThinkingPart.
-                # This is required for Gemini 3 Pro which returns multiple reasoning
-                # detail types that must be preserved separately for thought_signature handling.
-                vendor_id = f'reasoning_detail_{detail.type}_{i}'
+                # OpenRouter's index is stable across chunks, unlike the position in the current
+                # chunk. It distinguishes separate details while merging deltas for one detail.
+                # The type remains part of the identifier because Gemini 3 Pro can emit text and
+                # encrypted details with the same index; those must remain separate ThinkingParts
+                # for thought-signature handling.
+                vendor_id = f'reasoning_detail_{detail.type}_{detail.index if detail.index is not None else i}'
                 yield from self._parts_manager.handle_thinking_delta(
                     vendor_part_id=vendor_id,
                     id=thinking_part.id,

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -736,7 +736,11 @@ async def test_openrouter_streaming_reasoning(allow_model_requests: None, openro
 async def test_openrouter_streamed_reasoning_details_are_preserved(
     allow_model_requests: None,
 ) -> None:
-    """A streamed OpenRouter response keeps details with distinct indexes separate."""
+    """A streamed OpenRouter response keeps details with distinct indexes separate.
+
+    Mock-based rather than VCR — reasoning details spread across distinct indexes can't be reliably elicited
+    from a live provider, so the chunks are hand-built.
+    """
 
     async def consume_events(_: RunContext[object], event_stream: AsyncIterable[Any]) -> None:
         async for _event in event_stream:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import Sequence
+from collections.abc import AsyncIterable, Sequence
 from copy import deepcopy
 from decimal import Decimal
 from typing import Any, Literal, cast
@@ -20,6 +20,7 @@ from pydantic_ai import (
     ModelResponse,
     PartEndEvent,
     PartStartEvent,
+    RunContext,
     RunUsage,
     TextPart,
     ThinkingPart,
@@ -730,6 +731,83 @@ async def test_openrouter_streaming_reasoning(allow_model_requests: None, openro
                 TextPart(content='2 + 2 = 4'),
             ]
         )
+
+
+async def test_openrouter_streamed_reasoning_details_are_preserved(
+    allow_model_requests: None,
+) -> None:
+    """A streamed OpenRouter response keeps details with distinct indexes separate."""
+
+    async def consume_events(_: RunContext[object], event_stream: AsyncIterable[Any]) -> None:
+        async for _event in event_stream:
+            pass
+
+    def reasoning_chunk(
+        reasoning_detail: dict[str, Any], *, content: str = '', finish_reason: str | None = None
+    ) -> ChatCompletionChunk:
+        return _OpenRouterChatCompletionChunk.model_validate(
+            {
+                'id': 'gen-123',
+                'choices': [
+                    {
+                        'index': 0,
+                        'delta': {'role': 'assistant', 'content': content, 'reasoning_details': [reasoning_detail]},
+                        'finish_reason': finish_reason,
+                    }
+                ],
+                'created': 1704067200,
+                'model': 'openai/gpt-5.6-luna',
+                'object': 'chat.completion.chunk',
+                'provider': 'OpenAI',
+            }
+        )
+
+    mock_client = MockOpenAI(
+        stream=[
+            reasoning_chunk(
+                {'type': 'reasoning.summary', 'summary': 'first summary', 'format': 'openai-responses-v1', 'index': 0}
+            ),
+            reasoning_chunk(
+                {
+                    'type': 'reasoning.encrypted',
+                    'id': 'rs_123',
+                    'data': 'encrypted reasoning',
+                    'format': 'openai-responses-v1',
+                    'index': 1,
+                }
+            ),
+            reasoning_chunk(
+                {'type': 'reasoning.summary', 'summary': 'second summary', 'format': 'openai-responses-v1', 'index': 2},
+                content='first answer',
+                finish_reason='stop',
+            ),
+        ],
+    )
+    model = OpenRouterModel('openai/gpt-5.6-luna', provider=OpenRouterProvider(openai_client=cast(Any, mock_client)))
+    agent = Agent(model)
+
+    result = await agent.run('first prompt', event_stream_handler=consume_events)
+
+    assert result.response.parts == [
+        ThinkingPart(
+            content='first summary',
+            provider_name='openrouter',
+            provider_details={'format': 'openai-responses-v1', 'index': 0, 'type': 'reasoning.summary'},
+        ),
+        ThinkingPart(
+            content='',
+            id='rs_123',
+            signature='encrypted reasoning',
+            provider_name='openrouter',
+            provider_details={'format': 'openai-responses-v1', 'index': 1, 'type': 'reasoning.encrypted'},
+        ),
+        ThinkingPart(
+            content='second summary',
+            provider_name='openrouter',
+            provider_details={'format': 'openai-responses-v1', 'index': 2, 'type': 'reasoning.summary'},
+        ),
+        TextPart(content='first answer'),
+    ]
 
 
 async def test_openrouter_no_openrouter_details(openrouter_api_key: str) -> None:


### PR DESCRIPTION
### Problem description

When streaming responses from OpenRouter,  `OpenRouterStreamedResponse._map_thinking_delta` was not using the `reasoning_details.index` field in the model response's deltas, and instead was mapping `reasoning_detail` to `ThinkingPart` based only on the within-chunk position and `reasoning_details.type`. Because OpenRouter commonly sends one reasoning detail per SSE chunk, that position is always `0`.

For OpenAI models, a response can contain multiple independent reasoning details. OpenRouter emits them with the response-wide `reasoning_details.index` field

```json
  {"reasoning_details":[{"type":"reasoning.summary","index":0,"summary":"..."}]}
  {"reasoning_details":[{"type":"reasoning.summary","index":0,"summary":"..."}]}
  {"reasoning_details":[{"type":"reasoning.encrypted","index":1,"id":"rs_0123","data":"..."}]}
  {"reasoning_details":[{"type":"reasoning.summary","index":2,"summary":"..."}]}
  {"reasoning_details":[{"type":"reasoning.summary","index":2,"summary":"..."}]}
```

[Full OpenRouter SSE dump for gpt-5.6](https://gist.github.com/VictorPeralta/d334ce00138ecdf1592e16c3afc4f2e1)

Previously, the two summary blocks were merged because both were assigned the same within-chunk position (0). The resulting response contained only two `ThinkingParts`: one combined `reasoning.summary` part and one combined `reasoning.encrypted` part. This loses the original reasoning detail boundaries and can make a subsequent request with `message_history` invalid, and resulting in the error `"Item 'rs_123' of type 'reasoning' was provided without its required following item."` as described [in these docs](https://pydantic.dev/docs/ai/api/models/openai/#pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_send_reasoning_ids), even without using a history processor, because the streamed response stored in history is altered.

For the snippet in issue #7185, you can see in the [logfire request data for the second agent run](https://logfire-us.pydantic.dev/public-trace/ec2e2ad7-1d30-4c85-80cc-45f1e8707019?spanId=a04ce57ef640a10c) that we have the following reasoning details (note the indexes are 6 and 8):
```
[{'id': None, 'format': 'openai-responses-v1', 'index': 6, 'type': 'reasoning.summary', 'summary': '''...'''}, {'id': 'rs_0f042e8fc8a3a8ca016a72569ee820819184088ed6e5902c50', 'format': 'openai-responses-v1', 'index': 8, 'type': 'reasoning.encrypted', 'data': '...'}]
```
### Fix implementation

This PR changes a single line of code, using `reasoning_detail.index` as part of the streamed part identifier, while retaining the `reasoning_detail.type`. The example above now produces three distinct `ThinkingParts`:

1. `reasoning.summary, index 0`
2. `reasoning.encrypted, index 1`
3. `reasoning.summary, index 2`

The regression test verifies that these details remain separate in the streamed response. Providers whose streams use the same index for all reasoning details retain their previous behavior, because `reasoning_details.index` is always 0, and within-chunk position was always 0.

I've tested this fix resolves the issue in https://github.com/pydantic/pydantic-ai/issues/7185 with GPT-5.6 Luna, and continues to work with Gemini 3.1 Pro and Claude Sonnet 5, introducing no breaking changes. I have OpenRouter SSE dumps for the latter 2 as well:
[Gemini](https://gist.github.com/VictorPeralta/5004b77077588a5063c9f458e27d19f0)
[Claude](https://gist.github.com/VictorPeralta/6959f925d7a66d395a428146cdba6e03)


- Closes #7185 

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

