### PR TITLE
Sort OpenAI batch embeddings by response `index`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -143,7 +143,9 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e
 
-        embeddings = [item.embedding for item in response.data]
+        # OpenAI returns per-item `index` so batch results can be reordered to
+        # match the request. Do not assume response.data order equals inputs.
+        embeddings = [item.embedding for item in sorted(response.data, key=lambda item: item.index)]
 
         return EmbeddingResult(
             embeddings=embeddings,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -380,6 +380,7 @@ class TestOpenAI:
         mock_client = AsyncMock()
         mock_embedding_item = MagicMock()
         mock_embedding_item.embedding = [0.1, 0.2, 0.3]
+        mock_embedding_item.index = 0
 
         mock_response = MagicMock()
         mock_response.data = [mock_embedding_item]
@@ -402,6 +403,36 @@ class TestOpenAI:
                 timestamp=IsDatetime(),
             )
         )
+
+    async def test_batch_embeddings_sorted_by_index(self):
+        """Response items may arrive out of order; order by `index` to match inputs."""
+        mock_client = AsyncMock()
+
+        item_b = MagicMock()
+        item_b.index = 1
+        item_b.embedding = [0.2]
+
+        item_a = MagicMock()
+        item_a.index = 0
+        item_a.embedding = [0.1]
+
+        item_c = MagicMock()
+        item_c.index = 2
+        item_c.embedding = [0.3]
+
+        # Deliberately reverse of request order
+        mock_response = MagicMock()
+        mock_response.data = [item_c, item_a, item_b]
+        mock_response.usage = None
+        mock_response.model = 'test-model'
+        mock_client.embeddings.create.return_value = mock_response
+
+        provider = OpenAIProvider(openai_client=mock_client)
+        model = OpenAIEmbeddingModel('test-model', provider=provider)
+
+        result = await model.embed(['a', 'b', 'c'], input_type='document')
+        assert result.embeddings == [[0.1], [0.2], [0.3]]
+        assert result.inputs == ['a', 'b', 'c']
 
     @pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
     async def test_instrumentation(self, openai_api_key: str, capfire: CaptureLogfire):


### PR DESCRIPTION
- Closes #7284

### Summary

`OpenAIEmbeddingModel.embed()` built the result list from `response.data` in API order. The OpenAI embeddings schema includes a per-item `index` so batch results can be aligned with the request even if the server returns them out of order (litellm and historical openai-python clients re-sort by `index` for the same reason).

This change sorts `response.data` by `index` before collecting embeddings.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Test plan

```bash
uv run -- pytest tests/test_embeddings.py -k "test_batch_embeddings_sorted_by_index or test_response_with_no_usage" -q
# 2 passed
```

Added a unit test that feeds out-of-order mock embedding items and asserts embeddings match input order after sorting by `index`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

