### PR TITLE
fix(evals): fall back to ASCII microseconds

### DIFF
--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations as _annotations
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from functools import partial
 from io import StringIO
 from typing import Any, Generic, Literal, Protocol
 
@@ -480,9 +481,8 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         """Print this report to the console, optionally comparing it to a baseline report.
 
         On a console `rich` reports as ASCII-only — a non-UTF-8 stream, as Windows produces when stdout is
-        redirected to a file or a pipe — `v`, `x` and `->` stand in for the `✔`, `✗` and `→` glyphs. The `µs`
-        unit sub-millisecond durations render with is not covered yet, so a stream that can't encode `µ` can
-        still raise: see [#7291](https://github.com/pydantic/pydantic-ai/issues/7291).
+        redirected to a file or a pipe — `v`, `x`, `->` and `us` stand in for the `✔`, `✗`, `→` and `µs`
+        glyphs and units.
 
         If you want more control over the output, use `console_table` instead and pass it to `rich.Console.print`,
         forwarding `ascii_only=console.options.ascii_only` from the console you print to.
@@ -569,9 +569,10 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
         If a baseline is provided, returns a diff between this report and the baseline report.
         Optionally include input and output details.
 
-        `ascii_only` renders `v`, `x` and `->` in place of the `✔`, `✗` and `→` glyphs, for a console whose
-        stream can't encode them. Only the caller holding that console can answer this, so it defaults to
-        `False`; pass `ascii_only=console.options.ascii_only` from the console you print the table to.
+        `ascii_only` renders `v`, `x`, `->` and `us` in place of the `✔`, `✗`, `→` and `µs` glyphs and units,
+        for a console whose stream can't encode them. Only the caller holding that console can answer this, so
+        it defaults to `False`; pass `ascii_only=console.options.ascii_only` from the console you print the
+        table to.
         """
         renderer = EvaluationRenderer(
             include_input=include_input,
@@ -893,11 +894,21 @@ class _NumberRenderer:
     ) -> _NumberRenderer:
         value_formatter = config.get('value_formatter', UNSET)
         if isinstance(value_formatter, Unset):
-            value_formatter = default_render_number
+            value_formatter = (
+                partial(default_render_duration, ascii_only=ascii_only) if kind == 'duration' else default_render_number
+            )
+        elif value_formatter is default_render_duration:
+            value_formatter = partial(default_render_duration, ascii_only=ascii_only)
 
         diff_formatter = config.get('diff_formatter', UNSET)
         if isinstance(diff_formatter, Unset):
-            diff_formatter = default_render_number_diff
+            diff_formatter = (
+                partial(default_render_duration_diff, ascii_only=ascii_only)
+                if kind == 'duration'
+                else default_render_number_diff
+            )
+        elif diff_formatter is default_render_duration_diff:
+            diff_formatter = partial(default_render_duration_diff, ascii_only=ascii_only)
 
         diff_atol = config.get('diff_atol', UNSET)
         if isinstance(diff_atol, Unset):

--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -894,19 +894,13 @@ class _NumberRenderer:
     ) -> _NumberRenderer:
         value_formatter = config.get('value_formatter', UNSET)
         if isinstance(value_formatter, Unset):
-            value_formatter = (
-                partial(default_render_duration, ascii_only=ascii_only) if kind == 'duration' else default_render_number
-            )
+            value_formatter = default_render_number
         elif value_formatter is default_render_duration:
             value_formatter = partial(default_render_duration, ascii_only=ascii_only)
 
         diff_formatter = config.get('diff_formatter', UNSET)
         if isinstance(diff_formatter, Unset):
-            diff_formatter = (
-                partial(default_render_duration_diff, ascii_only=ascii_only)
-                if kind == 'duration'
-                else default_render_number_diff
-            )
+            diff_formatter = default_render_number_diff
         elif diff_formatter is default_render_duration_diff:
             diff_formatter = partial(default_render_duration_diff, ascii_only=ascii_only)
 

--- a/pydantic_evals/pydantic_evals/reporting/render_numbers.py
+++ b/pydantic_evals/pydantic_evals/reporting/render_numbers.py
@@ -94,22 +94,32 @@ def default_render_number_diff(old: float | int, new: float | int) -> str | None
         return f'{abs_diff_str} / {rel_diff_str}'
 
 
-def default_render_duration(seconds: float) -> str:
+def default_render_duration(seconds: float, *, ascii_only: bool = False) -> str:
     """Format a duration given in seconds to a string.
 
     If the duration is less than 1 millisecond, show microseconds.
     If it's less than one second, show milliseconds.
     Otherwise, show seconds.
+
+    If `ascii_only` is true, use `us` instead of `µs` for microseconds.
     """
+    if ascii_only:
+        return _render_duration(seconds, False, ascii_only=True)
     return _render_duration(seconds, False)
 
 
-def default_render_duration_diff(old: float, new: float) -> str | None:
-    """Format a duration difference (in seconds) with an explicit sign."""
+def default_render_duration_diff(old: float, new: float, *, ascii_only: bool = False) -> str | None:
+    """Format a duration difference (in seconds) with an explicit sign.
+
+    If `ascii_only` is true, use `us` instead of `µs` for microseconds.
+    """
     if old == new:
         return None
 
-    abs_diff_str = _render_duration(new - old, True)
+    if ascii_only:
+        abs_diff_str = _render_duration(new - old, True, ascii_only=True)
+    else:
+        abs_diff_str = _render_duration(new - old, True)
     rel_diff_str = _render_relative(new, old, BASE_THRESHOLD)
     if rel_diff_str is None:
         return abs_diff_str
@@ -161,7 +171,7 @@ def _render_relative(new: float, base: float, small_base_threshold: float) -> st
         return mult_str
 
 
-def _render_duration(seconds: float, force_signed: bool) -> str:
+def _render_duration(seconds: float, force_signed: bool, *, ascii_only: bool = False) -> str:
     """Format a duration given in seconds to a string.
 
     If the duration is less than 1 millisecond, show microseconds.
@@ -173,7 +183,7 @@ def _render_duration(seconds: float, force_signed: bool) -> str:
     precision = 1
     if (abs_seconds := abs(seconds)) < 1e-3:
         value = seconds * 1_000_000
-        unit = 'µs'
+        unit = 'us' if ascii_only else 'µs'
         if abs(value) >= 1:
             precision = 0
     elif abs_seconds < 1:

--- a/tests/evals/test_render_numbers.py
+++ b/tests/evals/test_render_numbers.py
@@ -109,3 +109,8 @@ def test_default_render_duration(value: float, expected: str):
 )
 def test_default_render_duration_diff(old: float, new: float, expected: str | None):
     assert default_render_duration_diff(old, new) == expected
+
+
+def test_default_render_duration_ascii_only():
+    assert default_render_duration(0.0000005, ascii_only=True) == '0.5us'
+    assert default_render_duration_diff(0, 0.0000005, ascii_only=True) == '+0.5us'

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -1375,17 +1375,19 @@ async def test_evaluation_renderer_diff_with_no_metadata(sample_report_case: Rep
 """)
 
 
-def render_to_non_utf8_console(report: EvaluationReport, baseline: EvaluationReport | None = None) -> str:
-    """Print a report to a console whose stream can only encode cp1252, and return what was written.
+def render_to_non_utf8_console(
+    report: EvaluationReport, baseline: EvaluationReport | None = None, *, encoding: str = 'cp1252'
+) -> str:
+    """Print a report to a console whose stream cannot encode all Unicode, and return what was written.
 
     This is Windows with stdout redirected to a file or a pipe: Python uses UTF-8 for the console
     itself, but falls back to the ANSI code page for a redirected stream.
     """
     buffer = BytesIO()
-    stream = TextIOWrapper(buffer, encoding='cp1252', errors='strict', newline='')
+    stream = TextIOWrapper(buffer, encoding=encoding, errors='strict', newline='')
     report.print(baseline=baseline, console=Console(file=stream, width=150))
     stream.flush()
-    return trim_trailing_whitespace(buffer.getvalue().decode('cp1252'))
+    return trim_trailing_whitespace(buffer.getvalue().decode(encoding))
 
 
 async def test_print_falls_back_to_ascii_glyphs_on_non_utf8_console(
@@ -1511,3 +1513,15 @@ async def test_console_table_renders_ascii_glyphs_when_asked(
 | Averages  | score1: 2.50 | label1: {'hello': 1.0} | accuracy: 0.950 | 50.0% v    |  100.0ms |
 +---------------------------------------------------------------------------------------------+
 """)
+
+
+async def test_print_falls_back_to_ascii_microseconds_on_non_utf8_console(sample_report_case: ReportCase):
+    report = EvaluationReport(
+        cases=[replace(sample_report_case, task_duration=0.0000005, total_duration=0.0000005)],
+        name='test_report',
+    )
+
+    rendered = render_to_non_utf8_console(report, encoding='cp932')
+
+    assert '0.5us' in rendered
+    assert 'µ' not in rendered


### PR DESCRIPTION
<!-- Follow-up to #7290; this PR targets the #7290 head branch to keep the diff focused. -->

Closes #7291

## Summary

Sub-millisecond durations still render the microsecond unit, which can make EvaluationReport.print() raise UnicodeEncodeError on ASCII-only redirected consoles such as cp932.

This follow-up:

- renders us only for the ASCII-only console path
- preserves the Unicode microsecond unit for the default UTF-8 path
- leaves user-supplied duration formatters unchanged
- covers both the duration formatters and the public EvaluationReport.print() path

## Testing

- pytest tests/evals/test_render_numbers.py - 60 passed
- pytest tests/evals/test_reporting.py -k ascii - 5 passed
- pytest tests/evals/test_reporting.py -k microseconds - 1 passed
- ruff format --check ... - passed
- ruff check ... - passed

The full test_reporting.py run in my temporary Windows environment has pre-existing Rich snapshot differences (border glyphs and column widths), so I have not represented that environment run as a full-suite pass.

### AI assistance

AI assistance was used in preparing this follow-up and its tests. The repository's human-author review checkbox remains unchecked and should only be checked after the account owner has reviewed the final diff line by line.

### Checklist

- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No breaking changes in accordance with the version policy: https://github.com/pydantic/pydantic-ai/releases
- [x] PR title is fit for the release changelog: https://github.com/pydantic/pydantic-ai/releases