### PR TITLE
Keep `ToolReturn.tools` in the redacted OTel shape

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -195,6 +195,8 @@ def _redact_binary_content(value: Any, active: set[int]) -> object:
                 'return_value': _redact_binary_content(value.return_value, active),
                 'content': _redact_binary_content(value.content, active),
                 'metadata': _redact_binary_content(value.metadata, active),
+                # Tool names, so never binary.
+                'tools': value.tools,
                 'kind': value.kind,
             }
         if isinstance(value, DeferredToolRequests):

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -254,6 +254,7 @@ CASES = [
                 'return_value': {**REDACTED_IMAGE, 'vendor_metadata': {'thumbnail': REDACTED_IMAGE}},
                 'content': ['here it is', REDACTED_IMAGE],
                 'metadata': {'img': REDACTED_IMAGE},
+                'tools': None,
                 'kind': 'tool-return',
             }
         ),
@@ -538,6 +539,37 @@ def test_binary_nested_in_a_user_type_is_not_redacted(capfire: CaptureLogfire) -
     assert IMAGE.base64 in json.dumps(final_result)
 
 
+def test_redacted_tool_return_keeps_the_tools_it_made_available(capfire: CaptureLogfire) -> None:
+    """Redacting a `ToolReturn` must not drop the deferred tools it revealed.
+
+    `ToolReturn.tools` names the tools the call made available, and telemetry is where that
+    reveal is observable — dropping it would hide why a later tool call became legal.
+    """
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('gen_image', {})])
+        return ModelResponse(parts=[TextPart('a kiwi')])
+
+    agent = Agent(
+        FunctionModel(respond),
+        capabilities=[Instrumentation(settings=InstrumentationSettings(include_binary_content=False))],
+        name='agent',
+    )
+
+    @agent.tool_plain
+    def gen_image() -> ToolReturn:
+        return ToolReturn(return_value='done', metadata={'img': IMAGE}, tools=['lookup_refund_policy'])
+
+    agent.run_sync('make an image')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    tool_spans = json.dumps([span['attributes'] for span in spans if span['name'] == 'execute_tool gen_image'])
+    assert 'lookup_refund_policy' in tool_spans
+    # The binary the same `ToolReturn` carried is still redacted.
+    assert IMAGE.base64 not in tool_spans
+
+
 def test_redacted_shapes_keep_every_field_but_the_data() -> None:
     """A field added to a redacted type has to be added to its redacted shape too.
 
@@ -547,7 +579,7 @@ def test_redacted_shapes_keep_every_field_but_the_data() -> None:
     dumped = ModelMessagesTypeAdapter.dump_python([ModelRequest(parts=[UserPromptPart(content=[IMAGE])])], mode='json')
     assert set(dumped[0]['parts'][0]['content'][0]) == set(REDACTED_IMAGE) | {'data'}
 
-    assert {f.name for f in fields(ToolReturn)} == {'return_value', 'content', 'metadata', 'kind'}
+    assert {f.name for f in fields(ToolReturn)} == {'return_value', 'content', 'metadata', 'tools', 'kind'}
     assert {f.name for f in fields(DeferredToolRequests)} == {'calls', 'approvals', 'metadata'}
 
 


### PR DESCRIPTION
**`main` is currently red — this fixes it.** Every PR's CI fails on `tests/test_include_binary_content.py::test_redacted_shapes_keep_every_field_but_the_data`.

Two PRs merged with a semantic conflict neither one's CI could see. #7104 added `ToolReturn.tools`; #7131 (merged after it, but with CI that ran against a `main` predating it) added a guard test asserting `ToolReturn`'s field set as `{'return_value', 'content', 'metadata', 'kind'}`. Those cannot both be true.

The guard was right to fire — it caught a real bug rather than just going stale. `_redact_binary_content` spells each redacted type's fields out rather than dumping and dropping `data`, exactly so a newly added field can't silently stop reaching telemetry. `ToolReturn.tools` was never added to that shape, so with `include_binary_content=False` the names of the deferred tools a call made available were dropped from the span — hiding why a later tool call became legal.

`tools` is `list[str] | None`, so it passes through verbatim rather than being walked.

Three changes: the redacted shape gains `tools`, the guard test's expected field set gains `tools`, and a new test pins the actual behavior (the revealed tool name reaches the span while the binary in the same `ToolReturn` is still redacted). Both tests fail if the field is dropped again.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

