### PR TITLE
fix(embeddings): preserve batch response order for OpenAI embeddings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -143,7 +143,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e
 
-        embeddings = [item.embedding for item in response.data]
+        embeddings = [item.embedding for item in sorted(response.data, key=lambda item: item.index)]
 
         return EmbeddingResult(
             embeddings=embeddings,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2306,3 +2306,41 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
             }
         ]
     )
+
+
+@pytest.mark.skipif(not openai_imports_successful(), reason='OpenAI not installed')
+async def test_openai_embedding_model_preserves_batch_order_by_index():
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/7284
+
+    OpenAI embeddings responses carry a per-item index because batch response
+    order is not guaranteed to match input order. embed() must re-sort by index
+    so vectors line up with their inputs.
+    """
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    mock_client = AsyncMock()
+    # Response order differs from input order (indices 2, 0, 1 for inputs a, b, c)
+    items = []
+    for index, vec in ((2, [0.3, 0.3, 0.3]), (0, [0.1, 0.1, 0.1]), (1, [0.2, 0.2, 0.2])):
+        item = MagicMock()
+        item.index = index
+        item.embedding = vec
+        items.append(item)
+
+    mock_response = MagicMock()
+    mock_response.data = items
+    mock_response.usage = None
+    mock_response.model = 'test-model'
+
+    mock_client.embeddings.create.return_value = mock_response
+
+    provider = OpenAIProvider(openai_client=mock_client)
+    model = OpenAIEmbeddingModel('test-model', provider=provider)
+
+    result = await model.embed(['a', 'b', 'c'], input_type='query')
+
+    assert result.embeddings == [
+        [0.1, 0.1, 0.1],
+        [0.2, 0.2, 0.2],
+        [0.3, 0.3, 0.3],
+    ]


### PR DESCRIPTION
Fixes #7284

## Summary

`OpenAIEmbeddingModel.embed()` built embeddings directly from `response.data` in whatever order the API returned them. OpenAI embeddings responses carry a per-item `index` field because batch response order is not guaranteed to match input order. Building from the raw response order can silently misalign vectors with their inputs.

This sorts `response.data` by `item.index` before building the result, matching what litellm and the legacy openai-python client already do.

## Test

Added a regression test that mocks a batch response returned out of order (indices 2, 0, 1) and asserts the embeddings are re-sorted to input order.

## Follow-up

`voyageai.py` has the same risk class: the VoyageAI API response carries a per-item `index`, but the voyageai SDK drops it and only exposes embeddings in array order, so pydantic-ai cannot re-sort there without an upstream SDK change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

