### PR TITLE
Forward events from `UIEventStream` callbacks that return an async iterator without being an async generator function

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
@@ -320,12 +320,24 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
         self, callback: _CallbackFunc[_CallbackArgT, EventT], arg: _CallbackArgT
     ) -> AsyncIterator[EventT]:
         if inspect.isasyncgenfunction(callback):
+            # Fast path for the common `async def ... yield` form.
             async for event in callback(arg):
                 yield event
         elif _utils.is_async_callable(callback):
+            # `async def ... return None`, or a callable object with a coroutine `__call__`.
             await callback(arg)
         else:
-            await _utils.run_in_executor(callback, arg)
+            # A plain callable can still return an async iterator or awaitable that neither
+            # `isasyncgenfunction` nor `is_async_callable` detects (a `def` that returns an async
+            # generator, or a callable instance whose `__call__` is an async generator). Run it
+            # off-thread in case it's blocking-sync, then honour whatever it returned so those
+            # `Callable[..., AsyncIterator]` / `Callable[..., Awaitable]` forms aren't silently dropped.
+            result = await _utils.run_in_executor(callback, arg)
+            if isinstance(result, AsyncIterator):
+                async for event in result:
+                    yield event
+            elif inspect.isawaitable(result):
+                await result
 
     async def _turn_to(self, to_turn: Literal['request', 'response'] | None) -> AsyncIterator[EventT]:
         """Fire hooks when turning from request to response or vice versa."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -74,7 +74,7 @@ pytest.importorskip('starlette')
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
-from pydantic_ai.ui import NativeEvent, UIAdapter, UIEventStream
+from pydantic_ai.ui import NativeEvent, OnCompleteFunc, UIAdapter, UIEventStream
 from pydantic_ai.ui._adapter import resolve_allow_uploaded_files
 
 pytestmark = [
@@ -1073,6 +1073,42 @@ async def test_run_stream_on_complete():
             '</stream>',
         ]
     )
+
+
+async def _custom_event_gen(run_result: AgentRunResult[Any]) -> AsyncIterator[str]:
+    yield '<custom>'
+
+
+def _on_complete_plain_returns_asyncgen(run_result: AgentRunResult[Any]) -> AsyncIterator[str]:
+    # A plain `def` that *returns* an async iterator: valid per `OnCompleteFunc`, but not an
+    # async generator function, so `inspect.isasyncgenfunction` does not detect it.
+    return _custom_event_gen(run_result)
+
+
+class _OnCompleteCallableObject:
+    # A callable instance whose `__call__` is an async generator: also valid per `OnCompleteFunc`
+    # and also invisible to `inspect.isasyncgenfunction`.
+    async def __call__(self, run_result: AgentRunResult[Any]) -> AsyncIterator[str]:
+        yield '<custom>'
+
+
+@pytest.mark.parametrize(
+    'on_complete',
+    [_on_complete_plain_returns_asyncgen, _OnCompleteCallableObject()],
+    ids=['plain-def-returns-asyncgen', 'callable-object'],
+)
+async def test_run_stream_on_complete_async_iterator_non_asyncgenfunction(
+    on_complete: OnCompleteFunc[str],
+):
+    """`on_complete` forms that return an async iterator without being an async generator function
+    must still have their events emitted, not silently dropped."""
+    agent = Agent(model=TestModel())
+    request = DummyUIRunInput(messages=[ModelRequest.user_text_prompt('Hello')])
+
+    adapter = DummyUIAdapter(agent, request)
+    events = [event async for event in adapter.run_stream(on_complete=on_complete)]
+
+    assert '<custom>' in events
 
 
 async def test_run_stream_metadata_forwarded():

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import warnings
-from collections.abc import AsyncIterator, MutableMapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, MutableMapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any
@@ -1109,6 +1109,24 @@ async def test_run_stream_on_complete_async_iterator_non_asyncgenfunction(
     events = [event async for event in adapter.run_stream(on_complete=on_complete)]
 
     assert '<custom>' in events
+
+
+async def test_run_stream_on_complete_plain_def_returns_awaitable():
+    """A plain `def` on_complete that returns an awaitable must have it awaited, not discarded."""
+    agent = Agent(model=TestModel())
+    request = DummyUIRunInput(messages=[ModelRequest.user_text_prompt('Hello')])
+    called: list[bool] = []
+
+    async def _record(run_result: AgentRunResult[Any]) -> None:
+        called.append(True)
+
+    def on_complete(run_result: AgentRunResult[Any]) -> Awaitable[None]:
+        return _record(run_result)
+
+    adapter = DummyUIAdapter(agent, request)
+    _ = [event async for event in adapter.run_stream(on_complete=on_complete)]
+
+    assert called == [True]
 
 
 async def test_run_stream_metadata_forwarded():


### PR DESCRIPTION
A self-found bug from Macroscope's re-review of #6324; the affected code shipped on `main` via #6497.

`UIEventStream`'s `on_complete` / `on_cancel` callbacks are typed as `_CallbackFunc`, whose third arm is `Callable[[arg], AsyncIterator[EventT]]` — a callback that emits protocol events. `_dispatch_callback` only forwarded those events when `inspect.isasyncgenfunction(callback)` was true, which holds for the common `async def ... yield` form but **not** for two other shapes the type admits:

- a plain `def` that *returns* an async iterator (`def cb(arg): return agen()`), and
- a callable instance whose `__call__` is an async generator.

Both fell through to the executor branch, where the returned async iterator was constructed and then discarded — the callback's protocol events were silently dropped.

The fix inspects the returned value in the fallback branch and forwards an async iterator (or awaits a returned awaitable), mirroring the existing probe pattern in `ProcessEventStream.wrap_run_event_stream`. Genuinely-sync callbacks still run in the executor as before.

### Tests

Regression tests in `tests/test_ui.py`, parametrized over both dropped shapes (plain `def` returning an async generator, and a callable instance with an async-generator `__call__`), plus a case for a plain `def` returning an awaitable. Verified failing before / passing after.

### Follow-ups

- A related but distinct sibling class — dispatch sites that use `is_async_callable` and mishandle a plain `def` returning a coroutine — is catalogued in #7257 rather than widened into this fix.
- Worth considering a shared dispatch helper (the "call, then inspect the returned value" pattern) so `_dispatch_callback`, `ProcessEventStream`, and the #7257 sites don't each re-implement it. Left for the #7257 follow-up.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
