### PR TITLE
Add MCP 2026-07-28 transport contract gates

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -33,6 +33,11 @@ Note that a shared `MCPToolset` instance connects to the server as a single iden
 
 The [Streamable HTTP](https://modelcontextprotocol.io/introduction#streamable-http) transport is the recommended way to connect to a remote MCP server.
 
+Pydantic AI delegates Streamable HTTP protocol-version negotiation and wire behavior to FastMCP. In
+particular, the [`2026-07-28 Streamable HTTP revision`](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports)
+is POST-only and removes protocol-level sessions. Use a FastMCP/MCP SDK version that supports the
+revision required by your server; `MCPToolset` does not emulate a newer protocol over an older client.
+
 !!! note
     A Streamable HTTP `MCPToolset` requires an MCP server to be running and accepting HTTP connections before running the agent. Running the server is not managed by Pydantic AI.
 

--- a/tests/test_mcp_2026_07_28.py
+++ b/tests/test_mcp_2026_07_28.py
@@ -1,0 +1,77 @@
+"""Contracts around the sessionless Streamable HTTP revision.
+
+The first test exercises Pydantic AI's ownership boundary today. The strict expected failures are
+dependency gates, not wire tests: once the MCP SDK can speak the revision, each must be replaced
+with a real request-level test against a 2026-07-28 server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import try_import
+
+with try_import() as imports_successful:
+    from fastmcp.client.transports import StreamableHttpTransport
+    from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
+
+    from pydantic_ai.mcp import MCPToolset
+
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='fastmcp not installed')
+
+_MODERN_PROTOCOL = '2026-07-28'
+
+
+def _requires_modern_protocol(contract: str) -> pytest.MarkDecorator:
+    """Mark a future wire contract unavailable on the currently locked MCP SDK."""
+    return pytest.mark.xfail(
+        strict=True,
+        reason=(
+            f'Dependency precondition for the {contract} wire contract: the locked MCP SDK supports '
+            'Streamable HTTP through 2025-11-25. MCP 2026-07-28 support requires the FastMCP 4 / '
+            'MCP SDK v2 compatibility work in #6738; replace this gate with a real wire test on XPASS.'
+        ),
+    )
+
+
+def test_http_toolsets_keep_credentials_and_transport_state_isolated() -> None:
+    """Per-user authentication must not share a client, transport, or configured credentials.
+
+    This is a construction-level contract because making a real server request would only test
+    FastMCP's legacy protocol behavior. It protects Pydantic AI's documented per-user isolation
+    boundary while the protocol implementation remains delegated to FastMCP.
+    """
+    alice = MCPToolset('https://example.com/mcp', headers={'Authorization': 'Bearer alice'})
+    bob = MCPToolset('https://example.com/mcp', headers={'Authorization': 'Bearer bob'})
+
+    assert alice.client is not bob.client
+    assert isinstance(alice.client.transport, StreamableHttpTransport)
+    assert isinstance(bob.client.transport, StreamableHttpTransport)
+    assert alice.client.transport is not bob.client.transport
+    assert alice.client.transport.headers == {'Authorization': 'Bearer alice'}
+    assert bob.client.transport.headers == {'Authorization': 'Bearer bob'}
+
+
+@_requires_modern_protocol('no-initialize')
+def test_2026_07_28_requires_no_initialize_handshake() -> None:
+    """Gate the future test that proves modern requests never send `initialize`."""
+    assert _MODERN_PROTOCOL in SUPPORTED_PROTOCOL_VERSIONS
+
+
+@_requires_modern_protocol('no-session-id')
+def test_2026_07_28_requires_no_mcp_session_id() -> None:
+    """Gate the future test that proves modern requests never send `Mcp-Session-Id`."""
+    assert _MODERN_PROTOCOL in SUPPORTED_PROTOCOL_VERSIONS
+
+
+@_requires_modern_protocol('POST-only, request-scoped SSE, and request metadata')
+def test_2026_07_28_requires_post_only_request_scoped_sse_and_metadata() -> None:
+    """Gate POST-only delivery, version/method headers, and operation-specific name headers."""
+    assert _MODERN_PROTOCOL in SUPPORTED_PROTOCOL_VERSIONS
+
+
+@_requires_modern_protocol('per-request authorization')
+def test_2026_07_28_requires_authorization_on_every_post() -> None:
+    """Gate the future test that proves credentials are sent on each independent HTTP request."""
+    assert _MODERN_PROTOCOL in SUPPORTED_PROTOCOL_VERSIONS


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Context

MCP `2026-07-28` is a breaking specification revision centered on protocol-level sessionlessness. It removes `initialize` / `notifications/initialized`, protocol sessions and `Mcp-Session-Id`, and the standalone GET stream. Streamable HTTP requests are independent POSTs with request metadata; request-scoped SSE remains available for a POST response. See the [release announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28/), [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog), and [Streamable HTTP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http).

Pydantic AI currently pins FastMCP below 4 and delegates transport negotiation and wire behavior to that dependency. [#6738](https://github.com/pydantic/pydantic-ai/pull/6738) is the existing FastMCP 4 / MCP SDK v2 compatibility PR. This PR intentionally targets `main` instead of stacking on #6738: it records the contracts without inheriting that PR's large compatibility diff, and it can merge or be reviewed independently.

## What this PR establishes now

- A passing construction-level contract proves separately constructed HTTP `MCPToolset`s do not share clients, transports, or configured credentials. This preserves the documented [per-user authentication boundary](https://pydantic.dev/docs/ai/mcp/client/#per-user-authentication).
- Four strict expected-failure dependency gates name the wire contracts that cannot yet run on the locked MCP SDK:
  - no initialization handshake;
  - no `Mcp-Session-Id`;
  - POST-only request delivery, request-scoped SSE, and required request metadata (`Mcp-Name` only for operations that require it);
  - authorization attached to every independent HTTP POST, as required by the [authorization specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization).
- The MCP client docs now state that `MCPToolset` does not emulate a newer wire revision over an older FastMCP/MCP SDK.

These xfails are deliberately strict and are explicitly dependency gates, not claims of wire conformance. Once the installed SDK advertises `2026-07-28`, XPASS must fail CI so each gate is replaced by an unmarked capture-server test that observes the real HTTP exchange.

## Follow-up after FastMCP 4 / MCP SDK v2 support

Replace the four gates with a real authenticated Streamable HTTP server test. The test should assert that every observed MCP operation is a POST, every request has the required protocol/method metadata and bearer authorization, operation-specific requests have `Mcp-Name`, no request is `initialize`, and no request contains `Mcp-Session-Id`.

Do not treat #6738's mocked modern-session compatibility tests as transport conformance; real request capture is required.

The following are deliberately deferred because they need a settled Pydantic AI owner or public API, not only a dependency upgrade:

- MRTR retry/input handling;
- `subscriptions/listen` lifecycle and invalidation;
- cache ownership and `private` versus `public` `cacheScope` behavior. Private cached results must not cross authorization contexts; public sharing is permitted rather than required by the [caching specification](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching).

## Verification

- Focused pytest: pass (one passing contract; four strict expected failures)
- Ruff: pass
- Pyright: pass
- Documentation build: blocked by the existing local CairoSVG/libcairo warnings, unrelated to this change

No dependency versions are changed in this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

