### PR TITLE
Tune Macroscope review discipline: scope to introduced changes, verify claims

### DIFF
--- a/.macroscope/correctness/review-discipline.md
+++ b/.macroscope/correctness/review-discipline.md
@@ -1,0 +1,39 @@
+---
+include:
+  - "**/*.py"
+  - "**/*.md"
+  - "**/*.yml"
+  - "**/*.yaml"
+  - "**/*.ts"
+  - "**/*.tsx"
+---
+
+Two rules that keep findings precise, applied to every finding.
+
+## Flag what this PR introduces, not what it inherits
+
+Raise a finding only for a problem the PR's own added or changed lines create. A
+real bug that already existed in code this PR merely touches, moves, or sits next
+to is out of scope: the PR did not introduce it, so flagging it as a blocking
+issue here is noise the author dismisses and tracks separately. If a serious
+pre-existing defect is genuinely worth surfacing, note it as low-severity and say
+it is pre-existing, do not rate it high on this PR.
+
+A line can show as added (`+`) without being new. When code is wrapped in a new
+block (a loop, `try`, `with`, `if`) or relocated, its indentation changes and git
+records the old line as a delete plus an add. Treat a `+` line as introduced only
+when the same text (ignoring leading whitespace) is not also deleted in the same
+hunk under unchanged semantics. When in doubt whether the line, and the problem
+with it, is genuinely new, prefer not flagging.
+
+## Verify the claim before flagging
+
+A finding must rest on a verified fact, not an inferred one -- the repo's own
+"trust but verify" principle applies to review too. Before asserting a mechanism,
+confirm it: what a function or stdlib call actually does, what actually failed and
+on which commit, how a relative link or path actually resolves from the file it
+lives in (`overview.md` referenced from `docs/ui/ag-ui.md` resolves to
+`docs/ui/overview.md`, not one directory up). You have code-browsing and web
+tools; use them. A finding whose premise is wrong, or a suggested fix that would
+itself break the code, costs more trust than a missed nit, so when the mechanism
+is unverified, do not raise it.

--- a/.macroscope/correctness/review-discipline.md
+++ b/.macroscope/correctness/review-discipline.md
@@ -14,16 +14,16 @@ Two rules that keep findings precise, applied to every finding.
 
 Raise a finding only for a problem the PR's own added or changed lines create. A
 real bug that already existed in code this PR merely touches, moves, or sits next
-to is out of scope: the PR did not introduce it, so flagging it as a blocking
-issue here is noise the author dismisses and tracks separately. If a serious
-pre-existing defect is genuinely worth surfacing, note it as low-severity and say
-it is pre-existing, do not rate it high on this PR.
+to is out of scope: the PR did not introduce it, so flagging it here is noise the
+author dismisses and tracks separately. A pre-existing defect worth surfacing
+belongs in its own issue, not in this PR's review output at any severity.
 
 A line can show as added (`+`) without being new. When code is wrapped in a new
 block (a loop, `try`, `with`, `if`) or relocated, its indentation changes and git
 records the old line as a delete plus an add. Treat a `+` line as introduced only
-when the same text (ignoring leading whitespace) is not also deleted in the same
-hunk under unchanged semantics. When in doubt whether the line, and the problem
+when the same text (ignoring leading whitespace) is not deleted anywhere in the
+PR's diff -- including another hunk or another file, since code moves across both
+-- under unchanged semantics. When in doubt whether the line, and the problem
 with it, is genuinely new, prefer not flagging.
 
 ## Verify the claim before flagging


### PR DESCRIPTION
Adds a Macroscope correctness instruction, from an audit of Macroscope's review comments on the last ~40 merged PRs. One false-positive class dominated the maintainer dismissals: Macroscope flagged real but **pre-existing** bugs that the PR only touched, not introduced ("correct on the mechanism, but not introduced here, tracked in #7159"). A couple of others rested on an **unverified mechanism** (a CI failure attributed to the wrong cause; a docs-link "fix" that would itself have broken the link).

`.macroscope/correctness/review-discipline.md` addresses both: flag only what the PR's changed lines introduce (with the added-but-relocated `+`-line carve-out), and verify a claim before raising it (grounded in the repo's own "trust but verify" rule). The repo previously had only `.macroscope/ignore.md`, so this is the first correctness tuning.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

