### PR TITLE
fix: forward output_tool_return_content in AgentRun.all_messages_json

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -160,20 +160,54 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
             self._traceparent(required=False),
         )
 
-    def all_messages(self) -> list[_messages.ModelMessage]:
+    def all_messages(self, *, output_tool_return_content: str | None = None) -> list[_messages.ModelMessage]:
         """Return all messages for the run so far.
 
         Messages from older runs are included.
+
+        Args:
+            output_tool_return_content: The return content of the tool call to set in the last message.
+                This provides a convenient way to modify the content of the output tool call if you want to continue
+                the conversation and want to set the response to the output tool call. If `None`, the last message will
+                not be modified.
         """
+        if output_tool_return_content is not None:
+            return self._set_output_tool_return(output_tool_return_content)
         return self.ctx.state.message_history
 
     def all_messages_json(self, *, output_tool_return_content: str | None = None) -> bytes:
         """Return all messages from [`all_messages`][pydantic_ai.agent.AgentRun.all_messages] as JSON bytes.
 
+        Args:
+            output_tool_return_content: The return content of the tool call to set in the last message.
+                See [`all_messages`][pydantic_ai.agent.AgentRun.all_messages].
+
         Returns:
             JSON bytes representing the messages.
         """
-        return _messages.ModelMessagesTypeAdapter.dump_json(self.all_messages())
+        return _messages.ModelMessagesTypeAdapter.dump_json(
+            self.all_messages(output_tool_return_content=output_tool_return_content)
+        )
+
+    def _set_output_tool_return(self, return_content: str) -> list[_messages.ModelMessage]:
+        """Set the output tool's return content on the last message, returning a copy."""
+        graph_run_output = self._graph_run.output
+        output_tool_name = graph_run_output.tool_name if graph_run_output is not None else None
+        if not output_tool_name:
+            raise ValueError('Cannot set output tool return content when the return type is `str`.')
+
+        messages = self._graph_run.state.message_history
+        last_message = messages[-1]
+        for idx, part in enumerate(last_message.parts):
+            if isinstance(part, _messages.ToolReturnPart) and part.tool_name == output_tool_name:
+                # Only do deepcopy when we have to modify
+                copied_messages = list(messages)
+                copied_last = deepcopy(last_message)
+                copied_last.parts[idx].content = return_content  # type: ignore[misc]
+                copied_messages[-1] = copied_last
+                return copied_messages
+
+        raise LookupError(f'No tool call found with tool name {output_tool_name!r}.')
 
     def new_messages(self) -> list[_messages.ModelMessage]:
         """Return the messages produced during this run so far.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1330,6 +1330,55 @@ def test_output_tool_return_content_no_tool():
         result.all_messages(output_tool_return_content='foobar')
 
 
+async def test_agent_run_all_messages_json_forwards_output_tool_return_content():
+    """`AgentRun.all_messages_json` must forward `output_tool_return_content`.
+
+    Regression for the asymmetry where `AgentRunResult.all_messages_json`
+    honours the param but `AgentRun.all_messages_json` silently ignored it.
+    """
+    call_index = 0
+
+    def return_int(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_index
+        assert info.output_tools is not None
+        call_index += 1
+        if call_index == 1:
+            return ModelResponse(parts=[TextPart(content='unknown')])
+        args_json = '{"response": 42}'
+        return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
+
+    agent = Agent(FunctionModel(return_int), output_type=ToolOutput(int))
+
+    async with agent.iter('Hello') as agent_run:
+        async for _ in agent_run:
+            pass
+
+    # The raw JSON still carries the default acknowledgement.
+    raw = agent_run.all_messages_json()
+    assert b'Final result processed.' in raw
+    assert b'CUSTOM OUTPUT ACK' not in raw
+
+    # Forwarding the param must replace that acknowledgement before encoding.
+    adjusted = agent_run.all_messages_json(output_tool_return_content='CUSTOM OUTPUT ACK')
+    assert b'CUSTOM OUTPUT ACK' in adjusted
+    assert b'Final result processed.' not in adjusted
+    assert agent_run.all_messages(output_tool_return_content='CUSTOM OUTPUT ACK')[-1] == snapshot(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='final_result',
+                    content='CUSTOM OUTPUT ACK',
+                    tool_call_id=IsStr(),
+                    timestamp=IsNow(tz=timezone.utc),
+                )
+            ],
+            timestamp=IsNow(tz=timezone.utc),
+            run_id=IsStr(),
+            conversation_id=IsStr(),
+        )
+    )
+
+
 def test_response_tuple():
     m = TestModel()
 


### PR DESCRIPTION
## Why

`AgentRun.all_messages_json()` accepted `output_tool_return_content` but silently ignored it — the serialized output-tool acknowledgement kept the default content. `AgentRunResult.all_messages_json()` already honoured the parameter, so the `AgentRun` behavior was inconsistent for users persisting an iterative run for replay.

## Summary

- `AgentRun.all_messages()` now accepts `output_tool_return_content` and returns the modified history when set
- `AgentRun.all_messages_json()` forwards the parameter to the message accessor before encoding
- Added a private `_set_output_tool_return` on `AgentRun` (mirroring `AgentRunResult`) that replaces the output-tool `ToolReturnPart` content in a copied history
- Added a regression test covering an iterative structured-output run

## Issue Number

Fixes pydantic/pydantic-ai#7317

## How to Test

```bash
pytest "tests/test_agent.py::test_agent_run_all_messages_json_forwards_output_tool_return_content" -o 'addopts=' -q
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`pyright` reports 0 errors on `pydantic_ai_slim/pydantic_ai/run.py`. The `# type: ignore[misc]` in the new `_set_output_tool_return` matches the identical pattern already committed in the sibling `AgentRunResult._set_output_tool_return`. Test suite for the affected area (output-tool return content + `agent.iter` + `test_run_cancellation.py`) is green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

