### PR TITLE
Use the Pydantic AI Gateway's reported cost for `RequestUsage.cost`

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -431,7 +431,7 @@ _(This example is complete, it can be run "as is" — you'll need to add `asynci
 
 You can retrieve usage statistics (tokens, requests, etc.) at any time from the [`AgentRun`][pydantic_ai.agent.AgentRun] object via `agent_run.usage`. This property returns a [`RunUsage`][pydantic_ai.usage.RunUsage] object containing the usage data.
 
-[`RunUsage.cost`][pydantic_ai.usage.RunUsage.cost] additionally holds a best-effort estimate of the run's total cost in USD, calculated from each request's usage with [genai-prices](https://github.com/pydantic/genai-prices). Requests to models or providers that genai-prices doesn't have pricing data for don't contribute to the total.
+[`RunUsage.cost`][pydantic_ai.usage.RunUsage.cost] additionally holds a best-effort estimate of the run's total cost in USD, calculated from each request's usage with [genai-prices](https://github.com/pydantic/genai-prices). Requests to models or providers that genai-prices doesn't have pricing data for don't contribute to the total. Most requests made through the [Pydantic AI Gateway](gateway.md) use the cost the gateway itself reported for the request, which takes precedence over the genai-prices estimate and also covers custom providers genai-prices can't price — see [request cost](gateway.md#request-cost) for coverage.
 
 Once the run finishes, `agent_run.result` becomes an [`AgentRunResult`][pydantic_ai.agent.AgentRunResult] object containing the final output (and related metadata).
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -150,6 +150,10 @@ The first known use of "hello, world" was in a 1974 textbook about the C program
 """
 ```
 
+#### Request cost
+
+The gateway includes its cost estimate for each non-streaming request in the response, and Pydantic AI surfaces it as [`RequestUsage.cost`][pydantic_ai.usage.RequestUsage.cost] (summed into [`RunUsage.cost`][pydantic_ai.usage.RunUsage.cost]). The gateway-reported cost takes precedence over the client-side [genai-prices](https://github.com/pydantic/genai-prices) estimate, so [`cost_limit`][pydantic_ai.usage.UsageLimits.cost_limit] and your own cost tracking use the number the gateway meters — including for custom providers genai-prices can't price. Streamed, Bedrock Converse, and Google requests fall back to the genai-prices estimate.
+
 ### Claude Code
 
 Before you start, log out of Claude Code using `/logout`.

--- a/pydantic_ai_slim/pydantic_ai/_cost.py
+++ b/pydantic_ai_slim/pydantic_ai/_cost.py
@@ -89,9 +89,9 @@ def best_effort_price(
 def fill_response_cost(response: ModelResponse) -> None:
     """Fill `response.usage.cost` with a best-effort price if it's still unset.
 
-    An already-set cost is never overwritten, so a provider-reported cost could take precedence in future; no model
-    sets one today. If pricing data is unavailable the cost stays `None`, distinguishing "unknown" from a genuine
-    zero cost.
+    An already-set cost is never overwritten; this is how the Pydantic AI Gateway's reported cost, set at usage
+    extraction time, takes precedence over the estimate. If pricing data is unavailable the cost stays `None`,
+    distinguishing "unknown" from a genuine zero cost.
     """
     if (
         response.usage.cost is None

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -466,13 +466,16 @@ def open_model_request_span(
 
                 # Compute cost before the `is_recording()` gate so `_record_metrics`
                 # always emits cost data, even when the span is dropped by sampling.
-                price_calculation = best_effort_price(
-                    response.usage,
-                    model_name=response.model_name,
-                    provider_api_url=response.provider_url,
-                    provider_name=response.provider_name,
-                    genai_request_timestamp=response.timestamp,
-                )
+                # A cost already on the usage (e.g. reported by the Pydantic AI Gateway) wins
+                # over the genai-prices estimate, mirroring `fill_response_cost`.
+                if response.usage.cost is None:
+                    price_calculation = best_effort_price(
+                        response.usage,
+                        model_name=response.model_name,
+                        provider_api_url=response.provider_url,
+                        provider_name=response.provider_name,
+                        genai_request_timestamp=response.timestamp,
+                    )
 
                 if not span.is_recording():
                     return
@@ -489,8 +492,11 @@ def open_model_request_span(
                     **response.usage.opentelemetry_attributes(),
                     'gen_ai.response.model': response_model,
                 }
-                if price_calculation is not None:
-                    attributes_to_set['operation.cost'] = float(price_calculation.total_price)
+                cost = response.usage.cost
+                if cost is None and price_calculation is not None:
+                    cost = price_calculation.total_price
+                if cost is not None:
+                    attributes_to_set['operation.cost'] = float(cost)
                 if response.provider_response_id is not None:
                     attributes_to_set['gen_ai.response.id'] = response.provider_response_id
                 if response.finish_reason is not None:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/instrumented.py
@@ -27,6 +27,24 @@ __all__ = 'instrument_embedding_model', 'InstrumentedEmbeddingModel'
 GEN_AI_PROVIDER_NAME_ATTRIBUTE = 'gen_ai.provider.name'
 
 
+def _resolve_cost(result: EmbeddingResult) -> float | None:
+    """Cost of the request for telemetry.
+
+    A cost already on the usage (e.g. reported by the Pydantic AI Gateway) wins over the
+    genai-prices estimate, mirroring the model instrumentation.
+    """
+    if result.usage.cost is not None:
+        return float(result.usage.cost)
+    try:
+        return float(result.cost().total_price)
+    except LookupError:
+        # The cost of this provider/model is unknown, which is common.
+        return None
+    except Exception as e:  # pragma: no cover
+        warnings.warn(f'Failed to get cost from response: {type(e).__name__}: {e}', CostCalculationFailedWarning)
+        return None
+
+
 def instrument_embedding_model(model: EmbeddingModel, instrument: InstrumentationSettings | bool) -> EmbeddingModel:
     """Instrument an embedding model with OpenTelemetry/logfire."""
     if instrument and not isinstance(model, InstrumentedEmbeddingModel):
@@ -116,7 +134,7 @@ class InstrumentedEmbeddingModel(WrapperEmbeddingModel):
                     provider_name = attributes[GEN_AI_PROVIDER_NAME_ATTRIBUTE]
                     request_model = attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]
                     response_model = result.model_name or request_model
-                    price_calculation = None
+                    cost = _resolve_cost(result)
 
                     def _record_metrics():
                         metric_attributes = {
@@ -132,24 +150,11 @@ class InstrumentedEmbeddingModel(WrapperEmbeddingModel):
                         tokens = result.usage.input_tokens or 0
                         if tokens:  # pragma: no branch
                             self.instrumentation_settings.tokens_histogram.record(tokens, token_attributes)
-                            if price_calculation is not None:
-                                self.instrumentation_settings.cost_histogram.record(
-                                    float(price_calculation.total_price),
-                                    metric_attributes,
-                                )
+                            if cost is not None:
+                                self.instrumentation_settings.cost_histogram.record(cost, metric_attributes)
 
                     nonlocal record_metrics
                     record_metrics = _record_metrics
-
-                    try:
-                        price_calculation = result.cost()
-                    except LookupError:
-                        # The cost of this provider/model is unknown, which is common.
-                        pass
-                    except Exception as e:  # pragma: no cover
-                        warnings.warn(
-                            f'Failed to get cost from response: {type(e).__name__}: {e}', CostCalculationFailedWarning
-                        )
 
                     if not span.is_recording():
                         return  # pragma: lax no cover
@@ -159,8 +164,8 @@ class InstrumentedEmbeddingModel(WrapperEmbeddingModel):
                         'gen_ai.response.model': response_model,
                     }
 
-                    if price_calculation:
-                        attributes_to_set['operation.cost'] = float(price_calculation.total_price)
+                    if cost is not None:
+                        attributes_to_set['operation.cost'] = cost
 
                     embeddings = result.embeddings
                     if embeddings:  # pragma: no branch

--- a/pydantic_ai_slim/pydantic_ai/embeddings/result.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/result.py
@@ -101,9 +101,11 @@ class EmbeddingResult:
         return self.embeddings[item]
 
     def cost(self) -> genai_types.PriceCalculation:
-        """Calculate the cost of the embedding request.
+        """Calculate the genai-prices estimate of the cost of the embedding request.
 
-        Uses [`genai-prices`](https://github.com/pydantic/genai-prices) for pricing data.
+        Uses [`genai-prices`](https://github.com/pydantic/genai-prices) for pricing data, and always
+        returns the estimate even when `usage.cost` carries a provider-reported cost (e.g. from the
+        Pydantic AI Gateway); `usage.cost` is the authoritative value.
 
         Returns:
             A price calculation object with `total_price`, `input_price`, and other cost details.

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2520,9 +2520,11 @@ class ModelResponse:
         ]
 
     def cost(self) -> genai_types.PriceCalculation:
-        """Calculate the cost of the usage.
+        """Calculate the genai-prices estimate of the cost of the usage.
 
-        Uses [`genai-prices`](https://github.com/pydantic/genai-prices).
+        Uses [`genai-prices`](https://github.com/pydantic/genai-prices), and always returns the
+        estimate even when `usage.cost` carries a provider-reported cost (e.g. from the Pydantic AI
+        Gateway); `usage.cost` is the authoritative value.
         """
         assert self.model_name, 'Model name is required to calculate price'
         return calculate_price_for_usage(

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2779,10 +2779,15 @@ def _map_usage(
 
     # Anthropic reports top-level tokens excluding compaction iteration usage; add the
     # compaction totals back in so the extracted `RequestUsage` reflects the real request cost.
-    usage_for_extraction = dict(details)
+    usage_for_extraction: dict[str, Any] = dict(details)
     for key in _COMPACTION_TOKEN_KEYS:
         if compaction_value := details.get(f'compaction_{key}'):
             usage_for_extraction[key] = usage_for_extraction.get(key, 0) + compaction_value
+
+    # `_extract_usage_details` keeps int fields only; carry the Pydantic AI Gateway's injected
+    # cost object through so `RequestUsage.extract` can pick it up.
+    if gateway_usage := getattr(response_usage, 'pydantic_ai_gateway', None):
+        usage_for_extraction['pydantic_ai_gateway'] = gateway_usage
 
     # Note: genai-prices already extracts cache_creation_input_tokens and cache_read_input_tokens
     # from the Anthropic response and maps them to cache_write_tokens and cache_read_tokens

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -301,9 +301,11 @@ class InstrumentationSettings:
                 continue
             token_attributes = {**attributes, 'gen_ai.token.type': typ}
             self.tokens_histogram.record(tokens, token_attributes)
-        if price_calculation:
-            cost = float(price_calculation.total_price)
-            self.cost_histogram.record(cost, attributes)
+        cost = response.usage.cost
+        if cost is None and price_calculation:
+            cost = price_calculation.total_price
+        if cost is not None:
+            self.cost_histogram.record(float(cost), attributes)
         if time_to_first_chunk is not None:
             self.time_to_first_chunk_histogram.record(time_to_first_chunk, attributes)
 

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -2,9 +2,10 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import warnings
+from collections.abc import Mapping
 from copy import copy
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from functools import cache
 from typing import Annotated, Any, cast
 
@@ -132,6 +133,9 @@ class UsageBase:
 
     Calculated with [genai-prices](https://github.com/pydantic/genai-prices). `None` (rather than zero) when the
     model or provider can't be priced, so "unknown" stays distinguishable from a genuine zero cost.
+
+    Requests made through the Pydantic AI Gateway use the cost the gateway itself reported for the
+    request, which takes precedence over the genai-prices estimate.
     """
 
     def __init__(self, *, details: dict[str, int] | None = None, **kwargs: Any):
@@ -324,14 +328,19 @@ class RequestUsage(UsageBase):
             details: Becomes the `details` field on the returned `RequestUsage` for convenience.
         """
         details = details or {}
+        cost = _gateway_reported_cost(data)
         for provider_id, provider_api_url in [(None, provider_url), (provider, None), (provider_fallback, None)]:
             try:
                 provider_obj = get_snapshot().find_provider(None, provider_id, provider_api_url)
                 _model_ref, extracted_usage = provider_obj.extract_usage(data, api_flavor=api_flavor)
-                return cls(**{k: v for k, v in extracted_usage.__dict__.items() if v is not None}, details=details)
+                return cls(
+                    **{k: v for k, v in extracted_usage.__dict__.items() if v is not None},
+                    details=details,
+                    cost=cost,
+                )
             except Exception:
                 pass
-        return cls(details=details)
+        return cls(details=details, cost=cost)
 
 
 @dataclass(repr=False, init=False, eq=False)
@@ -388,6 +397,30 @@ class RunUsage(UsageBase):
         new_usage = copy(self)
         new_usage.incr(other)
         return new_usage
+
+
+def _gateway_reported_cost(data: Any) -> Decimal | None:
+    """Cost the Pydantic AI Gateway injected into the response usage, if any.
+
+    The gateway adds `usage.pydantic_ai_gateway = {'cost_estimate': ...}` (a decimal string, or a
+    JSON number from older gateway versions) to non-streaming responses. A reported cost lands on
+    `RequestUsage.cost` at extraction time and wins over the genai-prices estimate, which
+    `fill_response_cost` only computes when `cost` is still unset.
+    """
+    usage_data = cast('Mapping[str, Any]', data).get('usage') if isinstance(data, Mapping) else None
+    if not isinstance(usage_data, Mapping):
+        return None
+    gateway_usage = cast('Mapping[str, Any]', usage_data).get('pydantic_ai_gateway')
+    if not isinstance(gateway_usage, Mapping):
+        return None
+    cost_estimate: Any = cast('Mapping[str, Any]', gateway_usage).get('cost_estimate')
+    if not isinstance(cost_estimate, (str, int, float)) or isinstance(cost_estimate, bool):
+        return None
+    try:
+        cost = Decimal(str(cost_estimate))
+    except InvalidOperation:
+        return None
+    return cost if cost.is_finite() and cost >= 0 else None
 
 
 def _incr_usage_cost(slf: RunUsage | RequestUsage, incr_usage: RunUsage | RequestUsage) -> None:

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
+from decimal import Decimal
 from typing import Literal
 
 import pytest
@@ -1414,6 +1415,50 @@ def test_message_with_thinking_parts():
             },
         ]
     )
+
+
+@pytest.mark.parametrize('model_name', ['gpt-4o', 'unpriceable-custom-model'])
+async def test_reported_cost_wins_in_telemetry(capfire: CaptureLogfire, model_name: str):
+    """A cost already on the usage (e.g. gateway-reported) is what telemetry records.
+
+    `gpt-4o` is priceable, so the estimate would differ (0.002225 in the sibling tests);
+    the unpriceable model would previously record no cost at all.
+    """
+
+    class ReportedCostModel(Model):
+        @property
+        def system(self) -> str:
+            return 'openai'
+
+        @property
+        def model_name(self) -> str:
+            return model_name
+
+        @property
+        def base_url(self) -> str:
+            return 'https://example.com:8000/foo'
+
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            return ModelResponse(
+                parts=[TextPart('ok')],
+                usage=RequestUsage(input_tokens=100, output_tokens=200, cost=Decimal('0.125')),
+                model_name=model_name,
+            )
+
+    model = InstrumentedModel(ReportedCostModel())
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('user_prompt')], timestamp=IsDatetime())]
+    await model.request(messages, model_settings=ModelSettings(), model_request_parameters=ModelRequestParameters())
+
+    [span] = capfire.exporter.exported_spans_as_dict()
+    assert span['attributes']['operation.cost'] == 0.125
+
+    [cost_metric] = [m for m in capfire.get_collected_metrics() if m['name'] == 'operation.cost']
+    assert cost_metric['data']['data_points'][0]['sum'] == 0.125
 
 
 async def test_response_cost_error(capfire: CaptureLogfire, monkeypatch: pytest.MonkeyPatch):

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -1,5 +1,6 @@
 import os
 import re
+from decimal import Decimal
 from typing import Any, Literal
 from unittest.mock import patch
 from urllib.parse import urlparse
@@ -185,6 +186,7 @@ async def test_gateway_provider_with_openai(allow_model_requests: None, gateway_
 
     result = await agent.run('What is the capital of France?')
     assert result.output == snapshot('Paris.')
+    assert result.usage.cost == snapshot(Decimal('0.00012625'))
 
 
 async def test_gateway_provider_with_openai_responses(allow_model_requests: None, gateway_api_key: str):
@@ -194,6 +196,7 @@ async def test_gateway_provider_with_openai_responses(allow_model_requests: None
 
     result = await agent.run('What is the capital of France?')
     assert result.output == snapshot('Paris.')
+    assert result.usage.cost == snapshot(Decimal('9.625000000000001E-5'))
 
 
 async def test_gateway_provider_with_groq(allow_model_requests: None, gateway_api_key: str):
@@ -203,6 +206,7 @@ async def test_gateway_provider_with_groq(allow_model_requests: None, gateway_ap
 
     result = await agent.run('What is the capital of France?')
     assert result.output == snapshot('The capital of France is Paris.')
+    assert result.usage.cost == snapshot(Decimal('0.0000311'))
 
 
 async def test_gateway_provider_with_google_cloud(allow_model_requests: None, gateway_api_key: str):
@@ -215,12 +219,15 @@ async def test_gateway_provider_with_google_cloud(allow_model_requests: None, ga
 
 
 async def test_gateway_provider_with_anthropic(allow_model_requests: None, gateway_api_key: str):
+    """The asserted cost carries the gateway's float artifacts (`...199999999999998`), which a clean
+    client-side genai-prices estimate can't produce, proving the reported cost took precedence."""
     provider = gateway_provider('anthropic', api_key=gateway_api_key, base_url='http://localhost:8787')
     model = AnthropicModel('claude-sonnet-4-5', provider=provider)
     agent = Agent(model)
 
     result = await agent.run('What is the capital of France?')
     assert result.output == snapshot('The capital of France is Paris.')
+    assert result.usage.cost == snapshot(Decimal('0.00019199999999999998'))
 
 
 async def test_gateway_provider_with_bedrock(allow_model_requests: None, gateway_api_key: str):

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
@@ -29,6 +29,7 @@ from pydantic_ai.embeddings import (
     Embedder,
     EmbeddingResult,
     EmbeddingSettings,
+    EmbedInputType,
     InstrumentedEmbeddingModel,
     KnownEmbeddingModelName,
     TestEmbeddingModel,
@@ -2196,6 +2197,32 @@ async def test_instrumented_embedding_model_server_attributes(
 
     [span] = capfire.exporter.exported_spans_as_dict()
     assert {k: v for k, v in span['attributes'].items() if k.startswith('server.')} == expected_server_attributes
+
+
+@pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
+async def test_instrumented_embedding_reported_cost_wins(capfire: CaptureLogfire):
+    """A cost already on the usage (e.g. gateway-reported) is what embeddings telemetry records.
+
+    `TestEmbeddingModel` is unpriceable by genai-prices, so telemetry would previously record
+    no cost at all. Unit test: no cassette can put a reported cost on an unpriceable model.
+    """
+
+    class ReportedCostEmbeddingModel(TestEmbeddingModel):
+        async def embed(
+            self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
+        ) -> EmbeddingResult:
+            result = await super().embed(inputs, input_type=input_type, settings=settings)
+            result.usage.cost = Decimal('0.125')
+            return result
+
+    model = InstrumentedEmbeddingModel(ReportedCostEmbeddingModel(), InstrumentationSettings())
+    await model.embed('Hello, world!', input_type='query')
+
+    [span] = capfire.exporter.exported_spans_as_dict()
+    assert span['attributes']['operation.cost'] == 0.125
+
+    [cost_metric] = [m for m in capfire.get_collected_metrics() if m['name'] == 'operation.cost']
+    assert cost_metric['data']['data_points'][0]['sum'] == 0.125
 
 
 def test_override():

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -1168,7 +1168,7 @@ def test_gateway_reported_cost_edge_cases():
     """Malformed `pydantic_ai_gateway` payloads never break extraction and set no cost.
 
     Unit test rather than VCR: the gateway only records well-formed payloads, so the defensive
-    branches (missing or unparseable `cost_estimate`, current string format vs the recorded
+    branches (missing or unparsable `cost_estimate`, current string format vs the recorded
     number format) can't be reached through a cassette. The happy path is covered by the
     `test_gateway_provider_with_*` VCR tests in `tests/providers/test_gateway.py`.
     """

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -1164,6 +1164,66 @@ def test_usage_unknown_provider():
     assert RequestUsage.extract({}, provider='unknown', provider_url='', provider_fallback='') == RequestUsage()
 
 
+def test_gateway_reported_cost_edge_cases():
+    """Malformed `pydantic_ai_gateway` payloads never break extraction and set no cost.
+
+    Unit test rather than VCR: the gateway only records well-formed payloads, so the defensive
+    branches (missing or unparseable `cost_estimate`, current string format vs the recorded
+    number format) can't be reached through a cassette. The happy path is covered by the
+    `test_gateway_provider_with_*` VCR tests in `tests/providers/test_gateway.py`.
+    """
+
+    def extract(gateway_usage: object) -> RequestUsage:
+        usage = {'prompt_tokens': 2, 'completion_tokens': 1, 'pydantic_ai_gateway': gateway_usage}
+        return RequestUsage.extract(
+            {'model': 'gpt-5', 'usage': usage},
+            provider='openai',
+            provider_url='https://api.openai.com/v1',
+            provider_fallback='openai',
+            api_flavor='chat',
+        )
+
+    assert extract({'cost_estimate': '0.00012625'}).cost == snapshot(Decimal('0.00012625'))
+    assert extract({}).cost is None
+    assert extract({'cost_estimate': 'not-a-number'}).cost is None
+    assert extract({'cost_estimate': True}).cost is None
+    assert extract('not-a-mapping').cost is None
+    # NaN would blow up `cost_limit` comparisons and a negative cost would reduce the run total.
+    assert extract({'cost_estimate': 'NaN'}).cost is None
+    assert extract({'cost_estimate': '-0.5'}).cost is None
+    # Token extraction is unaffected by the injected key.
+    assert extract({'cost_estimate': '0.00012625'}).input_tokens == 2
+    # Non-mapping response data degrades to empty usage instead of raising.
+    assert RequestUsage.extract('garbage', provider='openai', provider_url='', provider_fallback='') == RequestUsage()
+
+
+async def test_gateway_reported_cost_wins_over_estimate(allow_model_requests: None):
+    """A reported cost survives to the run total even when genai-prices can't price the model.
+
+    This is the motivating scenario: a custom provider behind the Pydantic AI Gateway that
+    genai-prices has no data for, where the gateway's reported cost is the only source.
+    `fill_response_cost` never overwrites an already-set cost, so the reported value wins.
+    Unit-style with `FunctionModel` because no cassette can produce an unpriceable model;
+    the priced-model precedence path is proven by `test_gateway_provider_with_anthropic`,
+    whose asserted value carries float artifacts a clean genai-prices estimate can't produce.
+    """
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[TextPart('4')],
+            usage=RequestUsage.extract(
+                {'model': 'custom-model', 'usage': {'pydantic_ai_gateway': {'cost_estimate': '0.125'}}},
+                provider='unknown-custom-provider',
+                provider_url='',
+                provider_fallback='',
+            ),
+        )
+
+    agent = Agent(FunctionModel(respond))
+    result = await agent.run('What is 2+2?')
+    assert result.usage.cost == snapshot(Decimal('0.125'))
+
+
 def test_usage_limits_explicit_zero():
     """Explicit 0 token limits round-trip correctly (regression: zero is not coerced to None)."""
     limits = UsageLimits(input_tokens_limit=0)


### PR DESCRIPTION
The Pydantic AI Gateway injects its cost estimate into non-streaming responses as `usage.pydantic_ai_gateway.cost_estimate`, but Pydantic AI dropped it. `RequestUsage.extract` now lifts it into `RequestUsage.cost`, where `fill_response_cost`'s existing never-overwrite rule makes the reported cost win over the client-side genai-prices estimate, including for custom providers genai-prices can't price.

- Covered: OpenAI Chat/Responses, Groq, Anthropic (its mapper needed a one-line carry-through past its int-only details filter).
- Fall back to the estimate: streaming (the gateway sends no cost after the stream ends), Bedrock Converse (botocore drops unmodeled response keys), Google (the gateway injects only into top-level `usage`, not `usageMetadata`). Gateway-side follow-ups tracked separately.
- Tests: cost assertions on the existing gateway VCR cassettes; the Anthropic value carries the gateway's float artifacts, which a clean client-side estimate can't produce, proving the reported cost took precedence. Malformed payloads (non-numeric, `NaN`, negative, bool) are rejected and unit-tested.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

