### PR TITLE
fix(otel): assign role='tool' to ToolReturnPart messages in OTel traces

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_otel_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/_otel_messages.py
@@ -105,7 +105,7 @@ class ThinkingPart(TypedDict):
 MessagePart: TypeAlias = 'TextPart | ToolCallPart | ToolCallResponsePart | MediaUrlPart | UriPart | FilePart | BinaryDataPart | BlobPart | ThinkingPart'
 
 
-Role = Literal['system', 'user', 'assistant']
+Role = Literal['system', 'user', 'assistant', 'tool']
 
 
 class ChatMessage(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -30,9 +30,11 @@ from .. import _otel_messages
 from .._run_context import RunContext
 from .._warnings import PydanticAIDeprecationWarning
 from ..messages import (
+    BaseToolReturnPart,
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    RetryPromptPart,
     SystemPromptPart,
     ToolAvailabilityDeltaPart,
 )
@@ -188,20 +190,24 @@ class InstrumentationSettings:
             )
 
     def messages_to_otel_messages(self, messages: list[ModelMessage]) -> list[_otel_messages.ChatMessage]:
+        def _request_role(part: Any) -> _otel_messages.Role:
+            if isinstance(part, SystemPromptPart | ToolAvailabilityDeltaPart):
+                return 'system'
+            if isinstance(part, BaseToolReturnPart):
+                return 'tool'
+            if isinstance(part, RetryPromptPart) and part.tool_name is not None:
+                return 'tool'
+            return 'user'
+
         result: list[_otel_messages.ChatMessage] = []
         for message in messages:
             if isinstance(message, ModelRequest):
-                for is_system, group in itertools.groupby(
-                    message.parts, key=lambda p: isinstance(p, SystemPromptPart | ToolAvailabilityDeltaPart)
-                ):
+                for role, group in itertools.groupby(message.parts, key=_request_role):
                     message_parts: list[_otel_messages.MessagePart] = []
                     for part in group:
                         if hasattr(part, 'otel_message_parts'):
                             message_parts.extend(part.otel_message_parts(self))
-
-                    result.append(
-                        _otel_messages.ChatMessage(role='system' if is_system else 'user', parts=message_parts)
-                    )
+                    result.append(_otel_messages.ChatMessage(role=role, parts=message_parts))
             elif isinstance(message, ModelResponse):  # pragma: no branch
                 otel_message = _otel_messages.OutputMessage(role='assistant', parts=message.otel_message_parts(self))
                 if message.finish_reason is not None:

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -232,10 +232,10 @@ async def test_instrumented_model(capfire: CaptureLogfire):
                     'logfire.msg': 'chat gpt-4o',
                     'gen_ai.input.messages': [
                         {'role': 'system', 'parts': [{'type': 'text', 'content': 'system_prompt'}]},
+                        {'role': 'user', 'parts': [{'type': 'text', 'content': 'user_prompt'}]},
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
-                                {'type': 'text', 'content': 'user_prompt'},
                                 {
                                     'type': 'tool_call_response',
                                     'id': 'tool_call_3',
@@ -252,6 +252,11 @@ retry_prompt1
 Fix the errors and try again.\
 """,
                                 },
+                            ],
+                        },
+                        {
+                            'role': 'user',
+                            'parts': [
                                 {
                                     'type': 'text',
                                     'content': """\
@@ -760,10 +765,10 @@ async def test_instrumented_model_attributes_mode(capfire: CaptureLogfire):
                                 {'type': 'text', 'content': 'system_prompt'},
                             ],
                         },
+                        {'role': 'user', 'parts': [{'type': 'text', 'content': 'user_prompt'}]},
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
-                                {'type': 'text', 'content': 'user_prompt'},
                                 {
                                     'type': 'tool_call_response',
                                     'id': 'tool_call_3',
@@ -780,6 +785,11 @@ retry_prompt1
 Fix the errors and try again.\
 """,
                                 },
+                            ],
+                        },
+                        {
+                            'role': 'user',
+                            'parts': [
                                 {
                                     'type': 'text',
                                     'content': """\
@@ -1381,8 +1391,8 @@ def test_messages_without_content(document_content: BinaryContent):
                     {'type': 'tool_call', 'id': IsStr(), 'name': 'my_tool'},
                 ],
             },
-            {'role': 'user', 'parts': [{'type': 'tool_call_response', 'id': 'tool_call_1', 'name': 'tool'}]},
-            {'role': 'user', 'parts': [{'type': 'tool_call_response', 'id': 'tool_call_2', 'name': 'tool'}]},
+            {'role': 'tool', 'parts': [{'type': 'tool_call_response', 'id': 'tool_call_1', 'name': 'tool'}]},
+            {'role': 'tool', 'parts': [{'type': 'tool_call_response', 'id': 'tool_call_2', 'name': 'tool'}]},
             {'role': 'user', 'parts': [{'type': 'text'}, {'type': 'blob', 'mime_type': 'application/pdf'}]},
             {'role': 'user', 'parts': [{'type': 'text'}]},
             {'role': 'assistant', 'parts': [{'type': 'blob', 'mime_type': 'application/pdf'}]},
@@ -2194,7 +2204,7 @@ def test_messages_to_otel_messages_serialization_errors():
                 'parts': [{'type': 'tool_call', 'id': 'tool_call_id', 'name': 'tool', 'arguments': {'arg': 'Foo()'}}],
             },
             {
-                'role': 'user',
+                'role': 'tool',
                 'parts': [
                     {
                         'type': 'tool_call_response',
@@ -2246,7 +2256,7 @@ def test_messages_to_otel_messages_serializes_bytes():
                 ],
             },
             {
-                'role': 'user',
+                'role': 'tool',
                 'parts': [
                     {
                         'type': 'tool_call_response',

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -290,7 +290,7 @@ def test_logfire(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -648,7 +648,7 @@ def test_instructions_with_structured_output(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -742,7 +742,7 @@ def test_instructions_with_structured_output_exclude_content(get_logfire_summary
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -969,7 +969,7 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -1226,7 +1226,7 @@ async def test_in_place_history_mutation_warns_and_leaves_stale_request_spans(ca
                     'parts': [{'type': 'tool_call', 'id': 'call_1', 'name': 'corrupt_history', 'arguments': {}}],
                 },
                 {
-                    'role': 'user',
+                    'role': 'tool',
                     'parts': [
                         {'type': 'tool_call_response', 'id': 'call_1', 'name': 'corrupt_history', 'result': 'ok'}
                     ],
@@ -1243,7 +1243,7 @@ async def test_in_place_history_mutation_warns_and_leaves_stale_request_spans(ca
                 'parts': [{'type': 'tool_call', 'id': 'call_1', 'name': 'corrupt_history', 'arguments': {}}],
             },
             {
-                'role': 'user',
+                'role': 'tool',
                 'parts': [{'type': 'tool_call_response', 'id': 'call_1', 'name': 'corrupt_history', 'result': 'ok'}],
             },
             {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'done'}]},
@@ -2655,7 +2655,7 @@ def test_static_function_instructions_in_agent_run_span(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -2825,7 +2825,7 @@ def test_dynamic_function_instructions_in_agent_run_span(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -2847,7 +2847,7 @@ def test_dynamic_function_instructions_in_agent_run_span(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',
@@ -2988,7 +2988,7 @@ def test_function_instructions_with_history_in_agent_run_span(
                             ],
                         },
                         {
-                            'role': 'user',
+                            'role': 'tool',
                             'parts': [
                                 {
                                     'type': 'tool_call_response',


### PR DESCRIPTION
Fixes #7235.

## Problem

`messages_to_otel_messages()` used a binary `itertools.groupby` key:

```python
key=lambda p: isinstance(p, SystemPromptPart | ToolAvailabilityDeltaPart)
```

This collapses every non-system `ModelRequest` part into a single `role='user'` message. In practice, `ToolReturnPart` and `RetryPromptPart` (when `tool_name` is set) both emit `type='tool_call_response'` OTel parts but land inside `role='user'`, violating the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) which require tool results in `role='tool'` messages.

## Solution

Replace the binary key with a three-way role mapper:

| Part type | OTel role |
|---|---|
| `SystemPromptPart` / `ToolAvailabilityDeltaPart` | `'system'` (unchanged) |
| `BaseToolReturnPart` subclasses (`ToolReturnPart`, `NativeToolReturnPart`, …) | `'tool'` |
| `RetryPromptPart` with `tool_name` set | `'tool'` |
| Everything else (`UserPromptPart`, bare `RetryPromptPart`, …) | `'user'` |

`ToolAvailabilityDeltaPart` intentionally stays as `'system'` — this matches the existing tested behaviour (see `test_messages_to_otel_message_parts_tool_availability_delta`) and the reasoning in its test docstring: _"The delta renders as its own system-voice message rather than blending into user content."_

Also adds `'tool'` to the `Role` literal in `_otel_messages.py`.

## Changes

- `pydantic_ai_slim/pydantic_ai/_otel_messages.py` — add `'tool'` to `Role`
- `pydantic_ai_slim/pydantic_ai/models/instrumented.py` — three-way role key in `messages_to_otel_messages()`, import `BaseToolReturnPart` and `RetryPromptPart`
- `tests/models/test_instrumented.py` — update snapshots
- `tests/test_logfire.py` — update snapshots

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

