### PR TITLE
Pin re-search healing when a reveal exchange is stripped from history

### DIFF
--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -32,7 +32,7 @@ from pydantic_ai._tool_search import (
     synthesize_local_from_native_call,
     synthesize_local_tool_search_messages,
 )
-from pydantic_ai.capabilities import CAPABILITY_TYPES, ToolSearch
+from pydantic_ai.capabilities import CAPABILITY_TYPES, ProcessHistory, ToolSearch
 from pydantic_ai.capabilities._ordering import collect_leaves
 from pydantic_ai.capabilities.abstract import AbstractCapability
 from pydantic_ai.capabilities.capability import Capability
@@ -981,6 +981,71 @@ async def test_search_corpus_includes_already_discovered_tools() -> None:
     await searchable.call_tool(_SEARCH_TOOLS_NAME, {'queries': ['first']}, ctx, search_tool)
 
     assert corpora == [['first_tool', 'second_tool']]
+
+
+async def test_stripped_reveal_exchange_heals_via_re_search() -> None:
+    """A history processor that strips a reveal exchange must not strand the revealed tool (#7259).
+
+    The search corpus never subtracts discovered names, so when the processor deletes the first
+    search exchange the model can simply search again; the new exchange survives, re-reveals the
+    tool, and the run completes. (A corpus that subtracted discovered names left the tool
+    simultaneously withheld on the wire and unsearchable — permanently unavailable.)
+    """
+
+    class SearchTwiceThenCallModel(TestModel):
+        request_number = 0
+
+        def _request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            type(self).request_number += 1
+            if self.request_number <= 2:
+                # Step 1 discovers the tool; the processor then strips that exchange, so step 2's
+                # history carries no evidence and the model searches again.
+                assert model_request_parameters.visibility_of('secret_lookup') == 'withheld'
+                return ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name=_SEARCH_TOOLS_NAME,
+                            args={'queries': ['secret lookup']},
+                            tool_call_id=f'search-{self.request_number}',
+                        )
+                    ]
+                )
+            # The second exchange survived: the tool is revealed again and callable.
+            assert model_request_parameters.visibility_of('secret_lookup') == 'visible'
+            if self.request_number == 3:
+                return ModelResponse(parts=[ToolCallPart(tool_name='secret_lookup', args={}, tool_call_id='lookup-1')])
+            return super()._request(messages, model_settings, model_request_parameters)
+
+    def strip_first_search_exchange(messages: list[ModelMessage]) -> list[ModelMessage]:
+        return [
+            replace(
+                message,
+                parts=[  # pyright: ignore[reportArgumentType]
+                    part
+                    for part in message.parts
+                    if not (
+                        isinstance(part, ToolCallPart | ToolSearchCallPart | ToolReturnPart | ToolSearchReturnPart)
+                        and part.tool_call_id == 'search-1'
+                    )
+                ],
+            )
+            for message in messages
+        ]
+
+    agent = Agent(SearchTwiceThenCallModel(), capabilities=[ProcessHistory(strip_first_search_exchange)])
+
+    @agent.tool_plain(defer_loading=True)
+    def secret_lookup() -> str:
+        return 'SECRET'
+
+    result = await agent.run('find and call the secret lookup tool')
+
+    assert 'SECRET' in str(result.output)
 
 
 async def test_tool_search_toolset_discovered_tools_keep_defer_loading():

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -1025,7 +1025,7 @@ async def test_stripped_reveal_exchange_heals_via_re_search() -> None:
         return [
             replace(
                 message,
-                parts=[  # pyright: ignore[reportArgumentType]
+                parts=[
                     part
                     for part in message.parts
                     if not (


### PR DESCRIPTION
- Closes #7259

Since #7225, the tool-search corpus no longer subtracts already-discovered tools: `_build_search_tool` ranks undiscovered tools first but keeps every searchable tool in the corpus, and a custom `search_fn` receives the full corpus. That means a history processor that strips a search/reveal exchange (the #7259 scenario) no longer makes the affected tool permanently unavailable — the model simply searches again and re-reveals it.

This PR pins that healing path end-to-end with a regression test: a scripted model searches, has its first search exchange stripped by a `ProcessHistory` processor, observes the tool withheld again, re-searches, and successfully calls the tool. Reintroducing the pre-#7225 corpus subtraction fails the test.

Test-only change; no runtime code is touched.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

