### PR TITLE
fix: preserve output tool retry guidance

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -347,15 +347,10 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         rather than raised inline so the caller can decide whether to re-raise (no other output
         produced a valid result) or absorb it as a skip.
         """
-        max_output_retries = self.ctx.deps.max_output_retries
         try:
             validated = await self.tool_manager.validate_output_tool_call(call, schema=self.schema)
         except exceptions.UnexpectedModelBehavior as e:
-            tool = self.tool_manager.tools.get(call.tool_name) if self.tool_manager.tools else None
-            # Defensive: an output tool is always present in the toolset, so the `None` fallback to
-            # the agent-level budget isn't expected in normal operation.
-            max_retries = tool.max_retries if tool is not None else max_output_retries
-            wrapped = exceptions.UnexpectedModelBehavior(f'Exceeded maximum output retries ({max_retries})')
+            wrapped = exceptions.UnexpectedModelBehavior(str(e))
             wrapped.__cause__ = e.__cause__ or e
             return _OutputCallResult(call=call, args_valid=False, raise_exc=wrapped)
 
@@ -372,8 +367,7 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         try:
             result_data: Any = await self.tool_manager.execute_output_tool_call(validated, schema=self.schema)
         except exceptions.UnexpectedModelBehavior as e:
-            max_retries = validated.tool.max_retries if validated.tool else max_output_retries
-            wrapped = exceptions.UnexpectedModelBehavior(f'Exceeded maximum output retries ({max_retries})')
+            wrapped = exceptions.UnexpectedModelBehavior(str(e))
             wrapped.__cause__ = e.__cause__ or e
             return _OutputCallResult(call=call, args_valid=True, raise_exc=wrapped)
         except ToolRetryError as e:

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -338,7 +338,7 @@ def test_output_tool_retry_error_handled():
         call_count += 1
         raise ModelRetry('Fail')
 
-    with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(2\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'final_result' exceeded max retries count of 2.*tool-retries"):
         agent.run_sync('Hello', model=TestModel())
 
     assert call_count == 3
@@ -382,7 +382,7 @@ def test_output_tool_retry_error_handled_with_custom_args():
 
     agent = Agent('test', output_type=ResultModel, retries={'tools': 2, 'output': 2})
 
-    with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(2\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'final_result' exceeded max retries count of 2.*tool-retries"):
         agent.run_sync('Hello', model=TestModel(custom_output_args={'foo': 'a', 'bar': 1}))
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6460,7 +6460,7 @@ class TestMultipleToolCalls:
             end_strategy='exhaustive',
         )
 
-        with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(1\)'):
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'output_tool' exceeded max retries count of 1.*tool-retries"):
             agent.run_sync('test')
 
     def test_exhaustive_skips_output_tool_exceeding_retries_on_validation(self):
@@ -12969,7 +12969,7 @@ def test_output_validator_exceeds_output_retries():
         retries_log.append(ctx.retry)
         raise ModelRetry(f'Retry {ctx.retry}')
 
-    with pytest.raises(UnexpectedModelBehavior, match='Exceeded maximum output retries \\(2\\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool '.+' exceeded max retries count of 2.*tool-retries"):
         agent.run_sync('Hello')
 
     assert retries_log == [0, 1, 2]
@@ -13240,7 +13240,7 @@ def test_output_retry_budget_resolution(case: OutputRetryBudgetCase):
         retries_log.append(ctx.retry)
         raise ModelRetry(f'retry {ctx.retry}')
 
-    expected_msg = rf'Exceeded maximum output retries \({case.expected_budget}\)'
+    expected_msg = rf"Tool '.+' exceeded max retries count of {case.expected_budget}.*tool-retries"
     override_ctx = agent.override(**case.override) if case.override is not None else nullcontext()
 
     with override_ctx:
@@ -13297,7 +13297,7 @@ def test_run_level_output_retry_override_without_validators():
     assert shared_toolset is not None
     assert shared_toolset.max_retries == 10
 
-    with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(2\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool '.+' exceeded max retries count of 2.*tool-retries"):
         agent.run_sync('Hello', retries={'output': 2})
 
     # 3 attempts: initial + 2 retries, capped by the run override at 2 (not the agent default 10)
@@ -13321,7 +13321,7 @@ def test_from_spec_preserves_zero_retry_budgets():
         output_type=ToolOutput(Foo),
     )
 
-    with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(0\)'):
+    with pytest.raises(UnexpectedModelBehavior, match=r"Tool '.+' exceeded max retries count of 0.*tool-retries"):
         output_agent.run_sync('Hello')
 
     assert output_call_count == 1
@@ -13590,7 +13590,7 @@ def test_wrapper_override_forwards_retries():
     wrapped = WrapperAgent(agent)
 
     with wrapped.override(retries=0):
-        with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum output retries \(0\)'):
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool '.+' exceeded max retries count of 0.*tool-retries"):
             wrapped.run_sync('Hello')
 
     assert call_count == 1


### PR DESCRIPTION
## Problem

When an output tool exhausted its retry limit, the final `UnexpectedModelBehavior` message discarded the tool name, the effective per-tool retry count, the suggestion to raise the limit, and the retry documentation link.

## Root Cause

`_ToolCallProcessor._run_output_tool_call` caught the detailed `UnexpectedModelBehavior` raised by `ToolManager._check_max_retries` and replaced its message with a generic agent-level retry message in both validation and execution paths.

## Solution

Preserve the original exception message when re-wrapping the exception, while keeping the existing exception type and cause chain behavior.

## Changes

- Preserve the detailed retry-exhaustion message for output-tool validation failures.
- Preserve the detailed retry-exhaustion message for output-tool execution failures.
- Update regression expectations to assert the tool name, effective retry count, and documentation link.

## Testing

- `D:\Python310\python.exe -m pytest tests\models\test_model_test.py tests\test_agent.py tests\test_streaming.py -q` ? 614 passed, 6 skipped, 3 xfailed.
- `D:\Python310\python.exe -m pytest tests\models\test_model_test.py tests\test_agent.py tests\test_streaming.py tests\test_capabilities.py -q -k "retry and output"` ? 49 passed.
- `D:\Python310\python.exe -m ruff check pydantic_ai_slim\pydantic_ai\_tool_execution.py tests\models\test_model_test.py tests\test_agent.py` ? passed.
- `git diff --check` ? passed.
- Ruff format check was not clean because the sparse Windows checkout reports existing CRLF/upstream formatting differences in the touched files; no unrelated formatting was included.
- Pyright was not clean in this sparse checkout because `pydantic_graph` and the configured `.venv` are unavailable, producing dependency-resolution and cascading baseline errors.

## Compatibility/Risk

This is a behavior-preserving diagnostic improvement for output-tool retry exhaustion. The exception type and retry control flow remain unchanged; only the final message now retains the more actionable per-tool details. No public API signatures change.

## Notes for Reviewer

Please verify both output-tool catch sites: validation failures and execution failures. The preserved message is produced by `ToolManager._check_max_retries` and includes the effective tool-specific retry budget.

## Linked Issue

Fixes #7203


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

