### PR TITLE
fix(durable-exec): reject override(spec) that drops durability in a flow

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2008,7 +2008,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             spec: Optional agent spec providing defaults for override. Explicit params take precedence
                 over spec values. When the spec includes `capabilities`, they replace (not merge with)
                 the agent's existing capabilities. To add capabilities without replacing, pass `spec`
-                to `run()` or `iter()` instead.
+                to `run()` or `iter()` instead. Inside a durable workflow/flow, `override(spec=...)`
+                with capabilities raises [`UserError`][pydantic_ai.exceptions.UserError] when the agent
+                has a durability capability: that capability is not spec-serializable, so the
+                replacement would silently drop durable wrapping.
         """
         # A bare `int` overrides both budgets; a partial `retries={'tools': ...}` / `{'output': ...}`
         # dict overrides only the named budget, so an unset budget still falls through to the run
@@ -2029,6 +2032,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         # override. Build it before resolving an overridden model so custom model IDs can
         # be preserved for that capability's async, deps-aware resolver.
         if resolved is not None and resolved.capability is not None:
+            # Durability capabilities are not spec-serializable, so this replacement would
+            # silently drop them inside a workflow/flow — reject instead (see #6911).
+            from ..durable_exec._base import BaseDurabilityCapability
+
+            BaseDurabilityCapability.reject_spec_capability_override(self)
             override_caps = list(resolved.capability.capabilities)
             _inject_auto_capabilities(override_caps)
             override_capability: CombinedCapability[AgentDepsT] | None = CombinedCapability(override_caps).for_agent(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -118,6 +118,29 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             raise UserError(f'Multiple {cls.__name__} capabilities are attached to this agent; attach at most one.')
         return found[0] if found else None
 
+    @classmethod
+    def reject_spec_capability_override(cls, agent: AbstractAgent[Any, Any]) -> None:
+        """Reject `override(spec=...)` with capabilities that would drop durability in a durable container.
+
+        A spec's `capabilities` list replaces the agent's root capability for the duration of the
+        override. Durability capabilities are not spec-serializable
+        ([`get_serialization_name`][pydantic_ai.durable_exec._base.BaseDurabilityCapability.get_serialization_name]
+        returns `None`), so the replacement always drops them — and inside a workflow/flow that
+        silently turns a durable run into a plain one. Outside a durable container the capability
+        is transparent, so the override is allowed.
+        """
+        durability = cls.from_agent(agent)
+        if durability is None or not durability.in_durable_context:
+            return
+        raise UserError(
+            f'`override(spec=...)` with capabilities cannot be used inside a {durability.engine_name} '
+            f'{durability._durable_container_noun} when the agent has a {type(durability).__name__} '
+            f'capability. A spec replaces the agent\'s root capability for the duration of the override, '
+            f'and durability capabilities are not spec-serializable, so the override would silently drop '
+            f'durable {durability._durable_unit_noun} wrapping. Construct the agent with the intended '
+            f'capabilities, or call `override(spec=...)` outside the {durability._durable_container_noun}.'
+        )
+
     def _reject_runtime_toolsets(self, toolset: AbstractToolset[AgentDepsT]) -> None:
         """Reject executing toolsets added per-run inside a durable workflow or flow.
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2375,6 +2375,45 @@ async def test_prefect_durability_rejects_per_run_capability_toolset() -> None:
         await run_agent()
 
 
+async def test_prefect_durability_rejects_spec_capability_override_in_flow() -> None:
+    """`override(spec=...)` with capabilities must not silently drop PrefectDurability inside a flow.
+
+    Spec capabilities replace the root capability, and durability is not spec-serializable, so the
+    override would turn a durable run into a plain one with no task wrapping.
+    """
+    agent = Agent(TestModel(), name='spec_override_reject', capabilities=[PrefectDurability()])
+
+    @flow
+    async def run_override() -> None:
+        with agent.override(spec={'capabilities': [{'Instrumentation': {}}]}):
+            pass  # pragma: no cover
+
+    with pytest.raises(
+        UserError,
+        match=r"override\(spec=\.\.\.\).*capabilities.*Prefect flow.*PrefectDurability",
+    ):
+        await run_override()
+
+
+async def test_prefect_durability_allows_spec_capability_override_outside_flow() -> None:
+    """Outside a flow, PrefectDurability is transparent, so a spec capability override is fine."""
+    agent = Agent(TestModel(), name='spec_override_outside', capabilities=[PrefectDurability()])
+    with agent.override(spec={'capabilities': [{'Instrumentation': {}}]}):
+        pass
+
+
+async def test_prefect_durability_allows_spec_without_capabilities_in_flow() -> None:
+    """A spec that does not replace capabilities leaves durability attached inside a flow."""
+    agent = Agent(TestModel(), name='spec_override_no_caps', capabilities=[PrefectDurability()])
+
+    @flow
+    async def run_override() -> None:
+        with agent.override(spec={'instructions': 'from spec'}):
+            pass
+
+    await run_override()
+
+
 def test_prefect_durability_rejects_duplicate_toolset_id() -> None:
     """Two distinct toolsets under one `id` are rejected at binding time.
 


### PR DESCRIPTION
## Summary

`Agent.override(spec=...)` with capabilities replaces the agent's root capability. Durability capabilities are not spec-serializable (`get_serialization_name()` → `None`), so inside a Prefect flow / DBOS workflow / Temporal workflow that replacement silently dropped durability and turned the run into a plain non-durable one.

This PR takes the **UserError reject** path from #6911 (aligned with how #6894 / #6954 / #6955 treat other un-checkpointable per-run changes):

- `BaseDurabilityCapability.reject_spec_capability_override()` raises when `from_agent(...)` finds a durability capability **and** `in_durable_context` is true
- `Agent.override` calls it before building the replacement capability
- Outside a durable container the override still works (durability is transparent there)
- Specs without `capabilities` are unchanged

Fixes #6911

## Test plan

- [x] `uv run pytest tests/test_prefect.py -k 'spec_capability_override or spec_without_capabilities' -v`
  - rejects `override(spec={capabilities: ...})` inside a Prefect flow
  - allows the same override outside a flow
  - allows `override(spec={instructions: ...})` inside a flow (no capability replacement)

Happy to add a short note under `docs/durable_execution/*.md` if maintainers want the reject semantics documented there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

