### PR TITLE
Use `httpx2` for Mistral clients

### DIFF
--- a/docs/models/mistral.md
+++ b/docs/models/mistral.md
@@ -58,10 +58,10 @@ agent = Agent(model)
 ...
 ```
 
-You can also customize the provider with a custom `httpx.AsyncClient`:
+You can also customize the provider with a custom `httpx2.AsyncClient`:
 
 ```python
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from pydantic_ai import Agent
 from pydantic_ai.models.mistral import MistralModel
@@ -75,3 +75,5 @@ model = MistralModel(
 agent = Agent(model)
 ...
 ```
+
+The Mistral provider also accepts a legacy `httpx.AsyncClient` during Pydantic AI v2, but emits a deprecation warning. Use `httpx2.AsyncClient` for new code; legacy HTTPX client support will be removed in Pydantic AI v3.

--- a/pydantic_ai_slim/pydantic_ai/_http.py
+++ b/pydantic_ai_slim/pydantic_ai/_http.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import warnings
+
 import httpx2
 
+from ._warnings import PydanticAIDeprecationWarning
 from .models import DEFAULT_HTTP_TIMEOUT, get_user_agent
 
 
@@ -10,3 +13,15 @@ def create_httpx2_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: int = 
         timeout=httpx2.Timeout(timeout=timeout, connect=connect),
         headers={'User-Agent': get_user_agent()},
     )
+
+
+def warn_if_legacy_httpx_client(http_client: object, *, consumer: str, stacklevel: int) -> None:
+    import httpx
+
+    if isinstance(http_client, httpx.AsyncClient):
+        warnings.warn(
+            f'`httpx.AsyncClient` support for {consumer} is deprecated and will be removed in v3; '
+            'use `httpx2.AsyncClient` instead.',
+            PydanticAIDeprecationWarning,
+            stacklevel=stacklevel + 1,
+        )

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-import warnings
 from collections.abc import Callable
 from typing import overload
 
@@ -9,8 +8,7 @@ import httpx
 import httpx2
 
 from pydantic_ai import ModelProfile
-from pydantic_ai._http import create_httpx2_client
-from pydantic_ai._warnings import PydanticAIDeprecationWarning
+from pydantic_ai._http import create_httpx2_client, warn_if_legacy_httpx_client
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
@@ -118,13 +116,8 @@ class MistralProvider(Provider[Mistral]):
                 http_client = create_httpx2_client()
                 self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
                 self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
-            elif isinstance(http_client, httpx.AsyncClient):
-                warnings.warn(
-                    '`httpx.AsyncClient` support for the Mistral provider is deprecated and will be removed in v3; '
-                    'use `httpx2.AsyncClient` instead.',
-                    PydanticAIDeprecationWarning,
-                    stacklevel=2,
-                )
+            else:
+                warn_if_legacy_httpx_client(http_client, consumer='the Mistral provider', stacklevel=2)
 
             # Mistral's runtime-checkable client protocol accepts HTTPX2, but its annotations name legacy HTTPX types.
             self._client = Mistral(

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -1,13 +1,17 @@
 from __future__ import annotations as _annotations
 
 import os
+import warnings
+from collections.abc import Callable
 from typing import overload
 
 import httpx
+import httpx2
 
 from pydantic_ai import ModelProfile
+from pydantic_ai._http import create_httpx2_client
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.providers import Provider
@@ -46,9 +50,14 @@ _ADJUSTABLE_REASONING_MODELS = frozenset(
     }
 )
 
+_MistralHTTPClient = httpx.AsyncClient | httpx2.AsyncClient
+
 
 class MistralProvider(Provider[Mistral]):
     """Provider for Mistral API."""
+
+    _own_http_client: _MistralHTTPClient | None = None
+    _http_client_factory: Callable[[], _MistralHTTPClient] | None = None
 
     @property
     def name(self) -> str:
@@ -73,7 +82,7 @@ class MistralProvider(Provider[Mistral]):
     def __init__(self, *, mistral_client: Mistral | None = None) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str | None = None, http_client: httpx.AsyncClient | None = None) -> None: ...
+    def __init__(self, *, api_key: str | None = None, http_client: _MistralHTTPClient | None = None) -> None: ...
 
     def __init__(
         self,
@@ -81,7 +90,7 @@ class MistralProvider(Provider[Mistral]):
         api_key: str | None = None,
         mistral_client: Mistral | None = None,
         base_url: str | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _MistralHTTPClient | None = None,
     ) -> None:
         """Create a new Mistral provider.
 
@@ -90,7 +99,7 @@ class MistralProvider(Provider[Mistral]):
                 will be used if available.
             mistral_client: An existing `Mistral` client to use, if provided, `api_key` and `http_client` must be `None`.
             base_url: The base url for the Mistral requests.
-            http_client: An existing async client to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         if mistral_client is not None:
             assert http_client is None, 'Cannot provide both `mistral_client` and `http_client`'
@@ -105,13 +114,25 @@ class MistralProvider(Provider[Mistral]):
                     'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
                     ' to use the Mistral provider.'
                 )
-            elif http_client is not None:
-                self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)
-            else:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-                self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)
+            if http_client is None:
+                http_client = create_httpx2_client()
+                self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
+                self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
+            elif isinstance(http_client, httpx.AsyncClient):
+                warnings.warn(
+                    '`httpx.AsyncClient` support for the Mistral provider is deprecated and will be removed in v3; '
+                    'use `httpx2.AsyncClient` instead.',
+                    PydanticAIDeprecationWarning,
+                    stacklevel=2,
+                )
 
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client.sdk_configuration.async_client = http_client
+            # Mistral's runtime-checkable client protocol accepts HTTPX2, but its annotations name legacy HTTPX types.
+            self._client = Mistral(
+                api_key=api_key,
+                async_client=http_client,  # pyright: ignore[reportArgumentType]
+                server_url=base_url,
+            )
+
+    # The generic Provider currently only knows the legacy HTTPX client type.
+    def _set_http_client(self, http_client: _MistralHTTPClient) -> None:
+        self._client.sdk_configuration.async_client = http_client  # pyright: ignore[reportAttributeAccessIssue]

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-import warnings
 from collections.abc import Callable, Mapping
 from typing import overload
 
@@ -9,8 +8,7 @@ import httpx
 import httpx2
 
 from pydantic_ai import ModelProfile
-from pydantic_ai._http import create_httpx2_client
-from pydantic_ai._warnings import PydanticAIDeprecationWarning
+from pydantic_ai._http import create_httpx2_client, warn_if_legacy_httpx_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.providers import Provider, missing_api_key_error
@@ -40,12 +38,9 @@ class _OpenAICompatibleProvider(Provider[AsyncOpenAI]):
             http_client = create_httpx2_client()
             self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
             self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
-        elif isinstance(http_client, httpx.AsyncClient):
-            warnings.warn(
-                '`httpx.AsyncClient` support for OpenAI-compatible providers is deprecated and will be removed in v3; '
-                'use `httpx2.AsyncClient` instead.',
-                PydanticAIDeprecationWarning,
-                stacklevel=warning_stacklevel,
+        else:
+            warn_if_legacy_httpx_client(
+                http_client, consumer='OpenAI-compatible providers', stacklevel=warning_stacklevel
             )
         return http_client
 

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -81,7 +81,6 @@ xai = ["xai-sdk>=1.14.0"]
 groq = ["groq>=0.25.0"]
 openrouter = ["openai[httpx2]>=2.47.0"]
 # `mistralai>=2.9.2` accepts `httpx2.AsyncClient` and no longer caps OpenTelemetry semantic conventions.
-# This floor also excludes `mistralai==2.4.6`, which was quarantined on PyPI due to a supply-chain attack (see #5382).
 mistral = ["mistralai>=2.9.2"]
 bedrock = ["boto3>=1.42.63"]
 # Amazon Bedrock Mantle serves OpenAI models through an OpenAI-compatible API via `AsyncBedrockOpenAI`,

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -80,10 +80,9 @@ anthropic = ["anthropic>=0.108.0"]
 xai = ["xai-sdk>=1.14.0"]
 groq = ["groq>=0.25.0"]
 openrouter = ["openai[httpx2]>=2.47.0"]
-# `mistralai>=2.4.2` is required for the `prompt_cache_key` parameter on `chat.complete_async`
-# and `chat.stream_async` (also covers the `reasoning_effort` parameter, which needed >=2.0.5).
-# `mistralai==2.4.6` was quarantined on PyPI due to a supply-chain attack (see #5382).
-mistral = ["mistralai>=2.4.2,!=2.4.6"]
+# `mistralai>=2.9.2` accepts `httpx2.AsyncClient` and no longer caps OpenTelemetry semantic conventions.
+# This floor also excludes `mistralai==2.4.6`, which was quarantined on PyPI due to a supply-chain attack (see #5382).
+mistral = ["mistralai>=2.9.2"]
 bedrock = ["boto3>=1.42.63"]
 # Amazon Bedrock Mantle serves OpenAI models through an OpenAI-compatible API via `AsyncBedrockOpenAI`,
 # which needs `openai` and (for AWS SigV4 auth) `botocore`; the bearer-token path needs `openai` alone.

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
 # WARNING if you add optional groups, please update docs/install.md
-logfire = ["logfire[httpx]>=4.39.0"]
+logfire = ["logfire[httpx]>=4.39.0", "opentelemetry-instrumentation-httpx>=0.65b0"]
 # Models
 openai = ["openai[httpx2]>=2.47.0", "tiktoken>=0.12.0"]
 cohere = ["cohere>=5.20.6; platform_system != 'Emscripten'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,7 +362,7 @@ filterwarnings = [
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
     # logfire 4.40 uses the SDK logging handler deprecated by OpenTelemetry 1.44.
-    # Remove after https://github.com/pydantic/logfire/pull/2094 is released.
+    # TODO(davidsf): Remove after https://github.com/pydantic/logfire/pull/2094 is released.
     "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,9 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
+    # logfire 4.40 uses the SDK logging handler deprecated by OpenTelemetry 1.44.
+    # Remove after https://github.com/pydantic/logfire/pull/2094 is released.
+    "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",
     # prefect has a Pydantic v2 compatibility issue in RRuleSchedule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,9 @@ pydantic-handlebars = false
 genai-prices = false
 logfire = false
 logfire-api = false
+# TODO: Remove after 2026-08-18 07:51 UTC. https://github.com/pydantic/pydantic-ai/issues/7376
+# This admits only the reviewed HTTPX2-compatible 2.9.2 artifacts; later Mistral artifacts remain quarantined.
+mistralai = "2026-08-11T07:51:18Z"
 
 [dependency-groups]
 dev = [
@@ -358,10 +361,6 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
-    # Released mistralai versions constrain opentelemetry-semantic-conventions<0.61, while HTTPX2 instrumentation
-    # requires opentelemetry-instrumentation-httpx>=0.65b0. https://github.com/mistralai/client-python/pull/605
-    # removed the cap on main; re-check the latest release and remove this filter once it includes that fix.
-    "ignore:`httpx2` will not be instrumented because it requires `opentelemetry-instrumentation-httpx>=0.65b0`:UserWarning",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",
     # prefect has a Pydantic v2 compatibility issue in RRuleSchedule

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -3,8 +3,10 @@ from __future__ import annotations as _annotations
 import re
 
 import httpx
+import httpx2
 import pytest
 
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.exceptions import UserError
 
 from ..conftest import TestEnv, try_import
@@ -18,12 +20,18 @@ with try_import() as imports_successful:
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='mistral not installed')
 
 
-def test_mistral_provider():
+async def test_mistral_provider():
     provider = MistralProvider(api_key='api-key')
     assert provider.name == 'mistral'
     assert provider.base_url == 'https://api.mistral.ai'
     assert isinstance(provider.client, Mistral)
     assert provider.client.sdk_configuration.security.api_key == 'api-key'  # pyright: ignore[reportFunctionMemberAccess, reportOptionalMemberAccess]
+    assert isinstance(provider.client.sdk_configuration.async_client, httpx2.AsyncClient)
+
+    async with provider:
+        pass
+
+    assert provider.client.sdk_configuration.async_client.is_closed
 
 
 def test_mistral_provider_need_api_key(env: TestEnv) -> None:
@@ -38,16 +46,43 @@ def test_mistral_provider_need_api_key(env: TestEnv) -> None:
         MistralProvider()
 
 
-def test_mistral_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = MistralProvider(http_client=http_client, api_key='api-key')
-    assert provider.client.sdk_configuration.async_client == http_client
+async def test_mistral_provider_pass_httpx2_client() -> None:
+    async with httpx2.AsyncClient() as http_client:
+        provider = MistralProvider(http_client=http_client, api_key='api-key')
+        assert provider.client.sdk_configuration.async_client is http_client
+
+        async with provider:
+            pass
+
+        assert not http_client.is_closed
 
 
-def test_mistral_provider_pass_groq_client() -> None:
-    mistral_client = Mistral(api_key='api-key')
-    provider = MistralProvider(mistral_client=mistral_client)
-    assert provider.client == mistral_client
+async def test_mistral_provider_deprecates_legacy_httpx_client() -> None:
+    async with httpx.AsyncClient() as http_client:
+        with pytest.warns(
+            PydanticAIDeprecationWarning,
+            match=r'`httpx\.AsyncClient`.*removed in v3.*`httpx2\.AsyncClient`',
+        ) as warnings:
+            provider = MistralProvider(http_client=http_client, api_key='api-key')
+
+        assert warnings[0].filename == __file__
+        assert provider.client.sdk_configuration.async_client is http_client
+        async with provider:
+            pass
+        assert not http_client.is_closed
+
+
+async def test_mistral_provider_pass_mistral_client() -> None:
+    async with httpx.AsyncClient() as http_client:
+        mistral_client = Mistral(api_key='api-key', async_client=http_client)
+        provider = MistralProvider(mistral_client=mistral_client)
+        assert provider.client is mistral_client
+
+        async with provider:
+            pass
+
+        assert provider.client.sdk_configuration.async_client is http_client
+        assert not http_client.is_closed
 
 
 def test_mistral_provider_with_base_url() -> None:

--- a/tests/test_httpx2_sdk_readiness.py
+++ b/tests/test_httpx2_sdk_readiness.py
@@ -8,6 +8,21 @@ import httpx2
 import pytest
 from pydantic import ValidationError
 
+from .conftest import try_import
+
+with try_import() as anthropic_imports_successful:
+    from anthropic import AsyncAnthropic
+
+with try_import() as groq_imports_successful:
+    from groq import AsyncGroq
+
+with try_import() as google_imports_successful:
+    from google.genai import Client as GoogleClient
+    from google.genai.types import HttpOptions
+
+with try_import() as mistral_imports_successful:
+    from mistralai.client import Mistral
+
 _HTTPX_FREE_CORE = """
 import sys
 
@@ -59,29 +74,22 @@ def test_core_runs_without_httpx() -> None:
     assert result.stderr == ''
 
 
+@pytest.mark.skipif(not anthropic_imports_successful(), reason='anthropic not installed')
 async def test_anthropic_still_rejects_httpx2_client() -> None:
-    pytest.importorskip('anthropic')
-    from anthropic import AsyncAnthropic
-
     async with httpx2.AsyncClient() as client:
         with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
             AsyncAnthropic(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
 
 
+@pytest.mark.skipif(not groq_imports_successful(), reason='groq not installed')
 async def test_groq_still_rejects_httpx2_client() -> None:
-    pytest.importorskip('groq')
-    from groq import AsyncGroq
-
     async with httpx2.AsyncClient() as client:
         with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
             AsyncGroq(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
 
 
+@pytest.mark.skipif(not google_imports_successful(), reason='google-genai not installed')
 async def test_google_still_rejects_httpx2_client() -> None:
-    pytest.importorskip('google.genai')
-    from google.genai import Client as GoogleClient
-    from google.genai.types import HttpOptions
-
     async with httpx2.AsyncClient() as client:
         with pytest.raises(ValidationError, match='httpx_async_client'):
             GoogleClient(
@@ -92,10 +100,8 @@ async def test_google_still_rejects_httpx2_client() -> None:
             )
 
 
+@pytest.mark.skipif(not mistral_imports_successful(), reason='mistral not installed')
 async def test_mistral_accepts_httpx2_client() -> None:
-    pytest.importorskip('mistralai')
-    from mistralai.client import Mistral
-
     async with httpx2.AsyncClient() as client:
         mistral_client = Mistral(api_key='test', async_client=client)  # pyright: ignore[reportArgumentType]
 

--- a/tests/test_httpx2_sdk_readiness.py
+++ b/tests/test_httpx2_sdk_readiness.py
@@ -90,3 +90,13 @@ async def test_google_still_rejects_httpx2_client() -> None:
                     httpx_async_client=client,  # pyright: ignore[reportArgumentType]
                 ),
             )
+
+
+async def test_mistral_accepts_httpx2_client() -> None:
+    pytest.importorskip('mistralai')
+    from mistralai.client import Mistral
+
+    async with httpx2.AsyncClient() as client:
+        mistral_client = Mistral(api_key='test', async_client=client)  # pyright: ignore[reportArgumentType]
+
+        assert mistral_client.sdk_configuration.async_client is client

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ genai-prices = false
 pydantic-extra-types = false
 pydantic-core = false
 pydantic = false
+mistralai = "2026-08-11T07:51:18Z"
 logfire-api = false
 
 [manifest]
@@ -3483,7 +3484,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.7.1"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
@@ -3495,9 +3496,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/e0/bc0188444f122083e1cd554a33440589f4c7a55bab57563333f004cf4934/mistralai-2.7.1.tar.gz", hash = "sha256:1b67a224a9387b33d8ca381d24cd8d075dbe6650af305d763d71c4cad06b2ddf", size = 530696, upload-time = "2026-07-21T13:12:51.041Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/d9/bc41311a7bd3f34f3aa508329fbaf675482643db7301efba2c3d7cdcc7c6/mistralai-2.9.2.tar.gz", hash = "sha256:50d98863aea6588d825a962aa3684361d1446d9f6f4530028705dac2799603ed", size = 537750, upload-time = "2026-08-11T07:51:17.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/1a/c502cad6ebb3363911ad30ec0318c216dcac4f5be485651b7672bdcd3ff7/mistralai-2.7.1-py3-none-any.whl", hash = "sha256:25a78835e52eb44ca8c10046dbb1635545c53c40a06397075df246c82f12b186", size = 1266550, upload-time = "2026-07-21T13:12:49.5Z" },
+    { url = "https://files.pythonhosted.org/packages/35/cf/3e90441960bfea6559cb6af5d1ca3c6ff9d39866a4fe0d19b4e85cc45786/mistralai-2.9.2-py3-none-any.whl", hash = "sha256:9d90b85b25c409e50aabe150350aa680f71e0803c0273d177a0379912f73bc45", size = 1282115, upload-time = "2026-08-11T07:51:16.005Z" },
 ]
 
 [[package]]
@@ -5734,7 +5735,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=1.3.4,<2.0.0" },
     { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.39.0" },
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
-    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.9.2" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'bedrock-mantle'", specifier = ">=2.47.0" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'openai'", specifier = ">=2.47.0" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'openrouter'", specifier = ">=2.47.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -5653,6 +5653,7 @@ huggingface = [
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },
+    { name = "opentelemetry-instrumentation-httpx" },
 ]
 mcp = [
     { name = "fastmcp-slim", extra = ["client"] },
@@ -5741,6 +5742,7 @@ requires-dist = [
     { name = "openai", extras = ["httpx2"], marker = "extra == 'snowflake'", specifier = ">=2.47.0" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'zai'", specifier = ">=2.47.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
+    { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'logfire'", specifier = ">=0.65b0" },
     { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.7.5" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2.12" },

--- a/uv.lock
+++ b/uv.lock
@@ -2679,7 +2679,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -4317,32 +4317,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -4353,14 +4352,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4368,14 +4367,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -4384,28 +4383,28 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asyncpg"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/ec/6bd1dba7435cf54b52046d89cac1541d0cc4411f74adbcec50420025f4f5/opentelemetry_instrumentation_asyncpg-0.60b1.tar.gz", hash = "sha256:56dbafc800b83de839e8048cc0a8b76dc2d4182fce6f1fd94aa95ba3f8a2f800", size = 8725, upload-time = "2025-12-11T13:36:48.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/de/21b57f84a41385d7055547c03b491b0de0531b0fa5a03cd4a6499a57a8f8/opentelemetry_instrumentation_asyncpg-0.65b0.tar.gz", hash = "sha256:0b14338886f17c18a9899d6764117a4c163a9826f6ed1577f68ee773f95ebbc2", size = 11202, upload-time = "2026-07-16T15:25:57.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/99/04899e21a64dff4e551c63b4426c921628a73df8fbe9cd1f60b18bd9142e/opentelemetry_instrumentation_asyncpg-0.60b1-py3-none-any.whl", hash = "sha256:3d64346571822188445bef7c8219709e6ee76f9ed2583a07c503e619f6dd4169", size = 10087, upload-time = "2025-12-11T13:35:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/18/c021ac484e447fd185a968cf3b134b67c30bfbda6f0add347da1d7c109e2/opentelemetry_instrumentation_asyncpg-0.65b0-py3-none-any.whl", hash = "sha256:9156d2501021b968da0f317eb508d3efb3e7506bf50e00ee477ce0636a12772a", size = 9744, upload-time = "2026-07-16T15:25:00.172Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-dbapi"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4413,14 +4412,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/b5/1e1f0642892a2abb6e75b7009ccee946e801cded88caac3d803cf46c8c73/opentelemetry_instrumentation_dbapi-0.60b1.tar.gz", hash = "sha256:a239d328249b86fba5e42900b98bf31ee99c07092530feca18afde92c600f901", size = 16311, upload-time = "2025-12-11T13:36:55.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/97/b2e0ae6951cbf93c0c211910077cb50f9478fb4b7e89a402800b9a98151c/opentelemetry_instrumentation_dbapi-0.65b0.tar.gz", hash = "sha256:da048bb683347ddad2f47344bacfe1e111bf7bfb2e5a39796b1083679ad4f0f3", size = 20247, upload-time = "2026-07-16T15:26:02.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/08/d4c78b6e317d9975d473dd98f7854f5731ff4a1d470c65d2630fa68a1484/opentelemetry_instrumentation_dbapi-0.60b1-py3-none-any.whl", hash = "sha256:5577189f678de5b9828c930c8fb72e8f1999b304131777b60099e5c4b3948193", size = 13968, upload-time = "2025-12-11T13:35:56.316Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e3/106953cea1d7f9318a4b56827ad10839fda3d033ecea2db717c051bf6a60/opentelemetry_instrumentation_dbapi-0.65b0-py3-none-any.whl", hash = "sha256:50b662578a6903b028e09b73f604de687752f5f904aa0ca032969157b29d60f2", size = 14815, upload-time = "2026-07-16T15:25:08.361Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4429,14 +4428,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4445,71 +4444,71 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/03/a529140241addd4d0acc73bafbd6f74691651b92fc0ae9b4513cf80f07fa/opentelemetry_instrumentation_httpx-0.65b0.tar.gz", hash = "sha256:4627aa9c6bb99bf4462c8b565b0ef6aeb9ffad95c6c92868be1ef7895de112ee", size = 26309, upload-time = "2026-07-16T15:26:07.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0f/c6144096b4914bbf44b43ba21c962e8f333ff045770b50a3e79ed8bd455f/opentelemetry_instrumentation_httpx-0.65b0-py3-none-any.whl", hash = "sha256:400f1b78afa4ee2332b5debe58e1ed1b317913d58812c952576be76660aeadb1", size = 17436, upload-time = "2026-07-16T15:25:15.772Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-sqlite3"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-dbapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/33/fafa354b529a7e9b5a5dc4155953bae1ff71622334a420d19f7e1d65e7cc/opentelemetry_instrumentation_sqlite3-0.60b1.tar.gz", hash = "sha256:d716b9d89d31dc426ccedefcdbf96cba1897dfe020d21e5e5ea82a782d03e1d6", size = 7922, upload-time = "2025-12-11T13:37:13.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/93/3716b653b0dd8f7122afe5228d77604309478378afbd4f92699a68f686e8/opentelemetry_instrumentation_sqlite3-0.65b0.tar.gz", hash = "sha256:f11fb91d159724037cadf970d5b612da720b38bd67d1c25d48c5ae09116eacc6", size = 8419, upload-time = "2026-07-16T15:26:19.834Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/64/be1c8a6d17cf2860f41206828cbabe39b71345cc95626b91c84f48e96066/opentelemetry_instrumentation_sqlite3-0.60b1-py3-none-any.whl", hash = "sha256:7666853b9df186b81e587320aaa03da3f1ce46ba9277b62d8ea20a745886031c", size = 9338, upload-time = "2025-12-11T13:36:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c9/636d87853b46228e1714063fb0c4f4fc69d85f9e06febce65620d60d3505/opentelemetry_instrumentation_sqlite3-0.65b0-py3-none-any.whl", hash = "sha256:d9ca2e3a5ab0e9f8ee1c55f4713e1b1bb626dfd57e57950e228cbd0aa9381ae1", size = 8525, upload-time = "2026-07-16T15:25:33.01Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

- Stacked on #7351; this PR targets `codex/httpx2-migration` because it depends on that PR's HTTPX2 infrastructure.
- Tracks removal of the temporary release cutoff in #7376.

## Summary

- raise the Mistral SDK floor to `mistralai>=2.9.2` and lock that release;
- use `httpx2.AsyncClient` for Pydantic AI-owned Mistral clients;
- accept caller-owned HTTPX2 clients while preserving legacy `httpx.AsyncClient` support through v2 with a v3 deprecation warning;
- preserve raw `mistral_client` injection and owned/borrowed client lifecycle behavior;
- require `opentelemetry-instrumentation-httpx>=0.65b0` in the shared `logfire` extra and refresh the lockstep OpenTelemetry family;
- remove the temporary Mistral/OpenTelemetry HTTPX2 warning filter and update Mistral HTTP-client documentation and tests.

The shared OpenTelemetry floor is coupled to this migration: HTTPX2 instrumentation starts in 0.65b0, but Mistral releases before 2.9.2 capped `opentelemetry-semantic-conventions<0.61`, preventing that instrumentation family from resolving. With the cap removed, both regular and lowest-direct installs can instrument HTTPX2. OpenTelemetry 1.44 also deprecates the logging handler still constructed by released Logfire 4.40, so the test configuration narrowly filters that specific deprecation until Logfire's already-merged compatibility fix is released.

The exact `mistralai` cutoff admits the reviewed 2.9.2 wheel and sdist without disabling the repository's quarantine for later Mistral artifacts. #7376 removes that absolute cutoff once the normal rolling seven-day window reaches this release.

## Upstream evidence

- [PyPI's 2.9.2 release metadata](https://pypi.org/pypi/mistralai/2.9.2/json) records the released artifacts and removes the upper bound from `opentelemetry-semantic-conventions`.
- [mistralai/client-python#605](https://github.com/mistralai/client-python/pull/605) is the merged OpenTelemetry constraint fix included in 2.9.2.
- [The 2.9.2 release commit](https://github.com/mistralai/client-python/commit/dd6a74325e825cbf2672fb301c4db736d203f902) descends directly from that merge.
- [OpenTelemetry HTTPX instrumentation 0.65b0 metadata](https://pypi.org/pypi/opentelemetry-instrumentation-httpx/0.65b0/json) declares HTTPX2 support and the lockstep 0.65b0 semantic-conventions dependency.
- [pydantic/logfire#2094](https://github.com/pydantic/logfire/pull/2094) is the merged Logfire compatibility fix for OpenTelemetry SDK 1.44.
- The released [`Mistral` constructor](https://github.com/mistralai/client-python/blob/dd6a74325e825cbf2672fb301c4db736d203f902/src/mistralai/client/sdk.py) accepts the SDK's runtime-checkable [`AsyncHttpClient` protocol](https://github.com/mistralai/client-python/blob/dd6a74325e825cbf2672fb301c4db736d203f902/src/mistralai/client/httpclient.py); the provider and SDK-readiness tests verify an injected `httpx2.AsyncClient` is retained by identity.

## Verification

- targeted provider, lifecycle, SDK-readiness, lowest-direct, and Logfire integration tests pass;
- all Mistral documentation examples pass;
- Ruff and targeted Pyright pass;
- commit-time formatting, lint, full Pyright, and cassette checks pass;
- the complete CI matrix and 100% coverage gate pass.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
