### PR TITLE
Only accept JSON request bodies on the web UI chat endpoint (v1 backport)

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -99,7 +99,7 @@ app = agent.to_web(instructions='Always respond in a friendly tone.')
 The web UI app uses the following routes which should not be overwritten:
 
 - `/` and `/{id}` - Serves the chat UI
-- `/api/chat` - Chat endpoint (POST, OPTIONS)
+- `/api/chat` - Chat endpoint (POST, OPTIONS). Requires `Content-Type: application/json`; other content types are rejected with `415`.
 - `/api/configure` - Frontend configuration (GET)
 - `/api/health` - Health check (GET)
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -23,6 +23,13 @@ OutputDataT = TypeVar('OutputDataT')
 # Type alias for models parameter - accepts model names/instances or a dict mapping labels to models
 ModelsParam = Sequence[Model | KnownModelName | str] | Mapping[str, Model | KnownModelName | str] | None
 
+# `/chat` accepts JSON request bodies only. This is deliberately an allowlist rather than a denylist
+# of the media types we don't want: a JSON body can arrive declared as several other media types, or
+# with no media type at all, and the endpoint's contract is `application/json` specifically. The
+# bundled UI — and the Vercel AI SDK's `DefaultChatTransport` generally — always sends
+# `application/json`; other clients need to set the header explicitly.
+JSON_MEDIA_TYPE = 'application/json'
+
 
 class ModelInfo(BaseModel, alias_generator=to_camel, populate_by_name=True):
     """Defines an AI model with its associated built-in tools."""
@@ -159,6 +166,14 @@ def create_api_app(
 
     async def post_chat(request: Request) -> Response:
         """Handle chat requests via Vercel AI Adapter."""
+        if (media_type := request.headers.get('content-type', '').split(';')[0].strip().lower()) != JSON_MEDIA_TYPE:
+            # Checked up front so a request that doesn't meet the endpoint's contract is turned away
+            # before the body is parsed and before the agent is dispatched.
+            return JSONResponse(
+                {'error': f'Expected `Content-Type: {JSON_MEDIA_TYPE}`, got {media_type or "no content type"}'},
+                status_code=415,
+            )
+
         adapter = await VercelAIAdapter[AgentDepsT, OutputDataT].from_request(request, agent=agent)
         extra_data = ChatRequestExtra.model_validate(adapter.run_input.__pydantic_extra__)
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -23,10 +23,18 @@ OutputDataT = TypeVar('OutputDataT')
 # Type alias for models parameter - accepts model names/instances or a dict mapping labels to models
 ModelsParam = Sequence[Model | KnownModelName | str] | Mapping[str, Model | KnownModelName | str] | None
 
-# `/chat` accepts JSON request bodies only. This is deliberately an allowlist rather than a denylist
-# of the media types we don't want: a JSON body can arrive declared as several other media types, or
-# with no media type at all, and the endpoint's contract is `application/json` specifically. The
-# bundled UI — and the Vercel AI SDK's `DefaultChatTransport` generally — always sends
+# `/chat` requires exactly this content type. This is a CSRF control, not content negotiation: a
+# browser can send the three CORS-safelisted content types (`text/plain`, `multipart/form-data`,
+# `application/x-www-form-urlencoded`) — or no content type at all — cross-origin with no preflight,
+# and every one of them can carry a JSON body. Without this check, a page the developer happens to
+# visit while running the web UI could start an agent run on their machine, and execute whatever
+# tools the served agent exposes. `application/json` is not safelisted, so requiring it forces a
+# preflight, which `options_chat` refuses.
+#
+# Keep this an allowlist. A denylist of the safelisted types would miss the no-content-type case,
+# and would silently stop covering anything added to the safelist later.
+#
+# The bundled UI — and the Vercel AI SDK's `DefaultChatTransport` generally — always sends
 # `application/json`; other clients need to set the header explicitly.
 JSON_MEDIA_TYPE = 'application/json'
 
@@ -149,7 +157,17 @@ def create_api_app(
     allowed_tool_ids = {tool.unique_id for tool in ui_native_tools}
 
     async def options_chat(request: Request) -> Response:
-        """Handle CORS preflight requests."""
+        """Answer CORS preflight requests without granting cross-origin access.
+
+        Deliberately carries no `Access-Control-Allow-*` header, so a browser refuses any
+        cross-origin request that needs a preflight. Together with the `application/json`
+        requirement in `post_chat()`, that is what keeps a page the developer visits from reaching
+        the local web UI: requiring a non-safelisted content type forces the preflight, and this
+        response denies it.
+
+        Do not add `Access-Control-Allow-Origin` here without an accompanying CSRF control — on its
+        own it re-opens the endpoint to any website the developer has open.
+        """
         return Response()
 
     async def configure_frontend(request: Request) -> Response:
@@ -167,8 +185,9 @@ def create_api_app(
     async def post_chat(request: Request) -> Response:
         """Handle chat requests via Vercel AI Adapter."""
         if (media_type := request.headers.get('content-type', '').split(';')[0].strip().lower()) != JSON_MEDIA_TYPE:
-            # Checked up front so a request that doesn't meet the endpoint's contract is turned away
-            # before the body is parsed and before the agent is dispatched.
+            # Checked up front so a cross-origin-forgeable request is turned away before the body is
+            # parsed and before the agent is dispatched — the attacker never needs to read the
+            # response, so the run itself is the damage.
             return JSONResponse(
                 {'error': f'Expected `Content-Type: {JSON_MEDIA_TYPE}`, got {media_type or "no content type"}'},
                 status_code=415,

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -300,6 +301,79 @@ def test_chat_app_options_endpoint():
     with TestClient(app) as client:
         response = client.options('/api/chat')
         assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    'content_type',
+    [
+        # Media types that can carry a JSON body without declaring it as JSON.
+        pytest.param('text/plain', id='text-plain'),
+        pytest.param('multipart/form-data; boundary=x', id='multipart-form-data'),
+        pytest.param('application/x-www-form-urlencoded', id='form-urlencoded'),
+        # A request can also omit the content type entirely.
+        pytest.param(None, id='no-content-type'),
+    ],
+)
+def test_chat_rejects_non_json_content_type(content_type: str | None):
+    """The chat endpoint turns away request bodies that aren't declared as JSON.
+
+    Asserting the status alone would be too weak — what this pins is that the rejection happens
+    before the agent is dispatched, so the tool never runs.
+
+    This is a unit test rather than a VCR one because the check runs before any model request, so
+    there is no HTTP traffic to record.
+    """
+    agent = Agent(TestModel())
+    tool_calls: list[str] = []
+
+    @agent.tool_plain
+    def side_effecting_tool() -> str:
+        tool_calls.append('called')  # pragma: no cover
+        return 'done'  # pragma: no cover
+
+    app = create_web_app(agent)
+    body = json.dumps(
+        {
+            'trigger': 'submit-message',
+            'id': 'test-id',
+            'messages': [{'id': 'msg-1', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Hello'}]}],
+        }
+    )
+    headers = {'content-type': content_type} if content_type is not None else {}
+
+    with TestClient(app) as client:
+        response = client.post('/api/chat', content=body, headers=headers)
+
+    assert response.status_code == 415
+    assert 'application/json' in response.json()['error']
+    assert tool_calls == []
+
+
+@pytest.mark.parametrize(
+    'content_type',
+    [
+        # What the bundled UI and the Vercel AI SDK's `DefaultChatTransport` send.
+        pytest.param('application/json', id='bare'),
+        pytest.param('application/json; charset=utf-8', id='with-charset'),
+        pytest.param('APPLICATION/JSON', id='uppercase'),
+    ],
+)
+def test_chat_accepts_json_content_type(content_type: str):
+    """The content-type check doesn't turn away the bundled UI or other JSON clients."""
+    agent = Agent(TestModel())
+    app = create_web_app(agent)
+    body = json.dumps(
+        {
+            'trigger': 'submit-message',
+            'id': 'test-id',
+            'messages': [{'id': 'msg-1', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Hello'}]}],
+        }
+    )
+
+    with TestClient(app) as client:
+        response = client.post('/api/chat', content=body, headers={'content-type': content_type})
+
+    assert response.status_code == 200
 
 
 def test_mcp_server_tool_label():

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -296,7 +296,10 @@ async def test_post_chat_endpoint():
 def test_chat_app_options_endpoint():
     """Test the OPTIONS /api/chat endpoint (CORS preflight).
 
-    Pins the headers the standalone app returns, which were previously unasserted.
+    The absence of `Access-Control-Allow-*` is the load-bearing half of the CSRF defence: it is what
+    makes a browser reject the preflight that `Content-Type: application/json` forces. Pinned here
+    so mounting a permissive `CORSMiddleware` on this app can't silently re-open cross-origin
+    access to the chat endpoint.
     """
     agent = Agent('test')
     app = create_web_app(agent)
@@ -310,20 +313,21 @@ def test_chat_app_options_endpoint():
 @pytest.mark.parametrize(
     'content_type',
     [
-        # Media types that can carry a JSON body without declaring it as JSON.
+        # The three CORS-safelisted content types: a browser can send each of these cross-origin
+        # with no preflight, and each can carry a raw JSON body from a page the developer visits.
         pytest.param('text/plain', id='text-plain'),
         pytest.param('multipart/form-data; boundary=x', id='multipart-form-data'),
         pytest.param('application/x-www-form-urlencoded', id='form-urlencoded'),
-        # A request can also omit the content type entirely.
+        # `fetch()` with a `Blob` that has no type sends no content type at all.
         pytest.param(None, id='no-content-type'),
     ],
 )
 def test_chat_rejects_non_json_content_type(content_type: str | None, monkeypatch: pytest.MonkeyPatch):
-    """The chat endpoint turns away request bodies that aren't declared as JSON.
+    """A cross-origin-forgeable request is rejected before the agent runs.
 
-    Asserting the status alone would be too weak: the contract is that a request the endpoint won't
-    accept costs nothing to reject, so this pins that the adapter is never built — which is what
-    puts the check ahead of both reading the body and starting a run.
+    Asserting the status alone would be too weak: an attacker never needs to read the response, so
+    what matters is that nothing runs. This pins that the adapter is never built, which puts the
+    check ahead of both reading the body and starting a run.
 
     This is a unit test rather than a VCR one because the check runs before any model request, so
     there is no HTTP traffic to record.

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -294,13 +294,17 @@ async def test_post_chat_endpoint():
 
 
 def test_chat_app_options_endpoint():
-    """Test the OPTIONS /api/chat endpoint (CORS preflight)."""
+    """Test the OPTIONS /api/chat endpoint (CORS preflight).
+
+    Pins the headers the standalone app returns, which were previously unasserted.
+    """
     agent = Agent('test')
     app = create_web_app(agent)
 
     with TestClient(app) as client:
         response = client.options('/api/chat')
         assert response.status_code == 200
+        assert not any(name.lower().startswith('access-control-') for name in response.headers)
 
 
 @pytest.mark.parametrize(
@@ -314,22 +318,19 @@ def test_chat_app_options_endpoint():
         pytest.param(None, id='no-content-type'),
     ],
 )
-def test_chat_rejects_non_json_content_type(content_type: str | None):
+def test_chat_rejects_non_json_content_type(content_type: str | None, monkeypatch: pytest.MonkeyPatch):
     """The chat endpoint turns away request bodies that aren't declared as JSON.
 
-    Asserting the status alone would be too weak — what this pins is that the rejection happens
-    before the agent is dispatched, so the tool never runs.
+    Asserting the status alone would be too weak: the contract is that a request the endpoint won't
+    accept costs nothing to reject, so this pins that the adapter is never built — which is what
+    puts the check ahead of both reading the body and starting a run.
 
     This is a unit test rather than a VCR one because the check runs before any model request, so
     there is no HTTP traffic to record.
     """
     agent = Agent(TestModel())
-    tool_calls: list[str] = []
-
-    @agent.tool_plain
-    def side_effecting_tool() -> str:
-        tool_calls.append('called')  # pragma: no cover
-        return 'done'  # pragma: no cover
+    mock_from_request = AsyncMock(side_effect=AssertionError('adapter should not be built'))
+    monkeypatch.setattr(VercelAIAdapter, 'from_request', mock_from_request)
 
     app = create_web_app(agent)
     body = json.dumps(
@@ -346,7 +347,7 @@ def test_chat_rejects_non_json_content_type(content_type: str | None):
 
     assert response.status_code == 415
     assert 'application/json' in response.json()['error']
-    assert tool_calls == []
+    assert mock_from_request.call_count == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
v1 backport of #7382.

`POST /api/chat` is a JSON API — the bundled chat UI, and the Vercel AI SDK's `DefaultChatTransport` generally, always send `Content-Type: application/json` — but the endpoint ignored the request's media type entirely and validated any body it was handed as JSON.

Check the media type up front and return `415` otherwise, so a request that doesn't meet the endpoint's contract is turned away before the body is parsed and before the agent is dispatched.

Re-derived against the v1 tree rather than cherry-picked, since v1 lacks the `sdk_version` plumbing, its `tests/test_ui_web.py` doesn't import `json`, and its `docs/web.md` predates the tool-approval warning. The `starlette` floor change from #7382 is deliberately **not** included: v1 receives security fixes only, and its users are the most likely to be pinned to an older FastAPI.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

