### PR TITLE
Pin hatchling below 1.32 for release builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,15 @@ constraint-dependencies = [
     "torch>=2.13.0",
     "transformers>=5.5.0",
 ]
+build-constraint-dependencies = [
+    # hatchling 1.32.0 (2026-08-11) bumped its default core metadata version to 2.5,
+    # which the pinned gh-action-pypi-publish validator rejects as "not a valid
+    # metadata version". Ceiling until the publish action (or PyPI's own validator)
+    # catches up. Affects `uv build`'s PEP 517 build isolation, not runtime installs.
+    # Not covered by `exclude-newer` above: hatchling 1.32.0 rolls out of that
+    # 7-day window on 2026-08-18, so this needs its own explicit ceiling.
+    "hatchling<1.32",
+]
 
 [tool.uv.exclude-newer-package]
 # These are our own packages, not worth defending from supply chain attacks on them.


### PR DESCRIPTION
## Summary

`hatchling` 1.32.0 (published 2026-08-11) bumped its default core metadata version to 2.5, which the pinned `gh-action-pypi-publish` validator rejects as an invalid metadata version, breaking release publishing. This already blocked tonight's `v1.107.3` release ([v1 fix: #7394](https://github.com/pydantic/pydantic-ai/pull/7394)).

`main`'s existing `exclude-newer = "7 days"` happened to still exclude hatchling 1.32.0 tonight, but that's a rolling window — it falls out of range on 2026-08-18, and the *next* release cut after that date would hit this identically. Adds an explicit `[tool.uv] build-constraint-dependencies` ceiling so it doesn't depend on the window's timing.

Verified locally: rebuilt all 6 packages, `twine check` passes on all 12 artifacts, `Metadata-Version: 2.4` restored.

## Checklist

- [x] No **breaking changes**.
- [x] **PR title** is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

