### PR TITLE
Fall back to ASCII in `EvaluationReport.print()` on non-UTF-8 consoles

### DIFF
--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -62,6 +62,22 @@ MISSING_VALUE_STR = '[i]<missing>[/i]'
 EMPTY_CELL_STR = '-'
 EMPTY_AGGREGATE_CELL_STR = ''
 
+
+# `rich` degrades its own box-drawing glyphs on a console whose stream can't encode them, but it passes
+# through text we hand it, so a report printed to e.g. a redirected Windows stdout (which falls back to the
+# ANSI code page) would raise `UnicodeEncodeError`. These pick the fallbacks off the same `ascii_only` signal.
+def _check_mark(ascii_only: bool) -> str:
+    return 'v' if ascii_only else '✔'
+
+
+def _cross_mark(ascii_only: bool) -> str:
+    return 'x' if ascii_only else '✗'
+
+
+def _arrow(ascii_only: bool) -> str:
+    return '->' if ascii_only else '→'
+
+
 InputsT = TypeVar('InputsT', default=Any)
 OutputT = TypeVar('OutputT', default=Any)
 MetadataT = TypeVar('MetadataT', default=Any)
@@ -463,13 +479,17 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
     ) -> None:
         """Print this report to the console, optionally comparing it to a baseline report.
 
+        If the console writes to a stream that can't encode the `✔`, `✗` and `→` glyphs — as Windows does when
+        stdout is redirected to a file or a pipe — `v`, `x` and `->` are used instead.
+
         If you want more control over the output, use `console_table` instead and pass it to `rich.Console.print`.
         """
         if console is None:  # pragma: no branch
             console = Console(width=width)
+        ascii_only = console.options.ascii_only
 
-        metadata_panel = self._metadata_panel(baseline=baseline)
-        renderable: RenderableType = self.console_table(
+        metadata_panel = self._metadata_panel(baseline=baseline, ascii_only=ascii_only)
+        renderable: RenderableType = self._build_table(
             baseline=baseline,
             include_input=include_input,
             include_metadata=include_metadata,
@@ -489,6 +509,7 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
             duration_config=duration_config,
             include_reasons=include_reasons,
             with_title=not metadata_panel,
+            ascii_only=ascii_only,
         )
         # Wrap table with experiment metadata panel if present
         if metadata_panel:
@@ -544,6 +565,58 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         If a baseline is provided, returns a diff between this report and the baseline report.
         Optionally include input and output details.
         """
+        return self._build_table(
+            baseline=baseline,
+            include_input=include_input,
+            include_metadata=include_metadata,
+            include_expected_output=include_expected_output,
+            include_output=include_output,
+            include_durations=include_durations,
+            include_total_duration=include_total_duration,
+            include_removed_cases=include_removed_cases,
+            include_averages=include_averages,
+            include_evaluator_failures=include_evaluator_failures,
+            input_config=input_config,
+            metadata_config=metadata_config,
+            output_config=output_config,
+            score_configs=score_configs,
+            label_configs=label_configs,
+            metric_configs=metric_configs,
+            duration_config=duration_config,
+            include_reasons=include_reasons,
+            with_title=with_title,
+            ascii_only=False,
+        )
+
+    def _build_table(
+        self,
+        *,
+        baseline: EvaluationReport[InputsT, OutputT, MetadataT] | None,
+        include_input: bool,
+        include_metadata: bool,
+        include_expected_output: bool,
+        include_output: bool,
+        include_durations: bool,
+        include_total_duration: bool,
+        include_removed_cases: bool,
+        include_averages: bool,
+        include_evaluator_failures: bool,
+        input_config: RenderValueConfig | None,
+        metadata_config: RenderValueConfig | None,
+        output_config: RenderValueConfig | None,
+        score_configs: dict[str, RenderNumberConfig] | None,
+        label_configs: dict[str, RenderValueConfig] | None,
+        metric_configs: dict[str, RenderNumberConfig] | None,
+        duration_config: RenderNumberConfig | None,
+        include_reasons: bool,
+        with_title: bool,
+        ascii_only: bool,
+    ) -> RenderableType:
+        """Build the report (or diff) table, selecting ASCII glyphs when the target console needs them.
+
+        `ascii_only` is not part of `console_table`'s signature because only the code holding the console
+        the table will be printed to knows whether its stream can encode the glyphs.
+        """
         renderer = EvaluationRenderer(
             include_input=include_input,
             include_metadata=include_metadata,
@@ -564,6 +637,7 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
             metric_configs=metric_configs or {},
             duration_config=duration_config or _DEFAULT_DURATION_CONFIG,
             include_reasons=include_reasons,
+            ascii_only=ascii_only,
         )
         if baseline is None:
             return renderer.build_table(self, with_title=with_title)
@@ -571,12 +645,13 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
             return renderer.build_diff_table(self, baseline, with_title=with_title)
 
     def _metadata_panel(
-        self, baseline: EvaluationReport[InputsT, OutputT, MetadataT] | None = None
+        self, baseline: EvaluationReport[InputsT, OutputT, MetadataT] | None = None, *, ascii_only: bool = False
     ) -> RenderableType | None:
         """Build an experiment metadata panel if metadata exists.
 
         Args:
             baseline: Optional baseline report for diff metadata.
+            ascii_only: Whether the target console needs ASCII fallbacks for the diff arrow.
 
         Returns:
             A `Panel` with the experiment (or diff) metadata, or `None` if there is no metadata to show.
@@ -601,7 +676,9 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         else:
             # Diff report - show metadata diff if either has metadata
             if self.experiment_metadata or baseline.experiment_metadata:
-                diff_name = baseline.name if baseline.name == self.name else f'{baseline.name} → {self.name}'
+                diff_name = (
+                    baseline.name if baseline.name == self.name else f'{baseline.name} {_arrow(ascii_only)} {self.name}'
+                )
                 metadata_text = Text()
                 lines_styles: list[tuple[str, str]] = []
                 if baseline.experiment_metadata and self.experiment_metadata:
@@ -617,7 +694,7 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
                         elif report_val is None:
                             lines_styles.append((f'- {key}: {baseline_val}', 'red'))
                         else:
-                            lines_styles.append((f'{key}: {baseline_val} → {report_val}', 'yellow'))
+                            lines_styles.append((f'{key}: {baseline_val} {_arrow(ascii_only)} {report_val}', 'yellow'))
                 elif self.experiment_metadata:
                     lines_styles = [(f'+ {k}: {v}', 'green') for k, v in self.experiment_metadata.items()]
                 else:  # baseline.experiment_metadata only
@@ -698,14 +775,16 @@ class _ValueRenderer:
     diff_checker: Callable[[Any, Any], bool] | None = lambda x, y: x != y
     diff_formatter: Callable[[Any, Any], str | None] | None = None
     diff_style: str = 'magenta'
+    ascii_only: bool = False
 
     @staticmethod
-    def from_config(config: RenderValueConfig) -> _ValueRenderer:
+    def from_config(config: RenderValueConfig, *, ascii_only: bool) -> _ValueRenderer:
         return _ValueRenderer(
             value_formatter=config.get('value_formatter', '{}'),
             diff_checker=config.get('diff_checker', lambda x, y: x != y),
             diff_formatter=config.get('diff_formatter'),
             diff_style=config.get('diff_style', 'magenta'),
+            ascii_only=ascii_only,
         )
 
     def render_value(self, name: str | None, v: Any) -> str:
@@ -720,7 +799,7 @@ class _ValueRenderer:
         if old_str == new_str:
             result = old_str
         else:
-            result = f'{old_str} → {new_str}'
+            result = f'{old_str} {_arrow(self.ascii_only)} {new_str}'
 
             has_diff = self.diff_checker and self.diff_checker(old, new)
             if has_diff:  # pragma: no branch
@@ -817,6 +896,7 @@ class _NumberRenderer:
     diff_rtol: float
     diff_increase_style: str
     diff_decrease_style: str
+    ascii_only: bool
 
     def render_value(self, name: str | None, v: float | int) -> str:
         result = self._get_value_str(v)
@@ -830,7 +910,7 @@ class _NumberRenderer:
         if old_str == new_str:
             result = old_str
         else:
-            result = f'{old_str} → {new_str}'
+            result = f'{old_str} {_arrow(self.ascii_only)} {new_str}'
 
             diff_style = self._get_diff_style(old, new)
             if diff_style:
@@ -849,7 +929,11 @@ class _NumberRenderer:
 
     @staticmethod
     def infer_from_config(
-        config: RenderNumberConfig, kind: Literal['score', 'metric', 'duration'], values: list[float | int]
+        config: RenderNumberConfig,
+        kind: Literal['score', 'metric', 'duration'],
+        values: list[float | int],
+        *,
+        ascii_only: bool,
     ) -> _NumberRenderer:
         value_formatter = config.get('value_formatter', UNSET)
         if isinstance(value_formatter, Unset):
@@ -883,6 +967,7 @@ class _NumberRenderer:
             diff_atol=diff_atol,
             diff_increase_style=diff_increase_style,
             diff_decrease_style=diff_decrease_style,
+            ascii_only=ascii_only,
         )
 
     def _get_value_str(self, value: float | int | None) -> str:
@@ -963,6 +1048,7 @@ class ReportCaseRenderer:
     label_renderers: Mapping[str, _ValueRenderer]
     metric_renderers: Mapping[str, _NumberRenderer]
     duration_renderer: _NumberRenderer
+    ascii_only: bool
 
     def build_base_table(self, title: str) -> Table:
         """Build and return a Rich Table for the diff output."""
@@ -1296,46 +1382,57 @@ class ReportCaseRenderer:
             return EMPTY_CELL_STR
         lines: list[str] = []
         for a in assertions:
-            line = '[green]✔[/]' if a.value else '[red]✗[/]'
+            line = self._render_assertion_mark(a)
             if self.include_reasons:
                 line = f'{a.name}: {line}\n'
                 line = f'{line}  Reason: {a.reason}\n\n' if a.reason else line
             lines.append(line)
         return ''.join(lines)
 
-    @staticmethod
     def _render_aggregate_assertions(
+        self,
         assertions: float | None,
     ) -> str:
         return (
-            default_render_percentage(assertions) + ' [green]✔[/]'
+            default_render_percentage(assertions) + f' [green]{_check_mark(self.ascii_only)}[/]'
             if assertions is not None
             else EMPTY_AGGREGATE_CELL_STR
         )
 
-    @staticmethod
     def _render_assertions_diff(
-        assertions: list[EvaluationResult[bool]], new_assertions: list[EvaluationResult[bool]]
+        self, assertions: list[EvaluationResult[bool]], new_assertions: list[EvaluationResult[bool]]
     ) -> str:
         if not assertions and not new_assertions:  # pragma: no cover
             return EMPTY_CELL_STR
 
-        old = ''.join(['[green]✔[/]' if a.value else '[red]✗[/]' for a in assertions])
-        new = ''.join(['[green]✔[/]' if a.value else '[red]✗[/]' for a in new_assertions])
-        return old if old == new else f'{old} → {new}'
+        old = ''.join([self._render_assertion_mark(a) for a in assertions])
+        new = ''.join([self._render_assertion_mark(a) for a in new_assertions])
+        return old if old == new else f'{old} {_arrow(self.ascii_only)} {new}'
 
-    @staticmethod
+    def _render_assertion_mark(self, assertion: EvaluationResult[bool]) -> str:
+        if assertion.value:
+            return f'[green]{_check_mark(self.ascii_only)}[/]'
+        return f'[red]{_cross_mark(self.ascii_only)}[/]'
+
     def _render_aggregate_assertions_diff(
+        self,
         baseline: float | None,
         new: float | None,
     ) -> str:
         if baseline is None and new is None:  # pragma: no cover
             return EMPTY_AGGREGATE_CELL_STR
+        check_mark = _check_mark(self.ascii_only)
         rendered_baseline = (
-            default_render_percentage(baseline) + ' [green]✔[/]' if baseline is not None else EMPTY_CELL_STR
+            default_render_percentage(baseline) + f' [green]{check_mark}[/]' if baseline is not None else EMPTY_CELL_STR
         )
-        rendered_new = default_render_percentage(new) + ' [green]✔[/]' if new is not None else EMPTY_CELL_STR
-        return rendered_new if rendered_baseline == rendered_new else f'{rendered_baseline} → {rendered_new}'
+        rendered_new = (
+            default_render_percentage(new) + f' [green]{check_mark}[/]' if new is not None else EMPTY_CELL_STR
+        )
+        return (
+            rendered_new
+            if rendered_baseline == rendered_new
+            else f'{rendered_baseline} {_arrow(self.ascii_only)} {rendered_new}'
+        )
 
     def _render_evaluator_failures(
         self,
@@ -1360,7 +1457,7 @@ class ReportCaseRenderer:
         new_str = self._render_evaluator_failures(new_failures)
         if baseline_str == new_str:
             return baseline_str  # pragma: no cover
-        return f'{baseline_str}\n→\n{new_str}'
+        return f'{baseline_str}\n{_arrow(self.ascii_only)}\n{new_str}'
 
 
 @dataclass(kw_only=True)
@@ -1394,6 +1491,9 @@ class EvaluationRenderer:
     include_error_stacktrace: bool
     include_evaluator_failures: bool
 
+    ascii_only: bool = False
+    """Whether to render ASCII fallbacks for the glyphs a non-UTF-8 console can't encode."""
+
     def include_scores(self, report: EvaluationReport, baseline: EvaluationReport | None = None):
         return any(case.scores for case in self._all_cases(report, baseline))
 
@@ -1426,14 +1526,17 @@ class EvaluationRenderer:
     def _get_case_renderer(
         self, report: EvaluationReport, baseline: EvaluationReport | None = None
     ) -> ReportCaseRenderer:
-        input_renderer = _ValueRenderer.from_config(self.input_config)
-        metadata_renderer = _ValueRenderer.from_config(self.metadata_config)
-        output_renderer = _ValueRenderer.from_config(self.output_config)
+        input_renderer = _ValueRenderer.from_config(self.input_config, ascii_only=self.ascii_only)
+        metadata_renderer = _ValueRenderer.from_config(self.metadata_config, ascii_only=self.ascii_only)
+        output_renderer = _ValueRenderer.from_config(self.output_config, ascii_only=self.ascii_only)
         score_renderers = self._infer_score_renderers(report, baseline)
         label_renderers = self._infer_label_renderers(report, baseline)
         metric_renderers = self._infer_metric_renderers(report, baseline)
         duration_renderer = _NumberRenderer.infer_from_config(
-            self.duration_config, 'duration', [x.task_duration for x in self._all_cases(report, baseline)]
+            self.duration_config,
+            'duration',
+            [x.task_duration for x in self._all_cases(report, baseline)],
+            ascii_only=self.ascii_only,
         )
 
         return ReportCaseRenderer(
@@ -1458,6 +1561,7 @@ class EvaluationRenderer:
             label_renderers=label_renderers,
             metric_renderers=metric_renderers,
             duration_renderer=duration_renderer,
+            ascii_only=self.ascii_only,
         )
 
     def build_table(self, report: EvaluationReport, *, with_title: bool = True) -> Table:
@@ -1521,7 +1625,11 @@ class EvaluationRenderer:
                 assert False, 'This should be unreachable'
 
         case_renderer = self._get_case_renderer(report, baseline)
-        diff_name = baseline.name if baseline.name == report.name else f'{baseline.name} → {report.name}'
+        diff_name = (
+            baseline.name
+            if baseline.name == report.name
+            else f'{baseline.name} {_arrow(self.ascii_only)} {report.name}'
+        )
 
         title = f'Evaluation Diff: {diff_name}' if with_title else ''
         table = case_renderer.build_base_table(title)
@@ -1573,7 +1681,9 @@ class EvaluationRenderer:
         for name, values in values_by_name.items():
             merged_config = _DEFAULT_NUMBER_CONFIG.copy()
             merged_config.update(self.score_configs.get(name, {}))
-            all_renderers[name] = _NumberRenderer.infer_from_config(merged_config, 'score', values)
+            all_renderers[name] = _NumberRenderer.infer_from_config(
+                merged_config, 'score', values, ascii_only=self.ascii_only
+            )
         return all_renderers
 
     def _infer_label_renderers(
@@ -1589,7 +1699,7 @@ class EvaluationRenderer:
         for name in all_names:
             merged_config = _DEFAULT_VALUE_CONFIG.copy()
             merged_config.update(self.label_configs.get(name, {}))
-            all_renderers[name] = _ValueRenderer.from_config(merged_config)
+            all_renderers[name] = _ValueRenderer.from_config(merged_config, ascii_only=self.ascii_only)
         return all_renderers
 
     def _infer_metric_renderers(
@@ -1606,7 +1716,9 @@ class EvaluationRenderer:
         for name, values in values_by_name.items():
             merged_config = _DEFAULT_NUMBER_CONFIG.copy()
             merged_config.update(self.metric_configs.get(name, {}))
-            all_renderers[name] = _NumberRenderer.infer_from_config(merged_config, 'metric', values)
+            all_renderers[name] = _NumberRenderer.infer_from_config(
+                merged_config, 'metric', values, ascii_only=self.ascii_only
+            )
         return all_renderers
 
     def _infer_duration_renderer(
@@ -1616,7 +1728,9 @@ class EvaluationRenderer:
         all_durations = [x.task_duration for x in all_cases]
         if self.include_total_duration:
             all_durations += [x.total_duration for x in all_cases]
-        return _NumberRenderer.infer_from_config(self.duration_config, 'duration', all_durations)
+        return _NumberRenderer.infer_from_config(
+            self.duration_config, 'duration', all_durations, ascii_only=self.ascii_only
+        )
 
 
 def _render_analysis(

--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -481,14 +481,13 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
 
         On a console `rich` reports as ASCII-only — a non-UTF-8 stream, as Windows produces when stdout is
         redirected to a file or a pipe — `v`, `x` and `->` stand in for the `✔`, `✗` and `→` glyphs. The `µs`
-        unit sub-millisecond durations render with is not covered yet, so a code page that can't encode `µ`
-        (`cp932`, `cp936`, `cp949`, `cp950`) can still raise: see
-        [#7291](https://github.com/pydantic/pydantic-ai/issues/7291).
+        unit sub-millisecond durations render with is not covered yet, so a stream that can't encode `µ` can
+        still raise: see [#7291](https://github.com/pydantic/pydantic-ai/issues/7291).
 
         If you want more control over the output, use `console_table` instead and pass it to `rich.Console.print`,
-        passing `ascii_only=True` when your own console needs the fallback.
+        forwarding `ascii_only=console.options.ascii_only` from the console you print to.
         """
-        if console is None:  # pragma: no branch
+        if console is None:
             console = Console(width=width)
         ascii_only = console.options.ascii_only
 
@@ -570,9 +569,9 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         If a baseline is provided, returns a diff between this report and the baseline report.
         Optionally include input and output details.
 
-        Pass `ascii_only=True` to render `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs, for a
-        console whose stream can't encode them. Only the caller holding that console can answer this, so
-        it defaults to `False`; `print` reads it off the console it was given.
+        `ascii_only` renders `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs, for a console whose
+        stream can't encode them. Only the caller holding that console can answer this, so it defaults to
+        `False`; pass `ascii_only=console.options.ascii_only` from the console you print the table to.
         """
         renderer = EvaluationRenderer(
             include_input=include_input,
@@ -1677,17 +1676,6 @@ class EvaluationRenderer:
                 merged_config, 'metric', values, ascii_only=self.ascii_only
             )
         return all_renderers
-
-    def _infer_duration_renderer(
-        self, report: EvaluationReport, baseline: EvaluationReport | None
-    ) -> _NumberRenderer:  # pragma: no cover
-        all_cases = self._all_cases(report, baseline)
-        all_durations = [x.task_duration for x in all_cases]
-        if self.include_total_duration:
-            all_durations += [x.total_duration for x in all_cases]
-        return _NumberRenderer.infer_from_config(
-            self.duration_config, 'duration', all_durations, ascii_only=self.ascii_only
-        )
 
 
 def _render_analysis(

--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -573,7 +573,7 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         this, so it defaults to `False`; pass `ascii_only=console.options.ascii_only` from the console you print the
         table to.
         """
-        if ascii_only and duration_config is None:
+        if ascii_only and not duration_config:
             duration_config = {
                 **_DEFAULT_DURATION_CONFIG,
                 'value_formatter': lambda value: default_render_duration(value).replace('µs', 'us'),

--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -480,9 +480,8 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         """Print this report to the console, optionally comparing it to a baseline report.
 
         On a console `rich` reports as ASCII-only — a non-UTF-8 stream, as Windows produces when stdout is
-        redirected to a file or a pipe — `v`, `x` and `->` stand in for the `✔`, `✗` and `→` glyphs. The `µs`
-        unit sub-millisecond durations render with is not covered yet, so a stream that can't encode `µ` can
-        still raise: see [#7291](https://github.com/pydantic/pydantic-ai/issues/7291).
+        redirected to a file or a pipe — `v`, `x` and `->` stand in for the `✔`, `✗` and `→` glyphs, and default
+        sub-millisecond duration formatters use `us` instead of `µs`.
 
         If you want more control over the output, use `console_table` instead and pass it to `rich.Console.print`,
         forwarding `ascii_only=console.options.ascii_only` from the console you print to.
@@ -569,10 +568,21 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         If a baseline is provided, returns a diff between this report and the baseline report.
         Optionally include input and output details.
 
-        `ascii_only` renders `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs, for a console whose
-        stream can't encode them. Only the caller holding that console can answer this, so it defaults to
-        `False`; pass `ascii_only=console.options.ascii_only` from the console you print the table to.
+        `ascii_only` renders `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs, and uses `us` instead of
+        `µs` from the default sub-millisecond duration formatters. Only the caller holding that console can answer
+        this, so it defaults to `False`; pass `ascii_only=console.options.ascii_only` from the console you print the
+        table to.
         """
+        if ascii_only and duration_config is None:
+            duration_config = {
+                **_DEFAULT_DURATION_CONFIG,
+                'value_formatter': lambda value: default_render_duration(value).replace('µs', 'us'),
+                'diff_formatter': lambda old, new: (
+                    rendered.replace('µs', 'us')
+                    if (rendered := default_render_duration_diff(old, new)) is not None
+                    else None
+                ),
+            }
         renderer = EvaluationRenderer(
             include_input=include_input,
             include_metadata=include_metadata,

--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -479,17 +479,21 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
     ) -> None:
         """Print this report to the console, optionally comparing it to a baseline report.
 
-        If the console writes to a stream that can't encode the `✔`, `✗` and `→` glyphs — as Windows does when
-        stdout is redirected to a file or a pipe — `v`, `x` and `->` are used instead.
+        On a console `rich` reports as ASCII-only — a non-UTF-8 stream, as Windows produces when stdout is
+        redirected to a file or a pipe — `v`, `x` and `->` stand in for the `✔`, `✗` and `→` glyphs. The `µs`
+        unit sub-millisecond durations render with is not covered yet, so a code page that can't encode `µ`
+        (`cp932`, `cp936`, `cp949`, `cp950`) can still raise: see
+        [#7291](https://github.com/pydantic/pydantic-ai/issues/7291).
 
-        If you want more control over the output, use `console_table` instead and pass it to `rich.Console.print`.
+        If you want more control over the output, use `console_table` instead and pass it to `rich.Console.print`,
+        passing `ascii_only=True` when your own console needs the fallback.
         """
         if console is None:  # pragma: no branch
             console = Console(width=width)
         ascii_only = console.options.ascii_only
 
         metadata_panel = self._metadata_panel(baseline=baseline, ascii_only=ascii_only)
-        renderable: RenderableType = self._build_table(
+        renderable: RenderableType = self.console_table(
             baseline=baseline,
             include_input=include_input,
             include_metadata=include_metadata,
@@ -559,63 +563,16 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         duration_config: RenderNumberConfig | None = None,
         include_reasons: bool = False,
         with_title: bool = True,
+        ascii_only: bool = False,
     ) -> RenderableType:
         """Return a table containing the data from this report.
 
         If a baseline is provided, returns a diff between this report and the baseline report.
         Optionally include input and output details.
-        """
-        return self._build_table(
-            baseline=baseline,
-            include_input=include_input,
-            include_metadata=include_metadata,
-            include_expected_output=include_expected_output,
-            include_output=include_output,
-            include_durations=include_durations,
-            include_total_duration=include_total_duration,
-            include_removed_cases=include_removed_cases,
-            include_averages=include_averages,
-            include_evaluator_failures=include_evaluator_failures,
-            input_config=input_config,
-            metadata_config=metadata_config,
-            output_config=output_config,
-            score_configs=score_configs,
-            label_configs=label_configs,
-            metric_configs=metric_configs,
-            duration_config=duration_config,
-            include_reasons=include_reasons,
-            with_title=with_title,
-            ascii_only=False,
-        )
 
-    def _build_table(
-        self,
-        *,
-        baseline: EvaluationReport[InputsT, OutputT, MetadataT] | None,
-        include_input: bool,
-        include_metadata: bool,
-        include_expected_output: bool,
-        include_output: bool,
-        include_durations: bool,
-        include_total_duration: bool,
-        include_removed_cases: bool,
-        include_averages: bool,
-        include_evaluator_failures: bool,
-        input_config: RenderValueConfig | None,
-        metadata_config: RenderValueConfig | None,
-        output_config: RenderValueConfig | None,
-        score_configs: dict[str, RenderNumberConfig] | None,
-        label_configs: dict[str, RenderValueConfig] | None,
-        metric_configs: dict[str, RenderNumberConfig] | None,
-        duration_config: RenderNumberConfig | None,
-        include_reasons: bool,
-        with_title: bool,
-        ascii_only: bool,
-    ) -> RenderableType:
-        """Build the report (or diff) table, selecting ASCII glyphs when the target console needs them.
-
-        `ascii_only` is not part of `console_table`'s signature because only the code holding the console
-        the table will be printed to knows whether its stream can encode the glyphs.
+        Pass `ascii_only=True` to render `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs, for a
+        console whose stream can't encode them. Only the caller holding that console can answer this, so
+        it defaults to `False`; `print` reads it off the console it was given.
         """
         renderer = EvaluationRenderer(
             include_input=include_input,
@@ -1048,7 +1005,7 @@ class ReportCaseRenderer:
     label_renderers: Mapping[str, _ValueRenderer]
     metric_renderers: Mapping[str, _NumberRenderer]
     duration_renderer: _NumberRenderer
-    ascii_only: bool
+    ascii_only: bool = False
 
     def build_base_table(self, title: str) -> Table:
         """Build and return a Rich Table for the diff output."""
@@ -1492,7 +1449,7 @@ class EvaluationRenderer:
     include_evaluator_failures: bool
 
     ascii_only: bool = False
-    """Whether to render ASCII fallbacks for the glyphs a non-UTF-8 console can't encode."""
+    """Whether to render `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs."""
 
     def include_scores(self, report: EvaluationReport, baseline: EvaluationReport | None = None):
         return any(case.scores for case in self._all_cases(report, baseline))

--- a/tests/evals/test_render_numbers.py
+++ b/tests/evals/test_render_numbers.py
@@ -109,3 +109,8 @@ def test_default_render_duration(value: float, expected: str):
 )
 def test_default_render_duration_diff(old: float, new: float, expected: str | None):
     assert default_render_duration_diff(old, new) == expected
+
+
+def test_default_duration_formatters_retain_microsecond_units():
+    assert default_render_duration(0.0001) == '100µs'
+    assert default_render_duration_diff(0.0001, 0.0002) == '+100µs / +100.0%'

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -9,10 +9,11 @@ from rich.console import Console
 
 from .._inline_snapshot import snapshot
 from ..conftest import try_import
-from .utils import render_table
+from .utils import render_table, trim_trailing_whitespace
 
 with try_import() as imports_successful:
     from pydantic_evals.evaluators import EvaluationResult, Evaluator, EvaluatorContext
+    from pydantic_evals.evaluators.evaluator import EvaluatorFailure
     from pydantic_evals.reporting import (
         EvaluationRenderer,
         EvaluationReport,
@@ -1374,7 +1375,7 @@ async def test_evaluation_renderer_diff_with_no_metadata(sample_report_case: Rep
 """)
 
 
-def print_to_non_utf8_console(report: EvaluationReport, baseline: EvaluationReport | None = None) -> str:
+def render_to_non_utf8_console(report: EvaluationReport, baseline: EvaluationReport | None = None) -> str:
     """Print a report to a console whose stream can only encode cp1252, and return what was written.
 
     This is Windows with stdout redirected to a file or a pipe: Python uses UTF-8 for the console
@@ -1384,8 +1385,7 @@ def print_to_non_utf8_console(report: EvaluationReport, baseline: EvaluationRepo
     stream = TextIOWrapper(buffer, encoding='cp1252', errors='strict', newline='')
     report.print(baseline=baseline, console=Console(file=stream, width=150))
     stream.flush()
-    rendered = buffer.getvalue().decode('cp1252')
-    return '\n'.join([line.rstrip() for line in rendered.split('\n')])
+    return trim_trailing_whitespace(buffer.getvalue().decode('cp1252'))
 
 
 async def test_print_falls_back_to_ascii_glyphs_on_non_utf8_console(
@@ -1400,7 +1400,7 @@ async def test_print_falls_back_to_ascii_glyphs_on_non_utf8_console(
     )
     report = EvaluationReport(cases=[case], name='test_report')
 
-    assert print_to_non_utf8_console(report) == snapshot("""\
+    assert render_to_non_utf8_console(report) == snapshot("""\
                                 Evaluation Summary: test_report
 +---------------------------------------------------------------------------------------------+
 | Case ID   | Scores       | Labels                 | Metrics         | Assertions | Duration |
@@ -1416,8 +1416,6 @@ async def test_print_diff_falls_back_to_ascii_glyphs_on_non_utf8_console(
     mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetadata], sample_report_case: ReportCase
 ):
     """Every `→` in a diff report degrades too: metadata panel, value/number diffs, and cell diffs."""
-    from pydantic_evals.evaluators.evaluator import EvaluatorFailure
-
     failed_assertion = EvaluationResult(name='MockEvaluator', value=False, reason=None, source=mock_evaluator.as_spec())
     baseline_case = replace(
         sample_report_case,
@@ -1450,7 +1448,7 @@ async def test_print_diff_falls_back_to_ascii_glyphs_on_non_utf8_console(
     )
     new_report = EvaluationReport(cases=[new_case], name='new_report', experiment_metadata={'model': 'gpt-4o'})
 
-    assert print_to_non_utf8_console(new_report, baseline=baseline_report) == snapshot("""\
+    assert render_to_non_utf8_console(new_report, baseline=baseline_report) == snapshot("""\
 +- Evaluation Diff: baseline_report -> new_report -+
 | model: gpt-4 -> gpt-4o                           |
 +--------------------------------------------------+
@@ -1473,7 +1471,7 @@ async def test_print_diff_title_falls_back_to_ascii_glyphs_on_non_utf8_console(s
     baseline_report = EvaluationReport(cases=[sample_report_case], name='baseline_report')
     new_report = EvaluationReport(cases=[replace(sample_report_case, metrics={'accuracy': 0.97})], name='new_report')
 
-    assert print_to_non_utf8_console(new_report, baseline=baseline_report) == snapshot("""\
+    assert render_to_non_utf8_console(new_report, baseline=baseline_report) == snapshot("""\
                              Evaluation Diff: baseline_report -> new_report
 +------------------------------------------------------------------------------------------------------+
 | Case ID   | Scores       | Labels                 | Metrics                  | Assertions | Duration |
@@ -1482,4 +1480,34 @@ async def test_print_diff_title_falls_back_to_ascii_glyphs_on_non_utf8_console(s
 |-----------+--------------+------------------------+--------------------------+------------+----------|
 | Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 -> 0.970 | 100.0% v   |  100.0ms |
 +------------------------------------------------------------------------------------------------------+
+""")
+
+
+async def test_console_table_renders_ascii_glyphs_when_asked(
+    mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetadata], sample_report_case: ReportCase
+):
+    """A caller holding its own non-UTF-8 console can ask `console_table` for the fallback and print it."""
+    failed_assertion = EvaluationResult(
+        name='FailingEvaluator', value=False, reason=None, source=mock_evaluator.as_spec()
+    )
+    case = replace(
+        sample_report_case, assertions={**sample_report_case.assertions, 'FailingEvaluator': failed_assertion}
+    )
+    report = EvaluationReport(cases=[case], name='test_report')
+
+    buffer = BytesIO()
+    stream = TextIOWrapper(buffer, encoding='cp1252', errors='strict', newline='')
+    console = Console(file=stream, width=150)
+    console.print(report.console_table(ascii_only=console.options.ascii_only))
+    stream.flush()
+
+    assert trim_trailing_whitespace(buffer.getvalue().decode('cp1252')) == snapshot("""\
+                                Evaluation Summary: test_report
++---------------------------------------------------------------------------------------------+
+| Case ID   | Scores       | Labels                 | Metrics         | Assertions | Duration |
+|-----------+--------------+------------------------+-----------------+------------+----------|
+| test_case | score1: 2.50 | label1: hello          | accuracy: 0.950 | vx         |  100.0ms |
+|-----------+--------------+------------------------+-----------------+------------+----------|
+| Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 50.0% v    |  100.0ms |
++---------------------------------------------------------------------------------------------+
 """)

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -1519,7 +1519,7 @@ async def test_console_table_renders_ascii_glyphs_when_asked(
     buffer = BytesIO()
     stream = TextIOWrapper(buffer, encoding='cp932', errors='strict', newline='')
     console = Console(file=stream, width=150)
-    console.print(report.console_table(ascii_only=True))
+    console.print(report.console_table(ascii_only=True, duration_config={}))
     stream.flush()
 
     assert trim_trailing_whitespace(buffer.getvalue().decode('cp932')) == snapshot("""\

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -1375,17 +1375,19 @@ async def test_evaluation_renderer_diff_with_no_metadata(sample_report_case: Rep
 """)
 
 
-def render_to_non_utf8_console(report: EvaluationReport, baseline: EvaluationReport | None = None) -> str:
-    """Print a report to a console whose stream can only encode cp1252, and return what was written.
+def render_to_non_utf8_console(
+    report: EvaluationReport, baseline: EvaluationReport | None = None, *, encoding: str = 'cp1252'
+) -> str:
+    """Print a report to a console whose stream can't encode Unicode report text, and return what was written.
 
     This is Windows with stdout redirected to a file or a pipe: Python uses UTF-8 for the console
     itself, but falls back to the ANSI code page for a redirected stream.
     """
     buffer = BytesIO()
-    stream = TextIOWrapper(buffer, encoding='cp1252', errors='strict', newline='')
+    stream = TextIOWrapper(buffer, encoding=encoding, errors='strict', newline='')
     report.print(baseline=baseline, console=Console(file=stream, width=150))
     stream.flush()
-    return trim_trailing_whitespace(buffer.getvalue().decode('cp1252'))
+    return trim_trailing_whitespace(buffer.getvalue().decode(encoding))
 
 
 async def test_print_falls_back_to_ascii_glyphs_on_non_utf8_console(
@@ -1409,6 +1411,25 @@ async def test_print_falls_back_to_ascii_glyphs_on_non_utf8_console(
 |-----------+--------------+------------------------+-----------------+------------+----------|
 | Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 50.0% v    |  100.0ms |
 +---------------------------------------------------------------------------------------------+
+""")
+
+
+async def test_print_falls_back_to_ascii_duration_units_on_cp932_console(sample_report_case: ReportCase):
+    """Default duration values and diffs use ASCII units on a console that can't encode the micro sign."""
+    baseline_report = EvaluationReport(
+        cases=[replace(sample_report_case, task_duration=0.0001)], name='baseline_report'
+    )
+    report = EvaluationReport(cases=[replace(sample_report_case, task_duration=0.0002)], name='test_report')
+
+    assert render_to_non_utf8_console(report, baseline=baseline_report, encoding='cp932') == snapshot("""\
+                                    Evaluation Diff: baseline_report -> test_report
++----------------------------------------------------------------------------------------------------------------------+
+| Case ID   | Scores       | Labels                 | Metrics         | Assertions |                          Duration |
+|-----------+--------------+------------------------+-----------------+------------+-----------------------------------|
+| test_case | score1: 2.50 | label1: hello          | accuracy: 0.950 | v          | 100us -> 200us (+100us / +100.0%) |
+|-----------+--------------+------------------------+-----------------+------------+-----------------------------------|
+| Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 100.0% v   | 100us -> 200us (+100us / +100.0%) |
++----------------------------------------------------------------------------------------------------------------------+
 """)
 
 
@@ -1493,21 +1514,33 @@ async def test_console_table_renders_ascii_glyphs_when_asked(
     case = replace(
         sample_report_case, assertions={**sample_report_case.assertions, 'FailingEvaluator': failed_assertion}
     )
-    report = EvaluationReport(cases=[case], name='test_report')
+    report = EvaluationReport(cases=[replace(case, task_duration=0.0001)], name='test_report')
 
     buffer = BytesIO()
-    stream = TextIOWrapper(buffer, encoding='cp1252', errors='strict', newline='')
+    stream = TextIOWrapper(buffer, encoding='cp932', errors='strict', newline='')
     console = Console(file=stream, width=150)
-    console.print(report.console_table(ascii_only=console.options.ascii_only))
+    console.print(report.console_table(ascii_only=True))
     stream.flush()
 
-    assert trim_trailing_whitespace(buffer.getvalue().decode('cp1252')) == snapshot("""\
+    assert trim_trailing_whitespace(buffer.getvalue().decode('cp932')) == snapshot("""\
                                 Evaluation Summary: test_report
 +---------------------------------------------------------------------------------------------+
 | Case ID   | Scores       | Labels                 | Metrics         | Assertions | Duration |
 |-----------+--------------+------------------------+-----------------+------------+----------|
-| test_case | score1: 2.50 | label1: hello          | accuracy: 0.950 | vx         |  100.0ms |
+| test_case | score1: 2.50 | label1: hello          | accuracy: 0.950 | vx         |    100us |
 |-----------+--------------+------------------------+-----------------+------------+----------|
-| Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 50.0% v    |  100.0ms |
+| Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 50.0% v    |    100us |
 +---------------------------------------------------------------------------------------------+
 """)
+
+
+async def test_console_table_keeps_custom_duration_formatters_on_ascii_only(sample_report_case: ReportCase):
+    """ASCII fallback applies only to renderer-supplied duration formatters."""
+    report = EvaluationReport(cases=[replace(sample_report_case, task_duration=0.0001)], name='test_report')
+
+    table = report.console_table(
+        ascii_only=True,
+        duration_config={'value_formatter': lambda _: 'custom µs'},
+    )
+
+    assert 'custom µs' in render_table(table)

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -1,9 +1,11 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from io import BytesIO, TextIOWrapper
 
 import pytest
 from pydantic import BaseModel
+from rich.console import Console
 
 from .._inline_snapshot import snapshot
 from ..conftest import try_import
@@ -1369,4 +1371,115 @@ async def test_evaluation_renderer_diff_with_no_metadata(sample_report_case: Rep
 ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
 │ test_case │ score1: 2.50 │ label1: hello │ accuracy: 0.950 │ ✔          │  100.0ms │
 └───────────┴──────────────┴───────────────┴─────────────────┴────────────┴──────────┘
+""")
+
+
+def print_to_non_utf8_console(report: EvaluationReport, baseline: EvaluationReport | None = None) -> str:
+    """Print a report to a console whose stream can only encode cp1252, and return what was written.
+
+    This is Windows with stdout redirected to a file or a pipe: Python uses UTF-8 for the console
+    itself, but falls back to the ANSI code page for a redirected stream.
+    """
+    buffer = BytesIO()
+    stream = TextIOWrapper(buffer, encoding='cp1252', errors='strict', newline='')
+    report.print(baseline=baseline, console=Console(file=stream, width=150))
+    stream.flush()
+    rendered = buffer.getvalue().decode('cp1252')
+    return '\n'.join([line.rstrip() for line in rendered.split('\n')])
+
+
+async def test_print_falls_back_to_ascii_glyphs_on_non_utf8_console(
+    mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetadata], sample_report_case: ReportCase
+):
+    """A report printed to a stream that can't encode `✔`/`✗` renders ASCII markers instead of raising."""
+    failed_assertion = EvaluationResult(
+        name='FailingEvaluator', value=False, reason=None, source=mock_evaluator.as_spec()
+    )
+    case = replace(
+        sample_report_case, assertions={**sample_report_case.assertions, 'FailingEvaluator': failed_assertion}
+    )
+    report = EvaluationReport(cases=[case], name='test_report')
+
+    assert print_to_non_utf8_console(report) == snapshot("""\
+                                Evaluation Summary: test_report
++---------------------------------------------------------------------------------------------+
+| Case ID   | Scores       | Labels                 | Metrics         | Assertions | Duration |
+|-----------+--------------+------------------------+-----------------+------------+----------|
+| test_case | score1: 2.50 | label1: hello          | accuracy: 0.950 | vx         |  100.0ms |
+|-----------+--------------+------------------------+-----------------+------------+----------|
+| Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 50.0% v    |  100.0ms |
++---------------------------------------------------------------------------------------------+
+""")
+
+
+async def test_print_diff_falls_back_to_ascii_glyphs_on_non_utf8_console(
+    mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetadata], sample_report_case: ReportCase
+):
+    """Every `→` in a diff report degrades too: metadata panel, value/number diffs, and cell diffs."""
+    from pydantic_evals.evaluators.evaluator import EvaluatorFailure
+
+    failed_assertion = EvaluationResult(name='MockEvaluator', value=False, reason=None, source=mock_evaluator.as_spec())
+    baseline_case = replace(
+        sample_report_case,
+        assertions={'MockEvaluator': failed_assertion},
+        metrics={'accuracy': 0.95},
+        evaluator_failures=[
+            EvaluatorFailure(
+                name='BaselineEvaluator',
+                error_message='Baseline error',
+                error_stacktrace='Baseline stacktrace',
+                source=mock_evaluator.as_spec(),
+            )
+        ],
+    )
+    new_case = replace(
+        sample_report_case,
+        labels={'label1': replace(sample_report_case.labels['label1'], value='goodbye')},
+        metrics={'accuracy': 0.97},
+        evaluator_failures=[
+            EvaluatorFailure(
+                name='NewEvaluator',
+                error_message='New error',
+                error_stacktrace='New stacktrace',
+                source=mock_evaluator.as_spec(),
+            )
+        ],
+    )
+    baseline_report = EvaluationReport(
+        cases=[baseline_case], name='baseline_report', experiment_metadata={'model': 'gpt-4'}
+    )
+    new_report = EvaluationReport(cases=[new_case], name='new_report', experiment_metadata={'model': 'gpt-4o'})
+
+    assert print_to_non_utf8_console(new_report, baseline=baseline_report) == snapshot("""\
++- Evaluation Diff: baseline_report -> new_report -+
+| model: gpt-4 -> gpt-4o                           |
++--------------------------------------------------+
++----------------------------------------------------------------------------------------------------------------------------------------------------+
+| Case ID   | Scores       | Labels                        | Metrics                  | Assertions         | Evaluator Failures           | Duration |
+|-----------+--------------+-------------------------------+--------------------------+--------------------+------------------------------+----------|
+| test_case | score1: 2.50 | label1: hello -> goodbye      | accuracy: 0.950 -> 0.970 | x -> v             | BaselineEvaluator: Baseline  |  100.0ms |
+|           |              |                               |                          |                    | error                        |          |
+|           |              |                               |                          |                    | ->                           |          |
+|           |              |                               |                          |                    | NewEvaluator: New error      |          |
+|-----------+--------------+-------------------------------+--------------------------+--------------------+------------------------------+----------|
+| Averages  | score1: 2.50 | label1: {'hello': 1.0} ->     | accuracy: 0.950 -> 0.970 | 0.0% v -> 100.0% v |                              |  100.0ms |
+|           |              | {'goodbye': 1.0}              |                          |                    |                              |          |
++----------------------------------------------------------------------------------------------------------------------------------------------------+
+""")
+
+
+async def test_print_diff_title_falls_back_to_ascii_glyphs_on_non_utf8_console(sample_report_case: ReportCase):
+    """Without an experiment-metadata panel the diff name lands in the table title, which degrades as well."""
+    baseline_report = EvaluationReport(cases=[sample_report_case], name='baseline_report')
+    new_report = EvaluationReport(cases=[replace(sample_report_case, metrics={'accuracy': 0.97})], name='new_report')
+
+    assert print_to_non_utf8_console(new_report, baseline=baseline_report) == snapshot("""\
+                             Evaluation Diff: baseline_report -> new_report
++------------------------------------------------------------------------------------------------------+
+| Case ID   | Scores       | Labels                 | Metrics                  | Assertions | Duration |
+|-----------+--------------+------------------------+--------------------------+------------+----------|
+| test_case | score1: 2.50 | label1: hello          | accuracy: 0.950 -> 0.970 | v          |  100.0ms |
+|-----------+--------------+------------------------+--------------------------+------------+----------|
+| Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 -> 0.970 | 100.0% v   |  100.0ms |
++------------------------------------------------------------------------------------------------------+
 """)

--- a/tests/evals/utils.py
+++ b/tests/evals/utils.py
@@ -3,11 +3,13 @@ from io import StringIO
 from rich.console import Console, RenderableType
 
 
+def trim_trailing_whitespace(rendered: str) -> str:
+    """Trim end-of-line whitespace to prevent snapshot diffs after pre-commit removes the whitespace."""
+    return '\n'.join([line.rstrip() for line in rendered.split('\n')])
+
+
 def render_table(table: RenderableType) -> str:
     """Render a rich renderable as a string."""
     string_io = StringIO()
     Console(width=300, file=string_io).print(table)
-    rendered = string_io.getvalue()
-    # Need to trim end-of-line whitespace to prevent snapshot diffs after pre-commit removes the whitespace
-    trimmed = '\n'.join([line.rstrip() for line in rendered.split('\n')])
-    return trimmed
+    return trim_trailing_whitespace(string_io.getvalue())


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

David reviewed this lightly.

- Closes #7281
- Fixes #7291

`EvaluationReport.print()` now uses ASCII fallbacks on non-UTF-8 consoles: `v`/`x`/`->` for status and diff glyphs, and `us` rather than `µs` for default sub-millisecond duration formatting. Public duration formatter functions retain their `µs` output, and custom duration formatters remain unchanged.

`console_table(ascii_only=True)` provides the same default-duration fallback for callers printing through their own console.

### Tests

- Direct default-duration formatter output retains `µs`.
- ASCII-only `console_table()` output uses `us`.
- `EvaluationReport.print()` succeeds through a strict `cp932` stream, including duration diffs.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).