### PR TITLE
Include `ToolReturn.tools` in the redacted instrumentation shape

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -196,6 +196,7 @@ def _redact_binary_content(value: Any, active: set[int]) -> object:
                 'content': _redact_binary_content(value.content, active),
                 'metadata': _redact_binary_content(value.metadata, active),
                 'kind': value.kind,
+                'tools': value.tools,
             }
         if isinstance(value, DeferredToolRequests):
             # Carries the metadata a deferring tool attached, so the run's own output has to drop

--- a/tests/test_include_binary_content.py
+++ b/tests/test_include_binary_content.py
@@ -255,6 +255,7 @@ CASES = [
                 'content': ['here it is', REDACTED_IMAGE],
                 'metadata': {'img': REDACTED_IMAGE},
                 'kind': 'tool-return',
+                'tools': None,
             }
         ),
     ),
@@ -547,7 +548,7 @@ def test_redacted_shapes_keep_every_field_but_the_data() -> None:
     dumped = ModelMessagesTypeAdapter.dump_python([ModelRequest(parts=[UserPromptPart(content=[IMAGE])])], mode='json')
     assert set(dumped[0]['parts'][0]['content'][0]) == set(REDACTED_IMAGE) | {'data'}
 
-    assert {f.name for f in fields(ToolReturn)} == {'return_value', 'content', 'metadata', 'kind'}
+    assert {f.name for f in fields(ToolReturn)} == {'return_value', 'content', 'metadata', 'kind', 'tools'}
     assert {f.name for f in fields(DeferredToolRequests)} == {'calls', 'approvals', 'metadata'}
 
 


### PR DESCRIPTION
`main` is currently red on every test shard. This fixes it.

### What broke

[#7104](https://github.com/pydantic/pydantic-ai/pull/7104) added `ToolReturn.tools`. [#7131](https://github.com/pydantic/pydantic-ai/pull/7131) added `test_redacted_shapes_keep_every_field_but_the_data`, which pins `ToolReturn`'s field set. #7104 was already on `main` when #7131 merged, but #7131's CI had run on a base predating it — so it went green and merged into a tree where its own assertion was already false.

### The assertion was right

It isn't drift. `_redact_binary_content` spells the redacted shape out field by field:

```python
if isinstance(value, ToolReturn):
    return {
        'return_value': ...,
        'content': ...,
        'metadata': ...,
        'kind': value.kind,
    }
```

So `ToolReturn.tools` was **silently absent from telemetry** under `include_binary_content=False` — exactly the failure that test's docstring describes ("a new field would otherwise silently stop reaching telemetry"). Adding `'tools'` to the pinned set alone would have papered over it, so the redacted shape is fixed too.

`tools` is `list[str] | None`, so it can't hold binary content and passes through unredacted, like `kind`.

### Test plan

- [x] `tests/test_include_binary_content.py` — 17 passed
- [x] Targeted pyright on both changed files — clean
- [x] Pre-commit (incl. whole-repo pyright) passed on commit

<details>
<summary>Why the snapshot was edited by hand</summary>

`--inline-snapshot=fix` refuses the `tool_return_result` case: its snapshot contains a star-expression (`{**REDACTED_IMAGE, ...}`), which inline-snapshot won't auto-edit. Added `'tools': None` manually rather than restructuring an unrelated test.
</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

