### PR TITLE
Strip the compaction provenance stamp in `sanitize_messages`

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -384,6 +384,8 @@ The `message_history` parameter is trusted server-side state. If you load histor
 
 [`sanitize_messages`][pydantic_ai.messages.sanitize_messages] applies the same default message sanitization used by the [UI adapters](ui/overview.md): it strips client-supplied system prompts, drops non-HTTP file URL schemes, resets non-allowlisted [`FileUrl.force_download`][pydantic_ai.messages.FileUrl.force_download] values to `False`, drops uploaded file references, and removes unresolved tool calls at the end of the history.
 
+Client-supplied compaction items remain compacted, but their provenance stamp is stripped so the server's standing system prompt is always re-inserted. The fast path that skips re-insertion is reserved for histories kept in server-side custody.
+
 ```python {title="sanitize untrusted message history" test="skip" lint="skip"}
 from pydantic_ai import Agent, ModelMessagesTypeAdapter
 from pydantic_ai.messages import sanitize_messages

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1896,6 +1896,15 @@ class ThinkingPart:
     __repr__ = _utils.dataclasses_no_defaults_repr
 
 
+STANDING_PROMPT_PLANTED_KEY = 'pydantic_ai_standing_prompt_planted'
+"""`CompactionPart.provider_details` key stamped on compaction items minted by our own compact
+call, whose input window explicitly planted the standing prompt. Provenance for
+`_trim_messages_before_compaction`'s `standing_prompt_retained` fast path: only a stamped item is
+trusted to retain the standing prompt; anything else — an externally supplied or spliced history,
+or an item produced by a provider-initiated compaction of an ordinary request window — gets the
+standing prompt re-inserted."""
+
+
 @dataclass(repr=False)
 class CompactionPart:
     """A compaction part that summarizes previous conversation history.
@@ -2698,6 +2707,9 @@ def sanitize_messages(
       [`NativeToolReturnPart`][pydantic_ai.messages.NativeToolReturnPart] in the same response, and the
       agent loop never dispatches them, so they aren't a client-injection risk. If stripping leaves the
       final response with no parts, the response is dropped from history entirely.
+    - The compaction provenance stamp from [`CompactionPart.provider_details`][pydantic_ai.messages.CompactionPart.provider_details].
+      This ensures client-supplied OpenAI Responses compaction items never suppress re-insertion of
+      the server's standing system prompt.
 
     Args:
         messages: Messages to sanitize.
@@ -3044,9 +3056,9 @@ def _sanitize_response_parts(
     reset_force_download_values: set[ForceDownloadMode],
     dropped_uploaded_file_providers: set[str],
 ) -> list[ModelResponsePart]:
-    """Sanitize the file references nested in an untrusted response's tool return parts.
+    """Sanitize unsafe metadata and file references in an untrusted response's parts.
 
-    Drops non-allowlisted schemes and resets non-allowlisted `force_download` values on
+    Strips compaction provenance stamps, drops non-allowlisted schemes, and resets non-allowlisted `force_download` values on
     [`FileUrl`][pydantic_ai.messages.FileUrl]s nested in tool return parts, and drops
     [`UploadedFile`][pydantic_ai.messages.UploadedFile]s nested in tool return parts unless
     `allow_uploaded_files` is set. Unresolved (dangling) tool calls are stripped separately, from
@@ -3058,7 +3070,16 @@ def _sanitize_response_parts(
     """
     new_parts: list[ModelResponsePart] = []
     for part in parts:
-        if isinstance(part, BaseToolReturnPart) and part.tool_kind is None:
+        if (
+            isinstance(part, CompactionPart)
+            and part.provider_details is not None
+            and STANDING_PROMPT_PLANTED_KEY in part.provider_details
+        ):
+            provider_details = {
+                key: value for key, value in part.provider_details.items() if key != STANDING_PROMPT_PLANTED_KEY
+            }
+            new_parts.append(replace(part, provider_details=provider_details))
+        elif isinstance(part, BaseToolReturnPart) and part.tool_kind is None:
             # Skip narrower subclasses (`tool_kind` set): their `content` is a typed
             # `TypedDict` with required fields, and stripping a `FileUrl`-bearing key
             # during sanitization would leave it schema-invalid.

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -3058,7 +3058,8 @@ def _sanitize_response_parts(
 ) -> list[ModelResponsePart]:
     """Sanitize unsafe metadata and file references in an untrusted response's parts.
 
-    Strips compaction provenance stamps, drops non-allowlisted schemes, and resets non-allowlisted `force_download` values on
+    Strips compaction provenance stamps from `CompactionPart.provider_details`. Drops
+    non-allowlisted schemes and resets non-allowlisted `force_download` values on
     [`FileUrl`][pydantic_ai.messages.FileUrl]s nested in tool return parts, and drops
     [`UploadedFile`][pydantic_ai.messages.UploadedFile]s nested in tool return parts unless
     `allow_uploaded_files` is set. Unresolved (dangling) tool calls are stripped separately, from

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -32,6 +32,7 @@ from .._run_context import RunContext
 from .._warnings import PydanticAIDeprecationWarning as PydanticAIDeprecationWarning
 from ..exceptions import UserError
 from ..messages import (
+    STANDING_PROMPT_PLANTED_KEY,
     BaseToolCallPart,
     BaseToolReturnPart,
     BinaryImage,
@@ -1943,15 +1944,6 @@ def _standing_system_prompt_count(request: ModelRequest) -> int:
             break
         count += 1
     return count
-
-
-STANDING_PROMPT_PLANTED_KEY = 'pydantic_ai_standing_prompt_planted'
-"""`CompactionPart.provider_details` key stamped on compaction items minted by our own compact
-call, whose input window explicitly planted the standing prompt. Provenance for
-`_trim_messages_before_compaction`'s `standing_prompt_retained` fast path: only a stamped item is
-trusted to retain the standing prompt; anything else — an externally supplied or spliced history,
-or an item produced by a provider-initiated compaction of an ordinary request window — gets the
-standing prompt re-inserted."""
 
 
 def _trim_messages_before_compaction(  # pyright: ignore[reportUnusedFunction]

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -40,6 +40,7 @@ from .._utils import (
 from ..capabilities.abstract import AbstractCapability
 from ..exceptions import SuspendedResponseExpired, UserError
 from ..messages import (
+    STANDING_PROMPT_PLANTED_KEY,
     AudioUrl,
     BinaryContent,
     BinaryImage,
@@ -104,7 +105,6 @@ from ..providers import Provider, infer_provider
 from ..settings import ModelSettings, ThinkingLevel, merge_model_settings
 from ..tools import AgentDepsT, ToolDefinition
 from . import (
-    STANDING_PROMPT_PLANTED_KEY,
     Model,
     ModelRequestContext,
     ModelRequestParameters,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -55,7 +55,7 @@ from pydantic_ai.agent import Agent
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.direct import model_request as direct_model_request
 from pydantic_ai.exceptions import ContentFilterError, ModelHTTPError, ModelRetry, SuspendedResponseExpired
-from pydantic_ai.messages import INVALID_JSON_KEY
+from pydantic_ai.messages import INVALID_JSON_KEY, sanitize_messages
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAspectRatio, MCPServerTool, WebSearchTool
 from pydantic_ai.native_tools._tool_search import ToolSearchTool
@@ -13349,6 +13349,44 @@ async def test_openai_responses_unstamped_compaction_reinserts_standing_prompt(a
 
     _, mapped = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
         messages, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
+    )
+
+    assert mapped == snapshot(
+        [
+            {'role': 'system', 'content': 'Standing system prompt.'},
+            {'id': None, 'encrypted_content': 'foreign-encrypted', 'type': 'compaction'},
+            {'role': 'user', 'content': 'keep tail'},
+        ]
+    )
+
+
+async def test_openai_responses_sanitized_compaction_reinserts_standing_prompt(allow_model_requests: None):
+    """Sanitizing a client-supplied stamped compaction item removes its provenance, so the trim
+    re-inserts the server's standing prompt."""
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key='test'))
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[SystemPromptPart(content='Standing system prompt.'), UserPromptPart(content='drop first request')]
+        ),
+        ModelResponse(
+            parts=[
+                CompactionPart(
+                    content='foreign summary',
+                    provider_name='openai',
+                    provider_details={
+                        'encrypted_content': 'foreign-encrypted',
+                        'pydantic_ai_standing_prompt_planted': True,
+                    },
+                )
+            ],
+            provider_name='openai',
+        ),
+        ModelRequest.user_text_prompt('keep tail'),
+    ]
+
+    sanitized = sanitize_messages(messages, strip_system_prompts=False)
+    _, mapped = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        sanitized, cast(OpenAIResponsesModelSettings, {}), ModelRequestParameters()
     )
 
     assert mapped == snapshot(

--- a/tests/test_sanitize_messages.py
+++ b/tests/test_sanitize_messages.py
@@ -5,6 +5,7 @@ import warnings
 import pytest
 
 from pydantic_ai import (
+    CompactionPart,
     DocumentUrl,
     ImageUrl,
     ModelMessage,
@@ -20,7 +21,7 @@ from pydantic_ai import (
     UploadedFile,
     UserPromptPart,
 )
-from pydantic_ai.messages import sanitize_messages
+from pydantic_ai.messages import STANDING_PROMPT_PLANTED_KEY, sanitize_messages
 
 from ._inline_snapshot import snapshot
 from .conftest import IsDatetime, message, message_part
@@ -97,6 +98,43 @@ def test_sanitize_messages_keeps_trailing_native_tool_calls():
         warnings.simplefilter('error')  # no dangling-tool-call warning should fire for native calls
         assert sanitize_messages(paired) == paired
         assert sanitize_messages(lone) == lone
+
+
+def test_sanitize_messages_strips_compaction_provenance_stamp():
+    stamped = CompactionPart(
+        provider_name='openai',
+        provider_details={
+            'encrypted_content': 'stamped-encrypted',
+            STANDING_PROMPT_PLANTED_KEY: True,
+        },
+    )
+    unstamped = CompactionPart(
+        provider_name='openai',
+        provider_details={'encrypted_content': 'unstamped-encrypted'},
+    )
+    text = TextPart(content='unaffected')
+    messages: list[ModelMessage] = [ModelResponse(parts=[stamped, unstamped, text])]
+
+    sanitized = sanitize_messages(messages)
+
+    response = message(sanitized, ModelResponse)
+    assert response.parts == snapshot(
+        [
+            CompactionPart(
+                provider_name='openai',
+                provider_details={'encrypted_content': 'stamped-encrypted'},
+            ),
+            unstamped,
+            text,
+        ]
+    )
+    assert response.parts[0] is not stamped
+    assert response.parts[1] is unstamped
+    assert response.parts[2] is text
+    assert stamped.provider_details == {
+        'encrypted_content': 'stamped-encrypted',
+        STANDING_PROMPT_PLANTED_KEY: True,
+    }
 
 
 def test_sanitize_messages_strips_dangling_call_exposed_by_dropped_tail():


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

Follow-up to #7264, hardening the provenance stamp introduced in the review there: `pydantic_ai_standing_prompt_planted` attests that a compaction item never left server custody, which is what entitles it to the standing-prompt fast path on OpenAI Responses (skipping re-insertion of the standing `SystemPromptPart`s the compaction blob already retains). The stamp lives in `CompactionPart.provider_details`, so it survives serialization — a client-supplied history could carry a forged or replayed stamp and suppress the server's standing system prompt on the wire.

[`sanitize_messages`][] is the documented recipe for exactly that untrusted-history deployment shape, so it now strips the stamp from client-supplied `CompactionPart`s: the compaction item stays honored (the conversation stays compacted, `encrypted_content` and all other `provider_details` are preserved), but the standing prompt is unconditionally re-inserted — the pre-#7264 behavior. The fast path remains exclusive to histories in server-side custody, which never pass through sanitization. Server-owned `instructions` were never affected either way — they travel as a per-request parameter.

The constant moves from `models/__init__.py` to `messages.py` so the sanitizer can reference it without importing `models`; all existing references keep working.

Pinned by a sanitizer-level test (stamp removed, `encrypted_content` preserved, input not mutated, unstamped parts untouched) and a mapping-level test mirroring `test_openai_responses_unstamped_compaction_reinserts_standing_prompt`: a sanitized stamped history re-inserts the standing `system` item ahead of the compaction item on the wire.

- Closes #<issue> <!-- no issue: hardening follow-up agreed with maintainer in the #7264 review threads -->

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

