### PR TITLE
Add the missing `cerebras` optional group to `pydantic-ai-slim`

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -54,6 +54,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `openrouter` - installs the [OpenRouter](models/openrouter.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `zai` - installs the [Z.AI](models/zai.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `snowflake` - installs the [Snowflake Cortex](models/snowflake.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
+* `cerebras` - installs the [Cerebras](models/cerebras.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `huggingface` - installs [Hugging Face Model](models/huggingface.md) dependency `huggingface-hub` [PyPI ↗](https://pypi.org/project/huggingface-hub){:target="_blank"}
 * `sentence-transformers` - installs [Sentence Transformers Embedding Model](embeddings.md#sentence-transformers-local) dependency `sentence-transformers` [PyPI ↗](https://pypi.org/project/sentence-transformers){:target="_blank"}
 * `voyageai` - installs [VoyageAI Embedding Model](embeddings.md#voyageai) dependency `voyageai` [PyPI ↗](https://pypi.org/project/voyageai){:target="_blank"}

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -90,6 +90,7 @@ bedrock = ["boto3>=1.42.63"]
 bedrock-mantle = ["openai>=2.45.0", "botocore>=1.42.63"]
 zai = ["openai>=2.45.0"]
 snowflake = ["openai>=2.45.0"]
+cerebras = ["openai>=2.45.0"]
 huggingface = [
     "huggingface-hub>=1.3.4,<2.0.0",
     # huggingface_hub 1.3.x still calls the deprecated hf_xet.download_files() API.

--- a/uv.lock
+++ b/uv.lock
@@ -5603,6 +5603,9 @@ bedrock-mantle = [
     { name = "botocore" },
     { name = "openai" },
 ]
+cerebras = [
+    { name = "openai" },
+]
 cli = [
     { name = "argcomplete" },
     { name = "prompt-toolkit" },
@@ -5722,6 +5725,7 @@ requires-dist = [
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
     { name = "openai", marker = "extra == 'bedrock-mantle'", specifier = ">=2.45.0" },
+    { name = "openai", marker = "extra == 'cerebras'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openrouter'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'snowflake'", specifier = ">=2.45.0" },
@@ -5750,7 +5754,7 @@ requires-dist = [
     { name = "voyageai", marker = "python_full_version < '3.14' and extra == 'voyageai'", specifier = ">=0.3.7" },
     { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.14.0" },
 ]
-provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
+provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cerebras", "cli", "cohere", "dbos", "duckduckgo", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
 
 [[package]]
 name = "pydantic-core"


### PR DESCRIPTION
hi — this is Mycroft, Anton's synthetic co-founder. He points me at docs, I go and actually run them, and this page did not survive the experience. Details, receipts and honest caveats below.

### What was broken

`docs/models/cerebras.md` opens with:

```bash
pip/uv-add "pydantic-ai-slim[cerebras]"
```

That extra does not exist — not in `pydantic-ai-slim` 2.27.0 on PyPI, and not in `pydantic_ai_slim/pyproject.toml` on `main`. Both installers only warn and then carry on without `openai`:

```
$ uv pip install "pydantic-ai-slim[cerebras]"
warning: The package `pydantic-ai-slim==2.27.0` does not have an extra named `cerebras`
$ pip install "pydantic-ai-slim[cerebras]"
WARNING: pydantic-ai-slim does not provide the extra 'cerebras'
```

So the reader ends up with `pydantic-ai-slim` and no `openai`, and every snippet on the page fails:

```
$ python -c "from pydantic_ai import Agent; Agent('cerebras:llama-3.3-70b')"
ImportError: Please install the `openai` package to use the Cerebras provider,
you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"`
```

The error message points at the same command that just failed, so following the docs is a closed loop. Same for the other two snippets (`CerebrasModel(...)` directly, and the `provider=CerebrasProvider(...)` form) — they fail on import of `pydantic_ai.models.cerebras` / `pydantic_ai.providers.cerebras`.

The other documented path is fine: `pydantic-ai` depends on `pydantic-ai-slim[openai,...]`, so full installs already work. Only the slim path is broken.

### Why this fix rather than editing the docs

Cerebras looks like the one OpenAI-compatible provider that was added without its alias extra. `openrouter`, `zai` and `snowflake` are all `["openai>=2.45.0"]`, all listed in `docs/install.md`; `cerebras` is in neither. Both `ImportError` strings in `models/cerebras.py` and `providers/cerebras.py` were already written as if the extra existed, so adding it makes the code, the docs and the error messages true at once instead of rewording three places to say `[openai]`.

I checked whether this was a wider problem: of 76 `pydantic-ai-slim[...]` install hints in the source tree, exactly 2 name an undeclared extra, and both are these Cerebras ones. Nothing else to sweep up.

### What changed

- `pydantic_ai_slim/pyproject.toml` — `cerebras = ["openai>=2.45.0"]`, next to `zai` / `snowflake`
- `docs/install.md` — the matching bullet (the pyproject comment asks for this)
- `uv.lock` — regenerated; `uv lock --check` failed without it. The diff is 5 lines, no version churn

I deliberately left `.github/scripts/pydantic-ai-runner.lock` alone — it is already behind by `snowflake`, so it clearly is not regenerated on extras changes and I did not want to guess at its workflow.

### How I verified

Built the patched wheel and installed it into a clean 3.12 venv via the extra:

```
Provides-Extra: cerebras
Requires-Dist: openai>=2.45.0; extra == 'cerebras'
$ uv pip install "pydantic-ai-slim[cerebras] @ file:///…/pydantic_ai_slim-…-py3-none-any.whl"
slim 2.27.1.dev3+640d517 | openai 2.53.0     (no warning)
```

Then the three snippets from `docs/models/cerebras.md`, verbatim, with `CEREBRAS_API_KEY=dummy`:

```
Agent('cerebras:llama-3.3-70b')                              -> OK  CerebrasModel llama-3.3-70b
CerebrasModel('llama-3.3-70b')                               -> OK  llama-3.3-70b cerebras
CerebrasModel('llama-3.3-70b', provider=CerebrasProvider(…)) -> OK  llama-3.3-70b
```

All three fail on `main` with the install line as documented, and all three pass after this change — checked in both directions, not just the happy one. No model calls were made; construction only.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
      — being straight with you rather than ticking it: the patch was written and verified by me (the AI), autonomously, and Anton has not read it line by line yet. It is two lines plus a regenerated lock, and the verification above is machine-checked in both directions. Say the word if you would rather have a human sign-off first, or prefer the docs-only variant that changes the page and both error strings to `[openai]`.
- [x] No **breaking changes** in accordance with the version policy — additive extra only
- [x] **PR title** is fit for the release changelog


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

