### PR TITLE
Document the `PYDANTIC_AI_GATEWAY_BASE_URL` environment variable

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -92,6 +92,14 @@ Set the `PYDANTIC_AI_GATEWAY_API_KEY` environment variable to your Gateway API k
 export PYDANTIC_AI_GATEWAY_API_KEY="pylf_v..."
 ```
 
+The Gateway base URL is inferred from the region encoded in your API key, so you normally do not
+need to set it. If your key predates region-encoded keys, Pydantic AI raises a `UserError` asking
+you to generate a new key or set the URL yourself, which you do with `PYDANTIC_AI_GATEWAY_BASE_URL`:
+
+```bash
+export PYDANTIC_AI_GATEWAY_BASE_URL="https://gateway-us.pydantic.dev/proxy"
+```
+
 You can access multiple models with the same API key, as shown in the code snippet below.
 
 ```python {title="hello_world.py"}


### PR DESCRIPTION
`gateway_provider` reads `PYDANTIC_AI_GATEWAY_BASE_URL`, and `_infer_base_url` raises a `UserError` that tells the user to "set the `PYDANTIC_AI_GATEWAY_BASE_URL` environment variable explicitly" when the API key does not encode a region. That variable appears nowhere in the Gateway docs, so anyone who hits that error and searches the page for it finds nothing.

Added a short paragraph to the setup section: the base URL is normally inferred from the region in the key, and this is the variable to set when it cannot be. Kept it next to `PYDANTIC_AI_GATEWAY_API_KEY` so the two are together.

Ran `uv run pytest tests/test_examples.py -k gateway` (5 passed) and `uv run mkdocs build --strict`, no new warnings. The override path itself is already exercised in `tests/providers/test_gateway.py`, which sets this variable to drive its parametrized provider tests.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. I left out the legacy `PAIG_BASE_URL` / `PAIG_API_KEY` fallbacks since they look deliberately undocumented, but happy to mention them if you would rather they be discoverable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

