### PR TITLE
fix: correct REASONING_VERSION docstring (#7140)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -22,7 +22,13 @@ carrier (`ReasoningEncryptedValueEvent`) is a separate `REASONING_*` event gated
 """
 
 REASONING_VERSION = (0, 1, 13)
-"""AG-UI version that introduced REASONING_* events (replacing THINKING_*)."""
+"""Minimum ag-ui-protocol version at which we emit ``REASONING_*`` events instead of ``THINKING_*`` events.
+
+``REASONING_*`` events are present in ag-ui-protocol from 0.1.11 onward (confirmed byte-identical
+across 0.1.11, 0.1.12, and 0.1.13).  This constant is the library's chosen *emission threshold*,
+not the version that introduced those events to the protocol.  Whether to lower it to (0, 1, 11)
+is a separate behavioural decision.
+"""
 
 MULTIMODAL_VERSION = (0, 1, 15)
 """AG-UI version that introduced typed multimodal input content (Image/Audio/Video/Document).


### PR DESCRIPTION
 Fix misleading REASONING_VERSION docstring

Closes #7140 (docstring part).

The old docstring implied 0.1.13 introduced REASONING_* events to the protocol, which is incorrect — those events already exist in 0.1.11 (ag_ui/core/events.py is byte-identical across 0.1.11, 0.1.12, and 0.1.13).

REASONING_VERSION = (0, 1, 13) is the library's chosen emission threshold, not the protocol introduction point. Updated the docstring to reflect this, and noted that lowering the value to (0, 1, 11) is a separate behavioural decision for maintainers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

