### PR TITLE
Point offline web UI hosting at the self-contained chat UI build

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -116,16 +116,25 @@ The app cannot currently be mounted at a subpath (e.g., `/chat`) because the UI 
 
 By default, the web UI is fetched from a CDN and cached locally. You can provide `html_source` to override this for offline usage or enterprise environments.
 
-For offline usage, download the html file once while you have internet access:
+### Offline and air-gapped deployments
+
+The default UI build is split across many files: `index.html` references a stylesheet and, at runtime,
+lazily imports chunks for syntax highlighting, diagrams and math. Those references point back at the
+CDN, so downloading `index.html` alone gives you a page that boots and then fails to render as soon as
+a code block or an equation appears.
+
+Use the **offline build** instead — a single self-contained file with every chunk, font and icon
+inlined, so it needs no network access beyond your own server:
 
 ```python
-from pydantic_ai.ui import DEFAULT_HTML_URL
+from pydantic_ai.ui import OFFLINE_HTML_URL
 
-print(DEFAULT_HTML_URL)  # Use this URL to download the UI HTML file
-#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.0.0/dist/index.html
+print(OFFLINE_HTML_URL)  # Use this URL to download the self-contained UI HTML file
+#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.1.0/offline/index.html
 ```
 
-You can then download the file using the URL printed above:
+Download it once from a machine that has internet access, then move it into the air-gapped
+environment:
 
 ```bash
 curl -o ~/pydantic-ai-ui.html <chat_ui_url>
@@ -143,4 +152,16 @@ app = agent.to_web(html_source='~/pydantic-ai-ui.html')
 
 # Or use a custom URL (e.g., for enterprise environments)
 app = agent.to_web(html_source='https://cdn.example.com/ui/index.html')
+```
+
+The offline file is around 16 MB. That is not extra weight so much as relocated weight — the default
+build ships the same assets across 400-odd files that the browser fetches from the CDN on demand,
+where the offline build front-loads all of them into the first request. The default `to_web()` path
+is unchanged and still uses the split build:
+
+```python
+from pydantic_ai.ui import DEFAULT_HTML_URL
+
+print(DEFAULT_HTML_URL)
+#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.1.0/dist/index.html
 ```

--- a/pydantic_ai_slim/pydantic_ai/ui/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/__init__.py
@@ -7,7 +7,7 @@ from ._event_stream import SSE_CONTENT_TYPE, NativeEvent, OnCancelFunc, OnComple
 from ._messages_builder import BuilderCheckpoint, MessagesBuilder
 
 if TYPE_CHECKING:
-    from ._web import DEFAULT_HTML_URL
+    from ._web import DEFAULT_HTML_URL, OFFLINE_HTML_URL
 
 __all__ = [
     'UIAdapter',
@@ -21,6 +21,7 @@ __all__ = [
     'MessagesBuilder',
     'BuilderCheckpoint',
     'DEFAULT_HTML_URL',
+    'OFFLINE_HTML_URL',
 ]
 
 
@@ -29,4 +30,8 @@ def __getattr__(name: str) -> object:
         from ._web import DEFAULT_HTML_URL
 
         return DEFAULT_HTML_URL
+    if name == 'OFFLINE_HTML_URL':
+        from ._web import OFFLINE_HTML_URL
+
+        return OFFLINE_HTML_URL
     raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/__init__.py
@@ -1,10 +1,11 @@
 """Web-based chat UI for Pydantic AI agents."""
 
 from .api import ModelsParam
-from .app import DEFAULT_HTML_URL, create_web_app
+from .app import DEFAULT_HTML_URL, OFFLINE_HTML_URL, create_web_app
 
 __all__ = [
     'create_web_app',
     'ModelsParam',
     'DEFAULT_HTML_URL',
+    'OFFLINE_HTML_URL',
 ]

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -26,8 +26,12 @@ except ImportError as _import_error:  # pragma: no cover
         'you can use the `web` optional group — `pip install "pydantic-ai-slim[web]"`'
     ) from _import_error
 
-CHAT_UI_VERSION = '2.0.0'
+CHAT_UI_VERSION = '2.1.0'
 DEFAULT_HTML_URL = f'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@{CHAT_UI_VERSION}/dist/index.html'
+# `dist/index.html` references its stylesheet and its lazily-imported chunks on the CDN, so a copy
+# downloaded for self-hosting still reaches the public internet at runtime. `offline/index.html` is
+# a single file with all of it inlined, for air-gapped deployments.
+OFFLINE_HTML_URL = f'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@{CHAT_UI_VERSION}/offline/index.html'
 
 AgentDepsT = TypeVar('AgentDepsT')
 OutputDataT = TypeVar('OutputDataT')


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David reviewed and approved the mechanism before implementation; the code has had a light review.

- Closes #5318

## The bug

`docs/web.md` tells anyone hosting offline to download `DEFAULT_HTML_URL`, which points at the chat UI's `dist/index.html`. That file is an entry point, not the app: it names its stylesheet on the CDN, and the bundle it loads carries the CDN base into the runtime chunk loader, which fetches ~400 lazily-imported chunks (syntax-highlighting grammars, mermaid, cytoscape) — and KaTeX's stylesheet `url()`s its fonts absolutely.

Downloaded on its own it therefore produces a page that boots and then reaches out to the public internet, failing at the first code block or equation. That is what the issue reports, and no amount of doc rewording fixes it.

## The change

`@pydantic/ai-chat-ui@2.1.0` (pydantic/ai-chat-ui#42) adds an `offline` build: a single file with every chunk, font and icon inlined, guarded by an E2E test that aborts every non-loopback request before rendering a code block and an equation.

This PR points the docs at it:

- `CHAT_UI_VERSION` `2.0.0` → `2.1.0`, the release that carries the `offline` build.
- New `OFFLINE_HTML_URL`, exported from `pydantic_ai.ui` alongside `DEFAULT_HTML_URL` through the same lazy `__getattr__` (importing `_web` eagerly would require `starlette`).
- `docs/web.md`: the offline section now downloads the self-contained file and says why the split build is the wrong thing to copy. `DEFAULT_HTML_URL` and the default `to_web()` path are unchanged — the split build is still what a connected deployment should serve.

`clai web --html-source` and `to_web(html_source=...)` already accept a path or URL, so the offline file works with both without a signature change.

## Deliberate non-changes

- **`DEFAULT_HTML_URL` still points at `dist/`.** Making the 16 MB single file the default would front-load the whole payload onto every `to_web()` user to fix a case only self-hosters hit.
- **No `pydantic-ai[offline-web-ui]` extra**, requested on the issue and on pydantic/ai-chat-ui#42. A Python extra can only add dependencies; it cannot conditionally add data files to a wheel, so the extra would require a second distribution vendoring the HTML (the `drf-spectacular-sidecar` shape). That is a package to own, release and hold in lockstep with an artifact that ships on npm's cadence, where skew presents as a broken chat box rather than an error. Coordinating the two packages that already exist is the cheaper contract. Answered in the thread rather than left open.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

