### PR TITLE
Restore the released legacy profile-key shim and fix two reveal-state edges (`is_tool_available`, `TestModel` native additions)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -282,7 +282,9 @@ class RunContext(Generic[RunContextAgentDepsT]):
         for the reveal state sent through the model-request pipeline.
         """
         if isinstance(tool, str):
-            if self.tool_manager is None:
+            if self.tool_manager is None or self.tool_manager.tools is None:
+                # Same live-state condition as `available_tool_names`: mid-`get_tools` the
+                # manager exists but its tool set isn't resolved yet, so fall back to history.
                 return tool in self.available_tool_names
             tool_def = self.tools.get(tool)
             if tool_def is None:

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -73,6 +73,7 @@ from ..profiles import (
     ModelProfileSpec,
     ToolAdditionMode,
     ToolDeferralMode,
+    _translate_legacy_profile_keys,  # pyright: ignore[reportPrivateUsage]
     merge_profile,
 )
 from ..providers import InterfaceClient, Provider, infer_provider, infer_provider_class
@@ -985,7 +986,9 @@ class Model(ABC, Generic[InterfaceClient]):
         if user is None:
             pass
         elif callable(user):
-            resolved = user(resolved)
+            # The callable form's result bypasses `merge_profile`, so translate deprecated key
+            # spellings here too.
+            resolved = _translate_legacy_profile_keys(user(resolved))
         else:
             # Partial dict — merge on top
             resolved = merge_profile(resolved, user)

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -168,7 +168,7 @@ class FunctionModel(Model):
         if not response.usage.has_values():  # pragma: no branch
             response.usage = _estimate_usage(
                 chain(messages, [response]),
-                allow_tool_availability_deltas=self.profile.get('tool_addition_mode') is not None,
+                allow_tool_availability_deltas=self.tool_addition_mode is not None,
             )
         return response
 

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -166,7 +166,10 @@ class FunctionModel(Model):
         response.model_name = self._model_name
         # Add usage data if not already present
         if not response.usage.has_values():  # pragma: no branch
-            response.usage = _estimate_usage(chain(messages, [response]))
+            response.usage = _estimate_usage(
+                chain(messages, [response]),
+                allow_tool_availability_deltas=self.profile.get('tool_addition_mode') is not None,
+            )
         return response
 
     @asynccontextmanager
@@ -395,10 +398,16 @@ class FunctionStreamedResponse(StreamedResponse):
         return self._timestamp
 
 
-def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.RequestUsage:  # noqa: C901
+def _estimate_usage(  # noqa: C901
+    messages: Iterable[ModelMessage], *, allow_tool_availability_deltas: bool = False
+) -> usage.RequestUsage:
     """Very rough guesstimate of the token usage associated with a series of messages.
 
     This is designed to be used solely to give plausible numbers for testing!
+
+    `allow_tool_availability_deltas` mirrors the calling model's profile: a delta part is
+    legitimately present when the profile advertises a native tool-addition channel, and a
+    contract violation (`prepare_messages` was skipped) otherwise.
     """
     # there seem to be about 50 tokens of overhead for both Gemini and OpenAI calls, so add that here ¯\_(ツ)_/¯
     request_tokens = 50
@@ -412,8 +421,10 @@ def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.RequestUsage:  # 
                     request_tokens += _estimate_string_tokens(part.model_response_str())
                 elif isinstance(part, RetryPromptPart):
                     request_tokens += _estimate_string_tokens(part.model_response())
-                elif isinstance(part, ToolAvailabilityDeltaPart):  # pragma: no cover
-                    raise _unsynthesized_tool_availability_delta_error()
+                elif isinstance(part, ToolAvailabilityDeltaPart):
+                    if not allow_tool_availability_deltas:
+                        raise _unsynthesized_tool_availability_delta_error()
+                    request_tokens += _estimate_string_tokens(' '.join(part.tools_added))
                 else:
                     assert_never(part)
         elif isinstance(message, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -133,7 +133,7 @@ class TestModel(Model):
         model_response = self._request(messages, model_settings, model_request_parameters)
         model_response.usage = _estimate_usage(
             [*messages, model_response],
-            allow_tool_availability_deltas=self.profile.get('tool_addition_mode') is not None,
+            allow_tool_availability_deltas=self.tool_addition_mode is not None,
         )
         model_response.provider_name = self._system
         return model_response
@@ -159,7 +159,7 @@ class TestModel(Model):
             _structured_response=model_response,
             _messages=messages,
             _provider_name=self._system,
-            _allow_tool_availability_deltas=self.profile.get('tool_addition_mode') is not None,
+            _allow_tool_availability_deltas=self.tool_addition_mode is not None,
         )
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -131,7 +131,10 @@ class TestModel(Model):
         )
         self.last_model_request_parameters = model_request_parameters
         model_response = self._request(messages, model_settings, model_request_parameters)
-        model_response.usage = _estimate_usage([*messages, model_response])
+        model_response.usage = _estimate_usage(
+            [*messages, model_response],
+            allow_tool_availability_deltas=self.profile.get('tool_addition_mode') is not None,
+        )
         model_response.provider_name = self._system
         return model_response
 
@@ -156,6 +159,7 @@ class TestModel(Model):
             _structured_response=model_response,
             _messages=messages,
             _provider_name=self._system,
+            _allow_tool_availability_deltas=self.profile.get('tool_addition_mode') is not None,
         )
 
     @property
@@ -186,10 +190,19 @@ class TestModel(Model):
         return _JsonSchemaTestData(tool_def.parameters_json_schema, self.seed).generate()
 
     def _get_tool_calls(self, model_request_parameters: ModelRequestParameters) -> list[tuple[str, ToolDefinition]]:
+        # `declared_function_tools` alone would exclude `'via_history'` tools — revealed deferred
+        # tools on a `tool_addition_mode='with_definitions'` profile, whose definitions travel via
+        # history rather than the `tools` collection. They are callable, so the simulation must
+        # include them; only `'withheld'` tools are invisible to the model.
+        callable_function_tools = [
+            tool
+            for tool in model_request_parameters.function_tools
+            if model_request_parameters.visibility_of(tool.name) != 'withheld'
+        ]
         if self.call_tools == 'all':
-            return [(r.name, r) for r in model_request_parameters.declared_function_tools]
+            return [(r.name, r) for r in callable_function_tools]
         else:
-            function_tools_lookup = {t.name: t for t in model_request_parameters.declared_function_tools}
+            function_tools_lookup = {t.name: t for t in callable_function_tools}
             all_function_tools_lookup = {t.name: t for t in model_request_parameters.function_tools}
             tools_to_call: list[ToolDefinition] = []
             for name in self.call_tools:
@@ -340,10 +353,11 @@ class TestStreamedResponse(StreamedResponse):
     _messages: InitVar[Iterable[ModelMessage]]
     _provider_name: str
     _provider_url: str | None = None
+    _allow_tool_availability_deltas: bool = False
     _timestamp: datetime = field(default_factory=_utils.now_utc, init=False)
 
     def __post_init__(self, _messages: Iterable[ModelMessage]):
-        self._usage = _estimate_usage(_messages)
+        self._usage = _estimate_usage(_messages, allow_tool_availability_deltas=self._allow_tool_availability_deltas)
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         for i, part in enumerate(self._structured_response.parts):

--- a/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
@@ -1,12 +1,14 @@
 from __future__ import annotations as _annotations
 
+import warnings
 from collections.abc import Callable
 from textwrap import dedent
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, cast
 
 from typing_extensions import TypedDict
 
 from .._json_schema import InlineDefsJsonSchemaTransformer, JsonSchemaTransformer
+from ..exceptions import PydanticAIDeprecationWarning
 from ..native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from ..output import StructuredOutputMode
 
@@ -158,6 +160,47 @@ class ModelProfile(TypedDict, total=False):
     tool removal (#6985) is not modeled yet and will get its own field.
     """
 
+    tool_additions: ToolAdditionMode | None
+    """Deprecated: use `tool_addition_mode` instead.
+
+    Translated (with a deprecation warning) whenever profiles are merged; an explicit
+    `tool_addition_mode` in the same profile wins.
+    """
+
+    deferred_tools_require_tool_search: bool
+    """Deprecated: use `tool_deferral_mode` instead.
+
+    `True` translates to `tool_deferral_mode='with_tool_search'` (with a deprecation warning)
+    whenever profiles are merged. `False` carried no signal on its own — deferral capability came
+    from native tool-search support — so it is dropped; an explicit `tool_deferral_mode` in the
+    same profile wins.
+    """
+
+
+def _translate_legacy_profile_keys(profile: ModelProfile) -> ModelProfile:
+    """Translate keys renamed after their v2.23 release into their current spellings, warning."""
+    if 'tool_additions' not in profile and 'deferred_tools_require_tool_search' not in profile:
+        return profile
+    translated = dict(profile)
+    if 'tool_additions' in translated:
+        warnings.warn(
+            '`ModelProfile` key `tool_additions` is deprecated, use `tool_addition_mode` instead.',
+            PydanticAIDeprecationWarning,
+            stacklevel=3,
+        )
+        value = translated.pop('tool_additions')
+        translated.setdefault('tool_addition_mode', value)
+    if 'deferred_tools_require_tool_search' in translated:
+        warnings.warn(
+            '`ModelProfile` key `deferred_tools_require_tool_search` is deprecated, use '
+            "`tool_deferral_mode='with_tool_search'` instead.",
+            PydanticAIDeprecationWarning,
+            stacklevel=3,
+        )
+        if translated.pop('deferred_tools_require_tool_search'):
+            translated.setdefault('tool_deferral_mode', 'with_tool_search')
+    return cast('ModelProfile', translated)
+
 
 DEFAULT_PROFILE: ModelProfile = {
     'supports_tools': True,
@@ -194,11 +237,13 @@ def merge_profile(base: ModelProfile | None, *overrides: ModelProfile | None) ->
     """Merge profiles via dict-spread. Later arguments override earlier ones; `None` is treated as empty.
 
     This is the canonical way to layer profiles in providers and tests; replaces the old `ModelProfile.update()` method.
+    Deprecated key spellings are translated per input before spreading, so a legacy key in an
+    override still overrides the base.
     """
     result: ModelProfile = {}
     if base:
-        result = {**result, **base}
+        result = {**result, **_translate_legacy_profile_keys(base)}
     for override in overrides:
         if override:
-            result = {**result, **override}
+            result = {**result, **_translate_legacy_profile_keys(override)}
     return result

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -32,6 +32,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
 from pydantic_ai.messages import ToolAvailabilityDeltaPart
+from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.test import TestModel, _chars, _JsonSchemaTestData  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.usage import RequestUsage, RunUsage
@@ -140,6 +141,17 @@ def test_native_tool_addition_profile_runs_without_crashing() -> None:
         if isinstance(message, ModelRequest)
         for part in message.parts
     )
+
+
+async def test_delta_part_without_native_profile_still_raises() -> None:
+    """On the default profile (no native addition channel), a delta part in a direct
+    `Model.request()` history still means `prepare_messages` was skipped — keep teaching that."""
+    model = TestModel()
+    messages: list[Any] = [
+        ModelRequest(parts=[ToolAvailabilityDeltaPart(tools_added=['hidden'])]),
+    ]
+    with pytest.raises(UserError, match=r'Call `model.prepare_messages\(messages\)` first'):
+        await model.request(messages, None, ModelRequestParameters())
 
 
 def test_revealed_via_history_tool_is_callable_in_named_mode() -> None:

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -25,12 +25,15 @@ from pydantic_ai import (
     RunContext,
     TextPart,
     ToolCallPart,
+    ToolReturn,
     ToolReturnPart,
     UserPromptPart,
     VideoUrl,
 )
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
+from pydantic_ai.messages import ToolAvailabilityDeltaPart
 from pydantic_ai.models.test import TestModel, _chars, _JsonSchemaTestData  # pyright: ignore[reportPrivateUsage]
+from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.usage import RequestUsage, RunUsage
 
 from .._inline_snapshot import snapshot
@@ -104,6 +107,50 @@ def test_call_unknown_tool_has_clear_error() -> None:
 
     with pytest.raises(UserError, match=r"TestModel was configured to call unknown tool 'missing'"):
         agent.run_sync('call missing')
+
+
+def _native_addition_agent(call_tools: list[str] | Literal['all']) -> Agent:
+    """An agent on a delta-native profile: reveals stay in history as `ToolAvailabilityDeltaPart`s
+    and the revealed tool's visibility resolves to `'via_history'` rather than `'visible'`."""
+    profile = ModelProfile(tool_deferral_mode='standalone', tool_addition_mode='with_definitions')
+    agent = Agent(TestModel(profile=profile, call_tools=call_tools))
+
+    @agent.tool_plain
+    def revealer() -> ToolReturn:
+        return ToolReturn(return_value='revealed', tools=['hidden'])
+
+    @agent.tool_plain(defer_loading=True)
+    def hidden() -> str:  # pragma: no cover
+        return 'hidden'
+
+    return agent
+
+
+def test_native_tool_addition_profile_runs_without_crashing() -> None:
+    """The delta part a native-addition profile keeps in history must not blow up usage
+    estimation — it is legitimately present, not a skipped-`prepare_messages` violation."""
+    result = _native_addition_agent('all').run_sync('go')
+
+    assert result.output == snapshot(
+        '{"revealer":"revealed","search_tools":{"discovered_tools":[],"message":"No matching tools found. The tools you need may not be available."}}'
+    )
+    assert any(
+        isinstance(part, ToolAvailabilityDeltaPart)
+        for message in result.all_messages()
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+    )
+
+
+def test_revealed_via_history_tool_is_callable_in_named_mode() -> None:
+    """A revealed tool whose definition travels via history is callable; replaying its history
+    must not raise the misleading 'must be revealed' error on later steps."""
+    history = _native_addition_agent('all').run_sync('go').all_messages()
+
+    result = _native_addition_agent(['hidden']).run_sync('continue', message_history=history)
+    assert result.output == snapshot(
+        '{"revealer":"revealed","search_tools":{"discovered_tools":[],"message":"No matching tools found. The tools you need may not be available."}}'
+    )
 
 
 def test_custom_output_text():

--- a/tests/profiles/test_legacy_keys.py
+++ b/tests/profiles/test_legacy_keys.py
@@ -1,0 +1,56 @@
+"""The v2.23-released spellings of the reveal-channel profile keys translate with a warning."""
+
+import pytest
+
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
+from pydantic_ai.models import ModelRequestParameters, ToolDefinition
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.profiles import ModelProfile, merge_profile
+
+
+def test_legacy_tool_additions_translates_and_warns():
+    with pytest.warns(PydanticAIDeprecationWarning, match=r'`tool_additions` is deprecated'):
+        profile = merge_profile({'tool_additions': 'by_reference'})
+    assert profile == {'tool_addition_mode': 'by_reference'}
+
+
+def test_legacy_deferred_tools_require_tool_search_translates_and_warns():
+    with pytest.warns(PydanticAIDeprecationWarning, match=r'`deferred_tools_require_tool_search` is deprecated'):
+        assert merge_profile({'deferred_tools_require_tool_search': True}) == {'tool_deferral_mode': 'with_tool_search'}
+    # `False` carried no signal on its own — deferral capability came from native tool-search
+    # support — so it is dropped rather than translated to a mode it never meant.
+    with pytest.warns(PydanticAIDeprecationWarning, match=r'`deferred_tools_require_tool_search` is deprecated'):
+        assert merge_profile({'deferred_tools_require_tool_search': False}) == {}
+
+
+def test_current_spelling_wins_over_legacy_in_the_same_profile():
+    with pytest.warns(PydanticAIDeprecationWarning):
+        profile = merge_profile({'tool_additions': 'by_reference', 'tool_addition_mode': 'with_definitions'})
+    assert profile == {'tool_addition_mode': 'with_definitions'}
+
+
+def test_legacy_key_in_override_still_overrides_base():
+    with pytest.warns(PydanticAIDeprecationWarning):
+        profile = merge_profile({'tool_addition_mode': 'with_definitions'}, {'tool_additions': 'by_reference'})
+    assert profile == {'tool_addition_mode': 'by_reference'}
+
+
+def test_legacy_keys_reach_resolution_through_model_profile_argument():
+    """The whole point: a v2.23-era `Model(profile=...)` keeps driving the resolve table."""
+    with pytest.warns(PydanticAIDeprecationWarning):
+        model = TestModel(profile=ModelProfile(tool_additions='by_reference', deferred_tools_require_tool_search=True))
+        assert model.tool_addition_mode == 'by_reference'
+        assert model.tool_deferral_mode == 'with_tool_search'
+
+    # The callable form bypasses `merge_profile`, so resolution translates its result directly.
+    with pytest.warns(PydanticAIDeprecationWarning):
+        callable_model = TestModel(profile=lambda _default: ModelProfile(tool_additions='with_definitions'))
+        assert callable_model.tool_addition_mode == 'with_definitions'
+
+    # `Model.profile` is cached per instance, so the warning fires once at resolution, not on
+    # every request — this call must run silently against the already-translated profile. And the
+    # translated claim drives the resolve table with v2.23 semantics: `with_tool_search` grants no
+    # deferral in a request that sends no tool-search tool, so the hidden tool stays withheld.
+    hidden = ToolDefinition(name='hidden_tool', defer_loading=True, capability_id='refunds')
+    _, prepared = model.prepare_request(None, ModelRequestParameters(function_tools=[hidden]))
+    assert prepared.tool_visibility == {'hidden_tool': 'withheld'}

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -4899,6 +4899,19 @@ def test_run_context_available_tool_names_includes_discovered_before_tool_manage
     assert not ctx.is_tool_available('unknown_tool')
 
 
+def test_run_context_is_tool_available_falls_back_while_tools_unresolved() -> None:
+    """Mid-`get_tools` the manager exists but its tool set is `None`; the name form must take
+    the same history fallback as `available_tool_names` instead of reporting `False`."""
+    ctx = _build_run_context()
+    ctx.tool_manager = ToolManager(FunctionToolset())
+    ctx.discovered_tool_names = {'discovered_tool'}
+
+    assert ctx.tool_manager.tools is None
+    assert ctx.available_tool_names == {'discovered_tool'}
+    assert ctx.is_tool_available('discovered_tool')
+    assert not ctx.is_tool_available('unknown_tool')
+
+
 async def test_run_context_available_tool_names_unions_discovered_current_tools() -> None:
     """Available tool names are always-visible current tools plus revealed corpus tools."""
     toolset = FunctionToolset()


### PR DESCRIPTION
Fixes three of the six main-side reveal-track findings from the 2026-08-07 Macroscope triage (flagged on #6324 as main-inherited; each verified by reproduction before fixing). One commit per finding:

**1. Restore the v2.23 legacy profile-key shim (accidental regression).** `tool_additions` and `deferred_tools_require_tool_search` shipped in v2.23.0–v2.25.0, were renamed in #7104, and CI Review caught the compat gap during that PR — commit `0753e5aed` deliberately added `_translate_legacy_profile_keys` + tests. A later commit on the same branch (`5792c7428`, "complete deferred tool reveal semantics") deleted the entire shim with no mention in its message, and that deletion shipped in the squash while the commit's other compat surfaces (`deferred_capability_ids`, the unloaded-capability reveal guard) survived. This restores the shim and `tests/profiles/test_legacy_keys.py`, adapted to the extracted `ToolDeferralMode`/`ToolAdditionMode` aliases. Not yet in any release, so restoring now closes the gap fully.

**2. `RunContext.is_tool_available(name)` returns `False` for revealed tools mid-`get_tools`.** With the manager present but the turn's tools unresolved (`tool_manager.tools is None`), the name form fell through to `tools.get(...)` on the empty dict instead of the history fallback — while the sibling `available_tool_names` handles that exact state, and the method's docstring promises the fallback "when live tool state is unavailable". Condition now matches `available_tool_names`; regression test mutation-verified. ([thread](https://github.com/pydantic/pydantic-ai/pull/6324#discussion_r3732493130))

**3. `TestModel`/`FunctionModel` can't simulate native tool additions.** Worse than flagged: with a `tool_addition_mode` profile the `ToolAvailabilityDeltaPart` legitimately stays in history and `_estimate_usage` crashed on it as a skipped-`prepare_messages` violation before `_get_tool_calls` was reached. The estimator now takes `allow_tool_availability_deltas` mirroring the model's profile (the pedagogical raise stays for non-native profiles), and `_get_tool_calls` includes `'via_history'` tools — fixing the spurious "must be revealed" error when a reveal-carrying history is replayed in named `call_tools` mode. Both fixes mutation-verified. ([thread](https://github.com/pydantic/pydantic-ai/pull/6324#discussion_r3732493119))

**Dispositions of the other three findings** (details in the triage notes):
- `visibility_of` same-name output-tool shadowing: reproduces at the accessor level only; unreachable through `Agent` (collision rejected with a clear `UserError`) — downgraded to defensive cleanup, not fixed here.
- History processors stripping reveal exchanges strand revealed tools (reproduced): filed as #7259 — same failure class as #7189, belongs with that corpus design discussion.
- #6793-era stale `tool_choice` with no emitted definitions: foreclosed by #7104 (`history_declared_tool_names` derives from current `function_tools`; verified on built request kwargs).

Full suite: 9962 passed, 5 known env-drift failures (google code_execution ×2, bedrock_mantle, zai ×2).

- [ ] The code has been formatted, linted, type-checked, and tested (see `CLAUDE.md` for commands)
- [ ] New behavior is covered by tests
- [ ] Documentation has been updated where relevant
- [ ] AI generated code has been marked as such


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

