### PR TITLE
Settle in-flight state and report `state_restored` honestly on realtime reconnect

### DIFF
--- a/docs/realtime/lifecycle.md
+++ b/docs/realtime/lifecycle.md
@@ -79,17 +79,22 @@ the [Gemini resumption settings](gemini.md#session-resumption). Their handles li
 and cannot be persisted for another process.
 
 [`RealtimeSessionReconnectEvent.state_restored`][pydantic_ai.realtime.RealtimeSessionReconnectEvent.state_restored]
-reports whether conversation state was recovered, by either mechanism.
+reports whether the reconnect carried the conversation through without cutting a turn off.
 
-A reply the drop cut off follows the same flag. With state restored, the recorded response simply
-stays open: output on the new connection continues it, and the turn completes with the response
-terminal as usual — except on Gemini, which closes the cut reply as an interrupted response (keeping
-any partial transcript in history) before the
-[`RealtimeSessionReconnectEvent`][pydantic_ai.realtime.RealtimeSessionReconnectEvent] and stays
-quiet until the next input. With state lost, treat the session as a fresh context: before emitting
-the event, the session settles everything the provider lost — the partial reply is recorded as an
-interrupted response, running tool calls get cancelled returns, and the turn ends so queued messages
-waiting for the boundary still flush.
+How a reply the drop caught in flight is handled depends on the mechanism. Under native resumption
+(xAI) the recorded response simply stays open: output on the new connection continues it, the turn
+completes with the response terminal as usual, and `state_restored` stays `True`. Gemini also reports
+`True` but closes the cut reply as an interrupted response (keeping any partial transcript in history)
+before the [`RealtimeSessionReconnectEvent`][pydantic_ai.realtime.RealtimeSessionReconnectEvent] and
+stays quiet until the next input.
+
+Local replay (OpenAI, Azure OpenAI) restores only the finalized turns, so a reply in flight when the
+socket dropped cannot continue. The session settles it before emitting the event — the partial reply
+becomes an interrupted response, running tool calls get cancelled returns, and the turn ends so queued
+messages waiting for the boundary still flush — and `state_restored` is `False` to say the turn was
+cut off. An answer that was solicited but had not started streaming is instead re-requested on the new
+connection, and a drop with nothing in flight restores the whole call as-is; both lose no output, so
+`state_restored` stays `True`.
 
 ## Provider session limits
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -4141,10 +4141,18 @@ class RealtimeSessionReconnectEvent:
     _: KW_ONLY
 
     state_restored: bool = False
-    """Whether prior conversation state is available again after the reconnect, regardless of
+    """Whether the reconnect carried the conversation through without cutting a turn off, regardless of
     mechanism — native provider resumption or a local-history replay.
 
-    `False` means prior turns were lost: treat the session as a fresh context.
+    `True` means nothing in flight was lost: the provider either resumed the in-flight response itself
+    (Gemini Live, xAI Grok Voice) or there was no turn in progress when the connection dropped.
+
+    `False` means a turn the drop interrupted was settled before continuing — its partial reply is
+    recorded as an interrupted response and any running tool calls as cancelled returns — so
+    [`all_messages()`][pydantic_ai.realtime.RealtimeSession.all_messages] stays a coherent history.
+    Finalized turns from before the drop survive where the provider restores them (the OpenAI/Azure
+    OpenAI local replay) and are lost where it does not; either way, treat the interrupted turn as over
+    and expect the model to stay quiet until the next input.
     """
 
     event_kind: Literal['realtime_session_reconnect'] = 'realtime_session_reconnect'

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1874,23 +1874,27 @@ class RealtimeSession:
     def _handle_reconnected(self, event: RealtimeSessionReconnectEvent) -> list[RealtimeEvent]:
         """Settle any in-flight state the reconnect did not actually carry, and report restoration honestly.
 
-        A provider that resumes natively (Gemini Live, xAI Grok Voice) continues the in-flight response
-        on the new connection, so `state_restored=True` holds as reported and there is nothing to
-        settle. A provider we reconnect by replaying local history (OpenAI, Azure OpenAI — where
-        `supports_session_seeding` is the mechanism) only restores *finalized* turns: the response and
-        tool calls that were in flight when the socket dropped are gone, and the fresh server-side
-        conversation knows nothing of them. Settle them here exactly as for a fully lost session — the
-        partial reply as an interrupted response, running tool calls as cancelled returns — so the
-        local history stays coherent and the turn ends (flushing anything queued behind it). Report
-        `state_restored=False` whenever something was actually in flight, so an app can branch on the
-        flag the same way on every provider; a drop with nothing in flight loses nothing and stays `True`.
+        A connection that resumes in-flight state (native resumption on xAI Grok Voice; Gemini Live,
+        which settles the cut turn in the connection itself) reports
+        [`reconnect_restores_in_flight_state`][pydantic_ai.realtime.codec.RealtimeConnection.reconnect_restores_in_flight_state],
+        so `state_restored=True` holds as reported and there is nothing more to settle. A connection we
+        reconnect by replaying local history (OpenAI, Azure OpenAI) only restores *finalized* turns: the
+        response and tool calls that were in flight when the socket dropped are gone, and the fresh
+        server-side conversation knows nothing of them. Settle them here exactly as for a fully lost
+        session — the partial reply as an interrupted response, running tool calls as cancelled returns —
+        so the local history stays coherent and the turn ends (flushing anything queued behind it).
+        Report `state_restored=False` whenever a response or tool call was actually in flight, so an app
+        can branch on the flag the same way on every provider; a drop with nothing in flight loses
+        nothing and stays `True`. Whether the settlement *emitted* events is not the test: an in-flight
+        response carried only by pending provider metadata is finalized into history without any.
         """
-        if event.state_restored and not self._profile.get('supports_session_seeding', False):
+        if event.state_restored and self._connection.reconnect_restores_in_flight_state:
             return [event]
-        lost = self._finalize_lost_state()
-        if lost:
+        lost_in_flight = self._response_in_flight or bool(self._pending_tool_calls)
+        events = self._finalize_lost_state()
+        if lost_in_flight:
             event = replace(event, state_restored=False)
-        return [*lost, event]
+        return [*events, event]
 
     def _finalize_lost_state(self) -> list[RealtimeEvent]:
         """Settle everything still open into history: user turns, an in-flight response, running tools.

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1872,10 +1872,25 @@ class RealtimeSession:
         return not self._is_replayed_item(item_id, tool_call_id)
 
     def _handle_reconnected(self, event: RealtimeSessionReconnectEvent) -> list[RealtimeEvent]:
-        """Close state the provider lost before starting the reconnected turn."""
-        if event.state_restored:
+        """Settle any in-flight state the reconnect did not actually carry, and report restoration honestly.
+
+        A provider that resumes natively (Gemini Live, xAI Grok Voice) continues the in-flight response
+        on the new connection, so `state_restored=True` holds as reported and there is nothing to
+        settle. A provider we reconnect by replaying local history (OpenAI, Azure OpenAI — where
+        `supports_session_seeding` is the mechanism) only restores *finalized* turns: the response and
+        tool calls that were in flight when the socket dropped are gone, and the fresh server-side
+        conversation knows nothing of them. Settle them here exactly as for a fully lost session — the
+        partial reply as an interrupted response, running tool calls as cancelled returns — so the
+        local history stays coherent and the turn ends (flushing anything queued behind it). Report
+        `state_restored=False` whenever something was actually in flight, so an app can branch on the
+        flag the same way on every provider; a drop with nothing in flight loses nothing and stays `True`.
+        """
+        if event.state_restored and not self._profile.get('supports_session_seeding', False):
             return [event]
-        return [*self._finalize_lost_state(), event]
+        lost = self._finalize_lost_state()
+        if lost:
+            event = replace(event, state_restored=False)
+        return [*lost, event]
 
     def _finalize_lost_state(self) -> list[RealtimeEvent]:
         """Settle everything still open into history: user turns, an in-flight response, running tools.

--- a/pydantic_ai_slim/pydantic_ai/realtime/codec.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/codec.py
@@ -435,6 +435,20 @@ class RealtimeConnection(ABC):
         """
         return True
 
+    @property
+    def reconnect_restores_in_flight_state(self) -> bool:
+        """Whether a reconnect continues the response and tool calls that were in flight when the socket dropped.
+
+        Otherwise it only brings back the finalized conversation. Native session resumption (xAI Grok Voice) restores the in-flight generation server-side, and
+        Gemini Live settles the cut turn in the connection before its
+        [`RealtimeSessionReconnectEvent`][pydantic_ai.messages.RealtimeSessionReconnectEvent], so in
+        both the [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] must not settle again and
+        trusts `state_restored`. Local replay (OpenAI, Azure OpenAI) restores only finalized turns, so
+        the session settles the interrupted turn itself and reports `state_restored=False`. Defaults to
+        `True`; the OpenAI connection overrides it.
+        """
+        return True
+
 
 __all__ = (
     # Connection ABC and the event/input unions it exchanges with a session.

--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -384,6 +384,13 @@ class OpenAIRealtimeConnection(RealtimeConnection):
         return self._message_history
 
     @property
+    def reconnect_restores_in_flight_state(self) -> bool:
+        # Local replay restores only the finalized turns; the response and tool calls in flight when
+        # the socket dropped are gone, so the session settles them. (The xAI clone resumes natively and
+        # overrides this back to `True`.)
+        return False
+
+    @property
     def input_transcription_enabled(self) -> bool:
         return self._input_transcription_enabled
 
@@ -758,10 +765,14 @@ class OpenAIRealtimeConnection(RealtimeConnection):
             # not yet confirmed by its `response.created` (`_response_active` without `_response_started`)
             # — the answer the caller is waiting on, which `_pending_response` alone does not cover. A
             # response already streaming when it dropped is *not* re-asked: its partial reply is settled
-            # as interrupted, matching the state-lost contract of staying quiet until the next input.
-            # Sent inside this guard because the new socket can drop before the frame reaches it, which
-            # has to consume an attempt like any other failed reconnect.
-            replay_response = self._pending_response or (self._response_active and not self._response_started)
+            # as interrupted, matching the state-lost contract of staying quiet until the next input. Nor
+            # is one the caller cancelled (`_cancel_sent`) before it started: re-asking would resurrect a
+            # response a barge-in explicitly stopped. Sent inside this guard because the new socket can
+            # drop before the frame reaches it, which has to consume an attempt like any other failed
+            # reconnect.
+            replay_response = self._pending_response or (
+                self._response_active and not self._response_started and not self._cancel_sent
+            )
             self._clear_active_response()
             # A fresh socket also drops anything the old one was still holding for us.
             self._cancelled_response_id = None

--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -346,6 +346,11 @@ class OpenAIRealtimeConnection(RealtimeConnection):
         # model is mid-answer) until the active response finishes, so the model still announces it.
         self._response_active = False
         self._active_response_id: str | None = None
+        # Whether the active response has been confirmed by its `response.created`. A response solicited
+        # (`response.create` sent) but not yet started is the one a mid-handshake drop would otherwise
+        # lose: `_pending_response` only covers responses deferred behind an *active* one, so without this
+        # a re-dial replays the finalized call but never re-asks for the answer the caller is waiting on.
+        self._response_started = False
         self._pending_response = False
         self._cancel_sent = False
         # Id of a response we cancelled (barge-in): the server keeps streaming a few straggler deltas
@@ -595,6 +600,7 @@ class OpenAIRealtimeConnection(RealtimeConnection):
         if event_type == 'response.created':
             created = RESPONSE_CREATED_EVENT_ADAPTER.validate_python(data)
             self._response_active = True
+            self._response_started = True
             self._active_response_id = created.response.id or None
             if self._cancel_sent and self._cancelled_response_id is None:
                 # A cancel raced ahead of this `response.created`: it was sent while the response the
@@ -745,12 +751,17 @@ class OpenAIRealtimeConnection(RealtimeConnection):
         assert self._dial is not None
         try:
             self._ws = await self._dial()
-            # A `response.create` deferred behind the response that died with the socket will never be
-            # released by that response's `response.done`, so replay it on the fresh socket (which has
-            # just replayed the call) rather than dropping it and leaving the session waiting for a turn
-            # that can never start. Sent inside this guard because the new socket can drop before the
-            # frame reaches it, which has to consume an attempt like any other failed reconnect.
-            replay_response = self._pending_response
+            # A response the socket dropped before it could complete will never be released by its
+            # `response.done`, so re-ask for it on the fresh socket (which has just replayed the call)
+            # rather than leaving the session waiting for a turn that can never start. Two shapes qualify:
+            # one deferred behind a now-dead active response (`_pending_response`), and one solicited but
+            # not yet confirmed by its `response.created` (`_response_active` without `_response_started`)
+            # — the answer the caller is waiting on, which `_pending_response` alone does not cover. A
+            # response already streaming when it dropped is *not* re-asked: its partial reply is settled
+            # as interrupted, matching the state-lost contract of staying quiet until the next input.
+            # Sent inside this guard because the new socket can drop before the frame reaches it, which
+            # has to consume an attempt like any other failed reconnect.
+            replay_response = self._pending_response or (self._response_active and not self._response_started)
             self._clear_active_response()
             # A fresh socket also drops anything the old one was still holding for us.
             self._cancelled_response_id = None
@@ -772,6 +783,7 @@ class OpenAIRealtimeConnection(RealtimeConnection):
     def _clear_active_response(self) -> None:
         """Forget the response currently being generated, so a new one can start."""
         self._response_active = False
+        self._response_started = False
         self._active_response_id = None
         self._cancel_sent = False
         self._current_item_id = None

--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -763,15 +763,20 @@ class OpenAIRealtimeConnection(RealtimeConnection):
             # rather than leaving the session waiting for a turn that can never start. Two shapes qualify:
             # one deferred behind a now-dead active response (`_pending_response`), and one solicited but
             # not yet confirmed by its `response.created` (`_response_active` without `_response_started`)
-            # — the answer the caller is waiting on, which `_pending_response` alone does not cover. A
-            # response already streaming when it dropped is *not* re-asked: its partial reply is settled
-            # as interrupted, matching the state-lost contract of staying quiet until the next input. Nor
-            # is one the caller cancelled (`_cancel_sent`) before it started: re-asking would resurrect a
-            # response a barge-in explicitly stopped. Sent inside this guard because the new socket can
-            # drop before the frame reaches it, which has to consume an attempt like any other failed
-            # reconnect.
+            # — the answer the caller is waiting on, which `_pending_response` alone does not cover. That
+            # second case is only ours to re-ask on a local-replay connection: one that restores in-flight
+            # state (`reconnect_restores_in_flight_state`, e.g. the inherited xAI clone) has the server
+            # resume that response itself, so re-asking would duplicate it. A response already streaming
+            # when it dropped is *not* re-asked either: its partial reply is settled as interrupted,
+            # matching the state-lost contract of staying quiet until the next input. Nor is one the
+            # caller cancelled (`_cancel_sent`) before it started: re-asking would resurrect a response a
+            # barge-in explicitly stopped. Sent inside this guard because the new socket can drop before
+            # the frame reaches it, which has to consume an attempt like any other failed reconnect.
             replay_response = self._pending_response or (
-                self._response_active and not self._response_started and not self._cancel_sent
+                not self.reconnect_restores_in_flight_state
+                and self._response_active
+                and not self._response_started
+                and not self._cancel_sent
             )
             self._clear_active_response()
             # A fresh socket also drops anything the old one was still holding for us.

--- a/pydantic_ai_slim/pydantic_ai/realtime/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/xai.py
@@ -294,6 +294,12 @@ class XaiRealtimeConnection(OpenAIRealtimeConnection):
         """Ignored: xAI restores the conversation itself, so replaying it would say everything twice."""
 
     @property
+    def reconnect_restores_in_flight_state(self) -> bool:
+        # xAI resumes the conversation server-side, so the in-flight turn is not the session's to settle
+        # (unlike the OpenAI base, which reconnects by replaying finalized history only).
+        return True
+
+    @property
     def conversation_id(self) -> str | None:
         """The xAI conversation ID used for native session resumption."""
         return self._conversation_id

--- a/tests/realtime/test_google.py
+++ b/tests/realtime/test_google.py
@@ -161,6 +161,12 @@ def _conn(session: _RecordingSession) -> GoogleRealtimeConnection:
     return GoogleRealtimeConnection(cast('AsyncSession', session))
 
 
+def test_google_connection_restores_in_flight_state_on_reconnect() -> None:
+    # Gemini settles the cut turn in the connection itself and resumes conversation state on re-dial, so
+    # the session does not settle again — it keeps the base connection's default.
+    assert _conn(_RecordingSession()).reconnect_restores_in_flight_state is True
+
+
 # --- helpers -----------------------------------------------------------------
 
 

--- a/tests/realtime/test_openai.py
+++ b/tests/realtime/test_openai.py
@@ -2983,6 +2983,63 @@ async def test_reconnect_replays_a_deferred_response_request() -> None:
 
 
 @pytest.mark.anyio
+async def test_reconnect_re_solicits_a_response_that_never_started() -> None:
+    # A `response.create` sent when idle goes out immediately (not deferred), so `_pending_response` is
+    # False while the connection waits for its `response.created`. If the socket drops in that window the
+    # answer the caller is waiting on is neither deferred nor streaming — without re-asking, the re-dial
+    # replays the finalized call but the turn never starts. `_response_active` without `_response_started`
+    # marks exactly that response, so it is re-solicited on the fresh socket.
+    replacement = FakeWebSocket([])
+    replacements = iter([replacement])
+
+    async def dial() -> Any:
+        try:
+            return next(replacements)
+        except StopIteration:
+            raise OSError('server is down')
+
+    conn = OpenAIRealtimeConnection(
+        DroppingWebSocket([]),  # type: ignore[arg-type]
+        dial=dial,
+        reconnect={'base_delay': 0.0, 'max_attempts': 1},
+    )
+    conn._response_active = True  # pyright: ignore[reportPrivateUsage]
+    conn._response_started = False  # pyright: ignore[reportPrivateUsage]
+
+    events = [e async for e in conn]
+    assert [type(e).__name__ for e in events] == ['RealtimeSessionReconnectEvent', 'RealtimeSessionErrorEvent']
+    assert replacement.sent == ['{"type":"response.create"}']
+
+
+@pytest.mark.anyio
+async def test_reconnect_does_not_re_solicit_a_response_that_was_streaming() -> None:
+    # A response already confirmed by its `response.created` (`_response_started`) had output the session
+    # settles as interrupted; re-asking for it would make the model answer a turn it was cut off mid-way
+    # through, contradicting the state-lost contract of staying quiet until the next input. So the fresh
+    # socket carries the replayed call but no `response.create`.
+    replacement = FakeWebSocket([])
+    replacements = iter([replacement])
+
+    async def dial() -> Any:
+        try:
+            return next(replacements)
+        except StopIteration:
+            raise OSError('server is down')
+
+    conn = OpenAIRealtimeConnection(
+        DroppingWebSocket([]),  # type: ignore[arg-type]
+        dial=dial,
+        reconnect={'base_delay': 0.0, 'max_attempts': 1},
+    )
+    conn._response_active = True  # pyright: ignore[reportPrivateUsage]
+    conn._response_started = True  # pyright: ignore[reportPrivateUsage]
+
+    events = [e async for e in conn]
+    assert [type(e).__name__ for e in events] == ['RealtimeSessionReconnectEvent', 'RealtimeSessionErrorEvent']
+    assert 'response.create' not in replacement.sent
+
+
+@pytest.mark.anyio
 async def test_reconnect_replay_failure_consumes_an_attempt() -> None:
     # The replayed `response.create` goes out on a socket that has only just come up, which can drop
     # before the frame reaches it. That has to look like any other failed reconnect — consuming an

--- a/tests/realtime/test_openai.py
+++ b/tests/realtime/test_openai.py
@@ -2982,6 +2982,12 @@ async def test_reconnect_replays_a_deferred_response_request() -> None:
     assert conn._response_active is True  # pyright: ignore[reportPrivateUsage]
 
 
+def test_openai_connection_does_not_restore_in_flight_state_on_reconnect() -> None:
+    # OpenAI reconnects by replaying finalized history only, so the session settles the in-flight turn.
+    conn = OpenAIRealtimeConnection(FakeWebSocket([]))  # type: ignore[arg-type]
+    assert conn.reconnect_restores_in_flight_state is False
+
+
 @pytest.mark.anyio
 async def test_reconnect_re_solicits_a_response_that_never_started() -> None:
     # A `response.create` sent when idle goes out immediately (not deferred), so `_pending_response` is
@@ -3009,6 +3015,35 @@ async def test_reconnect_re_solicits_a_response_that_never_started() -> None:
     events = [e async for e in conn]
     assert [type(e).__name__ for e in events] == ['RealtimeSessionReconnectEvent', 'RealtimeSessionErrorEvent']
     assert replacement.sent == ['{"type":"response.create"}']
+
+
+@pytest.mark.anyio
+async def test_reconnect_does_not_re_solicit_a_cancelled_response() -> None:
+    # A response the caller cancelled (barge-in) before its `response.created` arrived is `_response_active`
+    # without `_response_started`, but `_cancel_sent` marks it stopped. Re-asking would resurrect a
+    # response the user explicitly interrupted, producing unwanted output after the barge-in, so it is
+    # not replayed on the fresh socket.
+    replacement = FakeWebSocket([])
+    replacements = iter([replacement])
+
+    async def dial() -> Any:
+        try:
+            return next(replacements)
+        except StopIteration:
+            raise OSError('server is down')
+
+    conn = OpenAIRealtimeConnection(
+        DroppingWebSocket([]),  # type: ignore[arg-type]
+        dial=dial,
+        reconnect={'base_delay': 0.0, 'max_attempts': 1},
+    )
+    conn._response_active = True  # pyright: ignore[reportPrivateUsage]
+    conn._response_started = False  # pyright: ignore[reportPrivateUsage]
+    conn._cancel_sent = True  # pyright: ignore[reportPrivateUsage]
+
+    events = [e async for e in conn]
+    assert [type(e).__name__ for e in events] == ['RealtimeSessionReconnectEvent', 'RealtimeSessionErrorEvent']
+    assert 'response.create' not in replacement.sent
 
 
 @pytest.mark.anyio

--- a/tests/realtime/test_openai.py
+++ b/tests/realtime/test_openai.py
@@ -3043,7 +3043,7 @@ async def test_reconnect_does_not_re_solicit_a_cancelled_response() -> None:
 
     events = [e async for e in conn]
     assert [type(e).__name__ for e in events] == ['RealtimeSessionReconnectEvent', 'RealtimeSessionErrorEvent']
-    assert 'response.create' not in replacement.sent
+    assert not any(json.loads(frame).get('type') == 'response.create' for frame in replacement.sent)
 
 
 @pytest.mark.anyio
@@ -3071,7 +3071,7 @@ async def test_reconnect_does_not_re_solicit_a_response_that_was_streaming() -> 
 
     events = [e async for e in conn]
     assert [type(e).__name__ for e in events] == ['RealtimeSessionReconnectEvent', 'RealtimeSessionErrorEvent']
-    assert 'response.create' not in replacement.sent
+    assert not any(json.loads(frame).get('type') == 'response.create' for frame in replacement.sent)
 
 
 @pytest.mark.anyio

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -276,11 +276,13 @@ class FakeRealtimeConnection(RealtimeConnection):
         release: asyncio.Event | None = None,
         input_transcription_enabled: bool = True,
         model_name: str | None = None,
+        reconnect_restores_in_flight_state: bool = True,
     ) -> None:
         self._events = events
         self._release = release
         self._input_transcription_enabled = input_transcription_enabled
         self._model_name = model_name
+        self._reconnect_restores_in_flight_state = reconnect_restores_in_flight_state
         self.sent: list[RealtimeInput] = []
 
     @property
@@ -290,6 +292,10 @@ class FakeRealtimeConnection(RealtimeConnection):
     @property
     def input_transcription_enabled(self) -> bool:
         return self._input_transcription_enabled
+
+    @property
+    def reconnect_restores_in_flight_state(self) -> bool:
+        return self._reconnect_restores_in_flight_state
 
     async def send(self, content: RealtimeInput) -> None:
         self.sent.append(content)
@@ -3366,13 +3372,13 @@ _SETTLED_IN_FLIGHT = snapshot(
 
 
 @pytest.mark.parametrize(
-    ('supports_session_seeding', 'state_restored', 'expected_state_restored', 'expected'),
+    ('reconnect_restores_in_flight_state', 'state_restored', 'expected_state_restored', 'expected'),
     [
-        # Native resumption (Gemini Live, xAI): the provider genuinely continues the in-flight response
-        # on the new connection, so the two transcript halves belong to one response and nothing is
-        # settled. This is the only path that keeps `state_restored=True`.
+        # Native resumption (xAI; Gemini settles the cut turn in its own connection): the connection
+        # reports it restored the in-flight response, so the two transcript halves belong to one response
+        # and nothing is settled. This is the only path that keeps `state_restored=True`.
         pytest.param(
-            False,
+            True,
             True,
             True,
             snapshot(
@@ -3387,16 +3393,16 @@ _SETTLED_IN_FLIGHT = snapshot(
             id='native-resume-continues',
         ),
         # Local replay (OpenAI, Azure OpenAI): the connection reports `state_restored=True` because it
-        # replayed the *finalized* history, but the in-flight response the drop cut off is gone. The
-        # session settles it as an interrupted response and downgrades the user-facing flag to `False`,
-        # matching the fully-lost path so an app branches on the flag the same way everywhere.
-        pytest.param(True, True, False, _SETTLED_IN_FLIGHT, id='local-replay-settles-in-flight'),
+        # replayed the *finalized* history, but it does not restore in-flight state — the response the
+        # drop cut off is gone. The session settles it as an interrupted response and downgrades the
+        # user-facing flag to `False`, matching the fully-lost path so an app branches the same way.
+        pytest.param(False, True, False, _SETTLED_IN_FLIGHT, id='local-replay-settles-in-flight'),
         # Nothing restored at all: same settlement, flag already `False`.
-        pytest.param(True, False, False, _SETTLED_IN_FLIGHT, id='state-lost-settles-in-flight'),
+        pytest.param(False, False, False, _SETTLED_IN_FLIGHT, id='state-lost-settles-in-flight'),
     ],
 )
 async def test_reconnect_response_state(
-    supports_session_seeding: bool,
+    reconnect_restores_in_flight_state: bool,
     state_restored: bool,
     expected_state_restored: bool,
     expected: list[ModelMessage],
@@ -3407,9 +3413,10 @@ async def test_reconnect_response_state(
             RealtimeSessionReconnectEvent(state_restored=state_restored),
             OutputTranscript(text='after', is_final=True),
             ResponseDone(),
-        ]
+        ],
+        reconnect_restores_in_flight_state=reconnect_restores_in_flight_state,
     )
-    session = RealtimeSession(conn, profile=_profile(supports_session_seeding=supports_session_seeding))
+    session = RealtimeSession(conn)
     events = await collect_events(session)
     # The flag the app sees reflects what actually survived, not just what the connection replayed.
     assert [e.state_restored for e in events if isinstance(e, RealtimeSessionReconnectEvent)] == [
@@ -3427,9 +3434,10 @@ async def test_reconnect_while_idle_on_replay_provider_keeps_state_restored() ->
             RealtimeSessionReconnectEvent(state_restored=True),
             OutputTranscript(text='after', is_final=True),
             ResponseDone(),
-        ]
+        ],
+        reconnect_restores_in_flight_state=False,
     )
-    session = RealtimeSession(conn, profile=_profile(supports_session_seeding=True))
+    session = RealtimeSession(conn)
     events = await collect_events(session)
     assert [e.state_restored for e in events if isinstance(e, RealtimeSessionReconnectEvent)] == [True]
     assert session.new_messages() == snapshot(

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -3349,28 +3349,31 @@ async def test_audio_only_user_turn_finalized_on_each_manual_commit() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    ('state_restored', 'expected'),
+_SETTLED_IN_FLIGHT = snapshot(
     [
+        ModelResponse(
+            parts=[SpeechPart(speaker='assistant', transcript='before')],
+            timestamp=IsDatetime(),
+            state='interrupted',
+        ),
+        ModelResponse(
+            parts=[SpeechPart(speaker='assistant', transcript='after')],
+            timestamp=IsDatetime(),
+            finish_reason='stop',
+        ),
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    ('supports_session_seeding', 'state_restored', 'expected_state_restored', 'expected'),
+    [
+        # Native resumption (Gemini Live, xAI): the provider genuinely continues the in-flight response
+        # on the new connection, so the two transcript halves belong to one response and nothing is
+        # settled. This is the only path that keeps `state_restored=True`.
         pytest.param(
             False,
-            snapshot(
-                [
-                    ModelResponse(
-                        parts=[SpeechPart(speaker='assistant', transcript='before')],
-                        timestamp=IsDatetime(),
-                        state='interrupted',
-                    ),
-                    ModelResponse(
-                        parts=[SpeechPart(speaker='assistant', transcript='after')],
-                        timestamp=IsDatetime(),
-                        finish_reason='stop',
-                    ),
-                ]
-            ),
-            id='state-lost',
-        ),
-        pytest.param(
+            True,
             True,
             snapshot(
                 [
@@ -3381,11 +3384,23 @@ async def test_audio_only_user_turn_finalized_on_each_manual_commit() -> None:
                     )
                 ]
             ),
-            id='state-restored',
+            id='native-resume-continues',
         ),
+        # Local replay (OpenAI, Azure OpenAI): the connection reports `state_restored=True` because it
+        # replayed the *finalized* history, but the in-flight response the drop cut off is gone. The
+        # session settles it as an interrupted response and downgrades the user-facing flag to `False`,
+        # matching the fully-lost path so an app branches on the flag the same way everywhere.
+        pytest.param(True, True, False, _SETTLED_IN_FLIGHT, id='local-replay-settles-in-flight'),
+        # Nothing restored at all: same settlement, flag already `False`.
+        pytest.param(True, False, False, _SETTLED_IN_FLIGHT, id='state-lost-settles-in-flight'),
     ],
 )
-async def test_reconnect_response_state(state_restored: bool, expected: list[ModelMessage]) -> None:
+async def test_reconnect_response_state(
+    supports_session_seeding: bool,
+    state_restored: bool,
+    expected_state_restored: bool,
+    expected: list[ModelMessage],
+) -> None:
     conn = FakeRealtimeConnection(
         [
             OutputTranscript(text='before', is_final=False),
@@ -3394,9 +3409,38 @@ async def test_reconnect_response_state(state_restored: bool, expected: list[Mod
             ResponseDone(),
         ]
     )
-    session = RealtimeSession(conn)
-    await collect_events(session)
+    session = RealtimeSession(conn, profile=_profile(supports_session_seeding=supports_session_seeding))
+    events = await collect_events(session)
+    # The flag the app sees reflects what actually survived, not just what the connection replayed.
+    assert [e.state_restored for e in events if isinstance(e, RealtimeSessionReconnectEvent)] == [
+        expected_state_restored
+    ]
     assert session.new_messages() == expected
+
+
+async def test_reconnect_while_idle_on_replay_provider_keeps_state_restored() -> None:
+    # A local-replay provider (OpenAI/Azure) that drops while Listening loses nothing: the replay
+    # restores the finalized call and there is no in-flight turn to settle. The connection's
+    # `state_restored=True` stands, so an app is not told a seamless renewal was a disruption.
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeSessionReconnectEvent(state_restored=True),
+            OutputTranscript(text='after', is_final=True),
+            ResponseDone(),
+        ]
+    )
+    session = RealtimeSession(conn, profile=_profile(supports_session_seeding=True))
+    events = await collect_events(session)
+    assert [e.state_restored for e in events if isinstance(e, RealtimeSessionReconnectEvent)] == [True]
+    assert session.new_messages() == snapshot(
+        [
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='after')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            )
+        ]
+    )
 
 
 async def test_session_offers_the_conversation_for_replay_when_seeding_is_supported() -> None:

--- a/tests/realtime/test_xai.py
+++ b/tests/realtime/test_xai.py
@@ -474,7 +474,6 @@ class FakeWebSocket:
             yield self._incoming.pop(0)
 
 
-@pytest.mark.anyio
 def test_xai_connection_restores_in_flight_state_on_reconnect() -> None:
     # xAI resumes the conversation server-side, so the session keeps its in-flight state rather than
     # settling it (unlike the OpenAI base this connection is cloned from).
@@ -482,6 +481,34 @@ def test_xai_connection_restores_in_flight_state_on_reconnect() -> None:
     assert conn.reconnect_restores_in_flight_state is True
 
 
+@pytest.mark.anyio
+async def test_reconnect_does_not_re_solicit_an_unstarted_response() -> None:
+    # xAI inherits the OpenAI `_attempt_reconnect`, but because it resumes in-flight state server-side
+    # a response solicited before the drop is resumed by the server — re-soliciting it would duplicate
+    # the turn, so the re-solicit is gated off for this connection.
+    replacement = FakeWebSocket([])
+    replacements = iter([replacement])
+
+    async def dial() -> Any:
+        try:
+            return next(replacements)
+        except StopIteration:
+            raise OSError('server is down')
+
+    conn = XaiRealtimeConnection(
+        _DropAfterFrames([]),  # type: ignore[arg-type]
+        dial=dial,
+        reconnect={'base_delay': 0.0, 'max_attempts': 1},
+    )
+    conn._response_active = True  # pyright: ignore[reportPrivateUsage]
+    conn._response_started = False  # pyright: ignore[reportPrivateUsage]
+
+    events = [e async for e in conn]
+    assert any(isinstance(e, RealtimeSessionReconnectEvent) for e in events)
+    assert not any(json.loads(s).get('type') == 'response.create' for s in replacement.sent)
+
+
+@pytest.mark.anyio
 async def test_response_done_maps_xai_usage_extras() -> None:
     done = json.dumps(
         {

--- a/tests/realtime/test_xai.py
+++ b/tests/realtime/test_xai.py
@@ -475,6 +475,13 @@ class FakeWebSocket:
 
 
 @pytest.mark.anyio
+def test_xai_connection_restores_in_flight_state_on_reconnect() -> None:
+    # xAI resumes the conversation server-side, so the session keeps its in-flight state rather than
+    # settling it (unlike the OpenAI base this connection is cloned from).
+    conn = XaiRealtimeConnection(FakeWebSocket([]))  # type: ignore[arg-type]
+    assert conn.reconnect_restores_in_flight_state is True
+
+
 async def test_response_done_maps_xai_usage_extras() -> None:
     done = json.dumps(
         {


### PR DESCRIPTION
- Closes #7363

On OpenAI and Azure OpenAI, a realtime `reconnect` policy redials and replays the
**finalized** local history into the fresh server-side conversation. But the session
reported `RealtimeSessionReconnectEvent(state_restored=True)` and skipped in-flight
settlement — treating a local replay as if the provider had natively resumed.

It hadn't. The response and tool calls in flight when the socket dropped are gone from
the new session, so the old behavior left a partial reply and running tool calls open
against a conversation that never knew them. The documented promise for `state_restored=True`
("the recorded response simply stays open: output on the new connection continues it")
cannot hold on OpenAI, and in practice a cut-off turn never ended and a later response
could merge into the wrong `ModelResponse`.

### What changed

- **Settle in-flight state on local replay, keyed on the connection mechanism.** A new
  `RealtimeConnection.reconnect_restores_in_flight_state` (default `True`; `OpenAIRealtimeConnection`
  overrides to `False`, the xAI clone back to `True`) is the signal — the connection is what knows
  whether its reconnect restored the in-flight generation. A replay reconnect now settles the
  in-flight turn exactly as a fully lost session does — partial reply recorded as an interrupted
  response, running tool calls as cancelled returns, the turn ended so queued messages flush — so
  `all_messages()` stays a coherent history. Native resumption (Gemini Live, xAI) is unchanged.

- **Report `state_restored` honestly.** `False` whenever a turn was actually in flight and had to be
  settled — on any provider — and `True` when nothing was lost (native resume, or a drop with nothing
  in flight). An app can now branch on `if not event.state_restored:` the same way on every provider.
  Per the maintainer decision on the flag's contract, this is the "dynamic/honest" semantics rather
  than "always True on replay".

- **Re-solicit a response that was solicited but never started.** A `response.create` sent when idle
  goes out immediately (not deferred), so a drop before its `response.created` lost it and the caller
  waited forever. The connection now tracks `_response_started` and re-asks for that response on the
  fresh socket. A response *already streaming* when it dropped is not re-asked — it's settled as
  interrupted and the model stays quiet until the next input, matching the state-lost contract.

### Scope note

The replay snapshot is taken before settlement, so the fresh provider session does not receive the
interrupted assistant turn in its context. That's intentional — refeeding a half-spoken, interrupted
utterance as model context is not desirable, and the session-side history stays correct for an
`Agent.run(message_history=...)` handoff regardless.

### Tests

- `test_reconnect_response_state` reworked to distinguish native-resume (continues, stays `True`)
  from local-replay (settles in-flight, downgrades to `False`) and the fully-lost case.
- `test_reconnect_while_idle_on_replay_provider_keeps_state_restored` pins that a drop with nothing
  in flight keeps `True`.
- `test_reconnect_re_solicits_a_response_that_never_started` /
  `test_reconnect_does_not_re_solicit_a_response_that_was_streaming` pin the re-solicit gate.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


