### PR TITLE
Only accept JSON request bodies on the web UI chat endpoint

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -99,14 +99,14 @@ app = agent.to_web(instructions='Always respond in a friendly tone.')
 Tools that [require approval](deferred-tools.md#human-in-the-loop-tool-approval) are surfaced in the UI as approve/reject prompts: when the agent calls such a tool, the UI renders the pending call and lets you approve or deny it before the run continues. This works out of the box — no extra configuration is needed.
 
 !!! warning
-    The chat endpoint executes tool approvals relayed by the client, including for tools marked `requires_approval=True`. The server trusts the approval decision it receives, so a client with direct access to the endpoint can approve any pending call. As noted above, the web UI is meant for local development — this is fine when it's bound to localhost, but do not expose `to_web()` to untrusted clients without putting authentication in front of it.
+    The chat endpoint executes tool approvals relayed by the client, including for tools marked `requires_approval=True`. The server trusts the approval decision it receives, so any client that can reach the endpoint can approve any pending call. As noted above, the web UI is meant for local development: treat approval prompts as a convenience for the developer driving the UI rather than an authorization control, and don't expose `to_web()` to untrusted clients without putting authentication in front of it.
 
 ## Reserved Routes
 
 The web UI app uses the following routes which should not be overwritten:
 
 - `/` and `/{id}` - Serves the chat UI
-- `/api/chat` - Chat endpoint (POST, OPTIONS)
+- `/api/chat` - Chat endpoint (POST, OPTIONS). Requires `Content-Type: application/json`; other content types are rejected with `415`.
 - `/api/configure` - Frontend configuration (GET)
 - `/api/health` - Health check (GET)
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -99,7 +99,9 @@ app = agent.to_web(instructions='Always respond in a friendly tone.')
 Tools that [require approval](deferred-tools.md#human-in-the-loop-tool-approval) are surfaced in the UI as approve/reject prompts: when the agent calls such a tool, the UI renders the pending call and lets you approve or deny it before the run continues. This works out of the box — no extra configuration is needed.
 
 !!! warning
-    The chat endpoint executes tool approvals relayed by the client, including for tools marked `requires_approval=True`. The server trusts the approval decision it receives, so any client that can reach the endpoint can approve any pending call. As noted above, the web UI is meant for local development: treat approval prompts as a convenience for the developer driving the UI rather than an authorization control, and don't expose `to_web()` to untrusted clients without putting authentication in front of it.
+    The chat endpoint executes tool approvals relayed by the client, including for tools marked `requires_approval=True`. The server trusts the approval decision it receives, so any client that can reach the endpoint can approve any pending call.
+
+    Binding to localhost is not on its own a security boundary here: a web page open in the same browser can also reach `http://127.0.0.1:7932`. The chat endpoint therefore only accepts `Content-Type: application/json`, which a browser cannot send cross-origin without a preflight that the server refuses. Treat approval prompts as a convenience for the developer driving the UI rather than an authorization control, and don't expose `to_web()` to untrusted clients without putting authentication in front of it.
 
 ## Reserved Routes
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -31,6 +31,13 @@ ModelsParam = Sequence[Model | KnownModelName | str] | Mapping[str, Model | Know
 # (server + bundled UI). See `VercelAIAdapter.sdk_version`.
 BUNDLED_UI_SDK_VERSION: Literal[7] = 7
 
+# `/chat` accepts JSON request bodies only. This is deliberately an allowlist rather than a denylist
+# of the media types we don't want: a JSON body can arrive declared as several other media types, or
+# with no media type at all, and the endpoint's contract is `application/json` specifically. The
+# bundled UI — and the Vercel AI SDK's `DefaultChatTransport` generally — always sends
+# `application/json`; other clients need to set the header explicitly.
+JSON_MEDIA_TYPE = 'application/json'
+
 
 class ModelInfo(BaseModel, alias_generator=to_camel, populate_by_name=True):
     """Defines an AI model with its associated built-in tools."""
@@ -177,6 +184,14 @@ def create_api_app(
 
     async def post_chat(request: Request) -> Response:
         """Handle chat requests via Vercel AI Adapter."""
+        if (media_type := request.headers.get('content-type', '').split(';')[0].strip().lower()) != JSON_MEDIA_TYPE:
+            # Checked up front so a request that doesn't meet the endpoint's contract is turned away
+            # before the body is parsed and before the agent is dispatched.
+            return JSONResponse(
+                {'error': f'Expected `Content-Type: {JSON_MEDIA_TYPE}`, got {media_type or "no content type"}'},
+                status_code=415,
+            )
+
         adapter = await VercelAIAdapter[AgentDepsT, OutputDataT].from_request(
             request, agent=agent, sdk_version=sdk_version
         )

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -31,10 +31,18 @@ ModelsParam = Sequence[Model | KnownModelName | str] | Mapping[str, Model | Know
 # (server + bundled UI). See `VercelAIAdapter.sdk_version`.
 BUNDLED_UI_SDK_VERSION: Literal[7] = 7
 
-# `/chat` accepts JSON request bodies only. This is deliberately an allowlist rather than a denylist
-# of the media types we don't want: a JSON body can arrive declared as several other media types, or
-# with no media type at all, and the endpoint's contract is `application/json` specifically. The
-# bundled UI — and the Vercel AI SDK's `DefaultChatTransport` generally — always sends
+# `/chat` requires exactly this content type. This is a CSRF control, not content negotiation: a
+# browser can send the three CORS-safelisted content types (`text/plain`, `multipart/form-data`,
+# `application/x-www-form-urlencoded`) — or no content type at all — cross-origin with no preflight,
+# and every one of them can carry a JSON body. Without this check, a page the developer happens to
+# visit while running the web UI could start an agent run on their machine, and execute whatever
+# tools the served agent exposes. `application/json` is not safelisted, so requiring it forces a
+# preflight, which `options_chat` refuses.
+#
+# Keep this an allowlist. A denylist of the safelisted types would miss the no-content-type case,
+# and would silently stop covering anything added to the safelist later.
+#
+# The bundled UI — and the Vercel AI SDK's `DefaultChatTransport` generally — always sends
 # `application/json`; other clients need to set the header explicitly.
 JSON_MEDIA_TYPE = 'application/json'
 
@@ -167,7 +175,17 @@ def create_api_app(
     allowed_tool_ids = {tool.unique_id for tool in ui_native_tools}
 
     async def options_chat(request: Request) -> Response:
-        """Handle CORS preflight requests."""
+        """Answer CORS preflight requests without granting cross-origin access.
+
+        Deliberately carries no `Access-Control-Allow-*` header, so a browser refuses any
+        cross-origin request that needs a preflight. Together with the `application/json`
+        requirement in `post_chat()`, that is what keeps a page the developer visits from reaching
+        the local web UI: requiring a non-safelisted content type forces the preflight, and this
+        response denies it.
+
+        Do not add `Access-Control-Allow-Origin` here without an accompanying CSRF control — on its
+        own it re-opens the endpoint to any website the developer has open.
+        """
         return Response()
 
     async def configure_frontend(request: Request) -> Response:
@@ -185,8 +203,9 @@ def create_api_app(
     async def post_chat(request: Request) -> Response:
         """Handle chat requests via Vercel AI Adapter."""
         if (media_type := request.headers.get('content-type', '').split(';')[0].strip().lower()) != JSON_MEDIA_TYPE:
-            # Checked up front so a request that doesn't meet the endpoint's contract is turned away
-            # before the body is parsed and before the agent is dispatched.
+            # Checked up front so a cross-origin-forgeable request is turned away before the body is
+            # parsed and before the agent is dispatched — the attacker never needs to read the
+            # response, so the run itself is the damage.
             return JSONResponse(
                 {'error': f'Expected `Content-Type: {JSON_MEDIA_TYPE}`, got {media_type or "no content type"}'},
                 status_code=415,

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -132,8 +132,12 @@ evals = ["pydantic-evals=={{ version }}"]
 ui = ["starlette>=0.46.2"]
 # AG-UI
 ag-ui = ["ag-ui-protocol>=0.1.10", "starlette>=0.46.2"]
-# Web
-web = ["starlette>=0.46.2", "httpx>=0.27.0", "uvicorn>=0.38.0"]
+# Web — Starlette is floored higher here than in the `ui` and `ag-ui` extras because this extra
+# runs an HTTP server we ship (`Agent.to_web()` / `clai web`), so its Starlette version is ours to
+# pick. The adapters in `ui`/`ag-ui` are mounted into the user's own application, which owns its
+# own Starlette version; raising their floor would force a FastAPI upgrade on them for surfaces
+# they, not we, expose.
+web = ["starlette>=1.3.1", "httpx>=0.27.0", "uvicorn>=0.38.0"]
 # Retries
 retries = ["tenacity>=8.2.3"]
 # Temporal

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -542,13 +542,17 @@ async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_v
 
 
 def test_chat_app_options_endpoint():
-    """Test the OPTIONS /api/chat endpoint (CORS preflight)."""
+    """Test the OPTIONS /api/chat endpoint (CORS preflight).
+
+    Pins the headers the standalone app returns, which were previously unasserted.
+    """
     agent = Agent('test')
     app = create_web_app(agent)
 
     with TestClient(app) as client:
         response = client.options('/api/chat')
         assert response.status_code == 200
+        assert not any(name.lower().startswith('access-control-') for name in response.headers)
 
 
 @pytest.mark.parametrize(
@@ -562,22 +566,19 @@ def test_chat_app_options_endpoint():
         pytest.param(None, id='no-content-type'),
     ],
 )
-def test_chat_rejects_non_json_content_type(content_type: str | None):
+def test_chat_rejects_non_json_content_type(content_type: str | None, monkeypatch: pytest.MonkeyPatch):
     """The chat endpoint turns away request bodies that aren't declared as JSON.
 
-    Asserting the status alone would be too weak — what this pins is that the rejection happens
-    before the agent is dispatched, so the tool never runs.
+    Asserting the status alone would be too weak: the contract is that a request the endpoint won't
+    accept costs nothing to reject, so this pins that the adapter is never built — which is what
+    puts the check ahead of both reading the body and starting a run.
 
     This is a unit test rather than a VCR one because the check runs before any model request, so
     there is no HTTP traffic to record.
     """
     agent = Agent(TestModel())
-    tool_calls: list[str] = []
-
-    @agent.tool_plain
-    def side_effecting_tool() -> str:
-        tool_calls.append('called')  # pragma: no cover
-        return 'done'  # pragma: no cover
+    mock_from_request = AsyncMock(side_effect=AssertionError('adapter should not be built'))
+    monkeypatch.setattr(VercelAIAdapter, 'from_request', mock_from_request)
 
     app = create_web_app(agent)
     body = json.dumps(
@@ -594,7 +595,7 @@ def test_chat_rejects_non_json_content_type(content_type: str | None):
 
     assert response.status_code == 415
     assert 'application/json' in response.json()['error']
-    assert tool_calls == []
+    assert mock_from_request.call_count == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -544,7 +544,10 @@ async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_v
 def test_chat_app_options_endpoint():
     """Test the OPTIONS /api/chat endpoint (CORS preflight).
 
-    Pins the headers the standalone app returns, which were previously unasserted.
+    The absence of `Access-Control-Allow-*` is the load-bearing half of the CSRF defence: it is what
+    makes a browser reject the preflight that `Content-Type: application/json` forces. Pinned here
+    so mounting a permissive `CORSMiddleware` on this app can't silently re-open cross-origin
+    access to the chat endpoint.
     """
     agent = Agent('test')
     app = create_web_app(agent)
@@ -558,20 +561,21 @@ def test_chat_app_options_endpoint():
 @pytest.mark.parametrize(
     'content_type',
     [
-        # Media types that can carry a JSON body without declaring it as JSON.
+        # The three CORS-safelisted content types: a browser can send each of these cross-origin
+        # with no preflight, and each can carry a raw JSON body from a page the developer visits.
         pytest.param('text/plain', id='text-plain'),
         pytest.param('multipart/form-data; boundary=x', id='multipart-form-data'),
         pytest.param('application/x-www-form-urlencoded', id='form-urlencoded'),
-        # A request can also omit the content type entirely.
+        # `fetch()` with a `Blob` that has no type sends no content type at all.
         pytest.param(None, id='no-content-type'),
     ],
 )
 def test_chat_rejects_non_json_content_type(content_type: str | None, monkeypatch: pytest.MonkeyPatch):
-    """The chat endpoint turns away request bodies that aren't declared as JSON.
+    """A cross-origin-forgeable request is rejected before the agent runs.
 
-    Asserting the status alone would be too weak: the contract is that a request the endpoint won't
-    accept costs nothing to reject, so this pins that the adapter is never built — which is what
-    puts the check ahead of both reading the body and starting a run.
+    Asserting the status alone would be too weak: an attacker never needs to read the response, so
+    what matters is that nothing runs. This pins that the adapter is never built, which puts the
+    check ahead of both reading the body and starting a run.
 
     This is a unit test rather than a VCR one because the check runs before any model request, so
     there is no HTTP traffic to record.

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -551,6 +551,79 @@ def test_chat_app_options_endpoint():
         assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    'content_type',
+    [
+        # Media types that can carry a JSON body without declaring it as JSON.
+        pytest.param('text/plain', id='text-plain'),
+        pytest.param('multipart/form-data; boundary=x', id='multipart-form-data'),
+        pytest.param('application/x-www-form-urlencoded', id='form-urlencoded'),
+        # A request can also omit the content type entirely.
+        pytest.param(None, id='no-content-type'),
+    ],
+)
+def test_chat_rejects_non_json_content_type(content_type: str | None):
+    """The chat endpoint turns away request bodies that aren't declared as JSON.
+
+    Asserting the status alone would be too weak — what this pins is that the rejection happens
+    before the agent is dispatched, so the tool never runs.
+
+    This is a unit test rather than a VCR one because the check runs before any model request, so
+    there is no HTTP traffic to record.
+    """
+    agent = Agent(TestModel())
+    tool_calls: list[str] = []
+
+    @agent.tool_plain
+    def side_effecting_tool() -> str:
+        tool_calls.append('called')  # pragma: no cover
+        return 'done'  # pragma: no cover
+
+    app = create_web_app(agent)
+    body = json.dumps(
+        {
+            'trigger': 'submit-message',
+            'id': 'test-id',
+            'messages': [{'id': 'msg-1', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Hello'}]}],
+        }
+    )
+    headers = {'content-type': content_type} if content_type is not None else {}
+
+    with TestClient(app) as client:
+        response = client.post('/api/chat', content=body, headers=headers)
+
+    assert response.status_code == 415
+    assert 'application/json' in response.json()['error']
+    assert tool_calls == []
+
+
+@pytest.mark.parametrize(
+    'content_type',
+    [
+        # What the bundled UI and the Vercel AI SDK's `DefaultChatTransport` send.
+        pytest.param('application/json', id='bare'),
+        pytest.param('application/json; charset=utf-8', id='with-charset'),
+        pytest.param('APPLICATION/JSON', id='uppercase'),
+    ],
+)
+def test_chat_accepts_json_content_type(content_type: str):
+    """The content-type check doesn't turn away the bundled UI or other JSON clients."""
+    agent = Agent(TestModel())
+    app = create_web_app(agent)
+    body = json.dumps(
+        {
+            'trigger': 'submit-message',
+            'id': 'test-id',
+            'messages': [{'id': 'msg-1', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Hello'}]}],
+        }
+    )
+
+    with TestClient(app) as client:
+        response = client.post('/api/chat', content=body, headers={'content-type': content_type})
+
+    assert response.status_code == 200
+
+
 def test_mcp_server_tool_label():
     """Test MCPServerTool.label property."""
     tool = MCPServerTool(id='test-server', url='https://example.com')

--- a/uv.lock
+++ b/uv.lock
@@ -5781,7 +5781,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "python_full_version < '3.14' and extra == 'sentence-transformers'", specifier = ">=5.2.0" },
     { name = "starlette", marker = "extra == 'ag-ui'", specifier = ">=0.46.2" },
     { name = "starlette", marker = "extra == 'ui'", specifier = ">=0.46.2" },
-    { name = "starlette", marker = "extra == 'web'", specifier = ">=0.46.2" },
+    { name = "starlette", marker = "extra == 'web'", specifier = ">=1.3.1" },
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.5.0" },
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.24.0" },
     { name = "tenacity", marker = "extra == 'retries'", specifier = ">=8.2.3" },


### PR DESCRIPTION
`POST /api/chat` is a JSON API — the bundled chat UI, and the Vercel AI SDK's `DefaultChatTransport` generally, always send `Content-Type: application/json` — but the endpoint ignored the request's media type entirely and validated any body it was handed as JSON.

Check the media type up front and return `415` otherwise, so a request that doesn't meet the endpoint's contract is turned away before the body is parsed and before the agent is dispatched, rather than being dispatched on the strength of the body alone.

The check is an allowlist of `application/json` rather than a denylist, since a JSON body can arrive declared as several other media types or with none at all. Clients that call the endpoint directly without setting the header now need to.

Also in this PR:

- Pins the chat endpoint's response contract in tests. The `OPTIONS` handler's response headers were unasserted, and the rejection path asserted only that no tool happened to run — which a passing model would satisfy whether or not the check ran early. It now asserts the adapter is never constructed.
- Floors `starlette` at `1.3.1` for the `web` extra, which runs an HTTP server we ship, so its Starlette version is ours to pick. `ui` and `ag-ui` deliberately stay at `>=0.46.2`: those adapters are mounted into the user's own application, and raising their floor would force a FastAPI upgrade.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

