### PR TITLE
Improve model error diagnostics

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -203,6 +203,22 @@ When a provider returns a 4xx or 5xx response, Pydantic AI raises a
 attribute (a `dict[str, str]` with lowercase keys, or `None` for providers that don't
 surface headers, such as gRPC-based providers).
 
+For main-thread scripts that leave model API errors to `sys.excepthook`, install the model error
+handler to keep terminal output focused on application code and the provider error:
+
+```python {title="compact_model_errors.py" test="skip"}
+from pydantic_ai import Agent, install_model_error_handler
+
+install_model_error_handler()
+
+agent = Agent('openai:gpt-5.2')
+agent.run_sync('What is the capital of France?')
+```
+
+The handler only changes how uncaught [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]
+exceptions are displayed. It does not modify exceptions received by `except` blocks or debuggers.
+Pass `full_traceback=True` to show the complete provider, agent, and graph traceback instead.
+
 The motivating use case is propagating the `Retry-After` header from a 429 response to a
 caller's own HTTP client.  A convenience property
 [`retry_after`][pydantic_ai.exceptions.ModelHTTPError.retry_after] parses that header and

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -50,6 +50,7 @@ from .exceptions import (
     UnexpectedModelBehavior,
     UsageLimitExceeded,
     UserError,
+    install_model_error_handler,
 )
 from .format_prompt import format_as_xml
 from .messages import (
@@ -212,6 +213,7 @@ __all__ = (
     'ToolFailed',
     'ModelAPIError',
     'ModelHTTPError',
+    'install_model_error_handler',
     'FallbackExceptionGroup',
     'IncompleteToolCall',
     'RunCancelled',

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -254,6 +254,18 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         return type(self).wrap_node_run is not AbstractCapability.wrap_node_run
 
     @property
+    def _has_on_node_run_error(self) -> bool:
+        return type(self).on_node_run_error is not AbstractCapability.on_node_run_error
+
+    @property
+    def _has_wrap_model_request(self) -> bool:
+        return type(self).wrap_model_request is not AbstractCapability.wrap_model_request
+
+    @property
+    def _has_on_model_request_error(self) -> bool:
+        return type(self).on_model_request_error is not AbstractCapability.on_model_request_error
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         """Whether this capability (or any sub-capability) overrides wrap_run_event_stream."""
         return type(self).wrap_run_event_stream is not AbstractCapability.wrap_run_event_stream

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -87,6 +87,18 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         return any(c._has_wrap_node_run for c in self.capabilities)
 
     @property
+    def _has_on_node_run_error(self) -> bool:
+        return any(c._has_on_node_run_error for c in self.capabilities)
+
+    @property
+    def _has_wrap_model_request(self) -> bool:
+        return any(c._has_wrap_model_request for c in self.capabilities)
+
+    @property
+    def _has_on_model_request_error(self) -> bool:
+        return any(c._has_on_model_request_error for c in self.capabilities)
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         return any(c.has_wrap_run_event_stream for c in self.capabilities)
 
@@ -367,7 +379,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
+            if capability._has_wrap_node_run and _ctx_for_available_cap(capability, ctx) is not None:
                 chain = _make_node_run_wrap(capability, ctx, chain)
         return await chain(node)
 
@@ -379,6 +391,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: Exception,
     ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_node_run_error:
+                continue
             cap_ctx = _ctx_for_available_cap(capability, ctx)
             if cap_ctx is None:
                 continue
@@ -442,7 +456,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> ModelResponse:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
+            if capability._has_wrap_model_request and _ctx_for_available_cap(capability, ctx) is not None:
                 chain = _make_model_request_wrap(capability, ctx, chain)
         return await chain(request_context)
 
@@ -454,6 +468,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: Exception,
     ) -> ModelResponse:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_model_request_error:
+                continue
             cap_ctx = _ctx_for_available_cap(capability, ctx)
             if cap_ctx is None:
                 continue

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -854,6 +854,18 @@ class Hooks(AbstractCapability[AgentDepsT]):
         return bool(self._get('wrap_node_run'))
 
     @property
+    def _has_on_node_run_error(self) -> bool:
+        return bool(self._get('on_node_run_error'))
+
+    @property
+    def _has_wrap_model_request(self) -> bool:
+        return bool(self._get('wrap_model_request'))
+
+    @property
+    def _has_on_model_request_error(self) -> bool:
+        return bool(self._get('on_model_request_error'))
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         return bool(self._get('wrap_run_event_stream') or self._get('_on_event'))
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
@@ -102,6 +102,27 @@ class WrapperCapability(AbstractCapability[AgentDepsT]):
         return type(self).wrap_node_run is not WrapperCapability.wrap_node_run or self.wrapped._has_wrap_node_run
 
     @property
+    def _has_on_node_run_error(self) -> bool:
+        return (
+            type(self).on_node_run_error is not WrapperCapability.on_node_run_error
+            or self.wrapped._has_on_node_run_error
+        )
+
+    @property
+    def _has_wrap_model_request(self) -> bool:
+        return (
+            type(self).wrap_model_request is not WrapperCapability.wrap_model_request
+            or self.wrapped._has_wrap_model_request
+        )
+
+    @property
+    def _has_on_model_request_error(self) -> bool:
+        return (
+            type(self).on_model_request_error is not WrapperCapability.on_model_request_error
+            or self.wrapped._has_on_model_request_error
+        )
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         return (
             type(self).wrap_run_event_stream is not WrapperCapability.wrap_run_event_stream

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -2,13 +2,19 @@ from __future__ import annotations as _annotations
 
 import json
 import sys
-from collections.abc import Mapping, Sequence
+import traceback
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from pathlib import Path
+from types import TracebackType
 from typing import TYPE_CHECKING, Any
+from weakref import WeakKeyDictionary
 
 import pydantic_core
 from pydantic_core import core_schema
+
+import pydantic_graph
 
 from ._warnings import (
     CostCalculationFailedWarning as CostCalculationFailedWarning,
@@ -43,6 +49,7 @@ __all__ = (
     'ConcurrencyLimitExceeded',
     'ModelAPIError',
     'ModelHTTPError',
+    'install_model_error_handler',
     'ContentFilterError',
     'IncompleteToolCall',
     'MessageHistoryMutatedWarning',
@@ -52,6 +59,10 @@ __all__ = (
     'FallbackExceptionGroup',
     'ToolFailed',
 )
+
+
+_ExceptionHook = Callable[[type[BaseException], BaseException, TracebackType | None], None]
+_model_error_hook_delegates: WeakKeyDictionary[_ExceptionHook, _ExceptionHook] = WeakKeyDictionary()
 
 
 class ModelRetry(Exception):
@@ -589,6 +600,60 @@ class ModelHTTPError(ModelAPIError):
             return max(0.0, wait)
         except (ValueError, TypeError, AssertionError):
             return None
+
+
+def install_model_error_handler(*, full_traceback: bool = False) -> _ExceptionHook:
+    """Install concise rendering for uncaught model API errors.
+
+    The handler removes Pydantic AI, Pydantic Graph, and provider SDK frames from the displayed
+    traceback while preserving application frames and the provider cause's type and message.
+    It does not modify the exception or traceback received by `except` blocks or debuggers.
+
+    Args:
+        full_traceback: Delegate model API errors to the existing exception hook unchanged.
+
+    Returns:
+        The previously installed exception hook, which can be assigned back to `sys.excepthook`
+        to restore it.
+    """
+    current_hook = sys.excepthook
+    try:
+        previous_hook = _model_error_hook_delegates.get(current_hook, current_hook)
+    except TypeError:
+        previous_hook = current_hook
+    assert pydantic_graph.__file__ is not None
+    internal_roots = (Path(__file__).resolve().parent, Path(pydantic_graph.__file__).resolve().parent)
+
+    def model_error_hook(
+        exception_type: type[BaseException], exception: BaseException, traceback_: TracebackType | None
+    ) -> None:
+        if full_traceback or not isinstance(exception, ModelAPIError):
+            previous_hook(exception_type, exception, traceback_)
+            return
+
+        try:
+            rendered = traceback.TracebackException(exception_type, exception, traceback_)
+            rendered.stack = traceback.StackSummary.from_list(
+                [
+                    frame
+                    for frame in rendered.stack
+                    if not any(Path(frame.filename).resolve().is_relative_to(root) for root in internal_roots)
+                ]
+            )
+            chained = rendered.__cause__ or rendered.__context__
+            while chained is not None:
+                chained.stack = traceback.StackSummary.from_list([])
+                chained = chained.__cause__ or chained.__context__
+            sys.stderr.writelines(rendered.format(chain=True))
+            sys.stderr.write(
+                'Hint: call `install_model_error_handler(full_traceback=True)` to show the complete traceback.\n'
+            )
+        except Exception:
+            previous_hook(exception_type, exception, traceback_)
+
+    sys.excepthook = model_error_hook
+    _model_error_hook_delegates[model_error_hook] = previous_hook
+    return current_hook
 
 
 class FallbackExceptionGroup(ExceptionGroup[Any]):

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator, 
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
+from difflib import get_close_matches
 from functools import cache, cached_property, wraps
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar, cast, get_args, overload
@@ -1594,6 +1595,22 @@ def parse_model_id(model: str) -> tuple[str | None, str]:
     return None, model
 
 
+def _suggest_known_model_name(model: str, model_name: str) -> str | None:
+    known_ids = sorted(known_model_names(), key=lambda name: (name.startswith('gateway/'), name))
+    normalized_ids: list[str] = [known_id.replace(':', '-', 1) for known_id in known_ids if ':' in known_id]
+    normalized_model = model.replace(':', '-', 1)
+    if matches := get_close_matches(normalized_model, normalized_ids, n=1, cutoff=0.9):
+        return next(known_id for known_id in known_ids if known_id.replace(':', '-', 1) == matches[0])
+
+    known_names: list[str] = [known_id.split(':', maxsplit=1)[1] for known_id in known_ids if ':' in known_id]
+    matches = get_close_matches(model_name, known_names, n=1, cutoff=0.8)
+    if not matches:
+        matches = get_close_matches(normalized_model, known_names, n=1, cutoff=0.7)
+    if matches:
+        return next(known_id for known_id in known_ids if known_id.endswith(f':{matches[0]}'))
+    return None
+
+
 def infer_model_profile(model: str) -> ModelProfile:
     """Infer the model profile from a model id string without constructing a provider.
 
@@ -1647,9 +1664,20 @@ def infer_model(  # noqa: C901
 
     provider_name, model_name = parse_model_id(model)
     if provider_name is None:
-        raise UserError(f'Unknown model: {model}')
+        message = f'Unknown model: {model}'
+        if suggested_name := _suggest_known_model_name(model, model_name):
+            message += f". Did you mean '{suggested_name}'?"
+        raise UserError(message)
 
-    provider = provider_factory(provider_name)
+    try:
+        provider = provider_factory(provider_name)
+    except ValueError:
+        if provider_factory is not infer_provider:
+            raise
+        message = f'Unknown model: {model}'
+        if suggested_name := _suggest_known_model_name(model, model_name):
+            message += f". Did you mean '{suggested_name}'?"
+        raise UserError(message) from None
 
     model_kind = provider_name
     if model_kind.startswith('gateway/'):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,11 +1,12 @@
 import os
+import re
 import warnings
 from importlib import import_module
 from unittest.mock import patch
 
 import pytest
 
-from pydantic_ai import UserError
+from pydantic_ai import Agent, UserError
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.messages import (
     ModelMessage,
@@ -30,6 +31,7 @@ with try_import() as imports_successful:
     from pydantic_ai.models.mistral import MistralModel
     from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
     from pydantic_ai.models.openrouter import OpenRouterModel
+    from pydantic_ai.providers import openai
 
 if not imports_successful():
     pytest.skip('model packages were not installed', allow_module_level=True)  # pragma: lax no cover
@@ -259,8 +261,6 @@ def test_infer_model(
 
 
 def test_infer_model_with_provider():
-    from pydantic_ai.providers import openai
-
     provider_class = openai.OpenAIProvider(api_key='1234', base_url='http://test')
     m = infer_model('openai-chat:gpt-5', lambda x: provider_class)
 
@@ -269,9 +269,61 @@ def test_infer_model_with_provider():
     assert m._provider.base_url == 'http://test'  # pyright: ignore[reportPrivateUsage]
 
 
-def test_infer_str_unknown():
-    with pytest.raises(UserError, match='Unknown model: foobar'):
-        infer_model('foobar')
+@pytest.mark.parametrize(
+    ('model_name', 'message'),
+    [
+        pytest.param('foobar', 'Unknown model: foobar', id='unqualified'),
+        pytest.param(
+            'claude:sonnet-5',
+            "Unknown model: claude:sonnet-5. Did you mean 'anthropic:claude-sonnet-5'?",
+            id='close-match',
+        ),
+        pytest.param(
+            'claude:potato-5',
+            "Unknown model: claude:potato-5. Did you mean 'anthropic:claude-sonnet-5'?",
+            id='loose-match',
+        ),
+        pytest.param(
+            'anthropicc:claude-sonnet-5',
+            "Unknown model: anthropicc:claude-sonnet-5. Did you mean 'anthropic:claude-sonnet-5'?",
+            id='provider-typo',
+        ),
+        pytest.param(
+            'anthropic-claude-sonnet-5',
+            "Unknown model: anthropic-claude-sonnet-5. Did you mean 'anthropic:claude-sonnet-5'?",
+            id='missing-colon',
+        ),
+        pytest.param(
+            'openia:gpt-5.2',
+            "Unknown model: openia:gpt-5.2. Did you mean 'openai:gpt-5.2'?",
+            id='prefer-direct-provider',
+        ),
+        pytest.param('unknown:potato', 'Unknown model: unknown:potato', id='no-match'),
+    ],
+)
+def test_infer_str_unknown(model_name: str, message: str):
+    with pytest.raises(UserError, match=f'^{re.escape(message)}$'):
+        infer_model(model_name)
+
+
+def test_agent_suggests_known_model_name():
+    with pytest.raises(UserError, match="Did you mean 'anthropic:claude-sonnet-5'"):
+        Agent('claude:sonnet-5')
+
+
+def test_infer_model_allows_unknown_name_for_known_provider():
+    provider = openai.OpenAIProvider(api_key='1234', base_url='http://test')
+    model = infer_model('openai-chat:potato-5', lambda _: provider)
+
+    assert model.model_name == 'potato-5'
+
+
+def test_infer_model_preserves_custom_provider_factory_error():
+    def provider_factory(_provider_name: str):
+        raise ValueError('custom provider error')
+
+    with pytest.raises(ValueError, match='custom provider error'):
+        infer_model('openai:gpt-5', provider_factory)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from importlib.util import find_spec
 from pathlib import Path
+from traceback import extract_tb
 from types import NoneType
 from typing import Any, cast
 from uuid import UUID
@@ -5207,6 +5208,24 @@ class _FailIfDispatchedDeferredCap(AbstractCapability):
 @dataclass
 class _NoopCap(AbstractCapability):
     pass
+
+
+async def test_inherited_noop_capability_hooks_are_absent_from_traceback() -> None:
+    async def fail(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise RuntimeError('provider failure')
+
+    agent = Agent(FunctionModel(fail), capabilities=[_NoopCap(), WrapperCapability(wrapped=_NoopCap())])
+
+    with pytest.raises(RuntimeError, match='provider failure') as exc_info:
+        await agent.run('test')
+
+    frames = extract_tb(exc_info.value.__traceback__)
+    noop_hook_names = {'wrap_node_run', 'on_node_run_error', 'wrap_model_request', 'on_model_request_error'}
+    assert not any(
+        frame.filename.endswith(('pydantic_ai/capabilities/abstract.py', 'pydantic_ai/capabilities/wrapper.py'))
+        and frame.name in noop_hook_names
+        for frame in frames
+    )
 
 
 def _output_context() -> OutputContext:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,16 @@ def test_invalid_model(capfd: CaptureFixture[str]):
     assert capfd.readouterr().out.splitlines() == snapshot(['Error initializing potato:', 'Unknown model: potato'])
 
 
+def test_invalid_model_suggestion(capfd: CaptureFixture[str]):
+    assert cli(['--model', 'claude:sonnet-5']) == 1
+    assert capfd.readouterr().out.splitlines() == snapshot(
+        [
+            'Error initializing claude:sonnet-5:',
+            "Unknown model: claude:sonnet-5. Did you mean 'anthropic:claude-sonnet-5'?",
+        ]
+    )
+
+
 @pytest.fixture
 def create_test_module():
     def _create_test_module(**namespace: Any) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 """Tests for exception classes."""
 
 import pickle
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -8,7 +9,7 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 from pydantic_core import ErrorDetails
 
-from pydantic_ai import ModelRetry, ToolFailed
+from pydantic_ai import Agent, ModelRetry, ToolFailed, install_model_error_handler
 from pydantic_ai.exceptions import (
     AgentRunError,
     ApprovalRequired,
@@ -24,7 +25,121 @@ from pydantic_ai.exceptions import (
     UsageLimitExceeded,
     UserError,
 )
-from pydantic_ai.messages import RetryPromptPart, ToolReturnPart
+from pydantic_ai.messages import ModelMessage, ModelResponse, RetryPromptPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+
+async def _raise_model_http_error(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+    try:
+        raise RuntimeError('provider cause')
+    except RuntimeError as error:
+        raise ModelHTTPError(403, 'test-model', {'error': 'permission denied'}) from error
+
+
+def test_install_model_error_handler_renders_without_mutating_exception(capsys: pytest.CaptureFixture[str]) -> None:
+    original_hook = sys.excepthook
+    previous_calls: list[tuple[type[BaseException], BaseException, object]] = []
+
+    def previous_hook(exception_type: type[BaseException], exception: BaseException, traceback_: object) -> None:
+        previous_calls.append((exception_type, exception, traceback_))
+
+    sys.excepthook = previous_hook
+    previous = install_model_error_handler()
+    try:
+        with pytest.raises(ModelHTTPError) as exc_info:
+            Agent(FunctionModel(_raise_model_http_error)).run_sync('test')
+
+        error = exc_info.value
+        original_traceback = error.__traceback__
+        original_cause = error.__cause__
+        sys.excepthook(type(error), error, original_traceback)
+
+        output = capsys.readouterr().err
+        assert 'RuntimeError: provider cause' in output
+        assert 'The above exception was the direct cause' in output
+        assert 'pydantic_ai.exceptions.ModelHTTPError: status_code: 403' in output
+        assert 'tests/test_exceptions.py' in output
+        assert 'pydantic_ai_slim/pydantic_ai/' not in output
+        assert 'pydantic_graph/pydantic_graph/' not in output
+        assert 'Hint: call `install_model_error_handler(full_traceback=True)` to show the complete traceback.' in output
+        assert error.__traceback__ is original_traceback
+        assert error.__cause__ is original_cause
+        assert previous is previous_hook
+        assert previous_calls == []
+
+        try:
+            try:
+                raise RuntimeError('implicit cause')
+            except RuntimeError:
+                raise ModelAPIError('test-model', 'implicit model error')
+        except ModelAPIError as implicit_error:
+            sys.excepthook(type(implicit_error), implicit_error, implicit_error.__traceback__)
+        implicit_output = capsys.readouterr().err
+        assert 'RuntimeError: implicit cause' in implicit_output
+        assert "raise RuntimeError('implicit cause')" not in implicit_output
+        assert 'During handling of the above exception' in implicit_output
+
+        compact_hook = sys.excepthook
+        previous_on_reinstall = install_model_error_handler(full_traceback=True)
+        assert previous_on_reinstall is compact_hook
+        full_error = ModelHTTPError(500, 'test-model')
+        sys.excepthook(type(full_error), full_error, full_error.__traceback__)
+        assert previous_calls == [(type(full_error), full_error, full_error.__traceback__)]
+
+        sys.excepthook = previous_on_reinstall
+        previous_after_restore = install_model_error_handler(full_traceback=True)
+        assert previous_after_restore is compact_hook
+        sys.excepthook(type(full_error), full_error, full_error.__traceback__)
+        assert previous_calls == [
+            (type(full_error), full_error, full_error.__traceback__),
+            (type(full_error), full_error, full_error.__traceback__),
+        ]
+    finally:
+        sys.excepthook = original_hook
+
+
+@pytest.mark.parametrize('full_traceback', [False, True])
+def test_model_error_handler_delegates(full_traceback: bool) -> None:
+    original_hook = sys.excepthook
+    calls: list[tuple[type[BaseException], BaseException, object]] = []
+
+    def previous_hook(exception_type: type[BaseException], exception: BaseException, traceback_: object) -> None:
+        calls.append((exception_type, exception, traceback_))
+
+    sys.excepthook = previous_hook
+    install_model_error_handler(full_traceback=full_traceback)
+    try:
+        error: BaseException
+        if full_traceback:
+            error = ModelHTTPError(500, 'test-model')
+        else:
+            error = RuntimeError('programmer error')
+        sys.excepthook(type(error), error, error.__traceback__)
+        assert calls == [(type(error), error, error.__traceback__)]
+    finally:
+        sys.excepthook = original_hook
+
+
+def test_model_error_handler_preserves_non_weak_referenceable_hook() -> None:
+    original_hook = sys.excepthook
+    calls: list[tuple[type[BaseException], BaseException, object]] = []
+
+    class PreviousHook:
+        __slots__ = ()
+
+        def __call__(self, exception_type: type[BaseException], exception: BaseException, traceback_: object) -> None:
+            calls.append((exception_type, exception, traceback_))
+
+    previous_hook = PreviousHook()
+    sys.excepthook = previous_hook
+    previous = install_model_error_handler()
+    try:
+        error = RuntimeError('programmer error')
+        sys.excepthook(type(error), error, error.__traceback__)
+        assert previous is previous_hook
+        assert calls == [(type(error), error, error.__traceback__)]
+    finally:
+        sys.excepthook = original_hook
 
 
 def test_tool_failed_pydantic_schema_accepts_instance() -> None:


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

### Summary

- Suggest a close known model ID when model inference cannot resolve a model or provider string, preferring direct providers over gateway aliases.
- Add an opt-in concise renderer for uncaught model API errors, with unchanged exceptions for `except` blocks and debuggers and a full-traceback escape hatch.
- Skip inherited no-op capability wrappers and error hooks so they do not add irrelevant traceback frames.
- Document the handler and cover CLI, `Agent`, capability, rendering, and exception-hook composition paths.

A live invalid Vertex model run produced 13 lines of concise output instead of the original 217-line traceback.

### Verification

- [x] Targeted tests pass.
- [x] Formatting, lint, and type checking pass.
- [x] Local architecture, pattern, and independent reviews pass.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

