### PR TITLE
Export `HistoryProcessor` from the package root

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -15,6 +15,7 @@ from .agent import (
 )
 from .agent.spec import AgentSpec
 from .capabilities import AgentCapability, CapabilityFunc
+from ._history_processor import HistoryProcessor
 from .concurrency import (
     AbstractConcurrencyLimiter,
     AnyConcurrencyLimit,
@@ -337,6 +338,7 @@ __all__ = (
     # capabilities
     'AgentCapability',
     'CapabilityFunc',
+    'HistoryProcessor',
     # output
     'ToolOutput',
     'NativeOutput',

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -20,7 +20,8 @@ from pydantic_ai import (
     UserPromptPart,
     capture_run_messages,
 )
-from pydantic_ai.capabilities import HistoryProcessor, ProcessHistory, ReinjectSystemPrompt
+from pydantic_ai import HistoryProcessor
+from pydantic_ai.capabilities import ProcessHistory, ReinjectSystemPrompt
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.tools import RunContext
@@ -54,7 +55,7 @@ def function_model(received_messages: list[ModelMessage]) -> FunctionModel:
 
 
 async def test_history_processor_public_type(function_model: FunctionModel) -> None:
-    """`HistoryProcessor` is publicly importable so consumers can type their own processors."""
+    """`HistoryProcessor` is importable from the package root for consumer type annotations."""
 
     def drop_system_prompts(messages: list[ModelMessage]) -> list[ModelMessage]:
         return [


### PR DESCRIPTION
<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

`HistoryProcessor` is already exported from `pydantic_ai.capabilities`, but `from pydantic_ai import HistoryProcessor` raised `ImportError`. Re-export it from the package root (with `__all__`) so consumers can annotate processors without a private/capabilities-only import.

- Closes #7249

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Notes

- Additive re-export only; `pydantic_ai.capabilities.HistoryProcessor` remains unchanged.
- Existing public-type test now imports from the package root.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

