### PR TITLE
Correct SpanNode.duration return documentation

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -104,7 +104,7 @@ class SpanNode:
 
     @property
     def duration(self) -> timedelta:
-        """Return the span's duration as a timedelta, or None if start/end not set."""
+        """Return the span's duration as a `timedelta`."""
         return self.end_timestamp - self.start_timestamp
 
     @property


### PR DESCRIPTION
Fixes #7367

## Summary

Correct the `SpanNode.duration` docstring to state its actual `timedelta` return contract.

## Why

`SpanNode` requires both timestamps, and `duration` directly subtracts them. The prior API documentation incorrectly said that the property could return `None`.

## Impact

Generated API documentation no longer advertises an impossible `None` result.

## Root cause

The docstring had fallen out of sync with the property signature and implementation.

## Validation

- `uv run pytest tests/evals/test_otel.py -q` — 29 passed
- `uv run ruff format --check pydantic_evals/pydantic_evals/otel/span_tree.py`
- `uv run ruff check pydantic_evals/pydantic_evals/otel/span_tree.py`
- `uv run pyright pydantic_evals/pydantic_evals/otel/span_tree.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).