### PR TITLE
fix: dispatch combined tools with current definition

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -95,7 +95,8 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
     ) -> Any:
         assert isinstance(tool, _CombinedToolsetTool)
-        return await tool.source_toolset.call_tool(name, tool_args, ctx, tool.source_tool)
+        source_tool = replace(tool.source_tool, tool_def=tool.tool_def)
+        return await tool.source_toolset.call_tool(name, tool_args, ctx, source_tool)
 
     def apply(self, visitor: Callable[[AbstractToolset[AgentDepsT]], None]) -> None:
         for toolset in self.toolsets:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -279,6 +279,32 @@ async def test_function_toolset_with_defaults_overridden():
         return a - b  # pragma: no cover
 
 
+async def test_prepared_combined_toolset_dispatches_updated_tool_definition():
+    received_metadata: list[dict[str, str] | None] = []
+
+    class SpyToolset(FunctionToolset[None]):
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+        ) -> Any:
+            received_metadata.append(tool.tool_def.metadata)
+            return await super().call_tool(name, tool_args, ctx, tool)
+
+    source_toolset = SpyToolset()
+
+    @source_toolset.tool_plain
+    def echo(value: int) -> int:
+        return value
+
+    def prepare_metadata(ctx: RunContext[None], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
+        return [replace(tool_def, metadata={'source': 'prepared'}) for tool_def in tool_defs]
+
+    prepared_toolset = PreparedToolset(CombinedToolset([source_toolset]), prepare_metadata)
+    managed_toolset = await ToolManager(prepared_toolset).for_run_step(build_run_context(None))
+
+    assert await managed_toolset.handle_call(ToolCallPart(tool_name='echo', args={'value': 1})) == 1
+    assert received_metadata == [{'source': 'prepared'}]
+
+
 async def test_prepared_toolset_sync_prepare_func():
     """`PreparedToolset` accepts a synchronous prepare function (no await needed)."""
     base_toolset = FunctionToolset()


### PR DESCRIPTION
## Summary

- dispatch `CombinedToolset` calls with the current prepared `ToolDefinition`
- preserve metadata and other outer-wrapper mutations when forwarding to the source toolset
- add a regression test covering `PreparedToolset(CombinedToolset(...))`

Closes #7380

## Validation

- `uv run pytest tests/test_toolsets.py -q` — 106 passed
- `uv run ruff check pydantic_ai_slim/pydantic_ai/toolsets/combined.py tests/test_toolsets.py`
- `uv run pyright pydantic_ai_slim/pydantic_ai/toolsets/combined.py tests/test_toolsets.py`
- `git diff HEAD^ --check`

## Duplicate check

Rechecked the issue timeline, open pull requests, affected symbols, and current upstream main immediately before submission; no equivalent active PR or merged fix was found.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

