### PR TITLE
Raise `UserError` when a tool returns a non-JSON-serializable value

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Itera
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 
+from pydantic_core import PydanticSerializationError
 from typing_extensions import TypeVar, assert_never
 
 from pydantic_ai._utils import cancel_and_drain
@@ -657,6 +658,16 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
                 '`ToolReturn.tools` must be a list of tool names; pass a list of strings instead of a bare '
                 'string, non-sequence value, or non-string elements.'
             )
+
+        # Reject non-JSON-serializable return values here, before they enter message history:
+        # once stored, they crash later — and without the tool's name — in model request mapping,
+        # usage estimation, and history serialization.
+        try:
+            _messages.tool_return_ta.dump_json(tool_return.return_value, by_alias=True)
+        except PydanticSerializationError as e:
+            raise exceptions.UserError(
+                f'The return value of tool {call.tool_name!r} is not JSON-serializable: {e}'
+            ) from e
 
         # If the called tool's `ToolDefinition.tool_kind` declares a registered typed subclass
         # (e.g. `'tool-search'`), promote the return part to that subclass. This keeps the

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -141,6 +141,24 @@ def _prune_duplicate_tool_reveals(
                 break
 
 
+def _validated_return_value(tool_name: str, return_value: Any) -> Any:
+    """Materialize one-shot iterators and reject non-JSON-serializable tool return values.
+
+    One-shot iterators (generators, `map`/`filter` objects) are exhausted by their first
+    serialization — the probe here, or history re-serialization on a later request — leaving `[]`
+    for every consumer after it, so they are materialized first. Non-serializable values are
+    rejected before they enter message history: once stored, they crash later — and without the
+    tool's name — in model request mapping, usage estimation, and history serialization.
+    """
+    if isinstance(return_value, Iterator):
+        return_value = list(cast(Iterator[Any], return_value))
+    try:
+        _messages.tool_return_ta.dump_json(return_value, by_alias=True)
+    except PydanticSerializationError as e:
+        raise exceptions.UserError(f'The return value of tool {tool_name!r} is not JSON-serializable: {e}') from e
+    return return_value
+
+
 def _segment_by_barriers(indices: list[int], *, is_barrier: Callable[[int], bool]) -> list[list[int]]:
     """Split `indices` into execution segments around barrier tools.
 
@@ -659,15 +677,7 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
                 'string, non-sequence value, or non-string elements.'
             )
 
-        # Reject non-JSON-serializable return values here, before they enter message history:
-        # once stored, they crash later — and without the tool's name — in model request mapping,
-        # usage estimation, and history serialization.
-        try:
-            _messages.tool_return_ta.dump_json(tool_return.return_value, by_alias=True)
-        except PydanticSerializationError as e:
-            raise exceptions.UserError(
-                f'The return value of tool {call.tool_name!r} is not JSON-serializable: {e}'
-            ) from e
+        return_value = _validated_return_value(call.tool_name, tool_return.return_value)
 
         # If the called tool's `ToolDefinition.tool_kind` declares a registered typed subclass
         # (e.g. `'tool-search'`), promote the return part to that subclass. This keeps the
@@ -677,7 +687,7 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         return_part = _messages.ToolReturnPart(
             tool_name=call.tool_name,
             tool_call_id=call.tool_call_id,
-            content=tool_return.return_value,
+            content=return_value,
             metadata=tool_return.metadata,
             tool_kind=tool_def.tool_kind if tool_def else None,
         )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9340,6 +9340,30 @@ def test_tool_returning_unserializable_value():
         agent.run_sync('go')
 
 
+def test_tool_returning_iterator_is_materialized():
+    """A one-shot iterator return value is materialized so serialization doesn't consume it.
+
+    Without materialization, the first serialization of the part exhausts the iterator and every
+    later consumer — including history serialization for the next model request — sees `[]`.
+    """
+    agent = Agent('test')
+
+    @agent.tool_plain
+    def gen() -> Any:
+        return (x for x in [1, 2, 3])
+
+    result = agent.run_sync('go')
+    assert result.output == snapshot('{"gen":[1,2,3]}')
+
+    tool_returns = [
+        part.content
+        for message in result.all_messages()
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert tool_returns == snapshot([[1, 2, 3]])
+
+
 def test_override_toolsets():
     foo_toolset = FunctionToolset()
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9312,6 +9312,34 @@ def test_many_multimodal_tool_response():
         agent.run_sync('Please analyze the data')
 
 
+def test_tool_returning_unserializable_value():
+    """A non-JSON-serializable return value fails at the tool seam, naming the tool, before entering message history.
+
+    Without the check it would poison the history and crash later — without the tool's name — in
+    model request mapping, usage estimation, or history serialization.
+    """
+
+    def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('get_data', {})])
+        else:  # pragma: no cover
+            return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(llm))
+
+    @agent.tool_plain
+    def get_data() -> Any:
+        return dict  # a class, which pydantic-core cannot serialize
+
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            "The return value of tool 'get_data' is not JSON-serializable: Unable to serialize unknown type: <class 'type'>"
+        ),
+    ):
+        agent.run_sync('go')
+
+
 def test_override_toolsets():
     foo_toolset = FunctionToolset()
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9356,10 +9356,7 @@ def test_tool_returning_iterator_is_materialized():
     assert result.output == snapshot('{"gen":[1,2,3]}')
 
     tool_returns = [
-        part.content
-        for message in result.all_messages()
-        for part in message.parts
-        if isinstance(part, ToolReturnPart)
+        part.content for message in result.all_messages() for part in message.parts if isinstance(part, ToolReturnPart)
     ]
     assert tool_returns == snapshot([[1, 2, 3]])
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -872,7 +872,9 @@ def test_return_unknown():
         def return_pydantic_model() -> Foobar:
             return Foobar()
 
-    with pytest.raises(PydanticSerializationError, match='Unable to serialize unknown type:'):
+    with pytest.raises(
+        UserError, match=re.escape("The return value of tool 'return_pydantic_model' is not JSON-serializable:")
+    ):
         agent.run_sync('')
 
 


### PR DESCRIPTION
- Closes #7335

When a tool returns a value `pydantic-core` cannot serialize (a class, function, exception instance, ...), the poisoned part enters message history and the run only crashes on the *next* model request — in provider request mapping, usage estimation, or history serialization — with a `PydanticSerializationError` that names neither the tool nor the value. It also breaks `all_messages_json()` and durable-execution payloads after the fact.

This PR probes serializability at the tool-execution seam and raises `UserError` naming the tool before the `ToolReturnPart` is built, mirroring the existing `UserError` for nested `ToolReturn` values there. `test_return_unknown` previously pinned the raw late `PydanticSerializationError` and now pins the named early error.

Notes for review:

- This makes the de facto `ToolReturnPart.content` contract ("pydantic-core-serializable") explicit at the seam. A custom `Model` that deliberately passed live Python objects through `content` would now fail early instead of working — flagging for maintainer judgment.
- Cost is one extra `dump_json` per tool return; if that's a concern, the dumped payload could be memoized on the part and reused by `model_response_str()` in a follow-up.
- The model-*authored* variant (CodeMode's final expression evaluating to a non-serializable object) is handled harness-side as `ModelRetry`: pydantic/pydantic-ai-harness#405, pydantic/pydantic-ai-harness#530.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

