### PR TITLE
Add the `cerebras` optional dependency group

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -55,6 +55,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `zai` - installs the [Z.AI](models/zai.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `snowflake` - installs the [Snowflake Cortex](models/snowflake.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `crusoe` - installs the [Crusoe](models/crusoe.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
+* `cerebras` - installs the [Cerebras](models/cerebras.md) dependency `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}
 * `huggingface` - installs [Hugging Face Model](models/huggingface.md) dependency `huggingface-hub` [PyPI ↗](https://pypi.org/project/huggingface-hub){:target="_blank"}
 * `sentence-transformers` - installs [Sentence Transformers Embedding Model](embeddings.md#sentence-transformers-local) dependency `sentence-transformers` [PyPI ↗](https://pypi.org/project/sentence-transformers){:target="_blank"}
 * `voyageai` - installs [VoyageAI Embedding Model](embeddings.md#voyageai) dependency `voyageai` [PyPI ↗](https://pypi.org/project/voyageai){:target="_blank"}

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -91,6 +91,7 @@ bedrock-mantle = ["openai>=2.45.0", "botocore>=1.42.63"]
 zai = ["openai>=2.45.0"]
 snowflake = ["openai>=2.45.0"]
 crusoe = ["openai>=2.45.0"]
+cerebras = ["openai>=2.45.0"]
 huggingface = [
     "huggingface-hub>=1.3.4,<2.0.0",
     # huggingface_hub 1.3.x still calls the deprecated hf_xet.download_files() API.

--- a/uv.lock
+++ b/uv.lock
@@ -5623,6 +5623,9 @@ bedrock-mantle = [
     { name = "botocore" },
     { name = "openai" },
 ]
+cerebras = [
+    { name = "openai" },
+]
 cli = [
     { name = "argcomplete" },
     { name = "prompt-toolkit" },
@@ -5764,6 +5767,7 @@ requires-dist = [
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
     { name = "openai", marker = "extra == 'bedrock-mantle'", specifier = ">=2.45.0" },
+    { name = "openai", marker = "extra == 'cerebras'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'crusoe'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=2.45.0" },
@@ -5802,7 +5806,7 @@ requires-dist = [
     { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.14.0" },
     { name = "xai-sdk", marker = "extra == 'xai-realtime'", specifier = ">=1.14.0" },
 ]
-provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "crusoe", "dbos", "duckduckgo", "evals", "exa", "google", "google-realtime", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openai-realtime", "openrouter", "prefect", "realtime", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "xai-realtime", "zai"]
+provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cerebras", "cli", "cohere", "crusoe", "dbos", "duckduckgo", "evals", "exa", "google", "google-realtime", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openai-realtime", "openrouter", "prefect", "realtime", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "xai-realtime", "zai"]
 
 [[package]]
 name = "pydantic-core"


### PR DESCRIPTION
- Closes #7354

Adds the `cerebras = ["openai>=2.45.0"]` optional dependency group to `pydantic-ai-slim` (mirroring `openrouter`/`zai`/`snowflake`/`crusoe`) and lists it in `docs/install.md`.

Without it, `docs/models/cerebras.md` and both Cerebras `ImportError` hints (`models/cerebras.py`, `providers/cerebras.py`) tell the reader to `pip install "pydantic-ai-slim[cerebras]"` — an extra that was never declared. The slim install path therefore silently omits `openai`, and every Cerebras snippet then fails with an `ImportError` recommending the same command that just failed. The full `pydantic-ai` install path already pulls `openai`, so only the slim path was broken.

`uv.lock` regenerated; the diff is the `cerebras` extra alone, no version churn.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

