### PR TITLE
Backport #7357 to `v1`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1470,7 +1470,10 @@ class RetryPromptPart:
         if self.tool_name is None:
             return LogRecord(
                 attributes={'event.name': 'gen_ai.user.message'},
-                body={'content': self.model_response(), 'role': 'user'},
+                body={
+                    **({'content': self.model_response()} if settings.include_content else {}),
+                    'role': 'user',
+                },
             )
         else:
             return LogRecord(
@@ -1485,7 +1488,12 @@ class RetryPromptPart:
 
     def otel_message_parts(self, settings: InstrumentationSettings) -> list[_otel_messages.MessagePart]:
         if self.tool_name is None:
-            return [_otel_messages.TextPart(type='text', content=self.model_response())]
+            return [
+                _otel_messages.TextPart(
+                    type='text',
+                    **({'content': self.model_response()} if settings.include_content else {}),
+                )
+            ]
         else:
             part = _otel_messages.ToolCallResponsePart(
                 type='tool_call_response',

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1610,3 +1610,64 @@ def test_retry_prompt_tool_call_keeps_input_for_nested_errors():
     response = part.model_response()
     assert '"input": 42' in response
     assert '"name"' in response
+
+
+def test_retry_prompt_otel_include_content():
+    """Retry prompt parts honor `include_content` like every other message part, in both the
+    tool-call and non-tool branches, on both the event and message-part serialization paths."""
+    non_tool = RetryPromptPart(
+        content=[
+            {
+                'type': 'string_type',
+                'loc': ('items', 0, 'name'),
+                'msg': 'Input should be a valid string',
+                'input': 'model-generated value',
+            },
+        ],
+    )
+    tool = RetryPromptPart(tool_name='my_tool', tool_call_id='call_1', content='Try again')
+
+    with_content = InstrumentationSettings(include_content=True)
+    assert non_tool.otel_message_parts(with_content) == snapshot(
+        [
+            {
+                'type': 'text',
+                'content': """\
+1 validation error:
+```json
+[
+  {
+    "type": "string_type",
+    "loc": [
+      "items",
+      0,
+      "name"
+    ],
+    "msg": "Input should be a valid string",
+    "input": "model-generated value"
+  }
+]
+```
+
+Fix the errors and try again.""",
+            }
+        ]
+    )
+    assert non_tool.otel_event(with_content).body == {'content': non_tool.model_response(), 'role': 'user'}
+    assert tool.otel_message_parts(with_content) == snapshot(
+        [
+            {
+                'type': 'tool_call_response',
+                'id': 'call_1',
+                'name': 'my_tool',
+                'result': 'Try again\n\nFix the errors and try again.',
+            }
+        ]
+    )
+
+    without_content = InstrumentationSettings(include_content=False)
+    assert non_tool.otel_message_parts(without_content) == snapshot([{'type': 'text'}])
+    assert non_tool.otel_event(without_content).body == {'role': 'user'}
+    assert tool.otel_message_parts(without_content) == snapshot(
+        [{'type': 'tool_call_response', 'id': 'call_1', 'name': 'my_tool'}]
+    )


### PR DESCRIPTION
Backport of #7357 to the `v1` line; the `v1` tree needed an additional adjustment on top of the original patch.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

