### PR TITLE
feat: add DeepInfra as a model provider

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -54,6 +54,8 @@
 
 ::: pydantic_ai.providers.nebius.NebiusProvider
 
+::: pydantic_ai.providers.deepinfra.DeepInfraProvider
+
 ::: pydantic_ai.providers.ovhcloud.OVHcloudProvider
 
 ::: pydantic_ai.providers.alibaba.AlibabaProvider

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -973,6 +973,38 @@ print(result.output)
 #> The capital of France is Paris.
 ```
 
+### DeepInfra
+
+Go to [DeepInfra](https://deepinfra.com/) and create an API key.
+
+You can set the `DEEPINFRA_API_KEY` environment variable and use [`DeepInfraProvider`][pydantic_ai.providers.deepinfra.DeepInfraProvider] by name:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('deepinfra:deepseek-ai/DeepSeek-V3')
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+#> The capital of France is Paris.
+```
+
+Or initialise the model and provider directly:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.deepinfra import DeepInfraProvider
+
+model = OpenAIChatModel(
+    'deepseek-ai/DeepSeek-V3',
+    provider=DeepInfraProvider(api_key='your-deepinfra-api-key'),
+)
+agent = Agent(model)
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+#> The capital of France is Paris.
+```
+
 ### OVHcloud AI Endpoints
 
 To use OVHcloud AI Endpoints, you need to create a new API key. To do so, go to the [OVHcloud manager](https://ovh.com/manager), then in Public Cloud > AI Endpoints > API keys. Click on `Create a new API key` and copy your new key.

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -22,6 +22,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 
 - [Alibaba Cloud Model Studio (DashScope)](openai.md#alibaba-cloud-model-studio-dashscope)
 - [Azure AI Foundry](openai.md#azure-ai-foundry)
+- [DeepInfra](openai.md#deepinfra)
 - [DeepSeek](openai.md#deepseek)
 - [Fireworks AI](openai.md#fireworks-ai)
 - [GitHub Models](openai.md#github-models) (retired, deprecated)

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -122,6 +122,7 @@ OpenAIChatCompatibleProvider = TypeAliasType(
         'alibaba',
         'azure',
         'cerebras',
+        'deepinfra',
         'deepseek',
         'fireworks',
         'github',

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -231,6 +231,10 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .nebius import NebiusProvider
 
         return NebiusProvider
+    elif provider == 'deepinfra':
+        from .deepinfra import DeepInfraProvider
+
+        return DeepInfraProvider
     elif provider == 'ovhcloud':
         from .ovhcloud import OVHcloudProvider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/deepinfra.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepinfra.py
@@ -1,0 +1,109 @@
+from __future__ import annotations as _annotations
+
+import os
+from typing import overload
+
+import httpx
+
+from pydantic_ai import ModelProfile
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import google_model_profile
+from pydantic_ai.profiles.harmony import harmony_model_profile
+from pydantic_ai.profiles.meta import meta_model_profile
+from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.qwen import qwen_model_profile
+from pydantic_ai.providers import Provider
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'Please install the `openai` package to use the DeepInfra provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+
+
+class DeepInfraProvider(Provider[AsyncOpenAI]):
+    """Provider for DeepInfra API."""
+
+    @property
+    def name(self) -> str:
+        return 'deepinfra'
+
+    @property
+    def base_url(self) -> str:
+        return 'https://api.deepinfra.com/v1/openai'
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    @staticmethod
+    def model_profile(model_name: str) -> ModelProfile | None:
+        provider_to_profile = {
+            'meta-llama': meta_model_profile,
+            'deepseek-ai': deepseek_model_profile,
+            'qwen': qwen_model_profile,
+            'google': google_model_profile,
+            'openai': harmony_model_profile,  # used for gpt-oss models on DeepInfra
+            'mistralai': mistral_model_profile,
+            'moonshotai': moonshotai_model_profile,
+        }
+
+        profile = None
+
+        model_name = model_name.lower()
+        if '/' not in model_name:
+            return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer)
+
+        provider, model_name = model_name.split('/', 1)
+        if provider in provider_to_profile:
+            profile = provider_to_profile[provider](model_name)
+
+        # As DeepInfraProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
+        # we need to maintain that behavior unless json_schema_transformer is set explicitly
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+
+    @overload
+    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        api_key = api_key or os.getenv('DEEPINFRA_API_KEY')
+        if not api_key and openai_client is None:
+            raise UserError(
+                'Set the `DEEPINFRA_API_KEY` environment variable or pass it via '
+                '`DeepInfraProvider(api_key=...)` to use the DeepInfra provider.'
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+        elif http_client is not None:
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+        else:
+            http_client = create_async_http_client()
+            self._own_http_client = http_client
+            self._http_client_factory = create_async_http_client
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+
+    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/tests/providers/test_deepinfra.py
+++ b/tests/providers/test_deepinfra.py
@@ -1,0 +1,130 @@
+import re
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, google_model_profile
+from pydantic_ai.profiles.harmony import harmony_model_profile
+from pydantic_ai.profiles.meta import meta_model_profile
+from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
+from pydantic_ai.profiles.qwen import qwen_model_profile
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    import openai
+
+    from pydantic_ai.providers.deepinfra import DeepInfraProvider
+
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
+    pytest.mark.vcr,
+    pytest.mark.anyio,
+]
+
+
+def test_deepinfra_provider():
+    provider = DeepInfraProvider(api_key='api-key')
+    assert provider.name == 'deepinfra'
+    assert provider.base_url == 'https://api.deepinfra.com/v1/openai'
+    assert isinstance(provider.client, openai.AsyncOpenAI)
+    assert provider.client.api_key == 'api-key'
+
+
+def test_deepinfra_provider_need_api_key(env: TestEnv) -> None:
+    env.remove('DEEPINFRA_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'Set the `DEEPINFRA_API_KEY` environment variable or pass it via '
+            '`DeepInfraProvider(api_key=...)` to use the DeepInfra provider.'
+        ),
+    ):
+        DeepInfraProvider()
+
+
+def test_deepinfra_pass_openai_client() -> None:
+    openai_client = openai.AsyncOpenAI(api_key='api-key')
+    provider = DeepInfraProvider(openai_client=openai_client)
+    assert provider.client == openai_client
+
+
+def test_deepinfra_provider_pass_http_client() -> None:
+    http_client = httpx.AsyncClient()
+    provider = DeepInfraProvider(http_client=http_client, api_key='api-key')
+    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
+
+
+def test_deepinfra_provider_model_profile(mocker: MockerFixture):
+    provider = DeepInfraProvider(api_key='api-key')
+
+    ns = 'pydantic_ai.providers.deepinfra'
+
+    # Mock all profile functions
+    meta_mock = mocker.patch(f'{ns}.meta_model_profile', wraps=meta_model_profile)
+    deepseek_mock = mocker.patch(f'{ns}.deepseek_model_profile', wraps=deepseek_model_profile)
+    qwen_mock = mocker.patch(f'{ns}.qwen_model_profile', wraps=qwen_model_profile)
+    google_mock = mocker.patch(f'{ns}.google_model_profile', wraps=google_model_profile)
+    harmony_mock = mocker.patch(f'{ns}.harmony_model_profile', wraps=harmony_model_profile)
+    mistral_mock = mocker.patch(f'{ns}.mistral_model_profile', wraps=mistral_model_profile)
+    moonshotai_mock = mocker.patch(f'{ns}.moonshotai_model_profile', wraps=moonshotai_model_profile)
+
+    # Test meta provider
+    meta_profile = provider.model_profile('meta-llama/Llama-3.3-70B-Instruct')
+    meta_mock.assert_called_with('llama-3.3-70b-instruct')
+    assert meta_profile is not None
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+
+    # Test deepseek provider
+    profile = provider.model_profile('deepseek-ai/DeepSeek-V3')
+    deepseek_mock.assert_called_with('deepseek-v3')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    # Test qwen provider
+    qwen_profile = provider.model_profile('Qwen/Qwen3-30B-A3B')
+    qwen_mock.assert_called_with('qwen3-30b-a3b')
+    assert qwen_profile is not None
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+
+    # Test google provider
+    google_profile = provider.model_profile('google/gemma-3-27b-it')
+    google_mock.assert_called_with('gemma-3-27b-it')
+    assert google_profile is not None
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
+
+    # Test harmony (for openai gpt-oss) provider
+    profile = provider.model_profile('openai/gpt-oss-120b')
+    harmony_mock.assert_called_with('gpt-oss-120b')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    # Test mistral provider
+    profile = provider.model_profile('mistralai/Mistral-Small-3.2-24B-Instruct-2506')
+    mistral_mock.assert_called_with('mistral-small-3.2-24b-instruct-2506')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    # Test moonshotai provider
+    moonshotai_profile = provider.model_profile('moonshotai/Kimi-K2-Instruct')
+    moonshotai_mock.assert_called_with('kimi-k2-instruct')
+    assert moonshotai_profile is not None
+    assert moonshotai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    # Test unknown provider
+    unknown_profile = provider.model_profile('unknown-provider/unknown-model')
+    assert unknown_profile is not None
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+
+def test_deepinfra_provider_model_name_without_slash():
+    profile = DeepInfraProvider.model_profile('invalid-model-name')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -198,6 +198,7 @@ def test_docs_examples(
     env.set('VERCEL_AI_GATEWAY_API_KEY', 'testing')
     env.set('CEREBRAS_API_KEY', 'testing')
     env.set('NEBIUS_API_KEY', 'testing')
+    env.set('DEEPINFRA_API_KEY', 'testing')
     env.set('HEROKU_INFERENCE_KEY', 'testing')
     env.set('FIREWORKS_API_KEY', 'testing')
     env.set('TOGETHER_API_KEY', 'testing')


### PR DESCRIPTION
## Summary

Adds [DeepInfra](https://deepinfra.com/) as a model provider. DeepInfra offers an OpenAI-compatible inference API (`https://api.deepinfra.com/v1/openai`) serving a wide range of open-weight models (Llama, DeepSeek, Qwen, Gemma, GPT-OSS, Mistral, Kimi, ...).

Follows the established OpenAI-compatible provider pattern (mirrors `NebiusProvider`):

- `DeepInfraProvider` with `DEEPINFRA_API_KEY` env handling and model-profile inference for the families DeepInfra serves (meta-llama, deepseek-ai, Qwen, google, openai/gpt-oss via harmony, mistralai, moonshotai)
- `deepinfra:` string-shorthand registration — `Agent("deepinfra:deepseek-ai/DeepSeek-V3")`
- unit tests mirroring the Nebius provider tests
- docs (`models/openai.md`, `models/overview.md`, `api/providers.md`) and `DEEPINFRA_API_KEY` wiring in the docs example test env

## Verification

`tests/providers/test_deepinfra.py` — 6 passed; `test_nebius.py` still passes (no regression). `infer_provider("deepinfra")` and `infer_model("deepinfra:...")` resolve correctly.

Base URL and `org/model` naming confirmed against DeepInfra's official docs (OpenAI-compatible endpoint). DeepInfra is also an upstream provider in LiteLLM.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

