### PR TITLE
Gate OpenRouter off native mid-conversation system messages with `supports_inline_system_prompts=False`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -188,6 +188,8 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         #    accepts `reasoning` universally, so the gate also forces `supports_thinking=True` so the unified `thinking`
         #    setting is always forwarded regardless of the upstream model's own thinking support. OpenRouter only
         #    accepts the older `max_tokens` field, so `openai_chat_supports_max_completion_tokens=False`.
+        #    It also silently transforms mid-conversation system messages rather than handling them natively,
+        #    so `supports_inline_system_prompts=False` selects the deliberate `<system>`-wrapped fallback.
         return merge_profile(
             OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
             profile,
@@ -197,6 +199,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
                 openai_chat_supports_file_urls=True,
                 openai_chat_supports_web_search=True,
                 openai_chat_supports_max_completion_tokens=False,
+                supports_inline_system_prompts=False,
                 supports_thinking=True,
                 # OpenRouter's native tools (web search plugin, advisor) are gateway features that
                 # work with any underlying model, so the upstream profile's vendor-specific tool

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -21,6 +21,7 @@ from pydantic_ai import (
     PartEndEvent,
     PartStartEvent,
     RunUsage,
+    SystemPromptPart,
     TextPart,
     ThinkingPart,
     ToolCallPart,
@@ -47,6 +48,7 @@ with try_import() as imports_successful:
 
     from pydantic_ai.models.anthropic import AnthropicModelSettings
     from pydantic_ai.models.fallback import FallbackModel
+    from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.models.openrouter import (
         OpenRouterModel,
         OpenRouterModelSettings,
@@ -56,6 +58,7 @@ with try_import() as imports_successful:
         _OpenRouterChatCompletionChunk,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.models.test import TestModel
+    from pydantic_ai.providers.openai import OpenAIProvider
     from pydantic_ai.providers.openrouter import OpenRouterProvider
 
 pytestmark = [
@@ -1094,6 +1097,48 @@ def _openrouter_completion(content: str) -> ChatCompletion:
     choice = Choice.model_construct(index=0, message=message, finish_reason='stop', native_finish_reason='stop')
     return ChatCompletion.model_construct(
         id='123', choices=[choice], created=1704067200, model='test', object='chat.completion', provider='test'
+    )
+
+
+async def test_openrouter_wraps_mid_conversation_system_prompt(allow_model_requests: None) -> None:
+    """OpenRouter gets the fallback while the same history stays native on OpenAI.
+
+    Mocked clients pin the rendered request bodies directly: OpenRouter accepts an inline `system`
+    message but silently transforms it, so a successful gateway response cannot prove native support.
+    """
+    history = [
+        ModelRequest(parts=[SystemPromptPart(content='You are helpful.'), UserPromptPart(content='Hello.')]),
+        ModelResponse(parts=[TextPart(content='Hi.')]),
+        ModelRequest(parts=[SystemPromptPart(content='Answer in one sentence.')]),
+    ]
+    openrouter_client = MockOpenAI.create_mock(_openrouter_completion('Done.'))
+    openai_client = MockOpenAI.create_mock(_openrouter_completion('Done.'))
+
+    openrouter_model = OpenRouterModel('openai/gpt-5', provider=OpenRouterProvider(openai_client=openrouter_client))
+    openai_model = OpenAIChatModel('gpt-5', provider=OpenAIProvider(openai_client=openai_client))
+
+    await Agent(openrouter_model).run('Continue.', message_history=history)
+    await Agent(openai_model).run('Continue.', message_history=history)
+
+    assert openrouter_model.profile.get('supports_inline_system_prompts') is False
+    assert openai_model.profile.get('supports_inline_system_prompts') is True
+    assert get_mock_chat_completion_kwargs(openrouter_client)[0]['messages'] == snapshot(
+        [
+            {'role': 'system', 'content': 'You are helpful.'},
+            {'role': 'user', 'content': 'Hello.'},
+            {'role': 'assistant', 'content': 'Hi.'},
+            {'role': 'user', 'content': '<system>Answer in one sentence.</system>'},
+            {'role': 'user', 'content': 'Continue.'},
+        ]
+    )
+    assert get_mock_chat_completion_kwargs(openai_client)[0]['messages'] == snapshot(
+        [
+            {'role': 'system', 'content': 'You are helpful.'},
+            {'role': 'user', 'content': 'Hello.'},
+            {'role': 'assistant', 'content': 'Hi.'},
+            {'role': 'system', 'content': 'Answer in one sentence.'},
+            {'role': 'user', 'content': 'Continue.'},
+        ]
     )
 
 

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -887,7 +887,6 @@ def test_openrouter_openai_gpt_5_4():
             'supports_json_object_output': True,
             'supports_image_output': True,
             'json_schema_transformer': OpenAIJsonSchemaTransformer,
-            'supports_inline_system_prompts': True,
             'supports_thinking': True,
             'openai_chat_thinking_field': 'reasoning',
             'openai_chat_send_back_thinking_parts': 'field',


### PR DESCRIPTION
OpenRouter accepts a mid-history `{"role": "system"}` message with a 200 where the native APIs 400 — but it silently transforms it, with no native handling and no cache benefit (live-probed 2026-07-27). Since #6765 renders mid-history `SystemPromptPart`s natively wherever the profile allows, the gateway was riding a flag it doesn't actually honor: a successful response from a gateway is not evidence of native support.

This gates OpenRouter negatively: `supports_inline_system_prompts=False` in the provider's profile overrides, so mid-conversation system prompts take the deliberate `<system>`-wrapped fallback. The new test pins both request bodies — OpenRouter wrapped, the same history on OpenAI still native — so the gate can't silently widen.

Closes #7242

## Checklist

- [ ] The **issue on GitHub** exists and is linked above.
- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

