### PR TITLE
Pin hatchling below 1.32 for release builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,13 @@ constraint-dependencies = [
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.0",
 ]
+build-constraint-dependencies = [
+    # hatchling 1.32.0 (2026-08-11) bumped its default core metadata version to 2.5,
+    # which the pinned gh-action-pypi-publish validator rejects as "not a valid
+    # metadata version". Ceiling until the publish action (or PyPI's own validator)
+    # catches up. Affects `uv build`'s PEP 517 build isolation, not runtime installs.
+    "hatchling<1.32",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

`hatchling` 1.32.0 (published 2026-08-11) bumped its default core metadata version to 2.5, which the pinned `gh-action-pypi-publish` validator rejects as an invalid metadata version, breaking release publishing.

Adds a `[tool.uv] build-constraint-dependencies` ceiling so `uv build`'s PEP 517 isolation resolves hatchling < 1.32. Verified locally: rebuilt all 6 packages, `twine check` passes on all 12 artifacts, `Metadata-Version: 2.4` restored.

## Checklist

- [x] No **breaking changes**.
- [x] **PR title** is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

