### PR TITLE
test: bound model name HTTP lookups

### DIFF
--- a/tests/models/test_model_names.py
+++ b/tests/models/test_model_names.py
@@ -278,8 +278,11 @@ class HerokuModel(TypedDict):
     type: list[str]
 
 
+MODEL_LIST_HTTP_TIMEOUT = 10
+
+
 def get_heroku_model_names():
-    response = httpx.get('https://us.inference.heroku.com/available-models')
+    response = httpx.get('https://us.inference.heroku.com/available-models', timeout=MODEL_LIST_HTTP_TIMEOUT)
 
     if response.status_code != 200:
         pytest.skip(f'Heroku AI returned status code {response.status_code}')  # pragma: lax no cover
@@ -306,6 +309,7 @@ def get_cerebras_model_names():  # pragma: lax no cover
     response = httpx.get(
         'https://api.cerebras.ai/v1/models',
         headers={'Authorization': f'Bearer {api_key}', 'Accept': 'application/json', 'Accept-Encoding': 'identity'},
+        timeout=MODEL_LIST_HTTP_TIMEOUT,
     )
 
     if response.status_code != 200:


### PR DESCRIPTION
Closes #7322

## Problem

`tests/models/test_model_names.py` reaches the Heroku and Cerebras model-list endpoints with `httpx.get()` calls that did not pass a timeout. If either external service accepts a connection but stalls, this test helper can wait longer than intended during local or CI model-name checks.

## Before / after behavior

Before, the live model-name lookups relied on the client default behavior at each call site.

After, both lookups share a small `MODEL_LIST_HTTP_TIMEOUT` constant, so the test helper has an explicit network bound while preserving the existing status-code skip behavior.

## Verification

- `python -m ruff format --check tests/models/test_model_names.py`
- `python -m ruff check tests/models/test_model_names.py`
- `python -m compileall tests\models\test_model_names.py`
- Attempted `python -m pytest tests/models/test_model_names.py::test_known_model_names_accessor` with this checkout on `PYTHONPATH`; the test is skipped locally because optional model packages are not installed in this environment.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
