### PR TITLE
Fix dead MCP spec links in MCP client docs

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -91,7 +91,7 @@ logfire.instrument_pydantic_ai()
 
 ### SSE
 
-The [HTTP + Server-Sent Events](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports/#http-with-sse) transport is also supported. URLs ending in `/sse` are auto-detected as SSE; for any other path, pass an explicit [`SSETransport`](https://gofastmcp.com/clients/transports).
+The [HTTP + Server-Sent Events](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) transport is also supported. URLs ending in `/sse` are auto-detected as SSE; for any other path, pass an explicit [`SSETransport`](https://gofastmcp.com/clients/transports).
 
 !!! note
     The SSE transport in MCP is deprecated. You should prefer Streamable HTTP for new deployments.
@@ -106,7 +106,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ### Stdio
 
-MCP also offers the [stdio transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio), where the server is run as a subprocess and communicates with the client over `stdin` and `stdout`. Pass a path to a Python or Node.js script, or build a [`StdioTransport`](https://gofastmcp.com/clients/transports) for full control over the command, arguments, and environment.
+MCP also offers the [stdio transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#stdio), where the server is run as a subprocess and communicates with the client over `stdin` and `stdout`. Pass a path to a Python or Node.js script, or build a [`StdioTransport`](https://gofastmcp.com/clients/transports) for full control over the command, arguments, and environment.
 
 ```python {title="mcp_stdio_client.py" test="skip"}
 from fastmcp.client.transports import StdioTransport

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -91,7 +91,7 @@ logfire.instrument_pydantic_ai()
 
 ### SSE
 
-The [HTTP + Server-Sent Events](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#http-with-sse) transport is also supported. URLs ending in `/sse` are auto-detected as SSE; for any other path, pass an explicit [`SSETransport`](https://gofastmcp.com/clients/transports).
+The [HTTP + Server-Sent Events](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports/#http-with-sse) transport is also supported. URLs ending in `/sse` are auto-detected as SSE; for any other path, pass an explicit [`SSETransport`](https://gofastmcp.com/clients/transports).
 
 !!! note
     The SSE transport in MCP is deprecated. You should prefer Streamable HTTP for new deployments.
@@ -106,7 +106,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ### Stdio
 
-MCP also offers the [stdio transport](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio), where the server is run as a subprocess and communicates with the client over `stdin` and `stdout`. Pass a path to a Python or Node.js script, or build a [`StdioTransport`](https://gofastmcp.com/clients/transports) for full control over the command, arguments, and environment.
+MCP also offers the [stdio transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio), where the server is run as a subprocess and communicates with the client over `stdin` and `stdout`. Pass a path to a Python or Node.js script, or build a [`StdioTransport`](https://gofastmcp.com/clients/transports) for full control over the command, arguments, and environment.
 
 ```python {title="mcp_stdio_client.py" test="skip"}
 from fastmcp.client.transports import StdioTransport


### PR DESCRIPTION
Fix dead MCP spec links in the MCP client docs.

The two transport links in `docs/mcp/client.md` point to `spec.modelcontextprotocol.io`, whose subdomain no longer serves content (TLS handshake fails). The rest of the docs already link to `modelcontextprotocol.io` (e.g. the task-augmented execution and elicitation references), so this aligns the remaining outliers with the working domain. Verified: `https://modelcontextprotocol.io/specification/2024-11-05/basic/transports/` returns 200 with both `#http-with-sse` and `#stdio` anchors present.


### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

