### PR TITLE
Fix OpenAI strict mode inference for `tuple` fields (`prefixItems`)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -396,6 +396,8 @@ def openai_model_profile(model_name: str) -> ModelProfile:
 
 
 _STRICT_INCOMPATIBLE_KEYS = [
+    'minLength',
+    'maxLength',
     'patternProperties',
     'unevaluatedProperties',
     'propertyNames',

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -434,13 +434,9 @@ _sentinel = object()
 def _is_homogeneous_bounded_tuple(schema: JsonSchema, prefix_items: list[Any]) -> bool:
     """Whether an array schema is a tuple of elements sharing one schema, length-capped to the prefix.
 
-    Such a schema (e.g. `tuple[int, int]`, or a `NamedTuple` whose fields all have one type) means
-    the same as a length-bounded `list[int]`: `items` equal to the element schema plus `maxItems`
-    (and `minItems` if present), which OpenAI strict mode supports. Without `maxItems` capping the
-    length, elements beyond the prefix are unconstrained and the rewrite would narrow the schema.
-
-    Elements are compared as canonical JSON rather than with `==`: Python equality conflates
-    `True`/`1` and `1`/`1.0`, which are distinct in JSON Schema.
+    Such a schema (e.g. `tuple[int, int]`) means the same as `items` + `maxItems`, which strict mode
+    supports. Elements are compared as canonical JSON: Python `==` conflates `True` with `1`, which
+    JSON Schema distinguishes.
     """
     if schema.get('maxItems') != len(prefix_items):
         return False
@@ -574,19 +570,15 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                             self.is_strict_compatible = False
 
         if schema_type == 'array':
-            # OpenAI strict mode does not support `prefixItems` (tuple types): the API ignores the
-            # keyword and then rejects the array for not typing its elements. A tuple whose elements
-            # all share one schema and whose length is capped (e.g. `tuple[int, int]`) means the same
-            # as a length-bounded `list[int]`, so it's rewritten to the supported `items` +
-            # `minItems`/`maxItems` form. Any other `prefixItems` schema (a heterogeneous tuple like
-            # `tuple[int, str]`, no `maxItems` bound, or `items` alongside `prefixItems`) can't be
-            # rewritten without changing its meaning, so it's not strict-compatible.
+            # OpenAI strict mode does not support `prefixItems` (tuple types). A homogeneous
+            # length-capped tuple (e.g. `tuple[int, int]`) is rewritten to the equivalent supported
+            # `items` + `minItems`/`maxItems` form; any other `prefixItems` schema can't be rewritten
+            # without changing its meaning, so it's not strict-compatible.
             # See https://github.com/pydantic/pydantic-ai/issues/7315
             prefix_items = schema.get('prefixItems')
             if prefix_items is not None and self.strict is not False:
                 if not prefix_items:
-                    # An empty `prefixItems` constrains nothing, so the unsupported keyword can
-                    # simply be dropped.
+                    # empty `prefixItems` constrains nothing
                     del schema['prefixItems']
                 elif 'items' not in schema and _is_homogeneous_bounded_tuple(schema, prefix_items):
                     schema['items'] = prefix_items[0]

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -574,15 +574,18 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
         if schema_type == 'array':
             # OpenAI strict mode does not support `prefixItems` (tuple types). A homogeneous
             # length-capped tuple (e.g. `tuple[int, int]`) is rewritten to the equivalent supported
-            # `items` + `minItems`/`maxItems` form; any other `prefixItems` schema can't be rewritten
-            # without changing its meaning, so it's not strict-compatible.
+            # `items` + `minItems`/`maxItems` form; any other `prefixItems` schema (heterogeneous, or
+            # no `maxItems` cap) can't be rewritten without changing its meaning, so it's not
+            # strict-compatible.
             # See https://github.com/pydantic/pydantic-ai/issues/7315
             prefix_items = schema.get('prefixItems')
             if prefix_items is not None and self.strict is not False:
                 if not prefix_items:
                     # empty `prefixItems` constrains nothing
                     del schema['prefixItems']
-                elif 'items' not in schema and _is_homogeneous_bounded_tuple(schema, prefix_items):
+                elif _is_homogeneous_bounded_tuple(schema, prefix_items):
+                    # Any existing `items` only governs elements past the prefix, which `maxItems`
+                    # makes unreachable, so it's dead and safe to overwrite.
                     schema['items'] = prefix_items[0]
                     del schema['prefixItems']
                 elif self.strict is True:

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import json
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -395,8 +396,6 @@ def openai_model_profile(model_name: str) -> ModelProfile:
 
 
 _STRICT_INCOMPATIBLE_KEYS = [
-    'minLength',
-    'maxLength',
     'patternProperties',
     'unevaluatedProperties',
     'propertyNames',
@@ -430,6 +429,23 @@ Used to tell whether an array's `items` actually types its elements. A node with
 (e.g. `{}`, `True`, or `{'description': '...'}`) is untyped and rejected by OpenAI strict mode."""
 
 _sentinel = object()
+
+
+def _is_homogeneous_bounded_tuple(schema: JsonSchema, prefix_items: list[Any]) -> bool:
+    """Whether an array schema is a tuple of elements sharing one schema, length-capped to the prefix.
+
+    Such a schema (e.g. `tuple[int, int]`, or a `NamedTuple` whose fields all have one type) means
+    the same as a length-bounded `list[int]`: `items` equal to the element schema plus `maxItems`
+    (and `minItems` if present), which OpenAI strict mode supports. Without `maxItems` capping the
+    length, elements beyond the prefix are unconstrained and the rewrite would narrow the schema.
+
+    Elements are compared as canonical JSON rather than with `==`: Python equality conflates
+    `True`/`1` and `1`/`1.0`, which are distinct in JSON Schema.
+    """
+    if schema.get('maxItems') != len(prefix_items):
+        return False
+    first = json.dumps(prefix_items[0], sort_keys=True)
+    return all(json.dumps(item, sort_keys=True) == first for item in prefix_items[1:])
 
 
 def _regex_contains_lookaround(pattern: str) -> bool:
@@ -558,13 +574,39 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                             self.is_strict_compatible = False
 
         if schema_type == 'array':
-            # OpenAI strict mode requires an array to describe its elements' type, via either `items`
-            # (list types) or `prefixItems` (tuple types). A bare `list` produces an empty `items: {}`,
-            # `list[Any]` a boolean `items: true`, and a schema may omit `items` entirely; none of these
-            # give the element a type, so they're rejected by the API in strict mode and there's no way
-            # to repair them without inventing an element type. `items` only types its elements when it's
-            # a schema object carrying a type-bearing keyword (a boolean node, `{}`, or a metadata-only
-            # node like `{'description': ...}` does not).
+            # OpenAI strict mode does not support `prefixItems` (tuple types): the API ignores the
+            # keyword and then rejects the array for not typing its elements. A tuple whose elements
+            # all share one schema and whose length is capped (e.g. `tuple[int, int]`) means the same
+            # as a length-bounded `list[int]`, so it's rewritten to the supported `items` +
+            # `minItems`/`maxItems` form. Any other `prefixItems` schema (a heterogeneous tuple like
+            # `tuple[int, str]`, no `maxItems` bound, or `items` alongside `prefixItems`) can't be
+            # rewritten without changing its meaning, so it's not strict-compatible.
+            # See https://github.com/pydantic/pydantic-ai/issues/7315
+            prefix_items = schema.get('prefixItems')
+            if prefix_items is not None and self.strict is not False:
+                if not prefix_items:
+                    # An empty `prefixItems` constrains nothing, so the unsupported keyword can
+                    # simply be dropped.
+                    del schema['prefixItems']
+                elif 'items' not in schema and _is_homogeneous_bounded_tuple(schema, prefix_items):
+                    schema['items'] = prefix_items[0]
+                    del schema['prefixItems']
+                elif self.strict is True:
+                    raise UserError(
+                        'OpenAI strict mode does not support `prefixItems`. A tuple field can only be '
+                        'used in strict mode when all its elements have the same schema, e.g. '
+                        '`tuple[int, int]`. Use such a tuple, another field type, or set `strict=False`.'
+                    )
+                else:  # self.strict is None
+                    self.is_strict_compatible = False
+
+            # OpenAI strict mode requires an array to describe its elements' type via `items`. A bare
+            # `list` produces an empty `items: {}`, `list[Any]` a boolean `items: true`, and a schema
+            # may omit `items` entirely; none of these give the element a type, so they're rejected by
+            # the API in strict mode and there's no way to repair them without inventing an element
+            # type. `items` only types its elements when it's a schema object carrying a type-bearing
+            # keyword (a boolean node, `{}`, or a metadata-only node like `{'description': ...}` does
+            # not).
             # See https://github.com/pydantic/pydantic-ai/issues/4425
             items = schema.get('items')
             has_typed_items = isinstance(items, dict) and any(key in items for key in _TYPE_BEARING_KEYS)

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import json
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -433,19 +432,6 @@ Used to tell whether an array's `items` actually types its elements. A node with
 _sentinel = object()
 
 
-def _is_homogeneous_bounded_tuple(schema: JsonSchema, prefix_items: list[Any]) -> bool:
-    """Whether an array schema is a tuple of elements sharing one schema, length-capped to the prefix.
-
-    Such a schema (e.g. `tuple[int, int]`) means the same as `items` + `maxItems`, which strict mode
-    supports. Elements are compared as canonical JSON: Python `==` conflates `True` with `1`, which
-    JSON Schema distinguishes.
-    """
-    if schema.get('maxItems') != len(prefix_items):
-        return False
-    first = json.dumps(prefix_items[0], sort_keys=True)
-    return all(json.dumps(item, sort_keys=True) == first for item in prefix_items[1:])
-
-
 def _regex_contains_lookaround(pattern: str) -> bool:
     escaped = False
     for i, char in enumerate(pattern):
@@ -572,29 +558,16 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                             self.is_strict_compatible = False
 
         if schema_type == 'array':
-            # OpenAI strict mode does not support `prefixItems` (tuple types). A homogeneous
-            # length-capped tuple (e.g. `tuple[int, int]`) is rewritten to the equivalent supported
-            # `items` + `minItems`/`maxItems` form; any other `prefixItems` schema (heterogeneous, or
-            # no `maxItems` cap) can't be rewritten without changing its meaning, so it's not
-            # strict-compatible.
+            # OpenAI strict mode does not support `prefixItems` (tuple types): the API ignores the
+            # keyword and rejects the array as missing `items`.
             # See https://github.com/pydantic/pydantic-ai/issues/7315
-            prefix_items = schema.get('prefixItems')
-            if prefix_items is not None and self.strict is not False:
-                if not prefix_items:
-                    # empty `prefixItems` constrains nothing
-                    del schema['prefixItems']
-                elif _is_homogeneous_bounded_tuple(schema, prefix_items):
-                    # Any existing `items` only governs elements past the prefix, which `maxItems`
-                    # makes unreachable, so it's dead and safe to overwrite.
-                    schema['items'] = prefix_items[0]
-                    del schema['prefixItems']
-                elif self.strict is True:
+            if schema.get('prefixItems'):
+                if self.strict is True:
                     raise UserError(
-                        'OpenAI strict mode does not support `prefixItems`. A tuple field can only be '
-                        'used in strict mode when all its elements have the same schema, e.g. '
-                        '`tuple[int, int]`. Use such a tuple, another field type, or set `strict=False`.'
+                        'OpenAI strict mode does not support tuple types (`prefixItems`). '
+                        'Use a different field type, or set `strict=False`.'
                     )
-                else:  # self.strict is None
+                elif self.strict is None:
                     self.is_strict_compatible = False
 
             # OpenAI strict mode requires an array to describe its elements' type via `items`. A bare

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -5,6 +5,7 @@ import json
 import re
 import warnings
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -6267,10 +6268,11 @@ def test_transformer_prefix_items_not_strict_compatible(array_schema: dict[str, 
         'properties': {'value': array_schema},
         'required': ['value'],
     }
+    expected_prefix_items = deepcopy(array_schema['prefixItems'])
     transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
     result = transformer.walk()
 
-    assert result['properties']['value']['prefixItems'] == array_schema['prefixItems']
+    assert result['properties']['value']['prefixItems'] == expected_prefix_items
     assert transformer.is_strict_compatible is False
 
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Annotated, Any, Literal, NamedTuple, cast
+from typing import Annotated, Any, Literal, cast
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -3427,12 +3427,12 @@ def tool_with_heterogeneous_tuple(x: tuple[int, str]) -> str:
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
+                        'x': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
                         'y': {
                             'default': ['abc'],
-                            'items': {'type': 'string'},
                             'maxItems': 1,
                             'minItems': 1,
+                            'prefixItems': [{'type': 'string'}],
                             'type': 'array',
                         },
                     },
@@ -3443,35 +3443,24 @@ def tool_with_heterogeneous_tuple(x: tuple[int, str]) -> str:
             snapshot(None),
         ),
         (
-            tool_with_tuples,
-            True,
-            snapshot(
-                {
-                    'additionalProperties': False,
-                    'properties': {
-                        'x': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
-                        'y': {'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
-                    },
-                    'required': ['x', 'y'],
-                    'type': 'object',
-                }
-            ),
-            snapshot(True),
-        ),
-        (
             tool_with_fixed_tuple,
             None,
             snapshot(
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'items': {'type': 'integer'}, 'maxItems': 2, 'minItems': 2, 'type': 'array'},
+                        'x': {
+                            'maxItems': 2,
+                            'minItems': 2,
+                            'prefixItems': [{'type': 'integer'}, {'type': 'integer'}],
+                            'type': 'array',
+                        },
                     },
                     'required': ['x'],
                     'type': 'object',
                 }
             ),
-            snapshot(True),
+            snapshot(None),
         ),
         (
             tool_with_heterogeneous_tuple,
@@ -3548,7 +3537,6 @@ def test_strict_schema():
         # We have all these different crazy fields to achieve coverage
         my_recursive: MyModel | None = None
         my_patterns: dict[Annotated[str, Field(pattern='^my-pattern$')], str]
-        my_tuple: tuple[int]
         my_list: list[float]
         my_discriminated_union: Annotated[Apple | Banana, Discriminator('kind')]
 
@@ -3580,14 +3568,8 @@ def test_strict_schema():
                             'required': [],
                         },
                         'my_recursive': {'anyOf': [{'$ref': '#'}, {'type': 'null'}]},
-                        'my_tuple': {
-                            'items': {'type': 'integer'},
-                            'maxItems': 1,
-                            'minItems': 1,
-                            'type': 'array',
-                        },
                     },
-                    'required': ['my_recursive', 'my_patterns', 'my_tuple', 'my_list', 'my_discriminated_union'],
+                    'required': ['my_recursive', 'my_patterns', 'my_list', 'my_discriminated_union'],
                     'type': 'object',
                 },
             },
@@ -3600,11 +3582,10 @@ def test_strict_schema():
                     'properties': {},
                     'required': [],
                 },
-                'my_tuple': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                 'my_list': {'items': {'type': 'number'}, 'type': 'array'},
                 'my_discriminated_union': {'anyOf': [{'$ref': '#/$defs/Apple'}, {'$ref': '#/$defs/Banana'}]},
             },
-            'required': ['my_recursive', 'my_patterns', 'my_tuple', 'my_list', 'my_discriminated_union'],
+            'required': ['my_recursive', 'my_patterns', 'my_list', 'my_discriminated_union'],
             'type': 'object',
             'additionalProperties': False,
         }
@@ -6246,7 +6227,16 @@ def test_transformer_untyped_array_explicit_strict_raises():
         OpenAIJsonSchemaTransformer(schema, strict=True).walk()
 
 
-_UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
+_PREFIX_ITEMS_SCHEMAS = [
+    pytest.param(
+        {
+            'type': 'array',
+            'prefixItems': [{'type': 'integer'}, {'type': 'integer'}],
+            'minItems': 2,
+            'maxItems': 2,
+        },
+        id='homogeneous',
+    ),
     pytest.param(
         {
             'type': 'array',
@@ -6261,69 +6251,17 @@ _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
         id='no-length-bounds',
     ),
     pytest.param(
-        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}], 'minItems': 2},
-        id='min-items-only',
-    ),
-    pytest.param(
-        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}], 'maxItems': 3},
-        id='max-items-mismatch',
-    ),
-    pytest.param(
-        {'type': 'array', 'prefixItems': [{'const': True}, {'const': 1}], 'minItems': 2, 'maxItems': 2},
-        id='bool-vs-int-const',
-    ),
-    pytest.param(
-        {
-            'type': 'array',
-            'prefixItems': [{'type': 'integer'}, {'type': 'integer'}, {'type': 'string'}],
-            'minItems': 3,
-            'maxItems': 3,
-        },
-        id='mismatch-after-first-pair',
-    ),
-]
-
-_CONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
-    pytest.param(
-        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}], 'minItems': 2, 'maxItems': 2},
-        {'type': 'array', 'items': {'type': 'integer'}, 'minItems': 2, 'maxItems': 2},
-        id='plain-homogeneous',
-    ),
-    pytest.param(
-        {
-            'type': 'array',
-            'prefixItems': [{'type': 'integer'}],
-            'items': {'type': 'string'},
-            'minItems': 1,
-            'maxItems': 1,
-        },
-        {'type': 'array', 'items': {'type': 'integer'}, 'minItems': 1, 'maxItems': 1},
-        id='prefix-items-plus-unreachable-items',
+        {'type': 'array', 'prefixItems': [{'type': 'integer'}], 'items': {'type': 'string'}},
+        id='typed-items-alongside',
     ),
 ]
 
 
-@pytest.mark.parametrize('array_schema,expected', _CONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
-def test_transformer_convertible_prefix_items_rewritten(array_schema: dict[str, Any], expected: dict[str, Any]):
-    """A homogeneous length-capped tuple rewrites to `items` + bounds. Any pre-existing `items`
-    only governs elements past the prefix, which `maxItems` makes unreachable, so it can't block
-    the rewrite."""
-    schema: dict[str, Any] = {
-        'type': 'object',
-        'properties': {'value': array_schema},
-        'required': ['value'],
-    }
-    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
-    result = transformer.walk()
-
-    assert result['properties']['value'] == expected
-    assert transformer.is_strict_compatible is True
-
-
-@pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
-def test_transformer_unconvertible_prefix_items_not_strict_compatible(array_schema: dict[str, Any]):
-    """An unconvertible `prefixItems` schema has no strict-mode representation, so `strict=None`
-    must infer non-strict. See https://github.com/pydantic/pydantic-ai/issues/7315"""
+@pytest.mark.parametrize('array_schema', _PREFIX_ITEMS_SCHEMAS)
+def test_transformer_prefix_items_not_strict_compatible(array_schema: dict[str, Any]):
+    """OpenAI strict mode does not support `prefixItems` (tuple types), so `strict=None` must
+    infer non-strict instead of sending a schema the API rejects.
+    See https://github.com/pydantic/pydantic-ai/issues/7315"""
     schema: dict[str, Any] = {
         'type': 'object',
         'properties': {'value': array_schema},
@@ -6336,85 +6274,16 @@ def test_transformer_unconvertible_prefix_items_not_strict_compatible(array_sche
     assert transformer.is_strict_compatible is False
 
 
-@pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
-def test_transformer_unconvertible_prefix_items_explicit_strict_raises(array_schema: dict[str, Any]):
+@pytest.mark.parametrize('array_schema', _PREFIX_ITEMS_SCHEMAS)
+def test_transformer_prefix_items_explicit_strict_raises(array_schema: dict[str, Any]):
     """Explicit `strict=True` raises a clear error instead of letting OpenAI reject with a 400."""
     schema: dict[str, Any] = {
         'type': 'object',
         'properties': {'value': array_schema},
         'required': ['value'],
     }
-    with pytest.raises(UserError, match='OpenAI strict mode does not support `prefixItems`'):
+    with pytest.raises(UserError, match='OpenAI strict mode does not support tuple types'):
         OpenAIJsonSchemaTransformer(schema, strict=True).walk()
-
-
-def test_transformer_named_tuple_with_defaults_rewritten_for_strict_mode():
-    """A `NamedTuple` with defaults emits `maxItems` without `minItems` and still rewrites."""
-
-    class Point(NamedTuple):
-        x: int = 0
-        y: int = 0
-
-    class Model(BaseModel):
-        point: Point
-
-    result = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=True).walk()
-
-    assert result['$defs']['Point'] == {'type': 'array', 'items': {'type': 'integer'}, 'maxItems': 2}
-
-
-def test_transformer_mixed_type_literal_tuple_not_strict_compatible():
-    """`Literal[True, 'x']` and `Literal[1, 'x']` differ only by `True` vs `1` (equal in Python,
-    distinct in JSON), and must not be collapsed into one element schema."""
-
-    class Model(BaseModel):
-        pair: tuple[Literal[True, 'x'], Literal[1, 'x']]
-
-    transformer = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=None)
-    result = transformer.walk()
-
-    assert result['properties']['pair']['prefixItems'] == [{'enum': [True, 'x']}, {'enum': [1, 'x']}]
-    assert transformer.is_strict_compatible is False
-
-
-def test_transformer_empty_prefix_items_dropped():
-    """An empty `prefixItems` constrains nothing and is dropped."""
-    schema: dict[str, Any] = {
-        'type': 'object',
-        'properties': {'value': {'type': 'array', 'prefixItems': [], 'items': {'type': 'string'}}},
-        'required': ['value'],
-    }
-    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
-    result = transformer.walk()
-
-    assert result['properties']['value'] == {'type': 'array', 'items': {'type': 'string'}}
-    assert transformer.is_strict_compatible is True
-
-
-def test_transformer_prefix_items_key_order_insensitive():
-    """Element schemas that differ only in key order are the same schema and must still collapse."""
-    schema: dict[str, Any] = {
-        'type': 'object',
-        'properties': {
-            'value': {
-                'type': 'array',
-                'prefixItems': [{'type': 'string', 'description': 'x'}, {'description': 'x', 'type': 'string'}],
-                'minItems': 2,
-                'maxItems': 2,
-            }
-        },
-        'required': ['value'],
-    }
-    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
-    result = transformer.walk()
-
-    assert result['properties']['value'] == {
-        'type': 'array',
-        'items': {'type': 'string', 'description': 'x'},
-        'minItems': 2,
-        'maxItems': 2,
-    }
-    assert transformer.is_strict_compatible is True
 
 
 def test_transformer_prefix_items_untouched_when_not_strict():

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -6281,6 +6281,14 @@ _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
         },
         id='mismatch-after-first-pair',
     ),
+]
+
+_CONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
+    pytest.param(
+        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}], 'minItems': 2, 'maxItems': 2},
+        {'type': 'array', 'items': {'type': 'integer'}, 'minItems': 2, 'maxItems': 2},
+        id='plain-homogeneous',
+    ),
     pytest.param(
         {
             'type': 'array',
@@ -6289,9 +6297,27 @@ _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
             'minItems': 1,
             'maxItems': 1,
         },
-        id='prefix-items-plus-items',
+        {'type': 'array', 'items': {'type': 'integer'}, 'minItems': 1, 'maxItems': 1},
+        id='prefix-items-plus-unreachable-items',
     ),
 ]
+
+
+@pytest.mark.parametrize('array_schema,expected', _CONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
+def test_transformer_convertible_prefix_items_rewritten(array_schema: dict[str, Any], expected: dict[str, Any]):
+    """A homogeneous length-capped tuple rewrites to `items` + bounds. Any pre-existing `items`
+    only governs elements past the prefix, which `maxItems` makes unreachable, so it can't block
+    the rewrite."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': array_schema},
+        'required': ['value'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == expected
+    assert transformer.is_strict_compatible is True
 
 
 @pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -2950,10 +2950,6 @@ def tool_with_heterogeneous_tuple(x: tuple[int, str]) -> str:
     return f'{x}'  # pragma: no cover
 
 
-def tool_with_length_constraints(x: Annotated[str, Field(min_length=2, max_length=10)]) -> str:
-    return x  # pragma: no cover
-
-
 @pytest.mark.parametrize(
     'tool,tool_strict,expected_params,expected_strict',
     [
@@ -3060,7 +3056,7 @@ def tool_with_length_constraints(x: Annotated[str, Field(min_length=2, max_lengt
             snapshot(
                 {
                     'additionalProperties': False,
-                    'properties': {'x': {'minLength': 1, 'type': 'string', 'description': 'format=uri'}},
+                    'properties': {'x': {'type': 'string', 'description': 'minLength=1, format=uri'}},
                     'required': ['x'],
                     'type': 'object',
                 }
@@ -3496,19 +3492,6 @@ def tool_with_length_constraints(x: Annotated[str, Field(min_length=2, max_lengt
                 }
             ),
             snapshot(None),
-        ),
-        (
-            tool_with_length_constraints,
-            None,
-            snapshot(
-                {
-                    'additionalProperties': False,
-                    'properties': {'x': {'maxLength': 10, 'minLength': 2, 'type': 'string'}},
-                    'required': ['x'],
-                    'type': 'object',
-                }
-            ),
-            snapshot(True),
         ),
         # (tool, None, snapshot({}), snapshot({})),
         # (tool, True, snapshot({}), snapshot({})),
@@ -6389,7 +6372,7 @@ def test_transformer_prefix_items_key_order_insensitive():
         'properties': {
             'value': {
                 'type': 'array',
-                'prefixItems': [{'type': 'string', 'maxLength': 3}, {'maxLength': 3, 'type': 'string'}],
+                'prefixItems': [{'type': 'string', 'description': 'x'}, {'description': 'x', 'type': 'string'}],
                 'minItems': 2,
                 'maxItems': 2,
             }
@@ -6401,7 +6384,7 @@ def test_transformer_prefix_items_key_order_insensitive():
 
     assert result['properties']['value'] == {
         'type': 'array',
-        'items': {'type': 'string', 'maxLength': 3},
+        'items': {'type': 'string', 'description': 'x'},
         'minItems': 2,
         'maxItems': 2,
     }

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -6263,47 +6263,6 @@ def test_transformer_untyped_array_explicit_strict_raises():
         OpenAIJsonSchemaTransformer(schema, strict=True).walk()
 
 
-def test_transformer_length_constraints_strict_compatible():
-    """OpenAI strict mode accepts `minLength`/`maxLength`, so they must be kept and must not
-    downgrade the schema to non-strict.
-    See https://github.com/pydantic/pydantic-ai/issues/7315
-    """
-    schema: dict[str, Any] = {
-        'type': 'object',
-        'properties': {'value': {'type': 'string', 'minLength': 2, 'maxLength': 10}},
-        'required': ['value'],
-    }
-    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
-    result = transformer.walk()
-
-    assert result['properties']['value'] == {'type': 'string', 'minLength': 2, 'maxLength': 10}
-    assert transformer.is_strict_compatible is True
-
-
-@pytest.mark.parametrize('strict', [None, True])
-def test_transformer_homogeneous_tuple_rewritten_for_strict_mode(strict: bool | None):
-    """OpenAI strict mode rejects `prefixItems`, but a fixed-length homogeneous tuple like
-    `tuple[int, int]` means the same as a length-bounded `list[int]`, so it's rewritten to the
-    supported `items` + `minItems`/`maxItems` form and stays strict-compatible.
-    See https://github.com/pydantic/pydantic-ai/issues/7315
-    """
-
-    class Model(BaseModel):
-        bbox: tuple[int, int, int, int]
-
-    transformer = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=strict)
-    result = transformer.walk()
-
-    assert result['properties']['bbox'] == {
-        'type': 'array',
-        'items': {'type': 'integer'},
-        'minItems': 4,
-        'maxItems': 4,
-    }
-    if strict is None:
-        assert transformer.is_strict_compatible is True
-
-
 _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
     pytest.param(
         {
@@ -6354,12 +6313,8 @@ _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
 
 @pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
 def test_transformer_unconvertible_prefix_items_not_strict_compatible(array_schema: dict[str, Any]):
-    """A `prefixItems` schema that can't be rewritten to a plain typed array (a heterogeneous
-    tuple, missing length bounds, or `items` alongside `prefixItems`) has no strict-mode
-    representation, so with `strict=None` the schema must be inferred non-strict rather than
-    rejected by the API.
-    See https://github.com/pydantic/pydantic-ai/issues/7315
-    """
+    """An unconvertible `prefixItems` schema has no strict-mode representation, so `strict=None`
+    must infer non-strict. See https://github.com/pydantic/pydantic-ai/issues/7315"""
     schema: dict[str, Any] = {
         'type': 'object',
         'properties': {'value': array_schema},
@@ -6374,9 +6329,7 @@ def test_transformer_unconvertible_prefix_items_not_strict_compatible(array_sche
 
 @pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
 def test_transformer_unconvertible_prefix_items_explicit_strict_raises(array_schema: dict[str, Any]):
-    """With `strict=True` explicitly requested, an unconvertible `prefixItems` schema can't be
-    repaired without changing its meaning, so we raise a clear error instead of letting OpenAI
-    reject the request with an opaque 400."""
+    """Explicit `strict=True` raises a clear error instead of letting OpenAI reject with a 400."""
     schema: dict[str, Any] = {
         'type': 'object',
         'properties': {'value': array_schema},
@@ -6387,9 +6340,7 @@ def test_transformer_unconvertible_prefix_items_explicit_strict_raises(array_sch
 
 
 def test_transformer_named_tuple_with_defaults_rewritten_for_strict_mode():
-    """A `NamedTuple` with defaults emits `maxItems` but no matching `minItems`. Once the child
-    transform strips per-element `title` and (under explicit strict) `default`, the elements all
-    share one schema, so the tuple is still rewritten to the length-bounded `items` form."""
+    """A `NamedTuple` with defaults emits `maxItems` without `minItems` and still rewrites."""
 
     class Point(NamedTuple):
         x: int = 0
@@ -6404,9 +6355,8 @@ def test_transformer_named_tuple_with_defaults_rewritten_for_strict_mode():
 
 
 def test_transformer_mixed_type_literal_tuple_not_strict_compatible():
-    """Mixed-type Literals emit `enum` without `type`, so `Literal[True, 'x']` and `Literal[1, 'x']`
-    differ only by `True` vs `1`. Canonical JSON comparison must keep them distinct (Python `==`
-    treats `True == 1`) so the tuple is not collapsed into a single wrong element schema."""
+    """`Literal[True, 'x']` and `Literal[1, 'x']` differ only by `True` vs `1` (equal in Python,
+    distinct in JSON), and must not be collapsed into one element schema."""
 
     class Model(BaseModel):
         pair: tuple[Literal[True, 'x'], Literal[1, 'x']]
@@ -6419,8 +6369,7 @@ def test_transformer_mixed_type_literal_tuple_not_strict_compatible():
 
 
 def test_transformer_empty_prefix_items_dropped():
-    """An empty `prefixItems` constrains nothing, so the unsupported keyword is dropped and a
-    typed `items` keeps the schema strict-compatible."""
+    """An empty `prefixItems` constrains nothing and is dropped."""
     schema: dict[str, Any] = {
         'type': 'object',
         'properties': {'value': {'type': 'array', 'prefixItems': [], 'items': {'type': 'string'}}},

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal, NamedTuple, cast
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -2942,6 +2942,18 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
     return f'{x} {y}'  # pragma: no cover
 
 
+def tool_with_fixed_tuple(x: tuple[int, int]) -> str:
+    return f'{x}'  # pragma: no cover
+
+
+def tool_with_heterogeneous_tuple(x: tuple[int, str]) -> str:
+    return f'{x}'  # pragma: no cover
+
+
+def tool_with_length_constraints(x: Annotated[str, Field(min_length=2, max_length=10)]) -> str:
+    return x  # pragma: no cover
+
+
 @pytest.mark.parametrize(
     'tool,tool_strict,expected_params,expected_strict',
     [
@@ -3048,7 +3060,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
             snapshot(
                 {
                     'additionalProperties': False,
-                    'properties': {'x': {'type': 'string', 'description': 'minLength=1, format=uri'}},
+                    'properties': {'x': {'minLength': 1, 'type': 'string', 'description': 'format=uri'}},
                     'required': ['x'],
                     'type': 'object',
                 }
@@ -3419,12 +3431,12 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
+                        'x': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                         'y': {
                             'default': ['abc'],
+                            'items': {'type': 'string'},
                             'maxItems': 1,
                             'minItems': 1,
-                            'prefixItems': [{'type': 'string'}],
                             'type': 'array',
                         },
                     },
@@ -3441,10 +3453,58 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
-                        'y': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'string'}], 'type': 'array'},
+                        'x': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
+                        'y': {'items': {'type': 'string'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                     },
                     'required': ['x', 'y'],
+                    'type': 'object',
+                }
+            ),
+            snapshot(True),
+        ),
+        (
+            tool_with_fixed_tuple,
+            None,
+            snapshot(
+                {
+                    'additionalProperties': False,
+                    'properties': {
+                        'x': {'items': {'type': 'integer'}, 'maxItems': 2, 'minItems': 2, 'type': 'array'},
+                    },
+                    'required': ['x'],
+                    'type': 'object',
+                }
+            ),
+            snapshot(True),
+        ),
+        (
+            tool_with_heterogeneous_tuple,
+            None,
+            snapshot(
+                {
+                    'additionalProperties': False,
+                    'properties': {
+                        'x': {
+                            'maxItems': 2,
+                            'minItems': 2,
+                            'prefixItems': [{'type': 'integer'}, {'type': 'string'}],
+                            'type': 'array',
+                        },
+                    },
+                    'required': ['x'],
+                    'type': 'object',
+                }
+            ),
+            snapshot(None),
+        ),
+        (
+            tool_with_length_constraints,
+            None,
+            snapshot(
+                {
+                    'additionalProperties': False,
+                    'properties': {'x': {'maxLength': 10, 'minLength': 2, 'type': 'string'}},
+                    'required': ['x'],
                     'type': 'object',
                 }
             ),
@@ -3538,9 +3598,9 @@ def test_strict_schema():
                         },
                         'my_recursive': {'anyOf': [{'$ref': '#'}, {'type': 'null'}]},
                         'my_tuple': {
+                            'items': {'type': 'integer'},
                             'maxItems': 1,
                             'minItems': 1,
-                            'prefixItems': [{'type': 'integer'}],
                             'type': 'array',
                         },
                     },
@@ -3557,7 +3617,7 @@ def test_strict_schema():
                     'properties': {},
                     'required': [],
                 },
-                'my_tuple': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
+                'my_tuple': {'items': {'type': 'integer'}, 'maxItems': 1, 'minItems': 1, 'type': 'array'},
                 'my_list': {'items': {'type': 'number'}, 'type': 'array'},
                 'my_discriminated_union': {'anyOf': [{'$ref': '#/$defs/Apple'}, {'$ref': '#/$defs/Banana'}]},
             },
@@ -6201,6 +6261,215 @@ def test_transformer_untyped_array_explicit_strict_raises():
     }
     with pytest.raises(UserError, match='OpenAI strict mode requires array items to have a type'):
         OpenAIJsonSchemaTransformer(schema, strict=True).walk()
+
+
+def test_transformer_length_constraints_strict_compatible():
+    """OpenAI strict mode accepts `minLength`/`maxLength`, so they must be kept and must not
+    downgrade the schema to non-strict.
+    See https://github.com/pydantic/pydantic-ai/issues/7315
+    """
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': {'type': 'string', 'minLength': 2, 'maxLength': 10}},
+        'required': ['value'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == {'type': 'string', 'minLength': 2, 'maxLength': 10}
+    assert transformer.is_strict_compatible is True
+
+
+@pytest.mark.parametrize('strict', [None, True])
+def test_transformer_homogeneous_tuple_rewritten_for_strict_mode(strict: bool | None):
+    """OpenAI strict mode rejects `prefixItems`, but a fixed-length homogeneous tuple like
+    `tuple[int, int]` means the same as a length-bounded `list[int]`, so it's rewritten to the
+    supported `items` + `minItems`/`maxItems` form and stays strict-compatible.
+    See https://github.com/pydantic/pydantic-ai/issues/7315
+    """
+
+    class Model(BaseModel):
+        bbox: tuple[int, int, int, int]
+
+    transformer = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=strict)
+    result = transformer.walk()
+
+    assert result['properties']['bbox'] == {
+        'type': 'array',
+        'items': {'type': 'integer'},
+        'minItems': 4,
+        'maxItems': 4,
+    }
+    if strict is None:
+        assert transformer.is_strict_compatible is True
+
+
+_UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS = [
+    pytest.param(
+        {
+            'type': 'array',
+            'prefixItems': [{'type': 'integer'}, {'type': 'string'}],
+            'minItems': 2,
+            'maxItems': 2,
+        },
+        id='heterogeneous',
+    ),
+    pytest.param(
+        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}]},
+        id='no-length-bounds',
+    ),
+    pytest.param(
+        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}], 'minItems': 2},
+        id='min-items-only',
+    ),
+    pytest.param(
+        {'type': 'array', 'prefixItems': [{'type': 'integer'}, {'type': 'integer'}], 'maxItems': 3},
+        id='max-items-mismatch',
+    ),
+    pytest.param(
+        {'type': 'array', 'prefixItems': [{'const': True}, {'const': 1}], 'minItems': 2, 'maxItems': 2},
+        id='bool-vs-int-const',
+    ),
+    pytest.param(
+        {
+            'type': 'array',
+            'prefixItems': [{'type': 'integer'}, {'type': 'integer'}, {'type': 'string'}],
+            'minItems': 3,
+            'maxItems': 3,
+        },
+        id='mismatch-after-first-pair',
+    ),
+    pytest.param(
+        {
+            'type': 'array',
+            'prefixItems': [{'type': 'integer'}],
+            'items': {'type': 'string'},
+            'minItems': 1,
+            'maxItems': 1,
+        },
+        id='prefix-items-plus-items',
+    ),
+]
+
+
+@pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
+def test_transformer_unconvertible_prefix_items_not_strict_compatible(array_schema: dict[str, Any]):
+    """A `prefixItems` schema that can't be rewritten to a plain typed array (a heterogeneous
+    tuple, missing length bounds, or `items` alongside `prefixItems`) has no strict-mode
+    representation, so with `strict=None` the schema must be inferred non-strict rather than
+    rejected by the API.
+    See https://github.com/pydantic/pydantic-ai/issues/7315
+    """
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': array_schema},
+        'required': ['value'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value']['prefixItems'] == array_schema['prefixItems']
+    assert transformer.is_strict_compatible is False
+
+
+@pytest.mark.parametrize('array_schema', _UNCONVERTIBLE_PREFIX_ITEMS_SCHEMAS)
+def test_transformer_unconvertible_prefix_items_explicit_strict_raises(array_schema: dict[str, Any]):
+    """With `strict=True` explicitly requested, an unconvertible `prefixItems` schema can't be
+    repaired without changing its meaning, so we raise a clear error instead of letting OpenAI
+    reject the request with an opaque 400."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': array_schema},
+        'required': ['value'],
+    }
+    with pytest.raises(UserError, match='OpenAI strict mode does not support `prefixItems`'):
+        OpenAIJsonSchemaTransformer(schema, strict=True).walk()
+
+
+def test_transformer_named_tuple_with_defaults_rewritten_for_strict_mode():
+    """A `NamedTuple` with defaults emits `maxItems` but no matching `minItems`. Once the child
+    transform strips per-element `title` and (under explicit strict) `default`, the elements all
+    share one schema, so the tuple is still rewritten to the length-bounded `items` form."""
+
+    class Point(NamedTuple):
+        x: int = 0
+        y: int = 0
+
+    class Model(BaseModel):
+        point: Point
+
+    result = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=True).walk()
+
+    assert result['$defs']['Point'] == {'type': 'array', 'items': {'type': 'integer'}, 'maxItems': 2}
+
+
+def test_transformer_mixed_type_literal_tuple_not_strict_compatible():
+    """Mixed-type Literals emit `enum` without `type`, so `Literal[True, 'x']` and `Literal[1, 'x']`
+    differ only by `True` vs `1`. Canonical JSON comparison must keep them distinct (Python `==`
+    treats `True == 1`) so the tuple is not collapsed into a single wrong element schema."""
+
+    class Model(BaseModel):
+        pair: tuple[Literal[True, 'x'], Literal[1, 'x']]
+
+    transformer = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['pair']['prefixItems'] == [{'enum': [True, 'x']}, {'enum': [1, 'x']}]
+    assert transformer.is_strict_compatible is False
+
+
+def test_transformer_empty_prefix_items_dropped():
+    """An empty `prefixItems` constrains nothing, so the unsupported keyword is dropped and a
+    typed `items` keeps the schema strict-compatible."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': {'type': 'array', 'prefixItems': [], 'items': {'type': 'string'}}},
+        'required': ['value'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == {'type': 'array', 'items': {'type': 'string'}}
+    assert transformer.is_strict_compatible is True
+
+
+def test_transformer_prefix_items_key_order_insensitive():
+    """Element schemas that differ only in key order are the same schema and must still collapse."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {
+            'value': {
+                'type': 'array',
+                'prefixItems': [{'type': 'string', 'maxLength': 3}, {'maxLength': 3, 'type': 'string'}],
+                'minItems': 2,
+                'maxItems': 2,
+            }
+        },
+        'required': ['value'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == {
+        'type': 'array',
+        'items': {'type': 'string', 'maxLength': 3},
+        'minItems': 2,
+        'maxItems': 2,
+    }
+    assert transformer.is_strict_compatible is True
+
+
+def test_transformer_prefix_items_untouched_when_not_strict():
+    """With `strict=False` there's nothing to repair, so tuple schemas are passed through as-is."""
+
+    class Model(BaseModel):
+        pair: tuple[int, str]
+        bbox: tuple[int, int]
+
+    result = OpenAIJsonSchemaTransformer(Model.model_json_schema(), strict=False).walk()
+
+    assert result['properties']['pair']['prefixItems'] == [{'type': 'integer'}, {'type': 'string'}]
+    assert result['properties']['bbox']['prefixItems'] == [{'type': 'integer'}, {'type': 'integer'}]
 
 
 def chunk_with_usage(


### PR DESCRIPTION
- Part of #7315 (the `prefixItems` half; the `minLength`/`maxLength` half moves to a follow-up PR with an opt-in flag, per maintainer discussion)

**The bug.** `OpenAIJsonSchemaTransformer` assumes `prefixItems` (tuple fields) satisfies strict mode's element-typing requirement. It does not: the API ignores the keyword entirely, then rejects the array as untyped. Live-probed:

```python
class WithTuple(BaseModel):
    bbox: tuple[int, int, int, int]
```

is inferred strict-compatible, sent with `strict: true`, and every request fails: 400 `array schema missing items`.

**The fix.** `prefixItems` is treated as strict-incompatible, period — the schema is never mutated:

- `strict=None` (inference): any non-empty `prefixItems` marks the schema not strict-compatible, so the tool falls back to non-strict and the request succeeds.
- Explicit `strict=True`: raises `UserError` instead of an opaque 400, following the #4425 untyped-array precedent.
- Explicit `strict=False`: passed through untouched.

**Why raise instead of degrading?** Keywords like `minLength` degrade gracefully under explicit `strict=True` (popped into the description): removing them only loosens validation — the schema still describes the same data. `prefixItems` is structural: it *is* the element typing for each tuple position. Removing it leaves exactly the untyped array strict mode rejects (and where an `items` sibling exists, silently changes which elements `items` governs). With no safe degraded form and silently ignoring an explicit `strict=True` off the table, a clear error is the only honest option — same conclusion #4425 reached for untyped arrays.

An earlier revision rewrote homogeneous length-capped tuples (`tuple[int, int]`) into the equivalent `items` + `minItems`/`maxItems` form to keep them strict-eligible, but the rewrite kept accumulating correctness edge cases (heterogeneous elements, missing bounds, `True`-vs-`1` element equality, `items` siblings). Dropped in favor of the simple rule above; such tuples now run non-strict, which is safe. The rewrite can be revisited later as a pure optimization if wanted.

No public API changes; no change to `minLength`/`maxLength` handling.

Credit to @uuzzrm, whose auto-closed #7330 validated the same direction; the commit is co-authored.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
