### PR TITLE
Document Bedrock client timeouts and their environment fallbacks

### DIFF
--- a/docs/models/bedrock.md
+++ b/docs/models/bedrock.md
@@ -87,7 +87,8 @@ agent = Agent(model)
 ```
 
 These apply to clients the provider builds itself. A prebuilt `bedrock_client` is used as-is, so
-configure its timeouts on the client.
+configure its timeouts on the client. See [Timeouts](../timeouts.md) for how request timeouts work
+across model classes, including why `ModelSettings['timeout']` does not reach Bedrock.
 
 ### Customizing Bedrock Runtime API
 

--- a/docs/models/bedrock.md
+++ b/docs/models/bedrock.md
@@ -62,6 +62,33 @@ agent = Agent(model)
 ...
 ```
 
+### Timeouts
+
+Long generations can outlast the Bedrock client's default timeouts. Both are configurable on
+[`BedrockProvider`][pydantic_ai.providers.bedrock.BedrockProvider], and each falls back to an
+environment variable when omitted:
+
+| Argument | Environment variable | Default |
+| --- | --- | --- |
+| `aws_read_timeout` | `AWS_READ_TIMEOUT` | 300 seconds |
+| `aws_connect_timeout` | `AWS_CONNECT_TIMEOUT` | 60 seconds |
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.bedrock import BedrockConverseModel
+from pydantic_ai.providers.bedrock import BedrockProvider
+
+model = BedrockConverseModel(
+    'anthropic.claude-sonnet-4-5-20250929-v1:0',
+    provider=BedrockProvider(region_name='us-east-1', aws_read_timeout=600),
+)
+agent = Agent(model)
+...
+```
+
+These apply to clients the provider builds itself. A prebuilt `bedrock_client` is used as-is, so
+configure its timeouts on the client.
+
 ### Customizing Bedrock Runtime API
 
 You can customize the Bedrock Runtime API calls by adding additional parameters, such as [guardrail

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -624,8 +624,10 @@ class BedrockProvider(Provider[BaseClient]):
             base_url: The base URL for the Bedrock client.
             region_name: The AWS region name. If not set, the `AWS_DEFAULT_REGION` environment variable will be used if available.
             profile_name: The AWS profile name.
-            aws_read_timeout: The read timeout for Bedrock client.
-            aws_connect_timeout: The connect timeout for Bedrock client.
+            aws_read_timeout: The read timeout for the Bedrock client, in seconds. If not set, the
+                `AWS_READ_TIMEOUT` environment variable will be used if available, defaulting to 300.
+            aws_connect_timeout: The connect timeout for the Bedrock client, in seconds. If not set, the
+                `AWS_CONNECT_TIMEOUT` environment variable will be used if available, defaulting to 60.
         """
         if bedrock_client is not None:
             self._client = bedrock_client

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -624,10 +624,8 @@ class BedrockProvider(Provider[BaseClient]):
             base_url: The base URL for the Bedrock client.
             region_name: The AWS region name. If not set, the `AWS_DEFAULT_REGION` environment variable will be used if available.
             profile_name: The AWS profile name.
-            aws_read_timeout: The read timeout for the Bedrock client, in seconds. If not set, the
-                `AWS_READ_TIMEOUT` environment variable will be used if available, defaulting to 300.
-            aws_connect_timeout: The connect timeout for the Bedrock client, in seconds. If not set, the
-                `AWS_CONNECT_TIMEOUT` environment variable will be used if available, defaulting to 60.
+            aws_read_timeout: The read timeout for Bedrock client.
+            aws_connect_timeout: The connect timeout for Bedrock client.
         """
         if bedrock_client is not None:
             self._client = bedrock_client


### PR DESCRIPTION
`BedrockProvider` takes `aws_read_timeout` and `aws_connect_timeout`, each falling back to `AWS_READ_TIMEOUT` / `AWS_CONNECT_TIMEOUT` and then to 300 and 60 seconds, but the Bedrock page never mentions timeouts. Long generations are exactly where people hit the read timeout and go looking for the knob.

Adds a Timeouts section to `docs/models/bedrock.md` with a table of argument, environment variable and default, a short example, and a note that a prebuilt `bedrock_client` is used as-is so its timeouts belong on the client.

This reopens #7222, which the PR guard closed automatically. That one also touched the two argument docstrings in `providers/bedrock.py`, which put it outside the `docs/*|*.md|mkdocs.yml` docs-only exemption in `.github/workflows/pr-guard.yml`, so it was correctly caught by the rule. This version is documentation only. Happy to follow up on the docstrings behind an issue if that information is worth having in the API reference too.

The documented defaults and fallbacks are the ones `test_bedrock_provider_timeout` in `tests/providers/test_bedrock.py` already pins, by setting both environment variables and asserting they reach `config.read_timeout` and `config.connect_timeout`. Ran that test, `uv run pytest tests/test_examples.py -k bedrock` (21 passed, covering the new example), and `uv run mkdocs build --strict` with no new warnings.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. my mistake bundling a docstring change into a docs PR the first time, that is what tripped the guard.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

