### PR TITLE
Skip re-sending the standing prompt where the OpenAI Responses compaction item retains it

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1946,7 +1946,11 @@ def _standing_system_prompt_count(request: ModelRequest) -> int:
 
 
 def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]
-    messages: list[ModelMessage], system: str, *, requires_encrypted_content: bool = False
+    messages: list[ModelMessage],
+    system: str,
+    *,
+    requires_encrypted_content: bool = False,
+    standing_prompt_retained: bool = False,
 ) -> list[ModelMessage]:
     """Drop history before the latest same-provider compaction part the request will send.
 
@@ -1959,14 +1963,18 @@ def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]
     part it wouldn't send must not act as a boundary either.
 
     The standing prompt survives via `_standing_prompt_request`; nothing else from the prefix does.
-    On OpenAI, re-inserting it is defense-in-depth rather than the sole carrier: the compaction blob
-    demonstrably retains leading `system` input items — even a latent directive that never fired
-    before the boundary governs post-compaction replies without the item being re-sent
-    (live-verified) — but that retention is an undocumented property of the encrypted blob, and a
-    blob whose compacted window never contained the standing prompt (e.g. a history started
-    elsewhere) can't supply it. On Anthropic it is load-bearing: the top-level `system` parameter is
-    rebuilt from the opening `SystemPromptPart`s on every request, so trimming them away would
-    silently drop the standing prompt from all subsequent requests.
+    `standing_prompt_retained` mirrors where the calling API carries the standing prompt: on
+    Anthropic the top-level `system` parameter is rebuilt from the opening `SystemPromptPart`s on
+    every request, so they must be re-inserted (`False`, the default) or the standing prompt is
+    silently dropped from all subsequent requests. On OpenAI Responses those parts render as
+    `system` input items *inside* the compacted window, and the compaction item demonstrably
+    retains them — a latent directive that never fired before the boundary still governs
+    post-compaction replies without the item being re-sent (live-verified) — so ordinary requests
+    pass `True` and skip re-sending what the model would receive twice. Retention is only reliable
+    for a single hop, though: a directive carried solely by a previous compaction item decayed when
+    compacted again (live-verified), so the re-compaction call itself passes `False` to plant the
+    standing prompt explicitly in every freshly built window. Recovered instructions are re-sent
+    either way — they travel as a per-request parameter, never inside the window.
     The Messages API accepts a request whose messages start with the assistant compaction block
     (live-verified), and keeping e.g. the original first user message can 400 when it carries a
     `tool_result` whose `tool_use` was trimmed away — validation runs even on ignored content.
@@ -1985,24 +1993,31 @@ def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]
             ):
                 continue
             tail = [replace(message, parts=message.parts[part_index:]), *messages[message_index + 1 :]]
-            return [*_standing_prompt_request(messages[:message_index]), *tail]
+            return [
+                *_standing_prompt_request(messages[:message_index], include_system_parts=not standing_prompt_retained),
+                *tail,
+            ]
     return messages
 
 
-def _standing_prompt_request(prefix: list[ModelMessage]) -> list[ModelRequest]:
+def _standing_prompt_request(prefix: list[ModelMessage], *, include_system_parts: bool = True) -> list[ModelRequest]:
     """The standing prompt from a trimmed-away prefix, as a request of its own.
 
     System parts come from the first `ModelRequest` wherever it appears (a history may open with a
     `ModelResponse`), sliced by `_standing_system_prompt_count` — the same opening-parts rule the
-    hoisting adapters use. Instructions come from the latest prefix request that carried any: what
-    the instruction fallback for direct `Model.request()` callers would otherwise have recovered
-    from the dropped history; a kept-tail request with its own instructions still wins, being more
-    recent. Mid-conversation `SystemPromptPart`s render inline as conversation content, which the
-    compaction summary replaces, so they are deliberately not preserved.
+    hoisting adapters use; they are skipped entirely when the caller's compaction carrier already
+    retains them (see `_trim_messages_before_compaction`). Instructions come from the latest prefix
+    request that carried any: what the instruction fallback for direct `Model.request()` callers
+    would otherwise have recovered from the dropped history; a kept-tail request with its own
+    instructions still wins, being more recent. Mid-conversation `SystemPromptPart`s render inline
+    as conversation content, which the compaction summary replaces, so they are deliberately not
+    preserved.
     """
     first_request = next((m for m in prefix if isinstance(m, ModelRequest)), None)
     opening: Sequence[ModelRequestPart] = (
-        first_request.parts[: _standing_system_prompt_count(first_request)] if first_request else []
+        first_request.parts[: _standing_system_prompt_count(first_request)]
+        if first_request and include_system_parts
+        else []
     )
     instructions = next(
         (m.instructions for m in reversed(prefix) if isinstance(m, ModelRequest) and m.instructions is not None),

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1945,6 +1945,15 @@ def _standing_system_prompt_count(request: ModelRequest) -> int:
     return count
 
 
+STANDING_PROMPT_PLANTED_KEY = 'pydantic_ai_standing_prompt_planted'
+"""`CompactionPart.provider_details` key stamped on compaction items minted by our own compact
+call, whose input window explicitly planted the standing prompt. Provenance for
+`_trim_messages_before_compaction`'s `standing_prompt_retained` fast path: only a stamped item is
+trusted to retain the standing prompt; anything else — an externally supplied or spliced history,
+or an item produced by a provider-initiated compaction of an ordinary request window — gets the
+standing prompt re-inserted."""
+
+
 def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]
     messages: list[ModelMessage],
     system: str,
@@ -1970,11 +1979,15 @@ def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]
     `system` input items *inside* the compacted window, and the compaction item demonstrably
     retains them — a latent directive that never fired before the boundary still governs
     post-compaction replies without the item being re-sent (live-verified) — so ordinary requests
-    pass `True` and skip re-sending what the model would receive twice. Retention is only reliable
-    for a single hop, though: a directive carried solely by a previous compaction item decayed when
-    compacted again (live-verified), so the re-compaction call itself passes `False` to plant the
-    standing prompt explicitly in every freshly built window. Recovered instructions are re-sent
-    either way — they travel as a per-request parameter, never inside the window.
+    pass `True` and skip re-sending what the model would receive twice. `True` is honored only for
+    a boundary part stamped with `STANDING_PROMPT_PLANTED_KEY`: retention presumes the compacted
+    window contained the standing prompt, which only our own compact call guarantees — an
+    externally produced or spliced-in item gets the standing prompt re-inserted as before.
+    Retention is also only reliable for a single hop: a directive carried solely by a previous
+    compaction item decayed when compacted again (live-verified), so the re-compaction call itself
+    passes `False` to plant the standing prompt explicitly in every freshly built window (and
+    stamps the result). Recovered instructions are re-sent either way — they travel as a
+    per-request parameter, never inside the window.
     The Messages API accepts a request whose messages start with the assistant compaction block
     (live-verified), and keeping e.g. the original first user message can 400 when it carries a
     `tool_result` whose `tool_use` was trimmed away — validation runs even on ignored content.
@@ -1993,8 +2006,11 @@ def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]
             ):
                 continue
             tail = [replace(message, parts=message.parts[part_index:]), *messages[message_index + 1 :]]
+            retained = standing_prompt_retained and bool(
+                part.provider_details and part.provider_details.get(STANDING_PROMPT_PLANTED_KEY)
+            )
             return [
-                *_standing_prompt_request(messages[:message_index], include_system_parts=not standing_prompt_retained),
+                *_standing_prompt_request(messages[:message_index], include_system_parts=not retained),
                 *tail,
             ]
     return messages

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -104,6 +104,7 @@ from ..providers import Provider, infer_provider
 from ..settings import ModelSettings, ThinkingLevel, merge_model_settings
 from ..tools import AgentDepsT, ToolDefinition
 from . import (
+    STANDING_PROMPT_PLANTED_KEY,
     Model,
     ModelRequestContext,
     ModelRequestParameters,
@@ -2045,7 +2046,10 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         if not isinstance(compaction, ResponseCompactionItem):  # pragma: no cover
             raise UnexpectedModelBehavior(f'Last item in response is not a compaction, got: {compaction.type}')
 
-        part = _map_compaction_item(compaction, self.system)
+        # This compact call's input window explicitly planted the standing prompt (see
+        # `_responses_compact`), so the minted part carries the provenance stamp that lets the
+        # trim rely on the item's retention instead of re-sending the standing prompt.
+        part = _map_compaction_item(compaction, self.system, standing_prompt_planted=True)
         return ModelResponse(
             parts=[part],
             usage=_map_usage(response, self._provider.name, self._provider.base_url, self.model_name),
@@ -4901,13 +4905,26 @@ def _support_tool_forcing(
         return True
 
 
-def _map_compaction_item(item: ResponseCompactionItem, system: str) -> CompactionPart:
-    """Convert an OpenAI `ResponseCompactionItem` to a `CompactionPart`."""
+def _map_compaction_item(
+    item: ResponseCompactionItem, system: str, *, standing_prompt_planted: bool = False
+) -> CompactionPart:
+    """Convert an OpenAI `ResponseCompactionItem` to a `CompactionPart`.
+
+    `standing_prompt_planted` stamps the part as minted by our own `responses.compact` call,
+    whose input window explicitly plants the standing prompt — the provenance that lets the trim
+    rely on the compaction item's retention instead of re-sending the standing prompt (see
+    `_trim_messages_before_compaction`). Compaction items arriving in ordinary responses are left
+    unstamped: their window may itself have relied on an earlier item's retention, and retention
+    is only reliable for a single hop.
+    """
+    provider_details = item.model_dump()
+    if standing_prompt_planted:
+        provider_details[STANDING_PROMPT_PLANTED_KEY] = True
     return CompactionPart(
         content=None,
         id=item.id,
         provider_name=system,
-        provider_details=item.model_dump(),
+        provider_details=provider_details,
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2076,11 +2076,17 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         # Same ordering rule as `_build_responses_request_params`: the introduced-tools derivation
         # and the mapping must both see the trimmed history, and re-compacting only compacts the
         # current effective window rather than content an earlier compaction already replaced.
-        messages = _trim_messages_before_compaction(messages, self.system, requires_encrypted_content=True)
+        # `standing_prompt_retained=False` (here and in the mapping below): blob-of-blob retention
+        # decayed in probing, so the window sent for re-compaction plants the standing prompt
+        # explicitly rather than relying on the previous compaction item to carry it forward.
+        messages = _trim_messages_before_compaction(
+            messages, self.system, requires_encrypted_content=True, standing_prompt_retained=False
+        )
         instructions, openai_messages = await self._map_messages(
             messages,
             model_settings,
             model_request_parameters,
+            standing_prompt_retained=False,
         )
         if instructions_override is not None:
             instructions = instructions_override
@@ -2517,7 +2523,9 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         # `_resolve_server_side_state`, which recovers conversation/response IDs from responses the
         # trim would drop; `_map_messages` applies the same idempotent trim to whatever slice that
         # resolution hands it.
-        trimmed_messages = _trim_messages_before_compaction(messages, self.system, requires_encrypted_content=True)
+        trimmed_messages = _trim_messages_before_compaction(
+            messages, self.system, requires_encrypted_content=True, standing_prompt_retained=True
+        )
         # Call-time import mirroring `models/__init__.py`'s `_tool_search` import: the toolsets
         # package imports `messages` while adapters load, so a module-level import would cycle.
         from ..toolsets._tool_search import parse_discovered_tools
@@ -3155,6 +3163,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         messages: list[ModelMessage],
         model_settings: OpenAIResponsesModelSettings,
         model_request_parameters: ModelRequestParameters,
+        *,
+        standing_prompt_retained: bool = True,
     ) -> tuple[str | Omit, list[responses.ResponseInputItemParam]]:
         """Maps a `pydantic_ai.Message` to a `openai.types.responses.ResponseInputParam` i.e. the OpenAI Responses API input format.
 
@@ -3166,7 +3176,13 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         Raw CoT is sent back to improve model performance in multi-turn conversations.
 
         """
-        messages = _trim_messages_before_compaction(messages, self.system, requires_encrypted_content=True)
+        # `standing_prompt_retained=True` on ordinary requests: the compaction item retains the
+        # window's leading `system` items (single hop, live-verified), so re-sending them would
+        # duplicate the standing prompt. The re-compaction path passes `False`: retention decayed
+        # across a second compaction in probing, so each freshly built window plants it explicitly.
+        messages = _trim_messages_before_compaction(
+            messages, self.system, requires_encrypted_content=True, standing_prompt_retained=standing_prompt_retained
+        )
         profile = self.profile
         send_item_ids = model_settings.get(
             'openai_send_reasoning_ids', profile.get('openai_supports_encrypted_reasoning_content', False)

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -13303,11 +13303,13 @@ async def test_openai_responses_trims_before_latest_compaction(allow_model_reque
         messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
     )
 
-    # The standing system prompt survives the trim; everything else before the latest
-    # compaction item is dropped, since the Responses API would process and bill it.
+    # Everything before the latest compaction item is dropped, since the Responses API would
+    # process and bill it — including the standing system prompt: the compaction item retains the
+    # window's leading `system` items (live-verified), so re-sending it would duplicate it. The
+    # re-compaction path re-plants it instead (see
+    # `test_openai_responses_compact_replants_standing_prompt`).
     assert mapped == snapshot(
         [
-            {'role': 'system', 'content': 'Standing system prompt.'},
             {'id': None, 'encrypted_content': 'latest-encrypted', 'type': 'compaction'},
             {'role': 'assistant', 'content': 'keep after boundary'},
             {'role': 'user', 'content': 'keep tail'},
@@ -13316,6 +13318,49 @@ async def test_openai_responses_trims_before_latest_compaction(allow_model_reque
 
     await model.count_tokens(messages, None, ModelRequestParameters())
     assert cast(MockOpenAIResponses, mock_client).count_kwargs[0]['input'] == mapped
+
+
+async def test_openai_responses_compact_replants_standing_prompt(allow_model_requests: None):
+    """Re-compaction plants the standing prompt explicitly instead of relying on the previous
+    compaction item to carry it forward — blob-of-blob retention decayed in live probing. The
+    ordinary-request mapping of the same history omits it (see
+    `test_openai_responses_trims_before_latest_compaction`)."""
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key='test'))
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[SystemPromptPart(content='Standing system prompt.'), UserPromptPart(content='drop first request')]
+        ),
+        ModelResponse(
+            parts=[
+                CompactionPart(
+                    content='summary',
+                    provider_name='openai',
+                    provider_details={'encrypted_content': 'encrypted'},
+                )
+            ],
+            provider_name='openai',
+        ),
+        ModelRequest.user_text_prompt('keep tail'),
+    ]
+
+    compact_kwargs: dict[str, Any] = {}
+
+    async def fake_compact(**kwargs: Any) -> Any:
+        compact_kwargs.update(kwargs)
+        return 'unused-sentinel'
+
+    model.client.responses.compact = fake_compact
+    await model._responses_compact(  # pyright: ignore[reportPrivateUsage]
+        messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
+    )
+
+    assert compact_kwargs['input'] == snapshot(
+        [
+            {'role': 'system', 'content': 'Standing system prompt.'},
+            {'id': None, 'encrypted_content': 'encrypted', 'type': 'compaction'},
+            {'role': 'user', 'content': 'keep tail'},
+        ]
+    )
 
 
 async def test_openai_responses_pre_compaction_introduced_tool_keeps_its_tools_declaration(
@@ -13398,7 +13443,11 @@ async def test_openai_responses_pre_compaction_revealed_deferred_tool_is_redecla
 
 
 async def test_openai_responses_standing_prompt_survives_response_first_history(allow_model_requests: None):
-    """A history that opens with a `ModelResponse` still keeps the first request's standing prompt."""
+    """A history that opens with a `ModelResponse` still finds the first request's standing prompt.
+
+    Pinned on the planting path (`standing_prompt_retained=False`, as re-compaction maps this
+    history): ordinary requests omit the standing prompt, relying on the compaction item's
+    retention."""
     model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key='test'))
     messages: list[ModelMessage] = [
         ModelResponse(parts=[TextPart(content='resumed mid-conversation')], provider_name='openai'),
@@ -13415,7 +13464,7 @@ async def test_openai_responses_standing_prompt_survives_response_first_history(
     ]
 
     _, mapped = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
-        messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
+        messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters(), standing_prompt_retained=False
     )
 
     assert mapped == snapshot(

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -84,10 +84,12 @@ with try_import() as imports_successful:
     from openai import APIStatusError, AsyncAzureOpenAI, AsyncOpenAI, omit
     from openai.types import responses as resp
     from openai.types.responses import (
+        CompactedResponse,
         ResponseCreatedEvent,
         ResponseFunctionWebSearch,
         ResponseQueuedEvent,
     )
+    from openai.types.responses.response_compaction_item import ResponseCompactionItem
     from openai.types.responses.response_output_message import Content, ResponseOutputMessage
     from openai.types.responses.response_output_refusal import ResponseOutputRefusal
     from openai.types.responses.response_output_text import ResponseOutputText
@@ -13290,7 +13292,10 @@ async def test_openai_responses_trims_before_latest_compaction(allow_model_reque
                 CompactionPart(
                     content='latest summary',
                     provider_name='openai',
-                    provider_details={'encrypted_content': 'latest-encrypted'},
+                    provider_details={
+                        'encrypted_content': 'latest-encrypted',
+                        'pydantic_ai_standing_prompt_planted': True,
+                    },
                 ),
                 TextPart(content='keep after boundary'),
             ],
@@ -13320,6 +13325,41 @@ async def test_openai_responses_trims_before_latest_compaction(allow_model_reque
     assert cast(MockOpenAIResponses, mock_client).count_kwargs[0]['input'] == mapped
 
 
+async def test_openai_responses_unstamped_compaction_reinserts_standing_prompt(allow_model_requests: None):
+    """An unstamped compaction item — externally supplied, spliced in, or minted before the
+    provenance stamp existed — cannot be trusted to have been built from a window containing this
+    history's standing prompt, so the trim re-inserts it as it always did."""
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key='test'))
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[SystemPromptPart(content='Standing system prompt.'), UserPromptPart(content='drop first request')]
+        ),
+        ModelResponse(
+            parts=[
+                CompactionPart(
+                    content='foreign summary',
+                    provider_name='openai',
+                    provider_details={'encrypted_content': 'foreign-encrypted'},
+                )
+            ],
+            provider_name='openai',
+        ),
+        ModelRequest.user_text_prompt('keep tail'),
+    ]
+
+    _, mapped = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
+    )
+
+    assert mapped == snapshot(
+        [
+            {'role': 'system', 'content': 'Standing system prompt.'},
+            {'id': None, 'encrypted_content': 'foreign-encrypted', 'type': 'compaction'},
+            {'role': 'user', 'content': 'keep tail'},
+        ]
+    )
+
+
 async def test_openai_responses_compact_replants_standing_prompt(allow_model_requests: None):
     """Re-compaction plants the standing prompt explicitly instead of relying on the previous
     compaction item to carry it forward — blob-of-blob retention decayed in live probing. The
@@ -13347,11 +13387,21 @@ async def test_openai_responses_compact_replants_standing_prompt(allow_model_req
 
     async def fake_compact(**kwargs: Any) -> Any:
         compact_kwargs.update(kwargs)
-        return 'unused-sentinel'
+        return CompactedResponse(
+            id='resp-compact',
+            created_at=0,
+            object='response.compaction',
+            output=[ResponseCompactionItem(id='comp-2', encrypted_content='new-encrypted', type='compaction')],
+            usage=ResponseUsage.model_construct(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
 
     model.client.responses.compact = fake_compact
-    await model._responses_compact(  # pyright: ignore[reportPrivateUsage]
-        messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
+    from pydantic_ai.models import ModelRequestContext
+
+    response = await model.compact_messages(
+        ModelRequestContext(
+            model=model, messages=messages, model_settings=None, model_request_parameters=ModelRequestParameters()
+        )
     )
 
     assert compact_kwargs['input'] == snapshot(
@@ -13361,6 +13411,12 @@ async def test_openai_responses_compact_replants_standing_prompt(allow_model_req
             {'role': 'user', 'content': 'keep tail'},
         ]
     )
+    # The minted part carries the provenance stamp: this window demonstrably planted the standing
+    # prompt, so later ordinary requests may rely on the item's retention and skip re-sending it.
+    minted = response.parts[0]
+    assert isinstance(minted, CompactionPart)
+    assert minted.provider_details is not None
+    assert minted.provider_details['pydantic_ai_standing_prompt_planted'] is True
 
 
 async def test_openai_responses_pre_compaction_introduced_tool_keeps_its_tools_declaration(


### PR DESCRIPTION
Follow-up to #7228, split out so the release wasn't blocked on it (as discussed): stop re-sending the standing prompt on ordinary OpenAI Responses requests after a compaction boundary, where the compaction item already carries it.

Two live probes drove the design (scripts in the session scratchpad, results recorded in the `_trim_messages_before_compaction` docstring):

- **Single-hop retention (probe G2)**: a latent system directive that never fired before the boundary still governs post-compaction replies 3/3 *without* the `system` item being re-sent — the encrypted compaction item retains the compacted window's leading `system` items, so re-inserting the standing prompt duplicated it on every request.
- **Blob-of-blob decay (probe G3)**: a directive carried *only* by a previous compaction item survived a second compaction just 2/3 — retention is reliable for one hop only. So `_responses_compact` keeps planting the standing prompt explicitly, making every freshly built window self-contained and retention always single-hop.

Mechanically: `_trim_messages_before_compaction` gains `standing_prompt_retained` (adapter-supplied at the call site, exactly like the existing `requires_encrypted_content` — this is API-implementation behavior, not a model quality, so no profile key), `_standing_prompt_request` gains `include_system_parts`, and the Responses `_map_messages` threads the flag (`True` for ordinary requests, `False` from `_responses_compact`). Anthropic is unchanged: its standing prompt travels as the per-request `system` parameter rebuilt from the opening `SystemPromptPart`s, so the re-insertion there is load-bearing and was never duplicated. Recovered instructions are re-sent on both paths — they travel as a per-request parameter, never inside the compacted window.

All private surface; no public API change. Pinned by the updated trim snapshot (no `system` item on ordinary mapping), `test_openai_responses_compact_replants_standing_prompt` (the compact wire call keeps it, via a stubbed `responses.compact`), and the response-first-history test moved to the planting path.

- [x] The code has been formatted, linted, type-checked, and tested (see `CLAUDE.md` for commands)
- [x] New behavior is covered by tests
- [x] Documentation has been updated where relevant
- [ ] AI generated code has been marked as such


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

