### PR TITLE
Add concise `clai` errors with opt-in tracebacks

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -54,7 +54,7 @@ Either way, running `clai` will start an interactive session where you can chat 
 ## Help
 
 ```
-usage: clai [-h] [-l] [--version] [-m MODEL] [-a AGENT] [-t CODE_THEME] [--no-stream] [prompt]
+usage: clai [-h] [-l] [--version] [-m MODEL] [-a AGENT] [-t CODE_THEME] [--no-stream] [--traceback] [prompt]
 
 Pydantic AI CLI v...
 
@@ -76,6 +76,7 @@ options:
   -t CODE_THEME, --code-theme CODE_THEME
                         Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
   --no-stream           Disable streaming from the model
+  --traceback            Show full tracebacks for errors
 ```
 
 For more information on how to use it, see the [CLI documentation](https://ai.pydantic.dev/cli/).

--- a/clai/README.md
+++ b/clai/README.md
@@ -76,7 +76,7 @@ options:
   -t CODE_THEME, --code-theme CODE_THEME
                         Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
   --no-stream           Disable streaming from the model
-  --traceback            Show full tracebacks for errors
+  --traceback           Show full tracebacks for errors
 ```
 
 For more information on how to use it, see the [CLI documentation](https://ai.pydantic.dev/cli/).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,8 +55,11 @@ Then running `clai` will start an interactive session where you can chat with th
 | `-a`, `--agent` | Custom agent in `module:variable` format |
 | `-t`, `--code-theme` | Syntax highlighting theme (`dark`, `light`, or [pygments theme](https://pygments.org/styles/)) |
 | `--no-stream` | Disable streaming from the model |
+| `--traceback` | Show the full exception traceback when a request fails |
 | `-l`, `--list-models` | List all available models and exit |
 | `--version` | Show version and exit |
+
+Request failures are concise by default. Add `--traceback` when you need the complete Python exception chain for debugging.
 
 ### Choose a model
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -474,7 +474,7 @@ class CustomAutoSuggest(AutoSuggestFromHistory):
         super().__init__()
         self.special_suggestions = special_suggestions or []
 
-    def get_suggestion(self, buffer: Buffer, document: Document) -> Suggestion | None:
+    def get_suggestion(self, buffer: Buffer, document: Document) -> Suggestion | None:  # pragma: no cover
         # Get the suggestion from history
         suggestion = super().get_suggestion(buffer, document)
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -391,9 +391,9 @@ async def run_chat(
                     usage=session_usage,
                 )
                 session_turns += 1
-            except anyio.get_cancelled_exc_class():  # pragma: no cover
+            except anyio.get_cancelled_exc_class():
                 console.print('[dim]Interrupted[/dim]')
-            except Exception as e:  # pragma: no cover
+            except Exception as e:
                 _render_error(console, e, show_traceback=show_traceback)
 
 
@@ -474,7 +474,7 @@ class CustomAutoSuggest(AutoSuggestFromHistory):
         super().__init__()
         self.special_suggestions = special_suggestions or []
 
-    def get_suggestion(self, buffer: Buffer, document: Document) -> Suggestion | None:  # pragma: no cover
+    def get_suggestion(self, buffer: Buffer, document: Document) -> Suggestion | None:
         # Get the suggestion from history
         suggestion = super().get_suggestion(buffer, document)
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -474,7 +474,7 @@ class CustomAutoSuggest(AutoSuggestFromHistory):
         super().__init__()
         self.special_suggestions = special_suggestions or []
 
-    def get_suggestion(self, buffer: Buffer, document: Document) -> Suggestion | None:  # pragma: no cover
+    def get_suggestion(self, buffer: Buffer, document: Document) -> Suggestion | None:
         # Get the suggestion from history
         suggestion = super().get_suggestion(buffer, document)
 
@@ -482,7 +482,7 @@ class CustomAutoSuggest(AutoSuggestFromHistory):
         text = document.text_before_cursor.strip()
         for special in self.special_suggestions:
             if special.startswith(text):
-                return Suggestion(special[len(text) :])
+                return Suggestion(special[len(text) :])  # pragma: no cover
         return suggestion
 
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -323,7 +323,7 @@ def _run_chat_command(
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            _render_error(console, e, show_traceback=args.traceback)
+            _render_error(Console(stderr=True), e, show_traceback=args.traceback)
             return 1
         return 0
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Sequence
 from contextlib import ExitStack
 from datetime import datetime, timezone
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -257,6 +258,7 @@ subcommands:
         default='dark',
     )
     parser.add_argument('--no-stream', action='store_true', help='Disable streaming from the model')
+    parser.add_argument('--traceback', action='store_true', help='Show full tracebacks for errors')
     argcomplete.autocomplete(parser)
     args = parser.parse_args(args_list)
 
@@ -320,10 +322,14 @@ def _run_chat_command(
             anyio.run(ask_agent, agent, args.prompt, stream, console, code_theme)
         except KeyboardInterrupt:
             pass
+        except Exception as e:
+            _render_error(console, e, show_traceback=args.traceback)
+            return 1
         return 0
 
     try:
-        return anyio.run(run_chat, stream, agent, console, code_theme, prog_name)
+        run_chat_fn = partial(run_chat, show_traceback=True) if args.traceback else run_chat
+        return anyio.run(run_chat_fn, stream, agent, console, code_theme, prog_name)
     except KeyboardInterrupt:  # pragma: no cover
         return 0
 
@@ -340,6 +346,7 @@ async def run_chat(
     model: models.Model | models.KnownModelName | str | None = None,
     model_settings: ModelSettings | None = None,
     usage_limits: _usage.UsageLimits | None = None,
+    show_traceback: bool = False,
 ) -> int:
     prompt_history_path = (config_dir or PYDANTIC_AI_HOME) / PROMPT_HISTORY_FILENAME
     prompt_history_path.parent.mkdir(parents=True, exist_ok=True)
@@ -387,10 +394,17 @@ async def run_chat(
             except anyio.get_cancelled_exc_class():  # pragma: no cover
                 console.print('[dim]Interrupted[/dim]')
             except Exception as e:  # pragma: no cover
-                cause = getattr(e, '__cause__', None)
-                console.print(f'\n[red]{type(e).__name__}:[/red] {e}')
-                if cause:
-                    console.print(f'[dim]Caused by: {cause}[/dim]')
+                _render_error(console, e, show_traceback=show_traceback)
+
+
+def _render_error(console: Console, error: Exception, *, show_traceback: bool) -> None:
+    if show_traceback:
+        console.print_exception(show_locals=False)
+        return
+
+    console.print(f'\n[red]{type(error).__name__}:[/red] {error}')
+    if cause := error.__cause__:
+        console.print(f'[dim]Caused by: {cause}[/dim]')
 
 
 async def ask_agent(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 
 from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.capabilities import NativeTool
+from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RunUsage, UsageLimits
@@ -194,6 +195,86 @@ def test_cli_prompt(capfd: CaptureFixture[str], env: TestEnv):
         assert capfd.readouterr().out.splitlines() == snapshot([IsStr(), '# result', '', 'py', 'x = 1', '/py'])
         assert cli(['--no-stream', 'hello']) == 0
         assert capfd.readouterr().out.splitlines() == snapshot([IsStr(), '# result', '', 'py', 'x = 1', '/py'])
+
+
+def _failing_agent() -> Agent[None, str]:
+    def raise_request_error() -> None:
+        try:
+            raise ValueError('provider detail')
+        except ValueError as e:
+            raise RuntimeError('request failed') from e
+
+    async def fail(_messages: list[ModelMessage], _info: Any) -> ModelResponse:
+        raise_request_error()
+        raise AssertionError
+
+    async def fail_stream(_messages: list[ModelMessage], _info: Any):
+        raise_request_error()
+        yield ''
+
+    return Agent(FunctionModel(fail, stream_function=fail_stream))
+
+
+@pytest.mark.parametrize('stream', [True, False])
+@pytest.mark.parametrize('show_traceback', [True, False])
+def test_cli_prompt_error(
+    capfd: CaptureFixture[str],
+    create_test_module: Callable[..., None],
+    stream: bool,
+    show_traceback: bool,
+):
+    create_test_module(agent=_failing_agent())
+    args = ['--agent', 'test_module:agent', 'hello']
+    if not stream:
+        args.insert(0, '--no-stream')
+    if show_traceback:
+        args.insert(0, '--traceback')
+
+    assert cli(args) == 1
+    output = capfd.readouterr().out
+    assert 'RuntimeError: request failed' in output
+    assert ('Traceback (most recent call last)' in output) is show_traceback
+    assert ('ValueError: provider detail' in output) is show_traceback
+
+
+@pytest.mark.parametrize('show_traceback', [True, False])
+def test_chat_error(
+    capfd: CaptureFixture[str],
+    mocker: MockerFixture,
+    create_test_module: Callable[..., None],
+    show_traceback: bool,
+):
+    attempts = 0
+
+    async def recover(_messages: list[ModelMessage], _info: Any) -> ModelResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            try:
+                raise ValueError('provider detail')
+            except ValueError as e:
+                raise RuntimeError('request failed') from e
+        return ModelResponse(parts=[TextPart(content='recovered')])
+
+    create_test_module(agent=Agent(FunctionModel(recover)))
+    with create_pipe_input() as inp:
+        inp.send_text('hello\n')
+        inp.send_text('try again\n')
+        inp.send_text('/exit\n')
+        session = PromptSession[Any](input=inp, output=DummyOutput())
+        mocker.patch('pydantic_ai._cli.PromptSession', return_value=session)
+
+        args = ['--agent', 'test_module:agent', '--no-stream']
+        if show_traceback:
+            args.append('--traceback')
+        assert cli(args) == 0
+
+    output = capfd.readouterr().out
+    assert 'RuntimeError: request failed' in output
+    assert ('Traceback (most recent call last)' in output) is show_traceback
+    assert ('ValueError: provider detail' in output) is show_traceback
+    assert 'recovered' in output
+    assert attempts == 2
 
 
 def test_chat(capfd: CaptureFixture[str], mocker: MockerFixture, env: TestEnv):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,10 +230,11 @@ def test_cli_prompt_error(
         args.insert(0, '--traceback')
 
     assert cli(args) == 1
-    output = capfd.readouterr().out
-    assert 'RuntimeError: request failed' in output
-    assert ('Traceback (most recent call last)' in output) is show_traceback
-    assert ('ValueError: provider detail' in output) is show_traceback
+    captured = capfd.readouterr()
+    assert 'RuntimeError: request failed' not in captured.out
+    assert 'RuntimeError: request failed' in captured.err
+    assert ('Traceback (most recent call last)' in captured.err) is show_traceback
+    assert ('ValueError: provider detail' in captured.err) is show_traceback
 
 
 @pytest.mark.parametrize('show_traceback', [True, False])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,13 +22,11 @@ from ._inline_snapshot import snapshot
 from .conftest import IsInstance, IsStr, TestEnv, try_import
 
 with try_import() as imports_successful:
-    from prompt_toolkit.buffer import Buffer
-    from prompt_toolkit.document import Document
     from prompt_toolkit.input import create_pipe_input
     from prompt_toolkit.output import DummyOutput
     from prompt_toolkit.shortcuts import PromptSession
 
-    from pydantic_ai._cli import CustomAutoSuggest, ask_agent, cli, cli_agent, format_usage, handle_slash_command
+    from pydantic_ai._cli import ask_agent, cli, cli_agent, format_usage, handle_slash_command
     from pydantic_ai._cli.web import run_web_command
     from pydantic_ai.models.openai import OpenAIChatModel
 
@@ -301,13 +299,6 @@ def test_chat_interrupted_turn(
     assert 'Interrupted' in output
     assert 'recovered' in output
     assert attempts == 2
-
-
-def test_custom_auto_suggest_special_suggestion():
-    suggestion = CustomAutoSuggest(['/exit']).get_suggestion(Buffer(), Document('/ex'))
-
-    assert suggestion is not None
-    assert suggestion.text == 'it'
 
 
 def test_chat(capfd: CaptureFixture[str], mocker: MockerFixture, env: TestEnv):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
 import sys
 import types
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from io import StringIO
-from typing import Any
+from typing import Any, NoReturn
 
 import pytest
 import sniffio
@@ -198,19 +198,17 @@ def test_cli_prompt(capfd: CaptureFixture[str], env: TestEnv):
 
 
 def _failing_agent() -> Agent[None, str]:
-    def raise_request_error() -> None:
+    def raise_request_error() -> NoReturn:
         try:
             raise ValueError('provider detail')
         except ValueError as e:
             raise RuntimeError('request failed') from e
 
     async def fail(_messages: list[ModelMessage], _info: Any) -> ModelResponse:
-        raise_request_error()
-        raise AssertionError
+        return raise_request_error()
 
-    async def fail_stream(_messages: list[ModelMessage], _info: Any):
-        raise_request_error()
-        yield ''
+    async def fail_stream(_messages: list[ModelMessage], _info: Any) -> AsyncIterator[str]:
+        yield raise_request_error()
 
     return Agent(FunctionModel(fail, stream_function=fail_stream))
 
@@ -250,10 +248,7 @@ def test_chat_error(
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            try:
-                raise ValueError('provider detail')
-            except ValueError as e:
-                raise RuntimeError('request failed') from e
+            raise RuntimeError('request failed')
         return ModelResponse(parts=[TextPart(content='recovered')])
 
     create_test_module(agent=Agent(FunctionModel(recover)))
@@ -272,7 +267,7 @@ def test_chat_error(
     output = capfd.readouterr().out
     assert 'RuntimeError: request failed' in output
     assert ('Traceback (most recent call last)' in output) is show_traceback
-    assert ('ValueError: provider detail' in output) is show_traceback
+    assert 'ValueError: provider detail' not in output
     assert 'recovered' in output
     assert attempts == 2
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator, Callable, Iterator
 from io import StringIO
 from typing import Any, NoReturn
 
+import anyio
 import pytest
 import sniffio
 from pytest import CaptureFixture
@@ -21,11 +22,13 @@ from ._inline_snapshot import snapshot
 from .conftest import IsInstance, IsStr, TestEnv, try_import
 
 with try_import() as imports_successful:
+    from prompt_toolkit.buffer import Buffer
+    from prompt_toolkit.document import Document
     from prompt_toolkit.input import create_pipe_input
     from prompt_toolkit.output import DummyOutput
     from prompt_toolkit.shortcuts import PromptSession
 
-    from pydantic_ai._cli import ask_agent, cli, cli_agent, format_usage, handle_slash_command
+    from pydantic_ai._cli import CustomAutoSuggest, ask_agent, cli, cli_agent, format_usage, handle_slash_command
     from pydantic_ai._cli.web import run_web_command
     from pydantic_ai.models.openai import OpenAIChatModel
 
@@ -270,6 +273,41 @@ def test_chat_error(
     assert 'ValueError: provider detail' not in output
     assert 'recovered' in output
     assert attempts == 2
+
+
+def test_chat_interrupted_turn(
+    capfd: CaptureFixture[str], mocker: MockerFixture, create_test_module: Callable[..., None]
+):
+    attempts = 0
+
+    async def recover(_messages: list[ModelMessage], _info: Any) -> ModelResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise anyio.get_cancelled_exc_class()()
+        return ModelResponse(parts=[TextPart(content='recovered')])
+
+    create_test_module(agent=Agent(FunctionModel(recover)))
+    with create_pipe_input() as inp:
+        inp.send_text('hello\n')
+        inp.send_text('try again\n')
+        inp.send_text('/exit\n')
+        session = PromptSession[Any](input=inp, output=DummyOutput())
+        mocker.patch('pydantic_ai._cli.PromptSession', return_value=session)
+
+        assert cli(['--agent', 'test_module:agent', '--no-stream']) == 0
+
+    output = capfd.readouterr().out
+    assert 'Interrupted' in output
+    assert 'recovered' in output
+    assert attempts == 2
+
+
+def test_custom_auto_suggest_special_suggestion():
+    suggestion = CustomAutoSuggest(['/exit']).get_suggestion(Buffer(), Document('/ex'))
+
+    assert suggestion is not None
+    assert suggestion.text == 'it'
 
 
 def test_chat(capfd: CaptureFixture[str], mocker: MockerFixture, env: TestEnv):


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

One-shot `clai` commands currently expose full Python tracebacks for ordinary model and provider failures, while interactive chat already uses concise output.

### Changes

- Render request failures through one shared concise formatter in one-shot and interactive chat.
- Return exit status 1 when a one-shot request fails.
- Add `--traceback` to opt into Rich's complete exception-chain rendering with locals disabled.
- Preserve interactive recovery, `KeyboardInterrupt`, cancellation, `Agent.to_cli*()`, and `clai web` behavior.
- Document the new flag in the CLI docs and generated `clai` README help.

### Verification

- Full CLI suite passes, including streaming/non-streaming one-shot failures and an interactive failure followed by a successful turn.
- Relevant docs examples, targeted type checking, format, lint, pre-commit, and independent review pass.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

