### PR TITLE
Correct OpenAI strict schema compatibility for tuples and length constraints

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -395,8 +395,6 @@ def openai_model_profile(model_name: str) -> ModelProfile:
 
 
 _STRICT_INCOMPATIBLE_KEYS = [
-    'minLength',
-    'maxLength',
     'patternProperties',
     'unevaluatedProperties',
     'propertyNames',
@@ -407,6 +405,7 @@ _STRICT_INCOMPATIBLE_KEYS = [
     'minContains',
     'maxContains',
     'uniqueItems',
+    'prefixItems',
 ]
 
 _STRICT_COMPATIBLE_STRING_FORMATS = [
@@ -498,6 +497,22 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                 # So if there is a "description" field or any other extra info, we move the "$ref" into an "anyOf":
                 schema['anyOf'] = [{'$ref': schema.pop('$ref')}]
 
+        schema_type = schema.get('type')
+        if schema_type == 'array' and self.strict is not False:
+            prefix_items = schema.get('prefixItems')
+            if prefix_items and 'items' not in schema:
+                fixed_length = schema.get('minItems') == len(prefix_items) and schema.get('maxItems') == len(
+                    prefix_items
+                )
+                if fixed_length and all(item == prefix_items[0] for item in prefix_items[1:]):
+                    # A fixed-length homogeneous tuple is equivalent to an array with a typed `items` schema.
+                    schema['items'] = prefix_items[0]
+                    schema.pop('prefixItems')
+                elif self.strict is True:
+                    raise UserError(
+                        'OpenAI strict mode cannot represent this `prefixItems` schema without changing its meaning'
+                    )
+
         # Track strict-incompatible keys
         incompatible_values: dict[str, Any] = {}
         for key in _STRICT_INCOMPATIBLE_KEYS:
@@ -522,7 +537,6 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             elif self.strict is None:  # pragma: no branch
                 self.is_strict_compatible = False
 
-        schema_type = schema.get('type')
         if 'oneOf' in schema:
             # OpenAI does not support oneOf in strict mode
             if self.strict is True:
@@ -558,8 +572,9 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                             self.is_strict_compatible = False
 
         if schema_type == 'array':
-            # OpenAI strict mode requires an array to describe its elements' type, via either `items`
-            # (list types) or `prefixItems` (tuple types). A bare `list` produces an empty `items: {}`,
+            # OpenAI strict mode requires an array to describe its elements' type via `items`.
+            # Homogeneous fixed-length tuples are converted to this form above. A bare `list` produces an empty
+            # `items: {}`,
             # `list[Any]` a boolean `items: true`, and a schema may omit `items` entirely; none of these
             # give the element a type, so they're rejected by the API in strict mode and there's no way
             # to repair them without inventing an element type. `items` only types its elements when it's
@@ -568,7 +583,7 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             # See https://github.com/pydantic/pydantic-ai/issues/4425
             items = schema.get('items')
             has_typed_items = isinstance(items, dict) and any(key in items for key in _TYPE_BEARING_KEYS)
-            if not has_typed_items and not schema.get('prefixItems'):
+            if not has_typed_items:
                 if self.strict is True:
                     raise UserError(
                         'OpenAI strict mode requires array items to have a type, but got an untyped array '

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -3048,7 +3048,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
             snapshot(
                 {
                     'additionalProperties': False,
-                    'properties': {'x': {'type': 'string', 'description': 'minLength=1, format=uri'}},
+                    'properties': {'x': {'description': 'format=uri', 'minLength': 1, 'type': 'string'}},
                     'required': ['x'],
                     'type': 'object',
                 }
@@ -3419,12 +3419,12 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
+                        'x': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                         'y': {
                             'default': ['abc'],
+                            'items': {'type': 'string'},
                             'maxItems': 1,
                             'minItems': 1,
-                            'prefixItems': [{'type': 'string'}],
                             'type': 'array',
                         },
                     },
@@ -3441,8 +3441,8 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
-                        'y': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'string'}], 'type': 'array'},
+                        'x': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
+                        'y': {'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                     },
                     'required': ['x', 'y'],
                     'type': 'object',
@@ -3538,9 +3538,9 @@ def test_strict_schema():
                         },
                         'my_recursive': {'anyOf': [{'$ref': '#'}, {'type': 'null'}]},
                         'my_tuple': {
+                            'items': {'type': 'integer'},
                             'maxItems': 1,
                             'minItems': 1,
-                            'prefixItems': [{'type': 'integer'}],
                             'type': 'array',
                         },
                     },
@@ -3557,7 +3557,7 @@ def test_strict_schema():
                     'properties': {},
                     'required': [],
                 },
-                'my_tuple': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
+                'my_tuple': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                 'my_list': {'items': {'type': 'number'}, 'type': 'array'},
                 'my_discriminated_union': {'anyOf': [{'$ref': '#/$defs/Apple'}, {'$ref': '#/$defs/Banana'}]},
             },
@@ -6140,6 +6140,89 @@ def test_transformer_adds_properties_to_object_schemas():
     result = OpenAIJsonSchemaTransformer(schema, strict=None).walk()
 
     assert result['properties'] == {}
+
+
+def test_transformer_length_constraints_are_strict_compatible():
+    """OpenAI preserves string length constraints in strict mode."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': {'type': 'string', 'minLength': 1, 'maxLength': 10}},
+        'required': ['value'],
+    }
+
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == {'type': 'string', 'minLength': 1, 'maxLength': 10}
+    assert transformer.is_strict_compatible is True
+
+
+def test_transformer_homogeneous_tuple_is_strict_compatible():
+    """A fixed-length homogeneous tuple can be represented by OpenAI's typed `items` form."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {
+            'value': {
+                'type': 'array',
+                'prefixItems': [{'type': 'integer'}, {'type': 'integer'}],
+                'minItems': 2,
+                'maxItems': 2,
+            }
+        },
+        'required': ['value'],
+    }
+
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == {
+        'type': 'array',
+        'items': {'type': 'integer'},
+        'minItems': 2,
+        'maxItems': 2,
+    }
+    assert transformer.is_strict_compatible is True
+
+
+def test_transformer_heterogeneous_tuple_is_not_strict_compatible():
+    """A heterogeneous tuple has no lossless representation in OpenAI strict mode."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {
+            'value': {
+                'type': 'array',
+                'prefixItems': [{'type': 'integer'}, {'type': 'string'}],
+                'minItems': 2,
+                'maxItems': 2,
+            }
+        },
+        'required': ['value'],
+    }
+
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value']['prefixItems'] == [{'type': 'integer'}, {'type': 'string'}]
+    assert transformer.is_strict_compatible is False
+
+
+def test_transformer_heterogeneous_tuple_explicit_strict_raises():
+    """Explicit strict mode rejects heterogeneous tuples instead of sending an invalid schema."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {
+            'value': {
+                'type': 'array',
+                'prefixItems': [{'type': 'integer'}, {'type': 'string'}],
+                'minItems': 2,
+                'maxItems': 2,
+            }
+        },
+        'required': ['value'],
+    }
+
+    with pytest.raises(UserError, match='cannot represent this `prefixItems` schema'):
+        OpenAIJsonSchemaTransformer(schema, strict=True).walk()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #7315

## Summary

`OpenAIJsonSchemaTransformer` currently infers strict mode for schemas containing `prefixItems`, even though OpenAI rejects that keyword in strict structured outputs. It also treats `minLength` and `maxLength` as strict-incompatible even though OpenAI preserves them.

This PR:

- keeps `minLength` and `maxLength` when inferring strict compatibility;
- converts fixed-length homogeneous tuples to the equivalent typed `items` form;
- leaves heterogeneous tuples non-strict-compatible rather than widening their meaning;
- raises a clear error when heterogeneous tuple schemas are explicitly requested with `strict=True`;
- adds regression coverage for each case.

## Validation

- `pytest tests/models/test_openai.py -q` — 235 passed
- `ruff check pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py`
- `ruff format --check pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py`

AI assistance was used for the implementation and test drafting. The repository's UI-only AI-generated-code checkbox has not been checked; it requires the human PR author to review and stand behind the changes.

This draft PR is submitted from the issue-linked fork branch for maintainer review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

