### PR TITLE
V3 design spike: prototype capability lifecycle sequencing

### DIFF
--- a/agent_docs/pydantic-ai-slim.md
+++ b/agent_docs/pydantic-ai-slim.md
@@ -4,7 +4,7 @@ Use this guide for non-trivial changes to `pydantic-ai-slim`: public APIs, provi
 
 ## Ownership
 
-- `Agent` owns user-facing construction and run APIs. Prefer not to add constructor kwargs for behavior that can be modeled as a capability, toolset, model setting, or profile fact.
+- `Agent` owns user-facing construction and run APIs. `Agent.iter()` is the graph-run facade: `_prepare_run()` resolves per-run inputs into a private `_PreparedAgentRun`, whose `open()` method owns resource entry, capability lifecycle, recovery, and cleanup. Prefer not to add constructor kwargs for behavior that can be modeled as a capability, toolset, model setting, or profile fact.
 - `_agent_graph.py` owns loop orchestration: prompt assembly, model requests, tool/output processing, retries, usage checks, and finalization.
 - `tool_manager.py`, `tools.py`, and `toolsets/` own tool discovery, validation, execution, retries, approval/deferral, wrapper composition, and stable tool identity.
 - `output.py` is the public output API; `_output.py` owns internal output schemas, processors, output tools, and output validation/processing.
@@ -45,7 +45,7 @@ Feature code emits typed `AgentStreamEvent`s into the buffer once the public eve
 
 ## Cancellation Internals
 
-`_cancel.RunCancellation` is the run-scoped first-party cancellation controller, held on `GraphAgentDeps.cancellation` and shared by reference into every `RunContext` as the private `_cancellation` field (same never-`replace` invariant as `_event_stream_buffer` — see the comment in `build_run_context`). First-party cancellation works by cancelling the asyncio task driving the run, so it reuses the entire external-cancellation teardown; the `CancelledError` is classified exactly once, at the outer edge of `Agent.iter()`'s exit stack (`_translate_cancellation`), after all history-producing teardown has committed.
+`_cancel.RunCancellation` is the run-scoped first-party cancellation controller, held on `GraphAgentDeps.cancellation` and shared by reference into every `RunContext` as the private `_cancellation` field (same never-`replace` invariant as `_event_stream_buffer` — see the comment in `build_run_context`). First-party cancellation works by cancelling the asyncio task driving the run, so it reuses the entire external-cancellation teardown; the `CancelledError` is classified exactly once, at the outer edge of `_PreparedAgentRun.open()`'s exit stack (`_translate_cancellation`), after all history-producing teardown has committed.
 
 Three pieces of bookkeeping are load-bearing and easy to break from `_agent_graph.py` / `run.py`:
 

--- a/agent_docs/pydantic-ai-slim.md
+++ b/agent_docs/pydantic-ai-slim.md
@@ -35,6 +35,26 @@ Before editing, identify which contracts can change:
 - When changing tool/output execution, check ordering, retry semantics, deferred calls, output finalization, streaming events, and durable wrappers together.
 - When removing deprecated APIs, distinguish public surface cleanup from persisted-data compatibility. Old constructors/imports may be removed in a major version; old serialized histories may still need to deserialize.
 
+## Capability Lifecycle Internals
+
+`capabilities/_lifecycle.py` owns lifecycle sequencing. `LifecycleStack` is deliberately
+phase-agnostic: callers choose forward or reverse transformation, middleware nesting,
+recovery, stream wrapping, or deferred-result settlement, while the stack applies that
+algorithm consistently. Do not implement those algorithms again in a capability container
+or registration API.
+
+`CombinedCapability` adapts capability instances into the shared stack and remains responsible
+for availability and capability-owned-tool activation. `Hooks` adapts its typed decorator
+registrations into the same stack and remains responsible for timeouts and tool-name filters.
+Keep operation-specific adapters typed; a single `Callable[..., Any]` registry would centralize
+code while weakening the contract.
+
+Capability construction still has two distinct stages. Agent binding runs before model inference,
+with durability bound after ordinary capability toolsets are visible. Run preparation happens
+after bootstrap model resolution and resolves per-run or dynamic state exactly once. V3 may replace
+the public `for_agent()` / `for_run()` and capability-tree APIs, but must preserve these stages,
+stable capability and toolset identities, model-selection provenance, and durable registration.
+
 ## Run Event Stream Internals
 
 `GraphAgentState.event_stream_buffer` is the internal, run-scoped queue for framework events emitted outside the direct model/tool event generators. It's shared by reference into every `RunContext` this run as the private `_event_stream_buffer` field; framework code appends via `RunContext._emit_event(event)`. This is internal plumbing, not public API — there is deliberately no public `emit_event` surface yet (a follow-up custom-events PR will design one, accounting for durable runtimes like Temporal where tools run in activities with a deserialized `RunContext`).

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -12,7 +12,7 @@ from contextvars import ContextVar
 from copy import copy
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, cast, overload
 
 import anyio
 from opentelemetry.trace import NoOpTracer
@@ -44,7 +44,7 @@ from .._agent_graph import (
     build_run_context,
     capture_run_messages,
 )
-from .._cancel import CancellationToken, RunCancellation, take_run_binding
+from .._cancel import CancellationToken, RunBinding, RunCancellation, take_run_binding
 from .._deferred_capabilities import parse_loaded_capabilities
 from .._instructions import AgentInstructions
 from .._output import OutputToolset
@@ -116,8 +116,9 @@ from .wrapper import WrapperAgent
 if TYPE_CHECKING:
     from starlette.applications import Starlette
 
-    from pydantic_graph import GraphRunContext
+    from pydantic_graph import Graph, GraphRunContext
 
+    from .. import result as _result
     from ..ui._web import ModelsParam
 
 __all__ = (
@@ -181,6 +182,8 @@ def _normalize_agent_retry_overrides(retries: int | AgentRetries | None) -> Agen
 
 T = TypeVar('T')
 S = TypeVar('S')
+_PreparedDepsT = TypeVar('_PreparedDepsT')
+_PreparedOutputT = TypeVar('_PreparedOutputT')
 NoneType = type(None)
 
 
@@ -988,7 +991,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
     ) -> AbstractAsyncContextManager[AgentRun[AgentDepsT, RunOutputDataT]]: ...
 
     @asynccontextmanager
-    async def iter(  # noqa: C901
+    async def iter(
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
@@ -1111,6 +1114,51 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         if infer_name and self.name is None:
             self._infer_name(inspect.currentframe())
 
+        prepared = await self._prepare_run(
+            user_prompt,
+            output_type=output_type,
+            message_history=message_history,
+            deferred_tool_results=deferred_tool_results,
+            conversation_id=conversation_id,
+            run_id=run_id,
+            model=model,
+            instructions=instructions,
+            deps=deps,
+            model_settings=model_settings,
+            usage_limits=usage_limits,
+            cancellation_token=cancellation_token,
+            usage=usage,
+            metadata=metadata,
+            retries=retries,
+            toolsets=toolsets,
+            capabilities=capabilities,
+            spec=spec,
+        )
+        async with prepared.open() as agent_run:
+            yield agent_run
+
+    async def _prepare_run(  # noqa: C901
+        self,
+        user_prompt: str | Sequence[_messages.UserContent] | None = None,
+        *,
+        output_type: OutputSpec[Any] | None = None,
+        message_history: Sequence[_messages.ModelMessage] | None = None,
+        deferred_tool_results: DeferredToolResults | None = None,
+        conversation_id: str | None = None,
+        run_id: str | None = None,
+        model: models.Model | models.KnownModelName | str | None = None,
+        instructions: AgentInstructions[AgentDepsT] = None,
+        deps: AgentDepsT = None,
+        model_settings: AgentModelSettings[AgentDepsT] | None = None,
+        usage_limits: _usage.UsageLimits | None = None,
+        cancellation_token: CancellationToken | None = None,
+        usage: _usage.RunUsage | None = None,
+        metadata: AgentMetadata[AgentDepsT] | None = None,
+        retries: int | AgentRetries | None = None,
+        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
+        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
+        spec: dict[str, Any] | AgentSpec | None = None,
+    ) -> _PreparedAgentRun[AgentDepsT, Any]:
         # Consume the pending `AgentRunEvents` binding before ANY user-supplied code (capability /
         # toolset `for_run()` hooks below) runs in this context: a hook that starts a nested agent
         # run would otherwise consume it and attach the outer handle to the wrong run.
@@ -1595,18 +1643,22 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 resolved_models=resolved_models_by_selection,
             )
 
-        model_stack: AsyncExitStack | None = None
-        entered_model_ids = self._entered_model_ids.copy()
+        prepared = _PreparedAgentRun[AgentDepsT, Any](
+            graph=graph,
+            state=state,
+            binding=binding,
+            cancellation_token=cancellation_token,
+            model=model_used,
+            capability_owns_current_model=capability_owns_current_model,
+            run_capability=run_capability,
+            toolset=toolset,
+            usage_limits=usage_limits,
+            entered_model_ids=self._entered_model_ids.copy(),
+            concurrency_limiter=self._concurrency_limiter,
+            resolve_metadata=functools.partial(self._resolve_and_store_metadata, metadata=metadata),
+        )
 
-        async def enter_model(selected_model: models.Model) -> None:
-            model_identity = id(selected_model)
-            if model_identity in entered_model_ids:
-                return
-            assert model_stack is not None
-            await model_stack.enter_async_context(selected_model)
-            entered_model_ids.add(model_identity)
-
-        graph_deps = _agent_graph.GraphAgentDeps[AgentDepsT, OutputDataT](
+        prepared.graph_deps = _agent_graph.GraphAgentDeps[AgentDepsT, OutputDataT](
             user_deps=deps,
             agent=self,
             prompt=user_prompt,
@@ -1618,7 +1670,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             model_selector=model_selector,
             model_selected_for_step=model_selected_for_step,
             evaluate_model_selector=evaluate_model_selector,
-            enter_model=enter_model,
+            enter_model=prepared.enter_model,
             get_model_settings=get_model_settings,
             usage_limits=usage_limits,
             max_output_retries=effective_output_toolset_max_retries,
@@ -1638,7 +1690,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             cancellation=binding.cancellation if binding is not None else RunCancellation(),
         )
 
-        user_prompt_node = _agent_graph.UserPromptNode[AgentDepsT](
+        prepared.user_prompt_node = _agent_graph.UserPromptNode[AgentDepsT](
             user_prompt=user_prompt,
             deferred_tool_results=deferred_tool_results,
             instructions=instructions_literal,
@@ -1648,242 +1700,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             system_prompt_dynamic_functions=self._system_prompt_dynamic_functions,
         )
 
-        agent_name = self.name or 'agent'
+        prepared.agent_name = self.name or 'agent'
 
-        @asynccontextmanager
-        async def _translate_cancellation() -> AsyncGenerator[None]:
-            def _run_cancelled(message: str) -> exceptions.RunCancelled:
-                return _agent_graph.run_cancelled_snapshot(message, state, graph_deps)
-
-            try:
-                yield
-            except exceptions.RunCancelled as exc:
-                # A `RunCancelled` reaching this run's outer edge from below — e.g. a delegate tool
-                # awaited a sub-agent run that cancelled itself via `cancel()` — carries the
-                # *nested* run's history, not this run's. Presenting it to this run's caller
-                # unchanged would make `RunCancelled.all_messages()` (and a resume from it) silently
-                # use the wrong conversation. Re-stamp it with this run's state, keeping the nested
-                # cancellation as the cause. Whether a nested cancellation should terminate this run
-                # at all, or be isolated as a tool failure, is a separate semantics question tracked
-                # in https://github.com/pydantic/pydantic-ai/issues/7199.
-                raise _run_cancelled('The agent run was cancelled by a nested run.') from exc
-            except asyncio.CancelledError as exc:
-                first_party = graph_deps.cancellation.resolve()
-                if first_party:
-                    raise _run_cancelled('The agent run was cancelled.') from exc
-                # An external cancellation must keep propagating as `CancelledError`, but the run
-                # state rides along on the exception instance for `RunCancelled.from_cancellation()`.
-                # Nested runs attach to the same propagating exception; the outermost run attaches
-                # last and wins, giving its awaiter the outer run's history.
-                _run_cancelled('The agent run was cancelled by an external asyncio cancellation.')._attach_to(exc)  # pyright: ignore[reportPrivateUsage]
-                raise
-            finally:
-                # On every exit path — translation above, a clean exit after user code swallowed a
-                # requested cancellation, a superseded driving task, or a non-cancellation error
-                # overtaking a requested cancel — an issued-but-unresolved cancellation must not
-                # leak an elevated `Task.cancelling()` count past the run: it would spuriously
-                # cancel unrelated later work on the task that drove the run.
-                graph_deps.cancellation.release_issued()
-
-        async with AsyncExitStack() as stack:
-            # Enter first so cancellation is classified only after every other context has torn down.
-            await stack.enter_async_context(_translate_cancellation())
-
-            # Bind the run's cancellation controller to this task and register the token BEFORE any
-            # potentially-blocking setup (the concurrency limiter, model entry): a run queued behind
-            # the concurrency limiter must still be cancellable via its token or `cancel()`, and a
-            # pre-cancelled token must prevent it from starting. `finish` neutralizes `cancel()` once
-            # the run is over so it can never cancel unrelated later work on this task.
-            graph_deps.cancellation.bind()
-            stack.callback(graph_deps.cancellation.finish)
-            if cancellation_token is not None:
-                graph_deps.cancellation.attach_token(cancellation_token)
-
-            model_stack = stack
-            await stack.enter_async_context(
-                _concurrency.get_concurrency_context(self._concurrency_limiter, f'agent:{agent_name}')
-            )
-            if capability_owns_current_model:
-                await enter_model(model_used)
-            graph_run = await stack.enter_async_context(
-                graph.iter(
-                    inputs=user_prompt_node,
-                    state=state,
-                    deps=graph_deps,
-                    span=None,
-                    infer_name=False,
-                )
-            )
-            agent_run = AgentRun(graph_run)
-            if binding is not None:
-                # Hand the live `AgentRun` to the `AgentRunEvents` handle that started this run, so
-                # its `cancel()`/run-state accessors reach the run. The controller was already bound
-                # to this task above, before `wrap_run`/`before_run`.
-                binding.agent_run = agent_run
-            self._resolve_and_store_metadata(agent_run.ctx, metadata)
-
-            # Build RunContext for run lifecycle hooks
-            run_ctx = _agent_graph.build_run_context(agent_run.ctx)
-
-            # wrap_run cooperative hand-off protocol:
-            #
-            # 1. _do_run() calls before_run, sets _run_ready, then awaits _run_done.
-            # 2. wrap_run wraps _do_run via the capability middleware chain.
-            # 3. We await either _run_ready (handler started) or _wrap_task completion
-            #    (short-circuit: wrap_run returned without calling handler).
-            # 4. We yield agent_run to the caller for iteration.
-            # 5. When the caller finishes (or an error occurs), we set _run_done.
-            # 6. _do_run resumes: returns the result (success) or re-raises the error.
-            # 7. If wrap_run catches the error and returns a recovery result, we use it.
-            #    Otherwise the original error propagates.
-            _run_ready = asyncio.Event()
-            _run_done = asyncio.Event()
-            _run_error: BaseException | None = None
-            _wrap_context: list[tuple[ContextVar[Any], Any]] | None = None
-
-            async def _do_run() -> AgentRunResult[Any]:
-                nonlocal _wrap_context
-                await run_capability.before_run(run_ctx)
-                # Capture context vars set by wrap_run/before_run so
-                # they can be propagated to the outer task where
-                # agent_run.next() (and therefore node hooks) execute.
-                _current_ctx = contextvars.copy_context()
-                _wrap_context = [
-                    (var, _current_ctx[var])
-                    for var in _current_ctx
-                    if var not in _outer_context or _outer_context[var] is not _current_ctx[var]
-                ]
-                _run_ready.set()
-                await _run_done.wait()
-                if _run_error is not None:
-                    # Raise the original node error, not the potentially
-                    # transformed version from context manager __aexit__ chains.
-                    raise agent_run._node_error or _run_error  # pyright: ignore[reportPrivateUsage]
-                r = agent_run.result
-                assert r is not None
-                return r
-
-            _outer_context = contextvars.copy_context()
-            _wrap_task = asyncio.create_task(run_capability.wrap_run(run_ctx, handler=_do_run))
-            # Wait for handler to start or wrap_run to complete (short-circuit)
-            _ready_waiter = asyncio.create_task(_run_ready.wait())
-            try:
-                await asyncio.wait({_ready_waiter, _wrap_task}, return_when=asyncio.FIRST_COMPLETED)
-            except BaseException as exc:
-                # Unblock `_do_run` before draining, mirroring the streaming handoff: if
-                # `before_run`'s durable step absorbed the CancelledError (e.g. Temporal's
-                # cooperative cancellation) and returned, `_do_run` is parked on
-                # `_run_done.wait()`. Set `_run_error` so the survivor re-raises this error
-                # instead of asserting on a not-yet-produced result, then set `_run_done` so
-                # it can exit and `cancel_and_drain`'s gather can complete (it discards the
-                # survivor's exception). Harmless no-op when `_wrap_task` really died
-                # cancelled — it's already unwinding. See https://github.com/pydantic/pydantic-ai/issues/6422.
-                _run_error = exc
-                _run_done.set()
-                await _utils.cancel_and_drain(_ready_waiter, _wrap_task)
-                raise
-            else:
-                await _utils.cancel_and_drain(_ready_waiter)
-
-            # Propagate context vars set by wrap_run/before_run to
-            # the outer task so that agent_run.next() (and therefore
-            # node hooks) can see them.
-            _context_tokens: list[tuple[ContextVar[Any], contextvars.Token[Any]]] = []
-            # Note: indexing instead of tuple unpacking because pyright
-            # can't resolve types through nonlocal + Optional unpacking.
-            for _cv_pair in _wrap_context or ():
-                _context_tokens.append((_cv_pair[0], _cv_pair[0].set(_cv_pair[1])))
-
-            # Register context var restore on the stack so it happens in LIFO order
-            # (after toolset exit, before graph run exit).
-            def _restore_context_vars() -> None:
-                for _var, _token in _context_tokens:
-                    _var.reset(_token)
-
-            stack.callback(_restore_context_vars)
-
-            # Enter toolset AFTER context vars are propagated so that
-            # toolset __aenter__/__aexit__ run inside the run span context
-            # (set by the Instrumentation capability's wrap_run).
-            await stack.enter_async_context(toolset)
-
-            async def _finalize_result(r: AgentRunResult[Any]) -> None:
-                """Call after_run, store the result override, and clear any pending error."""
-                nonlocal _run_error
-                r = await run_capability.after_run(run_ctx, result=r)
-                usage_limits.check_cost(r.usage)
-                # Every completion path funnels through here — including `wrap_run`/`on_run_error`
-                # recovering from the very `CancelledError` an external cancel delivered. If that
-                # cancellation is still pending on this task, re-assert it rather than let the run
-                # finalize as a success. A first-party request remains terminal even if a hook
-                # consumed the task's cancellation counter.
-                _utils.raise_if_cancelling()
-                if graph_deps.cancellation.cancel_requested:
-                    raise asyncio.CancelledError('pydantic-ai: re-asserting a requested run cancellation')
-                agent_run._result_override = r  # pyright: ignore[reportPrivateUsage]
-                _run_error = None
-
-            _short_circuited = _wrap_task.done() and not _run_ready.is_set()
-            if _short_circuited:
-                await _finalize_result(_wrap_task.result())
-
-            try:
-                yield agent_run
-            except BaseException as _exc:
-                # Use the original node error if available, since context manager
-                # __aexit__ chains (GraphRun → anyio TaskGroup) may transform
-                # the exception (e.g. into CancelledError or ExceptionGroup).
-                _run_error = agent_run._node_error or _exc  # pyright: ignore[reportPrivateUsage]
-                # Don't attempt recovery for GeneratorExit/KeyboardInterrupt —
-                # awaiting _wrap_task during cleanup could delay shutdown.
-                if isinstance(_run_error, (GeneratorExit, KeyboardInterrupt)):
-                    raise
-                # Don't re-raise yet — give wrap_run a chance to recover.
-                # If wrap_run catches the error from handler() and returns
-                # a recovery result, the exception will be suppressed.
-            finally:
-                if agent_run.result is not None:
-                    self._resolve_and_store_metadata(agent_run.ctx, metadata)
-
-                if not _short_circuited:
-                    _run_done.set()
-                    if _run_error is None and agent_run.result is not None:
-                        await _finalize_result(await _wrap_task)
-                    elif _run_error is not None:
-                        # Error path: await wrap_run to see if it recovers.
-                        # _do_run() re-raises _run_error; if wrap_run catches
-                        # it and returns a result, recovery succeeds.
-                        try:
-                            await _finalize_result(await _wrap_task)
-                        except BaseException as _wrap_exc:
-                            # Attach wrap_run's own errors as context so they're
-                            # visible in tracebacks (but don't mask the original).
-                            # Skip CancelledError: it's expected cancellation propagation,
-                            # and setting __context__ on it causes hangs on Python 3.10.
-                            if not isinstance(_wrap_exc, asyncio.CancelledError) and _wrap_exc is not _run_error:
-                                # Only fires for bugs in `wrap_run` implementations.
-                                _run_error.__context__ = _wrap_exc  # pragma: no cover
-                    # `_run_done.set()` can't complete `_wrap_task` synchronously, so the task is always still pending here.
-                    elif not _wrap_task.done():  # pragma: no branch
-                        _wrap_task.cancel()
-                        try:
-                            await _wrap_task
-                        except (asyncio.CancelledError, BaseException):
-                            pass
-
-            # If wrap_run didn't recover, give on_run_error a chance.
-            if _run_error is not None:
-                try:
-                    _result = await run_capability.on_run_error(run_ctx, error=_run_error)
-                except BaseException as _on_error_exc:
-                    _run_error = _on_error_exc
-                else:
-                    await _finalize_result(_result)
-
-            # If on_run_error didn't recover either, re-raise.
-            # In an @asynccontextmanager, not re-raising suppresses the exception.
-            if _run_error is not None:
-                raise _run_error
+        return prepared
 
     def _get_metadata(
         self,
@@ -3168,6 +2987,284 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instructions=instructions,
             html_source=html_source,
         )
+
+
+@dataclasses.dataclass
+class _PreparedAgentRun(Generic[_PreparedDepsT, _PreparedOutputT]):
+    """The fully assembled inputs and resources for one graph-based agent run."""
+
+    graph: Graph[
+        _agent_graph.GraphAgentState,
+        _agent_graph.GraphAgentDeps[_PreparedDepsT, _PreparedOutputT],
+        _agent_graph.UserPromptNode[_PreparedDepsT, _PreparedOutputT],
+        _result.FinalResult[_PreparedOutputT],
+    ]
+    state: _agent_graph.GraphAgentState
+    binding: RunBinding | None
+    cancellation_token: CancellationToken | None
+    model: models.Model
+    capability_owns_current_model: bool
+    run_capability: AbstractCapability[_PreparedDepsT]
+    toolset: AbstractToolset[_PreparedDepsT]
+    usage_limits: _usage.UsageLimits
+    entered_model_ids: set[int]
+    concurrency_limiter: _concurrency.AbstractConcurrencyLimiter | None
+    resolve_metadata: Callable[
+        [GraphRunContext[_agent_graph.GraphAgentState, _agent_graph.GraphAgentDeps[_PreparedDepsT, _PreparedOutputT]]],
+        dict[str, Any] | None,
+    ]
+    user_prompt_node: _agent_graph.UserPromptNode[_PreparedDepsT, _PreparedOutputT] = dataclasses.field(init=False)
+    agent_name: str = dataclasses.field(init=False)
+    graph_deps: _agent_graph.GraphAgentDeps[_PreparedDepsT, _PreparedOutputT] = dataclasses.field(init=False)
+    _model_stack: AsyncExitStack | None = dataclasses.field(default=None, init=False, repr=False)
+
+    async def enter_model(self, selected_model: models.Model) -> None:
+        model_identity = id(selected_model)
+        if model_identity in self.entered_model_ids:
+            return
+        assert self._model_stack is not None
+        await self._model_stack.enter_async_context(selected_model)
+        self.entered_model_ids.add(model_identity)
+
+    @asynccontextmanager
+    async def open(self) -> AsyncGenerator[AgentRun[_PreparedDepsT, _PreparedOutputT]]:  # noqa: C901
+        graph_deps = self.graph_deps
+        state = self.state
+
+        @asynccontextmanager
+        async def _translate_cancellation() -> AsyncGenerator[None]:
+            def _run_cancelled(message: str) -> exceptions.RunCancelled:
+                return _agent_graph.run_cancelled_snapshot(message, state, graph_deps)
+
+            try:
+                yield
+            except exceptions.RunCancelled as exc:
+                # A `RunCancelled` reaching this run's outer edge from below — e.g. a delegate tool
+                # awaited a sub-agent run that cancelled itself via `cancel()` — carries the
+                # *nested* run's history, not this run's. Presenting it to this run's caller
+                # unchanged would make `RunCancelled.all_messages()` (and a resume from it) silently
+                # use the wrong conversation. Re-stamp it with this run's state, keeping the nested
+                # cancellation as the cause. Whether a nested cancellation should terminate this run
+                # at all, or be isolated as a tool failure, is a separate semantics question tracked
+                # in https://github.com/pydantic/pydantic-ai/issues/7199.
+                raise _run_cancelled('The agent run was cancelled by a nested run.') from exc
+            except asyncio.CancelledError as exc:
+                first_party = graph_deps.cancellation.resolve()
+                if first_party:
+                    raise _run_cancelled('The agent run was cancelled.') from exc
+                # An external cancellation must keep propagating as `CancelledError`, but the run
+                # state rides along on the exception instance for `RunCancelled.from_cancellation()`.
+                # Nested runs attach to the same propagating exception; the outermost run attaches
+                # last and wins, giving its awaiter the outer run's history.
+                _run_cancelled('The agent run was cancelled by an external asyncio cancellation.')._attach_to(exc)  # pyright: ignore[reportPrivateUsage]
+                raise
+            finally:
+                # On every exit path — translation above, a clean exit after user code swallowed a
+                # requested cancellation, a superseded driving task, or a non-cancellation error
+                # overtaking a requested cancel — an issued-but-unresolved cancellation must not
+                # leak an elevated `Task.cancelling()` count past the run: it would spuriously
+                # cancel unrelated later work on the task that drove the run.
+                graph_deps.cancellation.release_issued()
+
+        async with AsyncExitStack() as stack:
+            # Enter first so cancellation is classified only after every other context has torn down.
+            await stack.enter_async_context(_translate_cancellation())
+
+            # Bind the run's cancellation controller to this task and register the token BEFORE any
+            # potentially-blocking setup (the concurrency limiter, model entry): a run queued behind
+            # the concurrency limiter must still be cancellable via its token or `cancel()`, and a
+            # pre-cancelled token must prevent it from starting. `finish` neutralizes `cancel()` once
+            # the run is over so it can never cancel unrelated later work on this task.
+            graph_deps.cancellation.bind()
+            stack.callback(graph_deps.cancellation.finish)
+            if self.cancellation_token is not None:
+                graph_deps.cancellation.attach_token(self.cancellation_token)
+
+            self._model_stack = stack
+            await stack.enter_async_context(
+                _concurrency.get_concurrency_context(self.concurrency_limiter, f'agent:{self.agent_name}')
+            )
+            if self.capability_owns_current_model:
+                await self.enter_model(self.model)
+            graph_run = await stack.enter_async_context(
+                self.graph.iter(
+                    inputs=self.user_prompt_node,
+                    state=state,
+                    deps=graph_deps,
+                    span=None,
+                    infer_name=False,
+                )
+            )
+            agent_run = AgentRun(graph_run)
+            if self.binding is not None:
+                # Hand the live `AgentRun` to the `AgentRunEvents` handle that started this run, so
+                # its `cancel()`/run-state accessors reach the run. The controller was already bound
+                # to this task above, before `wrap_run`/`before_run`.
+                self.binding.agent_run = agent_run
+            self.resolve_metadata(agent_run.ctx)
+
+            # Build RunContext for run lifecycle hooks
+            run_ctx = _agent_graph.build_run_context(agent_run.ctx)
+
+            # wrap_run cooperative hand-off protocol:
+            #
+            # 1. _do_run() calls before_run, sets _run_ready, then awaits _run_done.
+            # 2. wrap_run wraps _do_run via the capability middleware chain.
+            # 3. We await either _run_ready (handler started) or _wrap_task completion
+            #    (short-circuit: wrap_run returned without calling handler).
+            # 4. We yield agent_run to the caller for iteration.
+            # 5. When the caller finishes (or an error occurs), we set _run_done.
+            # 6. _do_run resumes: returns the result (success) or re-raises the error.
+            # 7. If wrap_run catches the error and returns a recovery result, we use it.
+            #    Otherwise the original error propagates.
+            _run_ready = asyncio.Event()
+            _run_done = asyncio.Event()
+            _run_error: BaseException | None = None
+            _wrap_context: list[tuple[ContextVar[Any], Any]] | None = None
+
+            async def _do_run() -> AgentRunResult[_PreparedOutputT]:
+                nonlocal _wrap_context
+                await self.run_capability.before_run(run_ctx)
+                # Capture context vars set by wrap_run/before_run so
+                # they can be propagated to the outer task where
+                # agent_run.next() (and therefore node hooks) execute.
+                _current_ctx = contextvars.copy_context()
+                _wrap_context = [
+                    (var, _current_ctx[var])
+                    for var in _current_ctx
+                    if var not in _outer_context or _outer_context[var] is not _current_ctx[var]
+                ]
+                _run_ready.set()
+                await _run_done.wait()
+                if _run_error is not None:
+                    # Raise the original node error, not the potentially
+                    # transformed version from context manager __aexit__ chains.
+                    raise agent_run._node_error or _run_error  # pyright: ignore[reportPrivateUsage]
+                result = agent_run.result
+                assert result is not None
+                return result
+
+            _outer_context = contextvars.copy_context()
+            _wrap_task = asyncio.create_task(self.run_capability.wrap_run(run_ctx, handler=_do_run))
+            # Wait for handler to start or wrap_run to complete (short-circuit)
+            _ready_waiter = asyncio.create_task(_run_ready.wait())
+            try:
+                await asyncio.wait({_ready_waiter, _wrap_task}, return_when=asyncio.FIRST_COMPLETED)
+            except BaseException as exc:
+                # Unblock `_do_run` before draining, mirroring the streaming handoff: if
+                # `before_run`'s durable step absorbed the CancelledError (e.g. Temporal's
+                # cooperative cancellation) and returned, `_do_run` is parked on
+                # `_run_done.wait()`. Set `_run_error` so the survivor re-raises this error
+                # instead of asserting on a not-yet-produced result, then set `_run_done` so
+                # it can exit and `cancel_and_drain`'s gather can complete (it discards the
+                # survivor's exception). Harmless no-op when `_wrap_task` really died
+                # cancelled — it's already unwinding. See https://github.com/pydantic/pydantic-ai/issues/6422.
+                _run_error = exc
+                _run_done.set()
+                await _utils.cancel_and_drain(_ready_waiter, _wrap_task)
+                raise
+            else:
+                await _utils.cancel_and_drain(_ready_waiter)
+
+            # Propagate context vars set by wrap_run/before_run to
+            # the outer task so that agent_run.next() (and therefore
+            # node hooks) can see them.
+            _context_tokens: list[tuple[ContextVar[Any], contextvars.Token[Any]]] = []
+            # Note: indexing instead of tuple unpacking because pyright
+            # can't resolve types through nonlocal + Optional unpacking.
+            for _cv_pair in _wrap_context or ():
+                _context_tokens.append((_cv_pair[0], _cv_pair[0].set(_cv_pair[1])))
+
+            # Register context var restore on the stack so it happens in LIFO order
+            # (after toolset exit, before graph run exit).
+            def _restore_context_vars() -> None:
+                for _var, _token in _context_tokens:
+                    _var.reset(_token)
+
+            stack.callback(_restore_context_vars)
+
+            # Enter toolset AFTER context vars are propagated so that
+            # toolset __aenter__/__aexit__ run inside the run span context
+            # (set by the Instrumentation capability's wrap_run).
+            await stack.enter_async_context(self.toolset)
+
+            async def _finalize_result(result: AgentRunResult[_PreparedOutputT]) -> None:
+                """Call after_run, store the result override, and clear any pending error."""
+                nonlocal _run_error
+                result = await self.run_capability.after_run(run_ctx, result=result)
+                self.usage_limits.check_cost(result.usage)
+                # Every completion path funnels through here — including `wrap_run`/`on_run_error`
+                # recovering from the very `CancelledError` an external cancel delivered. If that
+                # cancellation is still pending on this task, re-assert it rather than let the run
+                # finalize as a success. A first-party request remains terminal even if a hook
+                # consumed the task's cancellation counter.
+                _utils.raise_if_cancelling()
+                if graph_deps.cancellation.cancel_requested:
+                    raise asyncio.CancelledError('pydantic-ai: re-asserting a requested run cancellation')
+                agent_run._result_override = result  # pyright: ignore[reportPrivateUsage]
+                _run_error = None
+
+            _short_circuited = _wrap_task.done() and not _run_ready.is_set()
+            if _short_circuited:
+                await _finalize_result(_wrap_task.result())
+
+            try:
+                yield agent_run
+            except BaseException as exc:
+                # Use the original node error if available, since context manager
+                # __aexit__ chains (GraphRun → anyio TaskGroup) may transform
+                # the exception (e.g. into CancelledError or ExceptionGroup).
+                _run_error = agent_run._node_error or exc  # pyright: ignore[reportPrivateUsage]
+                # Don't attempt recovery for GeneratorExit/KeyboardInterrupt —
+                # awaiting _wrap_task during cleanup could delay shutdown.
+                if isinstance(_run_error, (GeneratorExit, KeyboardInterrupt)):
+                    raise
+                # Don't re-raise yet — give wrap_run a chance to recover.
+                # If wrap_run catches the error from handler() and returns
+                # a recovery result, the exception will be suppressed.
+            finally:
+                if agent_run.result is not None:
+                    self.resolve_metadata(agent_run.ctx)
+
+                if not _short_circuited:
+                    _run_done.set()
+                    if _run_error is None and agent_run.result is not None:
+                        await _finalize_result(await _wrap_task)
+                    elif _run_error is not None:
+                        # Error path: await wrap_run to see if it recovers.
+                        # _do_run() re-raises _run_error; if wrap_run catches
+                        # it and returns a result, recovery succeeds.
+                        try:
+                            await _finalize_result(await _wrap_task)
+                        except BaseException as _wrap_exc:
+                            # Attach wrap_run's own errors as context so they're
+                            # visible in tracebacks (but don't mask the original).
+                            # Skip CancelledError: it's expected cancellation propagation,
+                            # and setting __context__ on it causes hangs on Python 3.10.
+                            if not isinstance(_wrap_exc, asyncio.CancelledError) and _wrap_exc is not _run_error:
+                                # Only fires for bugs in `wrap_run` implementations.
+                                _run_error.__context__ = _wrap_exc  # pragma: no cover
+                    # `_run_done.set()` can't complete `_wrap_task` synchronously, so the task is always still pending here.
+                    elif not _wrap_task.done():  # pragma: no branch
+                        _wrap_task.cancel()
+                        try:
+                            await _wrap_task
+                        except (asyncio.CancelledError, BaseException):
+                            pass
+
+            # If wrap_run didn't recover, give on_run_error a chance.
+            if _run_error is not None:
+                try:
+                    result = await self.run_capability.on_run_error(run_ctx, error=_run_error)
+                except BaseException as _on_error_exc:
+                    _run_error = _on_error_exc
+                else:
+                    await _finalize_result(result)
+
+            # If on_run_error didn't recover either, re-raise.
+            # In an @asynccontextmanager, not re-raising suppresses the exception.
+            if _run_error is not None:
+                raise _run_error
 
 
 def _merge_retries_with_spec(

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_lifecycle.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_lifecycle.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Generic, ParamSpec, TypeVar
+
+from pydantic_ai import _utils
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults
+
+_EntryT = TypeVar('_EntryT')
+_ValueT = TypeVar('_ValueT')
+_ResultT = TypeVar('_ResultT')
+_ErrorT = TypeVar('_ErrorT', bound=BaseException)
+_Params = ParamSpec('_Params')
+
+
+@dataclass(frozen=True)
+class SkipLifecycleEntry:
+    """Signal that a lifecycle entry is inactive for the current invocation."""
+
+
+SKIP_LIFECYCLE_ENTRY = SkipLifecycleEntry()
+
+
+@dataclass(frozen=True)
+class LifecycleStack(Generic[_EntryT]):
+    """Sequence lifecycle entries with consistent middleware ordering."""
+
+    entries: Sequence[_EntryT]
+
+    async def forward(
+        self,
+        value: _ValueT,
+        transform: Callable[[_EntryT, _ValueT], Awaitable[_ValueT]],
+    ) -> _ValueT:
+        """Transform a value from the outermost entry to the innermost."""
+        for entry in self.entries:
+            value = await transform(entry, value)
+        return value
+
+    async def reverse(
+        self,
+        value: _ValueT,
+        transform: Callable[[_EntryT, _ValueT], Awaitable[_ValueT]],
+    ) -> _ValueT:
+        """Transform a value from the innermost entry to the outermost."""
+        for entry in reversed(self.entries):
+            value = await transform(entry, value)
+        return value
+
+    async def notify(self, notify: Callable[[_EntryT], Awaitable[None]]) -> None:
+        """Notify entries from outermost to innermost."""
+        for entry in self.entries:
+            await notify(entry)
+
+    def wrap(
+        self,
+        handler: Callable[_Params, Awaitable[_ResultT]],
+        wrap: Callable[
+            [_EntryT, Callable[_Params, Awaitable[_ResultT]]],
+            Callable[_Params, Awaitable[_ResultT]],
+        ],
+    ) -> Callable[_Params, Awaitable[_ResultT]]:
+        """Build middleware with the first entry as the outermost layer."""
+        for entry in reversed(self.entries):
+            handler = wrap(entry, handler)
+        return handler
+
+    async def recover(
+        self,
+        error: _ErrorT,
+        recover: Callable[[_EntryT, _ErrorT], Awaitable[_ResultT | SkipLifecycleEntry]],
+        caught: type[_ErrorT] | tuple[type[_ErrorT], ...],
+        *,
+        reverse: bool = True,
+    ) -> _ResultT:
+        """Try recovery in the selected direction, forwarding replacement errors."""
+        entries = reversed(self.entries) if reverse else iter(self.entries)
+        for entry in entries:
+            try:
+                result = await recover(entry, error)
+                if isinstance(result, SkipLifecycleEntry):
+                    continue
+                return result
+            except caught as new_error:
+                error = new_error
+        raise error
+
+    @asynccontextmanager
+    async def stream(
+        self,
+        source: AsyncIterable[_ValueT],
+        wrap: Callable[[_EntryT, AsyncIterable[_ValueT]], AsyncIterable[_ValueT] | None],
+    ) -> AsyncGenerator[AsyncIterable[_ValueT]]:
+        """Wrap a stream and close every created layer in reverse creation order."""
+        stream = source
+        streams = [source]
+        for entry in reversed(self.entries):
+            wrapped = wrap(entry, stream)
+            if wrapped is not None:
+                stream = wrapped
+                streams.append(stream)
+        try:
+            yield stream
+        finally:
+            await _utils.aclose_all(reversed(streams))
+
+    async def settle_deferred(
+        self,
+        requests: DeferredToolRequests,
+        handle: Callable[[_EntryT, DeferredToolRequests], Awaitable[DeferredToolResults | None]],
+    ) -> DeferredToolResults | None:
+        """Accumulate deferred results while passing only unresolved calls forward."""
+        accumulated = DeferredToolResults()
+        remaining = requests
+        handled = False
+        for entry in self.entries:
+            result = await handle(entry, remaining)
+            if result is None or not (result.approvals or result.calls):
+                continue
+            handled = True
+            accumulated.update(result)
+            if (remaining_after_result := remaining.remaining(result)) is None:
+                break
+            remaining = remaining_after_result
+        return accumulated if handled else None

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions, normalize_instructions
-from pydantic_ai._utils import aclose_all, gather, replace_no_init
+from pydantic_ai._utils import gather, replace_no_init
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.settings import ModelSettings, merge_model_settings
@@ -24,6 +24,7 @@ from pydantic_ai.toolsets import AbstractToolset, AgentToolset, CombinedToolset
 from pydantic_ai.toolsets._capability_owned import CapabilityOwnedToolset
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
+from ._lifecycle import SKIP_LIFECYCLE_ENTRY, LifecycleStack, SkipLifecycleEntry
 from ._ordering import collect_leaves, is_innermost, sort_capabilities
 from .abstract import (
     AbstractCapability,
@@ -41,6 +42,12 @@ if TYPE_CHECKING:
     from pydantic_ai.result import FinalResult
     from pydantic_ai.run import AgentRunResult
     from pydantic_graph import End
+
+_ValueT = TypeVar('_ValueT')
+_ResultT = TypeVar('_ResultT')
+_ErrorT = TypeVar('_ErrorT', bound=BaseException)
+_DepsT = TypeVar('_DepsT')
+_Params = ParamSpec('_Params')
 
 
 @dataclass
@@ -266,20 +273,26 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
         tool_defs: list[ToolDefinition],
     ) -> list[ToolDefinition]:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                tool_defs = await capability.prepare_tools(cap_ctx, tool_defs)
-        return tool_defs
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            tool_defs,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.prepare_tools(cap_ctx, value),
+        )
 
     async def prepare_output_tools(
         self,
         ctx: RunContext[AgentDepsT],
         tool_defs: list[ToolDefinition],
     ) -> list[ToolDefinition]:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                tool_defs = await capability.prepare_output_tools(cap_ctx, tool_defs)
-        return tool_defs
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            tool_defs,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.prepare_output_tools(cap_ctx, value),
+        )
 
     # --- Run lifecycle hooks ---
 
@@ -287,9 +300,12 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         self,
         ctx: RunContext[AgentDepsT],
     ) -> None:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                await capability.before_run(cap_ctx)
+        await _notify_capabilities(
+            self.capabilities,
+            ctx,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx: capability.before_run(cap_ctx),
+        )
 
     async def after_run(
         self,
@@ -297,10 +313,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         result: AgentRunResult[Any],
     ) -> AgentRunResult[Any]:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                result = await capability.after_run(cap_ctx, result=result)
-        return result
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            result,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.after_run(cap_ctx, result=value),
+        )
 
     async def wrap_run(
         self,
@@ -308,10 +327,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         handler: Callable[[], Awaitable[AgentRunResult[Any]]],
     ) -> AgentRunResult[Any]:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
-                chain = _make_run_wrap(capability, ctx, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            _ctx_for_available_cap,
+            _make_run_wrap,
+        )
         return await chain()
 
     async def on_run_error(
@@ -320,15 +342,14 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         error: BaseException,
     ) -> AgentRunResult[Any]:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_available_cap(capability, ctx)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_run_error(cap_ctx, error=error)
-            except BaseException as new_error:
-                error = new_error
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, current: capability.on_run_error(cap_ctx, error=current),
+            BaseException,
+        )
 
     # --- Node run lifecycle hooks ---
 
@@ -338,10 +359,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         node: _agent_graph.AgentNode[AgentDepsT, Any],
     ) -> _agent_graph.AgentNode[AgentDepsT, Any]:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                node = await capability.before_node_run(cap_ctx, node=node)
-        return node
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            node,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.before_node_run(cap_ctx, node=value),
+        )
 
     async def after_node_run(
         self,
@@ -350,10 +374,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         node: _agent_graph.AgentNode[AgentDepsT, Any],
         result: _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]],
     ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                result = await capability.after_node_run(cap_ctx, node=node, result=result)
-        return result
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            result,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.after_node_run(cap_ctx, node=node, result=value),
+        )
 
     async def wrap_node_run(
         self,
@@ -365,10 +392,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
             Awaitable[_agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]],
         ],
     ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
-                chain = _make_node_run_wrap(capability, ctx, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            _ctx_for_available_cap,
+            _make_node_run_wrap,
+        )
         return await chain(node)
 
     async def on_node_run_error(
@@ -378,15 +408,14 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         node: _agent_graph.AgentNode[AgentDepsT, Any],
         error: Exception,
     ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_available_cap(capability, ctx)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_node_run_error(cap_ctx, node=node, error=error)
-            except Exception as new_error:
-                error = new_error
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, current: capability.on_node_run_error(cap_ctx, node=node, error=current),
+            Exception,
+        )
 
     # --- Event stream hook ---
 
@@ -396,16 +425,20 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         stream: AsyncIterable[AgentStreamEvent],
     ) -> AsyncIterable[AgentStreamEvent]:
-        wrapped_streams = [stream]
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                stream = capability.wrap_run_event_stream(cap_ctx, stream=stream)
-                wrapped_streams.append(stream)
-        try:
-            async for event in stream:
+        stack = LifecycleStack(self.capabilities)
+
+        def wrap(
+            capability: AbstractCapability[AgentDepsT],
+            source: AsyncIterable[AgentStreamEvent],
+        ) -> AsyncIterable[AgentStreamEvent] | None:
+            cap_ctx = _ctx_for_available_cap(capability, ctx)
+            if cap_ctx is None:
+                return None
+            return capability.wrap_run_event_stream(cap_ctx, stream=source)
+
+        async with stack.stream(stream, wrap) as wrapped:
+            async for event in wrapped:
                 yield event
-        finally:
-            await aclose_all(reversed(wrapped_streams))
 
     # --- Model request lifecycle hooks ---
 
@@ -414,10 +447,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
         request_context: ModelRequestContext,
     ) -> ModelRequestContext:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                request_context = await capability.before_model_request(cap_ctx, request_context)
-        return request_context
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            request_context,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.before_model_request(cap_ctx, value),
+        )
 
     async def after_model_request(
         self,
@@ -426,12 +462,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         response: ModelResponse,
     ) -> ModelResponse:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                response = await capability.after_model_request(
-                    cap_ctx, request_context=request_context, response=response
-                )
-        return response
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            response,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.after_model_request(
+                cap_ctx, request_context=request_context, response=value
+            ),
+        )
 
     async def wrap_model_request(
         self,
@@ -440,10 +479,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         handler: Callable[[ModelRequestContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
-                chain = _make_model_request_wrap(capability, ctx, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            _ctx_for_available_cap,
+            _make_model_request_wrap,
+        )
         return await chain(request_context)
 
     async def on_model_request_error(
@@ -453,15 +495,16 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         error: Exception,
     ) -> ModelResponse:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_available_cap(capability, ctx)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_model_request_error(cap_ctx, request_context=request_context, error=error)
-            except Exception as new_error:
-                error = new_error
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, current: capability.on_model_request_error(
+                cap_ctx, request_context=request_context, error=current
+            ),
+            Exception,
+        )
 
     # --- Tool validate lifecycle hooks ---
 
@@ -473,10 +516,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         tool_def: ToolDefinition,
         args: str | dict[str, Any],
     ) -> str | dict[str, Any]:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_tool_hook(capability, ctx, tool_def)) is not None:
-                args = await capability.before_tool_validate(cap_ctx, call=call, tool_def=tool_def, args=args)
-        return args
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            args,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, cap_ctx, value: capability.before_tool_validate(
+                cap_ctx, call=call, tool_def=tool_def, args=value
+            ),
+        )
 
     async def after_tool_validate(
         self,
@@ -486,10 +534,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         tool_def: ToolDefinition,
         args: dict[str, Any],
     ) -> dict[str, Any]:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_tool_hook(capability, ctx, tool_def)) is not None:
-                args = await capability.after_tool_validate(cap_ctx, call=call, tool_def=tool_def, args=args)
-        return args
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            args,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, cap_ctx, value: capability.after_tool_validate(
+                cap_ctx, call=call, tool_def=tool_def, args=value
+            ),
+        )
 
     async def wrap_tool_validate(
         self,
@@ -500,10 +553,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         args: str | dict[str, Any],
         handler: Callable[[str | dict[str, Any]], Awaitable[dict[str, Any]]],
     ) -> dict[str, Any]:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_tool_hook(capability, ctx, tool_def) is not None:
-                chain = _make_tool_validate_wrap(capability, ctx, call, tool_def, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, run_ctx, inner: _make_tool_validate_wrap(capability, run_ctx, call, tool_def, inner),
+        )
         return await chain(args)
 
     async def on_tool_validate_error(
@@ -515,19 +571,16 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         args: str | dict[str, Any],
         error: ValidationError | ModelRetry,
     ) -> dict[str, Any]:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_tool_hook(capability, ctx, tool_def)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_tool_validate_error(
-                    cap_ctx, call=call, tool_def=tool_def, args=args, error=error
-                )
-            except (ValidationError, ModelRetry) as new_error:
-                error = new_error
-            except Exception:
-                raise
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, cap_ctx, current: capability.on_tool_validate_error(
+                cap_ctx, call=call, tool_def=tool_def, args=args, error=current
+            ),
+            (ValidationError, ModelRetry),
+        )
 
     # --- Tool execute lifecycle hooks ---
 
@@ -539,10 +592,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         tool_def: ToolDefinition,
         args: dict[str, Any],
     ) -> dict[str, Any]:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_tool_hook(capability, ctx, tool_def)) is not None:
-                args = await capability.before_tool_execute(cap_ctx, call=call, tool_def=tool_def, args=args)
-        return args
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            args,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, cap_ctx, value: capability.before_tool_execute(
+                cap_ctx, call=call, tool_def=tool_def, args=value
+            ),
+        )
 
     async def after_tool_execute(
         self,
@@ -553,12 +611,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         args: dict[str, Any],
         result: Any,
     ) -> Any:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_tool_hook(capability, ctx, tool_def)) is not None:
-                result = await capability.after_tool_execute(
-                    cap_ctx, call=call, tool_def=tool_def, args=args, result=result
-                )
-        return result
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            result,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, cap_ctx, value: capability.after_tool_execute(
+                cap_ctx, call=call, tool_def=tool_def, args=args, result=value
+            ),
+        )
 
     async def wrap_tool_execute(
         self,
@@ -569,10 +630,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         args: dict[str, Any],
         handler: Callable[[dict[str, Any]], Awaitable[Any]],
     ) -> Any:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_tool_hook(capability, ctx, tool_def) is not None:
-                chain = _make_tool_execute_wrap(capability, ctx, call, tool_def, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, run_ctx, inner: _make_tool_execute_wrap(capability, run_ctx, call, tool_def, inner),
+        )
         return await chain(args)
 
     async def on_tool_execute_error(
@@ -584,17 +648,16 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         args: dict[str, Any],
         error: Exception,
     ) -> Any:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_tool_hook(capability, ctx, tool_def)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_tool_execute_error(
-                    cap_ctx, call=call, tool_def=tool_def, args=args, error=error
-                )
-            except Exception as new_error:
-                error = new_error
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            lambda capability, run_ctx: _ctx_for_tool_hook(capability, run_ctx, tool_def),
+            lambda capability, cap_ctx, current: capability.on_tool_execute_error(
+                cap_ctx, call=call, tool_def=tool_def, args=args, error=current
+            ),
+            Exception,
+        )
 
     # --- Output validate lifecycle hooks ---
 
@@ -605,10 +668,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output_context: OutputContext,
         output: RawOutput,
     ) -> RawOutput:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                output = await capability.before_output_validate(cap_ctx, output_context=output_context, output=output)
-        return output
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            output,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.before_output_validate(
+                cap_ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def after_output_validate(
         self,
@@ -617,10 +685,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output_context: OutputContext,
         output: Any,
     ) -> Any:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                output = await capability.after_output_validate(cap_ctx, output_context=output_context, output=output)
-        return output
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            output,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.after_output_validate(
+                cap_ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def wrap_output_validate(
         self,
@@ -630,10 +703,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output: RawOutput,
         handler: WrapOutputValidateHandler,
     ) -> Any:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
-                chain = _make_output_validate_wrap(capability, ctx, output_context, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            _ctx_for_available_cap,
+            lambda capability, run_ctx, inner: _make_output_validate_wrap(capability, run_ctx, output_context, inner),
+        )
         return await chain(output)
 
     async def on_output_validate_error(
@@ -644,20 +720,16 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output: RawOutput,
         error: ValidationError | ModelRetry,
     ) -> Any:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_available_cap(capability, ctx)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_output_validate_error(
-                    cap_ctx, output_context=output_context, output=output, error=error
-                )
-            except (ValidationError, ModelRetry) as new_error:
-                error = new_error
-            except Exception:  # pragma: no cover
-                # Defensive.
-                raise
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, current: capability.on_output_validate_error(
+                cap_ctx, output_context=output_context, output=output, error=current
+            ),
+            (ValidationError, ModelRetry),
+        )
 
     # --- Output process lifecycle hooks ---
 
@@ -668,10 +740,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output_context: OutputContext,
         output: Any,
     ) -> Any:
-        for capability in self.capabilities:
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                output = await capability.before_output_process(cap_ctx, output_context=output_context, output=output)
-        return output
+        return await _forward_capabilities(
+            self.capabilities,
+            ctx,
+            output,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.before_output_process(
+                cap_ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def after_output_process(
         self,
@@ -680,10 +757,15 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output_context: OutputContext,
         output: Any,
     ) -> Any:
-        for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
-                output = await capability.after_output_process(cap_ctx, output_context=output_context, output=output)
-        return output
+        return await _reverse_capabilities(
+            self.capabilities,
+            ctx,
+            output,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, value: capability.after_output_process(
+                cap_ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def wrap_output_process(
         self,
@@ -693,10 +775,13 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output: Any,
         handler: WrapOutputProcessHandler,
     ) -> Any:
-        chain = handler
-        for capability in reversed(self.capabilities):
-            if _ctx_for_available_cap(capability, ctx) is not None:
-                chain = _make_output_process_wrap(capability, ctx, output_context, chain)
+        chain = _wrap_capabilities(
+            self.capabilities,
+            ctx,
+            handler,
+            _ctx_for_available_cap,
+            lambda capability, run_ctx, inner: _make_output_process_wrap(capability, run_ctx, output_context, inner),
+        )
         return await chain(output)
 
     async def on_output_process_error(
@@ -707,17 +792,16 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         output: Any,
         error: Exception,
     ) -> Any:
-        for capability in reversed(self.capabilities):
-            cap_ctx = _ctx_for_available_cap(capability, ctx)
-            if cap_ctx is None:
-                continue
-            try:
-                return await capability.on_output_process_error(
-                    cap_ctx, output_context=output_context, output=output, error=error
-                )
-            except Exception as new_error:
-                error = new_error
-        raise error
+        return await _recover_capabilities(
+            self.capabilities,
+            ctx,
+            error,
+            _ctx_for_available_cap,
+            lambda capability, cap_ctx, current: capability.on_output_process_error(
+                cap_ctx, output_context=output_context, output=output, error=current
+            ),
+            Exception,
+        )
 
     async def handle_deferred_tool_calls(
         self,
@@ -725,23 +809,115 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         *,
         requests: DeferredToolRequests,
     ) -> DeferredToolResults | None:
-        accumulated = DeferredToolResults()
-        remaining = requests
-        any_handled = False
-        for capability in self.capabilities:
+        stack = LifecycleStack(self.capabilities)
+
+        async def handle(
+            capability: AbstractCapability[AgentDepsT], remaining: DeferredToolRequests
+        ) -> DeferredToolResults | None:
             cap_ctx = _ctx_for_available_cap(capability, ctx)
             if cap_ctx is None:
-                continue
-            result = await capability.handle_deferred_tool_calls(cap_ctx, requests=remaining)
-            if result is None or not (result.approvals or result.calls):
-                continue
-            any_handled = True
-            accumulated.update(result)
-            remaining_or_none = remaining.remaining(result)
-            if remaining_or_none is None:
-                break
-            remaining = remaining_or_none
-        return accumulated if any_handled else None
+                return None
+            return await capability.handle_deferred_tool_calls(cap_ctx, requests=remaining)
+
+        return await stack.settle_deferred(requests, handle)
+
+
+async def _forward_capabilities(
+    capabilities: Sequence[AbstractCapability[_DepsT]],
+    ctx: RunContext[_DepsT],
+    value: _ValueT,
+    get_context: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT]], RunContext[_DepsT] | None],
+    transform: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT], _ValueT], Awaitable[_ValueT]],
+) -> _ValueT:
+    stack = LifecycleStack(capabilities)
+
+    async def apply(capability: AbstractCapability[_DepsT], current: _ValueT) -> _ValueT:
+        cap_ctx = get_context(capability, ctx)
+        if cap_ctx is None:
+            return current
+        return await transform(capability, cap_ctx, current)
+
+    return await stack.forward(value, apply)
+
+
+async def _reverse_capabilities(
+    capabilities: Sequence[AbstractCapability[_DepsT]],
+    ctx: RunContext[_DepsT],
+    value: _ValueT,
+    get_context: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT]], RunContext[_DepsT] | None],
+    transform: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT], _ValueT], Awaitable[_ValueT]],
+) -> _ValueT:
+    stack = LifecycleStack(capabilities)
+
+    async def apply(capability: AbstractCapability[_DepsT], current: _ValueT) -> _ValueT:
+        cap_ctx = get_context(capability, ctx)
+        if cap_ctx is None:
+            return current
+        return await transform(capability, cap_ctx, current)
+
+    return await stack.reverse(value, apply)
+
+
+async def _notify_capabilities(
+    capabilities: Sequence[AbstractCapability[_DepsT]],
+    ctx: RunContext[_DepsT],
+    get_context: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT]], RunContext[_DepsT] | None],
+    notify: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT]], Awaitable[None]],
+) -> None:
+    stack = LifecycleStack(capabilities)
+
+    async def apply(capability: AbstractCapability[_DepsT]) -> None:
+        cap_ctx = get_context(capability, ctx)
+        if cap_ctx is not None:
+            await notify(capability, cap_ctx)
+
+    await stack.notify(apply)
+
+
+def _wrap_capabilities(
+    capabilities: Sequence[AbstractCapability[_DepsT]],
+    ctx: RunContext[_DepsT],
+    handler: Callable[_Params, Awaitable[_ResultT]],
+    get_context: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT]], RunContext[_DepsT] | None],
+    wrap: Callable[
+        [
+            AbstractCapability[_DepsT],
+            RunContext[_DepsT],
+            Callable[_Params, Awaitable[_ResultT]],
+        ],
+        Callable[_Params, Awaitable[_ResultT]],
+    ],
+) -> Callable[_Params, Awaitable[_ResultT]]:
+    stack = LifecycleStack(capabilities)
+
+    def apply(
+        capability: AbstractCapability[_DepsT],
+        inner: Callable[_Params, Awaitable[_ResultT]],
+    ) -> Callable[_Params, Awaitable[_ResultT]]:
+        if get_context(capability, ctx) is None:
+            return inner
+        return wrap(capability, ctx, inner)
+
+    return stack.wrap(handler, apply)
+
+
+async def _recover_capabilities(
+    capabilities: Sequence[AbstractCapability[_DepsT]],
+    ctx: RunContext[_DepsT],
+    error: _ErrorT,
+    get_context: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT]], RunContext[_DepsT] | None],
+    recover: Callable[[AbstractCapability[_DepsT], RunContext[_DepsT], _ErrorT], Awaitable[_ResultT]],
+    caught: type[_ErrorT] | tuple[type[_ErrorT], ...],
+) -> _ResultT:
+    stack = LifecycleStack(capabilities)
+
+    async def apply(capability: AbstractCapability[_DepsT], current: _ErrorT) -> _ResultT | SkipLifecycleEntry:
+        cap_ctx = get_context(capability, ctx)
+        if cap_ctx is None:
+            return SKIP_LIFECYCLE_ENTRY
+        return await recover(capability, cap_ctx, current)
+
+    return await stack.recover(error, apply, caught)
 
 
 # --- Composition helpers ---

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -34,6 +34,7 @@ from pydantic_ai.exceptions import AgentRunError, ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import AgentDepsT, DeferredToolRequests, DeferredToolResults, RunContext, ToolDefinition
 
+from ._lifecycle import LifecycleStack
 from .abstract import (
     AbstractCapability,
     AgentNode,
@@ -872,37 +873,38 @@ class Hooks(AbstractCapability[AgentDepsT]):
     # These dispatch to registered hook functions in self._registry.
 
     async def before_run(self, ctx: RunContext[AgentDepsT]) -> None:
-        for entry in self._get('before_run'):
-            await _call_entry(entry, 'before_run', ctx)
+        stack = LifecycleStack(self._get('before_run'))
+        await stack.notify(lambda entry: _call_entry(entry, 'before_run', ctx))
 
     async def after_run(self, ctx: RunContext[AgentDepsT], *, result: AgentRunResult[Any]) -> AgentRunResult[Any]:
-        for entry in self._get('after_run'):
-            result = await _call_entry(entry, 'after_run', ctx, result=result)
-        return result
+        stack = LifecycleStack(self._get('after_run'))
+        return await stack.forward(result, lambda entry, value: _call_entry(entry, 'after_run', ctx, result=value))
 
     async def wrap_run(self, ctx: RunContext[AgentDepsT], *, handler: WrapRunHandler) -> AgentRunResult[Any]:
-        entries = self._get('wrap_run')
-        if not entries:
-            return await handler()
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(entry, 'wrap_run', ctx, {}, chain, None)
+        stack = LifecycleStack(self._get('wrap_run'))
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(entry, 'wrap_run', ctx, {}, inner, None),
+        )
         return await chain()
 
     async def on_run_error(self, ctx: RunContext[AgentDepsT], *, error: BaseException) -> AgentRunResult[Any]:
-        for entry in self._get('on_run_error'):
-            try:
-                return await _call_entry(entry, 'on_run_error', ctx, error=error)
-            except BaseException as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(self._get('on_run_error'))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(entry, 'on_run_error', ctx, error=current),
+            BaseException,
+            reverse=False,
+        )
 
     async def before_node_run(
         self, ctx: RunContext[AgentDepsT], *, node: AgentNode[AgentDepsT]
     ) -> AgentNode[AgentDepsT]:
-        for entry in self._get('before_node_run'):
-            node = await _call_entry(entry, 'before_node_run', ctx, node=node)
-        return node
+        stack = LifecycleStack(self._get('before_node_run'))
+        return await stack.forward(
+            node,
+            lambda entry, value: _call_entry(entry, 'before_node_run', ctx, node=value),
+        )
 
     async def after_node_run(
         self,
@@ -911,9 +913,11 @@ class Hooks(AbstractCapability[AgentDepsT]):
         node: AgentNode[AgentDepsT],
         result: NodeResult[AgentDepsT],
     ) -> NodeResult[AgentDepsT]:
-        for entry in self._get('after_node_run'):
-            result = await _call_entry(entry, 'after_node_run', ctx, node=node, result=result)
-        return result
+        stack = LifecycleStack(self._get('after_node_run'))
+        return await stack.forward(
+            result,
+            lambda entry, value: _call_entry(entry, 'after_node_run', ctx, node=node, result=value),
+        )
 
     async def wrap_node_run(
         self,
@@ -922,49 +926,43 @@ class Hooks(AbstractCapability[AgentDepsT]):
         node: AgentNode[AgentDepsT],
         handler: WrapNodeRunHandler[AgentDepsT],
     ) -> NodeResult[AgentDepsT]:
-        entries = self._get('wrap_node_run')
-        if not entries:
-            return await handler(node)
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(entry, 'wrap_node_run', ctx, {}, chain, 'node')
+        stack = LifecycleStack(self._get('wrap_node_run'))
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(entry, 'wrap_node_run', ctx, {}, inner, 'node'),
+        )
         return await chain(node)
 
     async def on_node_run_error(
         self, ctx: RunContext[AgentDepsT], *, node: AgentNode[AgentDepsT], error: Exception
     ) -> NodeResult[AgentDepsT]:
-        for entry in self._get('on_node_run_error'):
-            try:
-                return await _call_entry(entry, 'on_node_run_error', ctx, node=node, error=error)
-            except Exception as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(self._get('on_node_run_error'))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(entry, 'on_node_run_error', ctx, node=node, error=current),
+            Exception,
+            reverse=False,
+        )
 
     async def wrap_run_event_stream(
         self, ctx: RunContext[AgentDepsT], *, stream: AsyncIterable[AgentStreamEvent]
     ) -> AsyncIterable[AgentStreamEvent]:
-        wrapped_streams = [stream]
-        # First, wrap with per-event callbacks (innermost)
         event_entries = self._get('_on_event')
         if event_entries:
             stream = _event_callback_stream(ctx, stream, event_entries)
-            wrapped_streams.append(stream)
-        # Then chain explicit stream wrappers (outermost)
-        for entry in reversed(self._get('wrap_run_event_stream')):
-            stream = entry.func(ctx, stream=stream)
-            wrapped_streams.append(stream)
-        try:
-            async for event in stream:
+        stack = LifecycleStack(self._get('wrap_run_event_stream'))
+        async with stack.stream(stream, lambda entry, source: entry.func(ctx, stream=source)) as wrapped:
+            async for event in wrapped:
                 yield event
-        finally:
-            await _utils.aclose_all(reversed(wrapped_streams))
 
     async def before_model_request(
         self, ctx: RunContext[AgentDepsT], request_context: ModelRequestContext
     ) -> ModelRequestContext:
-        for entry in self._get('before_model_request'):
-            request_context = await _call_entry(entry, 'before_model_request', ctx, request_context)
-        return request_context
+        stack = LifecycleStack(self._get('before_model_request'))
+        return await stack.forward(
+            request_context,
+            lambda entry, value: _call_entry(entry, 'before_model_request', ctx, value),
+        )
 
     async def after_model_request(
         self,
@@ -973,11 +971,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         response: ModelResponse,
     ) -> ModelResponse:
-        for entry in self._get('after_model_request'):
-            response = await _call_entry(
-                entry, 'after_model_request', ctx, request_context=request_context, response=response
-            )
-        return response
+        stack = LifecycleStack(self._get('after_model_request'))
+        return await stack.forward(
+            response,
+            lambda entry, value: _call_entry(
+                entry, 'after_model_request', ctx, request_context=request_context, response=value
+            ),
+        )
 
     async def wrap_model_request(
         self,
@@ -986,51 +986,60 @@ class Hooks(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
-        entries = self._get('wrap_model_request')
-        if not entries:
-            return await handler(request_context)
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(entry, 'wrap_model_request', ctx, {}, chain, 'request_context')
+        stack = LifecycleStack(self._get('wrap_model_request'))
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(entry, 'wrap_model_request', ctx, {}, inner, 'request_context'),
+        )
         return await chain(request_context)
 
     async def on_model_request_error(
         self, ctx: RunContext[AgentDepsT], *, request_context: ModelRequestContext, error: Exception
     ) -> ModelResponse:
-        for entry in self._get('on_model_request_error'):
-            try:
-                return await _call_entry(
-                    entry, 'on_model_request_error', ctx, request_context=request_context, error=error
-                )
-            except Exception as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(self._get('on_model_request_error'))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(
+                entry, 'on_model_request_error', ctx, request_context=request_context, error=current
+            ),
+            Exception,
+            reverse=False,
+        )
 
     async def prepare_tools(self, ctx: RunContext[AgentDepsT], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
-        for entry in self._get('prepare_tools'):
-            tool_defs = await _call_entry(entry, 'prepare_tools', ctx, tool_defs)
-        return tool_defs
+        stack = LifecycleStack(self._get('prepare_tools'))
+        return await stack.forward(tool_defs, lambda entry, value: _call_entry(entry, 'prepare_tools', ctx, value))
 
     async def prepare_output_tools(
         self, ctx: RunContext[AgentDepsT], tool_defs: list[ToolDefinition]
     ) -> list[ToolDefinition]:
-        for entry in self._get('prepare_output_tools'):
-            tool_defs = await _call_entry(entry, 'prepare_output_tools', ctx, tool_defs)
-        return tool_defs
+        stack = LifecycleStack(self._get('prepare_output_tools'))
+        return await stack.forward(
+            tool_defs,
+            lambda entry, value: _call_entry(entry, 'prepare_output_tools', ctx, value),
+        )
 
     async def before_tool_validate(
         self, ctx: RunContext[AgentDepsT], *, call: ToolCallPart, tool_def: ToolDefinition, args: RawToolArgs
     ) -> RawToolArgs:
-        for entry in _filter_tool_entries(self._get('before_tool_validate'), call=call):
-            args = await _call_entry(entry, 'before_tool_validate', ctx, call=call, tool_def=tool_def, args=args)
-        return args
+        stack = LifecycleStack(_filter_tool_entries(self._get('before_tool_validate'), call=call))
+        return await stack.forward(
+            args,
+            lambda entry, value: _call_entry(
+                entry, 'before_tool_validate', ctx, call=call, tool_def=tool_def, args=value
+            ),
+        )
 
     async def after_tool_validate(
         self, ctx: RunContext[AgentDepsT], *, call: ToolCallPart, tool_def: ToolDefinition, args: ValidatedToolArgs
     ) -> ValidatedToolArgs:
-        for entry in _filter_tool_entries(self._get('after_tool_validate'), call=call):
-            args = await _call_entry(entry, 'after_tool_validate', ctx, call=call, tool_def=tool_def, args=args)
-        return args
+        stack = LifecycleStack(_filter_tool_entries(self._get('after_tool_validate'), call=call))
+        return await stack.forward(
+            args,
+            lambda entry, value: _call_entry(
+                entry, 'after_tool_validate', ctx, call=call, tool_def=tool_def, args=value
+            ),
+        )
 
     async def wrap_tool_validate(
         self,
@@ -1042,13 +1051,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         handler: WrapToolValidateHandler,
     ) -> ValidatedToolArgs:
         entries = _filter_tool_entries(self._get('wrap_tool_validate'), call=call)
-        if not entries:
-            return await handler(args)
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(
-                entry, 'wrap_tool_validate', ctx, {'call': call, 'tool_def': tool_def}, chain, 'args'
-            )
+        stack = LifecycleStack(entries)
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(
+                entry, 'wrap_tool_validate', ctx, {'call': call, 'tool_def': tool_def}, inner, 'args'
+            ),
+        )
         return await chain(args)
 
     async def on_tool_validate_error(
@@ -1060,21 +1069,26 @@ class Hooks(AbstractCapability[AgentDepsT]):
         args: RawToolArgs,
         error: ValidationError | ModelRetry,
     ) -> ValidatedToolArgs:
-        for entry in _filter_tool_entries(self._get('on_tool_validate_error'), call=call):
-            try:
-                return await _call_entry(
-                    entry, 'on_tool_validate_error', ctx, call=call, tool_def=tool_def, args=args, error=error
-                )
-            except (ValidationError, ModelRetry) as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(_filter_tool_entries(self._get('on_tool_validate_error'), call=call))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(
+                entry, 'on_tool_validate_error', ctx, call=call, tool_def=tool_def, args=args, error=current
+            ),
+            (ValidationError, ModelRetry),
+            reverse=False,
+        )
 
     async def before_tool_execute(
         self, ctx: RunContext[AgentDepsT], *, call: ToolCallPart, tool_def: ToolDefinition, args: ValidatedToolArgs
     ) -> ValidatedToolArgs:
-        for entry in _filter_tool_entries(self._get('before_tool_execute'), call=call):
-            args = await _call_entry(entry, 'before_tool_execute', ctx, call=call, tool_def=tool_def, args=args)
-        return args
+        stack = LifecycleStack(_filter_tool_entries(self._get('before_tool_execute'), call=call))
+        return await stack.forward(
+            args,
+            lambda entry, value: _call_entry(
+                entry, 'before_tool_execute', ctx, call=call, tool_def=tool_def, args=value
+            ),
+        )
 
     async def after_tool_execute(
         self,
@@ -1085,11 +1099,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         args: ValidatedToolArgs,
         result: Any,
     ) -> Any:
-        for entry in _filter_tool_entries(self._get('after_tool_execute'), call=call):
-            result = await _call_entry(
-                entry, 'after_tool_execute', ctx, call=call, tool_def=tool_def, args=args, result=result
-            )
-        return result
+        stack = LifecycleStack(_filter_tool_entries(self._get('after_tool_execute'), call=call))
+        return await stack.forward(
+            result,
+            lambda entry, value: _call_entry(
+                entry, 'after_tool_execute', ctx, call=call, tool_def=tool_def, args=args, result=value
+            ),
+        )
 
     async def wrap_tool_execute(
         self,
@@ -1101,13 +1117,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         handler: WrapToolExecuteHandler,
     ) -> Any:
         entries = _filter_tool_entries(self._get('wrap_tool_execute'), call=call)
-        if not entries:
-            return await handler(args)
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(
-                entry, 'wrap_tool_execute', ctx, {'call': call, 'tool_def': tool_def}, chain, 'args'
-            )
+        stack = LifecycleStack(entries)
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(
+                entry, 'wrap_tool_execute', ctx, {'call': call, 'tool_def': tool_def}, inner, 'args'
+            ),
+        )
         return await chain(args)
 
     async def on_tool_execute_error(
@@ -1119,23 +1135,26 @@ class Hooks(AbstractCapability[AgentDepsT]):
         args: ValidatedToolArgs,
         error: Exception,
     ) -> Any:
-        for entry in _filter_tool_entries(self._get('on_tool_execute_error'), call=call):
-            try:
-                return await _call_entry(
-                    entry, 'on_tool_execute_error', ctx, call=call, tool_def=tool_def, args=args, error=error
-                )
-            except Exception as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(_filter_tool_entries(self._get('on_tool_execute_error'), call=call))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(
+                entry, 'on_tool_execute_error', ctx, call=call, tool_def=tool_def, args=args, error=current
+            ),
+            Exception,
+            reverse=False,
+        )
 
     async def before_output_validate(
         self, ctx: RunContext[AgentDepsT], *, output_context: OutputContext, output: RawOutput
     ) -> RawOutput:
-        for entry in self._get('before_output_validate'):
-            output = await _call_entry(
-                entry, 'before_output_validate', ctx, output_context=output_context, output=output
-            )
-        return output
+        stack = LifecycleStack(self._get('before_output_validate'))
+        return await stack.forward(
+            output,
+            lambda entry, value: _call_entry(
+                entry, 'before_output_validate', ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def after_output_validate(
         self,
@@ -1144,11 +1163,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         output_context: OutputContext,
         output: Any,
     ) -> Any:
-        for entry in self._get('after_output_validate'):
-            output = await _call_entry(
-                entry, 'after_output_validate', ctx, output_context=output_context, output=output
-            )
-        return output
+        stack = LifecycleStack(self._get('after_output_validate'))
+        return await stack.forward(
+            output,
+            lambda entry, value: _call_entry(
+                entry, 'after_output_validate', ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def wrap_output_validate(
         self,
@@ -1158,14 +1179,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         output: RawOutput,
         handler: WrapOutputValidateHandler,
     ) -> Any:
-        entries = self._get('wrap_output_validate')
-        if not entries:
-            return await handler(output)
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(
-                entry, 'wrap_output_validate', ctx, {'output_context': output_context}, chain, 'output'
-            )
+        stack = LifecycleStack(self._get('wrap_output_validate'))
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(
+                entry, 'wrap_output_validate', ctx, {'output_context': output_context}, inner, 'output'
+            ),
+        )
         return await chain(output)
 
     async def on_output_validate_error(
@@ -1176,41 +1196,42 @@ class Hooks(AbstractCapability[AgentDepsT]):
         output: RawOutput,
         error: ValidationError | ModelRetry,
     ) -> Any:
-        for entry in self._get('on_output_validate_error'):
-            try:
-                return await _call_entry(
-                    entry,
-                    'on_output_validate_error',
-                    ctx,
-                    output_context=output_context,
-                    output=output,
-                    error=error,
-                )
-            except (ValidationError, ModelRetry) as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(self._get('on_output_validate_error'))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(
+                entry,
+                'on_output_validate_error',
+                ctx,
+                output_context=output_context,
+                output=output,
+                error=current,
+            ),
+            (ValidationError, ModelRetry),
+            reverse=False,
+        )
 
     async def before_output_process(
         self, ctx: RunContext[AgentDepsT], *, output_context: OutputContext, output: Any
     ) -> Any:
-        for entry in self._get('before_output_process'):
-            output = await _call_entry(
-                entry, 'before_output_process', ctx, output_context=output_context, output=output
-            )
-        return output
+        stack = LifecycleStack(self._get('before_output_process'))
+        return await stack.forward(
+            output,
+            lambda entry, value: _call_entry(
+                entry, 'before_output_process', ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def after_output_process(
         self, ctx: RunContext[AgentDepsT], *, output_context: OutputContext, output: Any
     ) -> Any:
-        for entry in self._get('after_output_process'):
-            output = await _call_entry(
-                entry,
-                'after_output_process',
-                ctx,
-                output_context=output_context,
-                output=output,
-            )
-        return output
+        stack = LifecycleStack(self._get('after_output_process'))
+        return await stack.forward(
+            output,
+            lambda entry, value: _call_entry(
+                entry, 'after_output_process', ctx, output_context=output_context, output=value
+            ),
+        )
 
     async def wrap_output_process(
         self,
@@ -1220,14 +1241,13 @@ class Hooks(AbstractCapability[AgentDepsT]):
         output: Any,
         handler: WrapOutputProcessHandler,
     ) -> Any:
-        entries = self._get('wrap_output_process')
-        if not entries:
-            return await handler(output)
-        chain: Callable[..., Any] = handler
-        for entry in reversed(entries):
-            chain = _make_wrap_link(
-                entry, 'wrap_output_process', ctx, {'output_context': output_context}, chain, 'output'
-            )
+        stack = LifecycleStack(self._get('wrap_output_process'))
+        chain = stack.wrap(
+            handler,
+            lambda entry, inner: _make_wrap_link(
+                entry, 'wrap_output_process', ctx, {'output_context': output_context}, inner, 'output'
+            ),
+        )
         return await chain(output)
 
     async def on_output_process_error(
@@ -1238,14 +1258,15 @@ class Hooks(AbstractCapability[AgentDepsT]):
         output: Any,
         error: Exception,
     ) -> Any:
-        for entry in self._get('on_output_process_error'):
-            try:
-                return await _call_entry(
-                    entry, 'on_output_process_error', ctx, output_context=output_context, output=output, error=error
-                )
-            except Exception as new_error:
-                error = new_error
-        raise error
+        stack = LifecycleStack(self._get('on_output_process_error'))
+        return await stack.recover(
+            error,
+            lambda entry, current: _call_entry(
+                entry, 'on_output_process_error', ctx, output_context=output_context, output=output, error=current
+            ),
+            Exception,
+            reverse=False,
+        )
 
     async def handle_deferred_tool_calls(
         self,
@@ -1253,20 +1274,11 @@ class Hooks(AbstractCapability[AgentDepsT]):
         *,
         requests: DeferredToolRequests,
     ) -> DeferredToolResults | None:
-        accumulated = DeferredToolResults()
-        remaining = requests
-        any_handled = False
-        for entry in self._get('handle_deferred_tool_calls'):
-            result = await _call_entry(entry, 'handle_deferred_tool_calls', ctx, requests=remaining)
-            if result is None or not (result.approvals or result.calls):
-                continue
-            any_handled = True
-            accumulated.update(result)
-            remaining_or_none = remaining.remaining(result)
-            if remaining_or_none is None:
-                break
-            remaining = remaining_or_none
-        return accumulated if any_handled else None
+        stack = LifecycleStack(self._get('handle_deferred_tool_calls'))
+        return await stack.settle_deferred(
+            requests,
+            lambda entry, remaining: _call_entry(entry, 'handle_deferred_tool_calls', ctx, requests=remaining),
+        )
 
 
 # --- Wrap chain helper ---

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -20,6 +20,7 @@ from pydantic_ai import (
     Agent,
     AgentRetries,
     AgentRunResultEvent,
+    AgentSpec,
     AudioUrl,
     BinaryContent,
     BinaryImage,
@@ -39,6 +40,7 @@ from pydantic_ai import (
     ModelResponse,
     ModelResponsePart,
     ModelRetry,
+    ModelSelectionContext,
     PrefixedToolset,
     RequestUsage,
     RetryPromptPart,
@@ -72,6 +74,7 @@ from pydantic_ai.capabilities import (
     PrepareOutputTools,
     PrepareTools,
     RaiseContentFilterError,
+    SelectModel,
     WrapRunHandler,
 )
 from pydantic_ai.exceptions import ContentFilterError
@@ -4203,6 +4206,70 @@ async def test_agent_iter_metadata_surfaces_on_result() -> None:
     assert agent_run.metadata == {'env': 'tests'}
     assert agent_run.result is not None
     assert agent_run.result.metadata == {'env': 'tests'}
+
+
+async def test_agent_iter_prepares_all_run_inputs() -> None:
+    selected_steps: list[int] = []
+    seen_tools: list[list[str]] = []
+    output_retries: list[int] = []
+
+    def output(ctx: RunContext[object], result: str) -> str:
+        assert ctx.max_retries == 1
+        output_retries.append(ctx.retry)
+        if ctx.retry == 0:
+            raise ModelRetry('retry once')
+        return result
+
+    run_toolset = FunctionToolset()
+
+    @run_toolset.tool_plain
+    def run_tool() -> str:
+        return 'from run toolset'
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen_tools.append([tool.name for tool in info.function_tools])
+        has_run_tool_return = any(
+            isinstance(part, ToolReturnPart) and part.tool_name == 'run_tool'
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if not has_run_tool_return:
+            return ModelResponse(parts=[ToolCallPart('run_tool', {})])
+
+        return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, {'result': 'done'})])
+
+    selected_model = FunctionModel(respond)
+
+    def select(ctx: ModelSelectionContext[object]) -> Model:
+        selected_steps.append(ctx.run_step)
+        return selected_model
+
+    agent = Agent(
+        None,
+        metadata={'agent': 'metadata'},
+        output_type=ToolOutput(output),
+        retries={'output': 3},
+    )
+
+    async with agent.iter(
+        'hi',
+        spec=AgentSpec(metadata={'spec': 'metadata'}, retries={'output': 0}),
+        capabilities=[SelectModel(select)],
+        toolsets=[run_toolset],
+        metadata={'run': 'metadata'},
+        retries={'output': 1},
+    ) as agent_run:
+        assert agent_run.metadata == {'agent': 'metadata', 'spec': 'metadata', 'run': 'metadata'}
+        async for _ in agent_run:
+            pass
+
+    assert agent_run.result is not None
+    assert agent_run.result.output == 'done'
+    assert agent_run.result.metadata == {'agent': 'metadata', 'spec': 'metadata', 'run': 'metadata'}
+    assert selected_steps == [1, 2, 3]
+    assert seen_tools == [['run_tool'], ['run_tool'], ['run_tool']]
+    assert output_retries == [0, 1]
 
 
 async def test_agent_metadata_persisted_when_run_fails() -> None:

--- a/tests/test_capability_lifecycle.py
+++ b/tests/test_capability_lifecycle.py
@@ -1,0 +1,180 @@
+"""Definitory tests for the private capability lifecycle sequencing engine.
+
+Provider recordings cannot precisely assert internal ordering, replacement-error
+propagation, or stream ownership, so these contracts require focused unit tests.
+Public capability behavior remains covered by the integration test suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
+
+import pytest
+from inline_snapshot import snapshot
+from typing_extensions import Self
+
+from pydantic_ai.capabilities._lifecycle import SKIP_LIFECYCLE_ENTRY, LifecycleStack, SkipLifecycleEntry
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults
+
+
+async def test_lifecycle_stack_ordering_and_recovery() -> None:
+    stack = LifecycleStack(['outer', 'inner'])
+    events: list[str] = []
+
+    async def transform(entry: str, value: str) -> str:
+        events.append(f'transform:{entry}')
+        return f'{value}:{entry}'
+
+    assert await stack.forward('start', transform) == 'start:outer:inner'
+    assert await stack.reverse('start', transform) == 'start:inner:outer'
+
+    async def notify(entry: str) -> None:
+        events.append(f'notify:{entry}')
+
+    await stack.notify(notify)
+
+    async def handler(value: str) -> str:
+        events.append(f'handler:{value}')
+        return 'result'
+
+    def wrap(entry: str, inner: Callable[[str], Awaitable[str]]) -> Callable[[str], Awaitable[str]]:
+        async def wrapped(value: str) -> str:
+            events.append(f'enter:{entry}')
+            result = await inner(value)
+            events.append(f'exit:{entry}')
+            return result
+
+        return wrapped
+
+    assert await stack.wrap(handler, wrap)('value') == 'result'
+
+    async def recover(entry: str, error: Exception) -> str:
+        events.append(f'recover:{entry}:{error}')
+        if entry == 'inner':
+            raise RuntimeError('replacement')
+        return 'recovered'
+
+    assert await stack.recover(ValueError('original'), recover, Exception) == 'recovered'
+    assert events == snapshot(
+        [
+            'transform:outer',
+            'transform:inner',
+            'transform:inner',
+            'transform:outer',
+            'notify:outer',
+            'notify:inner',
+            'enter:outer',
+            'enter:inner',
+            'handler:value',
+            'exit:inner',
+            'exit:outer',
+            'recover:inner:original',
+            'recover:outer:replacement',
+        ]
+    )
+
+
+async def test_lifecycle_stack_recovery_can_skip_entries_and_run_forward() -> None:
+    stack = LifecycleStack(['first', 'skipped', 'last'])
+    errors: list[str] = []
+
+    async def recover(entry: str, error: Exception) -> str | SkipLifecycleEntry:
+        errors.append(f'{entry}:{error}')
+        if entry == 'skipped':
+            return SKIP_LIFECYCLE_ENTRY
+        if entry == 'first':
+            raise RuntimeError('replacement')
+        return 'recovered'
+
+    assert await stack.recover(ValueError('original'), recover, Exception, reverse=False) == 'recovered'
+    assert errors == ['first:original', 'skipped:replacement', 'last:replacement']
+
+
+async def test_lifecycle_stack_all_skipped_recovery_preserves_error_traceback() -> None:
+    stack = LifecycleStack(['first', 'second', 'third'])
+    error = ValueError('original')
+
+    async def skip(_entry: str, _error: Exception) -> SkipLifecycleEntry:
+        return SKIP_LIFECYCLE_ENTRY
+
+    with pytest.raises(ValueError) as exc_info:
+        await stack.recover(error, skip, Exception)
+
+    assert exc_info.value is error
+    assert [entry.name for entry in exc_info.traceback] == [
+        'test_lifecycle_stack_all_skipped_recovery_preserves_error_traceback',
+        'recover',
+    ]
+
+
+class _TrackingStream(AsyncIterator[int]):
+    def __init__(
+        self,
+        name: str,
+        closed: list[str],
+        source: AsyncIterable[int] | None = None,
+    ) -> None:
+        self.name = name
+        self.closed = closed
+        self.source = source.__aiter__() if source is not None else None
+        self.yielded = False
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> int:
+        if self.source is not None:
+            return await self.source.__anext__()
+        if self.yielded:
+            raise StopAsyncIteration
+        self.yielded = True
+        return 1
+
+    async def aclose(self) -> None:
+        self.closed.append(self.name)
+
+
+async def test_lifecycle_stack_stream_skips_entries_and_closes_every_layer() -> None:
+    closed: list[str] = []
+    source = _TrackingStream('source', closed)
+    stack = LifecycleStack(['outer', 'skipped', 'inner'])
+
+    def wrap(entry: str, stream: AsyncIterable[int]) -> AsyncIterable[int] | None:
+        if entry == 'skipped':
+            return None
+        return _TrackingStream(entry, closed, stream)
+
+    async with stack.stream(source, wrap) as stream:
+        assert [value async for value in stream] == [1]
+
+    assert closed == ['outer', 'inner', 'source']
+
+
+async def test_lifecycle_stack_deferred_settlement_passes_only_unresolved_calls() -> None:
+    requests = DeferredToolRequests(
+        approvals=[ToolCallPart('approve', {}, tool_call_id='approval')],
+        calls=[ToolCallPart('external', {}, tool_call_id='call')],
+    )
+    seen: list[tuple[str, list[str], list[str]]] = []
+    stack = LifecycleStack(['approval-handler', 'call-handler'])
+
+    async def handle(entry: str, remaining: DeferredToolRequests) -> DeferredToolResults:
+        seen.append(
+            (
+                entry,
+                [call.tool_call_id for call in remaining.approvals],
+                [call.tool_call_id for call in remaining.calls],
+            )
+        )
+        if entry == 'approval-handler':
+            return DeferredToolResults(approvals={'approval': True})
+        return DeferredToolResults(calls={'call': 'result'})
+
+    assert await stack.settle_deferred(requests, handle) == DeferredToolResults(
+        approvals={'approval': True}, calls={'call': 'result'}
+    )
+    assert seen == [
+        ('approval-handler', ['approval'], ['call']),
+        ('call-handler', [], ['call']),
+    ]


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

> [!IMPORTANT]
> **Non-merging design spike.** This PR is for architecture review only. It does not close #7339 and is not proposed for standalone merge. The code probes one possible dispatch seam while the durable-runtime contract in #5477 and the ecosystem migration plan are still being designed.

This is stacked on #7345, which isolates run preparation and lifecycle ownership. Review the capability-specific commit independently; #7345 can land without this spike.

## Question this spike answers

Can capability containers and typed `Hooks` registrations share one framework-owned sequencing engine without changing ordering, recovery, filtering, deferred settlement, or stream ownership?

The probe adds a private, typed `LifecycleStack` and routes both adapters through it:

- `CombinedCapability` retains availability and capability-owned-tool activation.
- `Hooks` retains registration order, timeout handling, and tool-name filters.
- The stack owns forward/reverse transforms, notifications, middleware nesting, recovery, stream cleanup, and partial deferred-result settlement.
- An explicit inactive-entry sentinel prevents skipped capabilities from mutating propagated tracebacks.

## What we learned

The common sequencing behavior can be centralized without changing observable behavior, but this patch is not yet the simplification described by #7339. `CombinedCapability` and `Hooks` still mirror the lifecycle operations and adapt each one separately; the probe adds net production code instead of deleting the public hierarchy.

Two design dependencies need agreement before the mergeable v3 implementation:

1. #5477 must settle which finite operations the framework owns and which execution, registration, gating, and policy responsibilities belong to durable runtimes.
2. Published integrations use `AbstractCapability`, `CombinedCapability`, `WrapperCapability`, `Hooks`, `for_agent()`, `for_run()`, ordering, and root-capability introspection. Removing those surfaces needs an explicit migration contract, not an internal-only rename.

## Proposed roadmap

1. Land or otherwise agree on the run-preparation boundary demonstrated by #7345.
2. Settle the framework/durable-runtime boundary in #5477.
3. Design typed contribution and lifecycle-registration primitives around that boundary.
4. Validate the migration against first-party and published integrations, including stable IDs, tool ownership, dynamic state reuse, model provenance, and durable registration.
5. Implement the mergeable #7339 change on `v3-main`, deleting the mirrored dispatch and obsolete public composition mechanics rather than retaining this scaffold.

## Preserved contracts

- Capability composition remains forward for `before_*`, reverse for `after_*` and capability recovery, and first-entry-outermost for middleware.
- `Hooks` registrations retain registration order for transforms and recovery.
- Agent binding remains distinct from exactly-once per-run preparation.
- Stream layers close deterministically on completion, failure, cancellation, and early exit.
- Deferred handlers receive only unresolved calls and accumulate partial results.
- No public API is added or removed by the spike.

## Verification

- Focused capability, hook, stream teardown, event-stream, and lifecycle-engine tests pass with the required 100% coverage bar.
- Temporal, Prefect, and DBOS capability/toolset integration spot checks pass.
- Formatting, lint, targeted type checking, and commit hooks pass.
- Independent review approved the patch for its explicitly non-merging spike purpose.

Related to #7339.
Related to #5477.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

