### PR TITLE
chore: remove temporary HTTPX2 workarounds

### DIFF
--- a/.github/scripts/check_http_dependencies.py
+++ b/.github/scripts/check_http_dependencies.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import email
+import zipfile
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+
+def wheel_requirements(pattern: str) -> list[Requirement]:
+    wheel = next(Path('dist').glob(pattern))
+    with zipfile.ZipFile(wheel) as archive:
+        metadata_path = next(name for name in archive.namelist() if name.endswith('.dist-info/METADATA'))
+        metadata = email.message_from_bytes(archive.read(metadata_path))
+    return [Requirement(value) for value in metadata.get_all('Requires-Dist', [])]
+
+
+slim = wheel_requirements('pydantic_ai_slim-*.whl')
+graph = wheel_requirements('pydantic_graph-*.whl')
+root = wheel_requirements('pydantic_ai-[0-9]*.whl')
+
+slim_httpx = [requirement for requirement in slim if requirement.name == 'httpx']
+assert len(slim_httpx) == 1
+assert str(slim_httpx[0].marker) == 'extra == "retries"'
+assert not any(requirement.name == 'httpx' for requirement in graph)
+assert not any(requirement.name == 'httpx' for requirement in root)
+
+slim_httpx2 = [requirement for requirement in slim if requirement.name == 'httpx2']
+assert len(slim_httpx2) == 1 and slim_httpx2[0].marker is None
+
+openai_extras = {'openai', 'openrouter', 'bedrock-mantle', 'zai', 'snowflake'}
+openai_requirements = [requirement for requirement in slim if requirement.name == 'openai']
+assert len(openai_requirements) == len(openai_extras)
+for requirement in openai_requirements:
+    assert requirement.extras == {'httpx2'}
+    assert requirement.specifier.contains('2.47.0')
+    assert requirement.marker is not None
+    assert str(requirement.marker).removeprefix('extra == ').strip('"') in openai_extras
+
+root_slim = [requirement for requirement in root if requirement.name == 'pydantic-ai-slim']
+assert root_slim
+assert all('retries' not in requirement.extras for requirement in root_slim if requirement.marker is None)
+assert any(requirement.extras == {'retries'} and requirement.marker is not None for requirement in root_slim)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           UV_NO_SYNC: "1"
 
       - run: uv build --all-packages
+      - run: uv run python .github/scripts/check_http_dependencies.py
       - run: ls -lh dist/
 
   # mypy and lint are a bit slower than other jobs, so we run them separately

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ pip/uv-add pydantic-ai
 
 (Requires Python 3.10+)
 
-This installs the `pydantic_ai` package, core dependencies, and libraries required to use the OpenAI, Anthropic, and Google models, plus the [CLI](cli.md), [MCP](mcp/client.md), [Evals](evals.md), [Web UI](ui/overview.md), [Retries](models/http-request-retries.md), and [Logfire](logfire.md) integrations.
+This installs the `pydantic_ai` package, core dependencies, and libraries required to use the OpenAI, Anthropic, and Google models, plus the [CLI](cli.md), [MCP](mcp/client.md), [Evals](evals.md), [Web UI](ui/overview.md), and [Logfire](logfire.md) integrations.
 To use any other models or integrations, add the relevant extras to your install command, e.g. `pydantic-ai[bedrock,temporal]`. Alternatively, you can install the [`pydantic-ai-slim`](#slim-install) package with only the extras you need.
 
 ## Use with Pydantic Logfire
@@ -64,9 +64,9 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `cli` - installs [CLI](cli.md) dependencies `rich` [PyPI ↗](https://pypi.org/project/rich){:target="_blank"}, `prompt-toolkit` [PyPI ↗](https://pypi.org/project/prompt-toolkit){:target="_blank"}, and `argcomplete` [PyPI ↗](https://pypi.org/project/argcomplete){:target="_blank"}
 * `mcp` - installs [MCP](mcp/client.md) dependency `fastmcp-slim[client]` [PyPI ↗](https://pypi.org/project/fastmcp-slim){:target="_blank"}
 * `ui` - installs [UI Event Streams](ui/overview.md) dependency `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"}
-* `web` - installs [Web UI](ui/overview.md) dependencies `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"}, `httpx` [PyPI ↗](https://pypi.org/project/httpx){:target="_blank"}, and `uvicorn` [PyPI ↗](https://pypi.org/project/uvicorn){:target="_blank"}
+* `web` - installs [Web UI](ui/overview.md) dependencies `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"} and `uvicorn` [PyPI ↗](https://pypi.org/project/uvicorn){:target="_blank"}
 * `ag-ui` - installs [AG-UI Event Stream Protocol](ui/ag-ui.md) dependencies `ag-ui-protocol` [PyPI ↗](https://pypi.org/project/ag-ui-protocol){:target="_blank"} and `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"}
-* `retries` - installs [HTTP Retries](models/http-request-retries.md) dependency `tenacity` [PyPI ↗](https://pypi.org/project/tenacity){:target="_blank"}
+* `retries` - installs [HTTP Retries](models/http-request-retries.md) dependency `tenacity` [PyPI ↗](https://pypi.org/project/tenacity){:target="_blank"}, plus legacy `httpx` [PyPI ↗](https://pypi.org/project/httpx){:target="_blank"} support until Pydantic AI v3
 * `temporal` - installs [Temporal Durable Execution](durable_execution/temporal.md) dependency `temporalio` [PyPI ↗](https://pypi.org/project/temporalio){:target="_blank"}
 * `dbos` - installs [DBOS Durable Execution](durable_execution/dbos.md) dependency `dbos` [PyPI ↗](https://pypi.org/project/dbos){:target="_blank"}
 * `prefect` - installs [Prefect Durable Execution](durable_execution/prefect.md) dependency `prefect` [PyPI ↗](https://pypi.org/project/prefect){:target="_blank"}

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -110,7 +110,7 @@ We can also query data with SQL in Logfire to monitor the performance of an appl
 As per Hamel Husain's influential 2024 blog post ["Fuck You, Show Me The Prompt."](https://hamel.dev/blog/posts/prompt/)
 (bear with the capitalization, the point is valid), it's often useful to be able to view the raw HTTP requests and responses made to model providers.
 
-To observe raw HTTP requests made to model providers, you can use Logfire's [HTTPX instrumentation](https://logfire.pydantic.dev/docs/integrations/http-clients/httpx/) since all provider SDKs (except for [Bedrock](models/bedrock.md)) use the [HTTPX](https://www.python-httpx.org/) library internally:
+To observe raw HTTP requests made to model providers, you can use Logfire's [HTTPX instrumentation](https://logfire.pydantic.dev/docs/integrations/http-clients/httpx/). Provider SDKs use either HTTPX or [HTTPX2](https://httpx2.pydantic.dev/) internally, except for [Bedrock](models/bedrock.md), which uses boto3:
 
 
 ```py {title="with_logfire_instrument_httpx.py" hl_lines="7"}
@@ -128,7 +128,9 @@ print(result.output)
 #> The capital of France is Paris.
 ```
 
-1. See the [`logfire.instrument_httpx` docs][logfire.Logfire.instrument_httpx] more details, `capture_all=True` means both headers and body are captured for both the request and response.
+1. See the [`logfire.instrument_httpx` docs][logfire.Logfire.instrument_httpx] for more details. `capture_all=True` means both headers and body are captured for both the request and response.
+
+    HTTPX2 instrumentation requires `opentelemetry-instrumentation-httpx>=0.65b0`. If another installed SDK constrains an older OpenTelemetry version, Logfire emits a warning and continues tracing Pydantic AI model calls without the lower-level HTTPX2 spans.
 
 ![Logfire with HTTPX instrumentation](img/logfire-with-httpx.png)
 

--- a/docs/models/cerebras.md
+++ b/docs/models/cerebras.md
@@ -58,10 +58,10 @@ agent = Agent(model)
 ...
 ```
 
-You can also customize the `CerebrasProvider` with a custom `httpx.AsyncClient`:
+You can also customize the `CerebrasProvider` with a custom `httpx2.AsyncClient`:
 
 ```python
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from pydantic_ai import Agent
 from pydantic_ai.models.cerebras import CerebrasModel

--- a/docs/models/http-request-retries.md
+++ b/docs/models/http-request-retries.md
@@ -8,7 +8,8 @@ This is the lowest of the [several layers that can retry](../retries.md) in an a
 ## Overview
 
 The retry functionality is built on top of the [tenacity](https://github.com/jd/tenacity) library and integrates
-seamlessly with httpx clients. You can configure retry behavior for any provider that accepts a custom HTTP client.
+seamlessly with [HTTPX2](https://httpx2.pydantic.dev/) clients. You can configure retry behavior for providers whose
+SDK accepts a custom HTTPX2 client.
 
 ## Installation
 
@@ -23,13 +24,17 @@ pip/uv-add 'pydantic-ai-slim[retries]'
 Here's an example of adding retry functionality with smart retry handling:
 
 ```python {title="smart_retry_example.py"}
-from httpx import AsyncClient, HTTPStatusError
+from httpx2 import AsyncClient, ConnectError, HTTPStatusError
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
-from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
+from pydantic_ai.retries import (
+    AsyncHTTPX2TenacityTransport,
+    RetryConfig,
+    wait_retry_after,
+)
 
 
 def create_retrying_client():
@@ -40,10 +45,10 @@ def create_retrying_client():
         if response.status_code in (429, 502, 503, 504):
             response.raise_for_status()  # This will raise HTTPStatusError
 
-    transport = AsyncTenacityTransport(
+    transport = AsyncHTTPX2TenacityTransport(
         config=RetryConfig(
             # Retry on HTTP errors and connection issues
-            retry=retry_if_exception_type((HTTPStatusError, ConnectionError)),
+            retry=retry_if_exception_type((HTTPStatusError, ConnectError)),
             # Smart waiting: respects Retry-After headers, falls back to exponential backoff
             wait=wait_retry_after(
                 fallback_strategy=wait_exponential(multiplier=1, max=60),
@@ -94,15 +99,15 @@ This wait strategy:
 
 ## Transport Classes
 
-### AsyncTenacityTransport
+### AsyncHTTPX2TenacityTransport
 
 For asynchronous HTTP clients (recommended for most use cases):
 
 ```python {title="async_transport_example.py"}
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 from tenacity import stop_after_attempt
 
-from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig
+from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig
 
 
 def validator(response):
@@ -112,7 +117,7 @@ def validator(response):
     response.raise_for_status()
 
 # Create the transport
-transport = AsyncTenacityTransport(
+transport = AsyncHTTPX2TenacityTransport(
     config=RetryConfig(stop=stop_after_attempt(3), reraise=True),
     validate_response=validator
 )
@@ -121,15 +126,15 @@ transport = AsyncTenacityTransport(
 client = AsyncClient(transport=transport)
 ```
 
-### TenacityTransport
+### HTTPX2TenacityTransport
 
 For synchronous HTTP clients:
 
 ```python {title="sync_transport_example.py"}
-from httpx import Client
+from httpx2 import Client
 from tenacity import stop_after_attempt
 
-from pydantic_ai.retries import RetryConfig, TenacityTransport
+from pydantic_ai.retries import HTTPX2TenacityTransport, RetryConfig
 
 
 def validator(response):
@@ -139,7 +144,7 @@ def validator(response):
     response.raise_for_status()
 
 # Create the transport
-transport = TenacityTransport(
+transport = HTTPX2TenacityTransport(
     config=RetryConfig(stop=stop_after_attempt(3), reraise=True),
     validate_response=validator
 )
@@ -153,15 +158,19 @@ client = Client(transport=transport)
 ### Rate Limit Handling with Retry-After Support
 
 ```python {title="rate_limit_handling.py"}
-from httpx import AsyncClient, HTTPStatusError
+from httpx2 import AsyncClient, HTTPStatusError
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
+from pydantic_ai.retries import (
+    AsyncHTTPX2TenacityTransport,
+    RetryConfig,
+    wait_retry_after,
+)
 
 
 def create_rate_limit_client():
     """Create a client that respects Retry-After headers from rate limiting responses."""
-    transport = AsyncTenacityTransport(
+    transport = AsyncHTTPX2TenacityTransport(
         config=RetryConfig(
             retry=retry_if_exception_type(HTTPStatusError),
             wait=wait_retry_after(
@@ -185,27 +194,27 @@ The `wait_retry_after` function automatically detects `Retry-After` headers in 4
 ### Network Error Handling
 
 ```python {title="network_error_handling.py"}
-import httpx
+import httpx2
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig
+from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig
 
 
 def create_network_resilient_client():
     """Create a client that handles network errors with retries."""
-    transport = AsyncTenacityTransport(
+    transport = AsyncHTTPX2TenacityTransport(
         config=RetryConfig(
             retry=retry_if_exception_type((
-                httpx.TimeoutException,
-                httpx.ConnectError,
-                httpx.ReadError
+                httpx2.TimeoutException,
+                httpx2.ConnectError,
+                httpx2.ReadError
             )),
             wait=wait_exponential(multiplier=1, max=10),
             stop=stop_after_attempt(3),
             reraise=True
         )
     )
-    return httpx.AsyncClient(transport=transport)
+    return httpx2.AsyncClient(transport=transport)
 
 # Example usage
 client = create_network_resilient_client()
@@ -215,22 +224,26 @@ client = create_network_resilient_client()
 ### Custom Retry Logic
 
 ```python {title="custom_retry_logic.py"}
-import httpx
+import httpx2
 from tenacity import retry_if_exception, stop_after_attempt, wait_exponential
 
-from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
+from pydantic_ai.retries import (
+    AsyncHTTPX2TenacityTransport,
+    RetryConfig,
+    wait_retry_after,
+)
 
 
 def create_custom_retry_client():
     """Create a client with custom retry logic."""
     def custom_retry_condition(exception):
         """Custom logic to determine if we should retry."""
-        if isinstance(exception, httpx.HTTPStatusError):
+        if isinstance(exception, httpx2.HTTPStatusError):
             # Retry on server errors but not client errors
             return 500 <= exception.response.status_code < 600
-        return isinstance(exception, httpx.TimeoutException | httpx.ConnectError)
+        return isinstance(exception, httpx2.TimeoutException | httpx2.ConnectError)
 
-    transport = AsyncTenacityTransport(
+    transport = AsyncHTTPX2TenacityTransport(
         config=RetryConfig(
             retry=retry_if_exception(custom_retry_condition),
             # Use wait_retry_after for smart waiting on rate limits,
@@ -244,15 +257,16 @@ def create_custom_retry_client():
         ),
         validate_response=lambda r: r.raise_for_status()
     )
-    return httpx.AsyncClient(transport=transport)
+    return httpx2.AsyncClient(transport=transport)
 
 client = create_custom_retry_client()
 # Client will retry server errors (5xx) and network errors, but not client errors (4xx)
 ```
 
-## Using with Different Providers
+## Using with HTTPX2-Compatible Providers
 
-The retry transports work with any provider that accepts a custom HTTP client:
+The retry transports work with providers that accept an HTTPX2 client, including OpenAI and OpenAI-compatible
+providers:
 
 ### OpenAI
 
@@ -265,20 +279,6 @@ from smart_retry_example import create_retrying_client
 
 client = create_retrying_client()
 model = OpenAIChatModel('gpt-5.2', provider=OpenAIProvider(http_client=client))
-agent = Agent(model)
-```
-
-### Anthropic
-
-```python {title="anthropic_with_retries.py" requires="smart_retry_example.py"}
-from pydantic_ai import Agent
-from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.providers.anthropic import AnthropicProvider
-
-from smart_retry_example import create_retrying_client
-
-client = create_retrying_client()
-model = AnthropicModel('claude-sonnet-4-5-20250929', provider=AnthropicProvider(http_client=client))
 agent = Agent(model)
 ```
 
@@ -313,7 +313,7 @@ agent = Agent(model)
 
 4. **Handle Rate Limits Properly**: Respect `Retry-After` headers when possible.
 
-5. **Log Retry Attempts**: Add logging to monitor retry behavior in production. (This will be picked up by Logfire automatically if you instrument httpx.)
+5. **Log Retry Attempts**: Add logging to monitor retry behavior in production. (This will be picked up by Logfire automatically if you instrument HTTPX2.)
 
 6. **Consider Circuit Breakers**: For high-traffic applications, consider implementing circuit breaker patterns.
 
@@ -356,7 +356,7 @@ For more advanced retry configurations, refer to the [tenacity documentation](ht
 
 ### AWS Bedrock
 
-The AWS Bedrock provider uses boto3's built-in retry mechanisms instead of httpx. To configure retries for Bedrock, use boto3's `Config`:
+The AWS Bedrock provider uses boto3's built-in retry mechanisms instead of HTTPX2. To configure retries for Bedrock, use boto3's `Config`:
 
 ```python
 from botocore.config import Config

--- a/docs/models/mistral.md
+++ b/docs/models/mistral.md
@@ -58,10 +58,10 @@ agent = Agent(model)
 ...
 ```
 
-You can also customize the provider with a custom `httpx.AsyncClient`:
+You can also customize the provider with a custom `httpx2.AsyncClient`:
 
 ```python
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from pydantic_ai import Agent
 from pydantic_ai.models.mistral import MistralModel
@@ -75,3 +75,5 @@ model = MistralModel(
 agent = Agent(model)
 ...
 ```
+
+The Mistral provider also accepts a legacy `httpx.AsyncClient` during Pydantic AI v2, but emits a deprecation warning. Use `httpx2.AsyncClient` for new code; legacy HTTPX client support will be removed in Pydantic AI v3.

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -553,7 +553,7 @@ agent = Agent(model)
 You can also customize any provider with a custom `http_client`:
 
 ```python
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
@@ -569,6 +569,8 @@ model = OpenAIChatModel(
 agent = Agent(model)
 ...
 ```
+
+OpenAI-compatible providers also accept a legacy `httpx.AsyncClient` during Pydantic AI v2, but emit a deprecation warning. Use `httpx2.AsyncClient` for new code; legacy HTTPX client support will be removed in Pydantic AI v3.
 
 As an alternative to the Chat Completions API shown above, DeepSeek also serves an OpenAI-compatible [Responses API](#responses-api-features), [currently for the `deepseek-v4-flash` model only](https://api-docs.deepseek.com/guides/responses_api). Use it by pairing [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] with [`DeepSeekProvider`][pydantic_ai.providers.deepseek.DeepSeekProvider]:
 

--- a/docs/models/snowflake.md
+++ b/docs/models/snowflake.md
@@ -62,10 +62,10 @@ agent = Agent(model)
 ...
 ```
 
-You can also customize the [`SnowflakeProvider`][pydantic_ai.providers.snowflake.SnowflakeProvider] with a custom `base_url` (e.g. when connecting through [private connectivity](https://docs.snowflake.com/en/user-guide/private-snowflake-service)) or `httpx.AsyncClient`:
+You can also customize the [`SnowflakeProvider`][pydantic_ai.providers.snowflake.SnowflakeProvider] with a custom `base_url` (e.g. when connecting through [private connectivity](https://docs.snowflake.com/en/user-guide/private-snowflake-service)) or `httpx2.AsyncClient`:
 
 ```python
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from pydantic_ai import Agent
 from pydantic_ai.models.snowflake import SnowflakeModel

--- a/docs/models/zai.md
+++ b/docs/models/zai.md
@@ -81,10 +81,10 @@ See the [Z.AI thinking mode documentation](https://docs.z.ai/guides/capabilities
 
 ## `provider` argument
 
-You can provide a custom [`Provider`][pydantic_ai.providers.Provider] via the `provider` argument. In the simplest case, pass [`ZaiProvider`][pydantic_ai.providers.zai.ZaiProvider] with just an API key. If you also want to customize the underlying `httpx.AsyncClient`, pass it when constructing the provider:
+You can provide a custom [`Provider`][pydantic_ai.providers.Provider] via the `provider` argument. In the simplest case, pass [`ZaiProvider`][pydantic_ai.providers.zai.ZaiProvider] with just an API key. If you also want to customize the underlying `httpx2.AsyncClient`, pass it when constructing the provider:
 
 ```python
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from pydantic_ai import Agent
 from pydantic_ai.models.zai import ZaiModel

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -6,7 +6,7 @@
 
 | Layer | What it re-attempts | Configured with | What it adds to message history |
 |---|---|---|---|
-| [Transport](#transport-retries) | The same HTTP request to the provider | [`AsyncTenacityTransport`][pydantic_ai.retries.AsyncTenacityTransport] on your HTTP client | Nothing — the agent never sees the attempts |
+| [Transport](#transport-retries) | The same HTTP request to the provider | [`AsyncHTTPX2TenacityTransport`][pydantic_ai.retries.AsyncHTTPX2TenacityTransport] on your HTTP client | Nothing — the agent never sees the attempts |
 | [Model fallback](#model-fallback-is-not-a-retry) | The same request against a *different* model | [`FallbackModel`][pydantic_ai.models.fallback.FallbackModel] | Only the winning response |
 | [Tool](#tool-retries) | One tool call, by asking the model to correct it | `retries={'tools': N}` and per-tool limits | A [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart] in place of the tool's result |
 | [Output](#output-retries) | The model's final answer, by asking it to correct it | `retries={'output': N}` and [`ToolOutput(max_retries=N)`][pydantic_ai.output.ToolOutput.max_retries] | A `RetryPromptPart` — see [below](#output-retries) for where it lands |
@@ -18,7 +18,7 @@ Only the last three are "agent retries" — they cost a model round trip each, b
 
 Transport retries live below the model client: a failed HTTP request is re-sent without the agent ever knowing. Nothing retries at this layer unless you install a retrying transport on the HTTP client you pass to the provider, and you decide which errors qualify.
 
-This is the right layer for rate limits, connection resets, and 5xx responses. See [HTTP Request Retries](models/http-request-retries.md) for the transports, the `Retry-After`-aware wait strategy, and per-provider notes — including AWS Bedrock, which retries through boto3 rather than httpx.
+This is the right layer for rate limits, connection resets, and 5xx responses. See [HTTP Request Retries](models/http-request-retries.md) for the transports, the `Retry-After`-aware wait strategy, and per-provider notes — including AWS Bedrock, which retries through boto3 rather than HTTPX2.
 
 When you build your own backoff outside a transport, [`ModelHTTPError.retry_after`][pydantic_ai.exceptions.ModelHTTPError.retry_after] gives you the provider's `Retry-After` header already parsed into seconds.
 

--- a/pydantic_ai_slim/pydantic_ai/_http.py
+++ b/pydantic_ai_slim/pydantic_ai/_http.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import warnings
+
 import httpx2
 
+from ._warnings import PydanticAIDeprecationWarning
 from .models import DEFAULT_HTTP_TIMEOUT, get_user_agent
 
 
@@ -10,3 +13,15 @@ def create_httpx2_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: int = 
         timeout=httpx2.Timeout(timeout=timeout, connect=connect),
         headers={'User-Agent': get_user_agent()},
     )
+
+
+def warn_if_legacy_httpx_client(http_client: object, *, consumer: str, stacklevel: int) -> None:
+    import httpx
+
+    if isinstance(http_client, httpx.AsyncClient):
+        warnings.warn(
+            f'`httpx.AsyncClient` support for {consumer} is deprecated and will be removed in v3; '
+            'use `httpx2.AsyncClient` instead.',
+            PydanticAIDeprecationWarning,
+            stacklevel=stacklevel + 1,
+        )

--- a/pydantic_ai_slim/pydantic_ai/_http.py
+++ b/pydantic_ai_slim/pydantic_ai/_http.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import httpx2
+
+from .models import DEFAULT_HTTP_TIMEOUT, get_user_agent
+
+
+def create_httpx2_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: int = 5) -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(
+        timeout=httpx2.Timeout(timeout=timeout, connect=connect),
+        headers={'User-Agent': get_user_agent()},
+    )

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -157,7 +157,7 @@ if _legacy_httpx is not None:
         (httpx2.HTTPStatusError, _legacy_httpx.HTTPStatusError),
         {'__init__': _compatible_http_status_error_init},
     )
-else:
+else:  # pragma: no cover
     _CompatibleRequestError = httpx2.RequestError
     _CompatibleHTTPStatusError = httpx2.HTTPStatusError
 

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -17,7 +17,7 @@ import httpx2
 
 try:
     import httpx as _legacy_httpx
-except ImportError:  # pragma: no cover
+except ImportError:
     _legacy_httpx = None
 
 from ._http import create_httpx2_client
@@ -157,7 +157,7 @@ if _legacy_httpx is not None:
         (httpx2.HTTPStatusError, _legacy_httpx.HTTPStatusError),
         {'__init__': _compatible_http_status_error_init},
     )
-else:  # pragma: no cover
+else:
     _CompatibleRequestError = httpx2.RequestError
     _CompatibleHTTPStatusError = httpx2.HTTPStatusError
 

--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -13,10 +13,15 @@ import zlib
 from dataclasses import dataclass
 from urllib.parse import urlparse, urlunparse
 
-import httpx
+import httpx2
 
+try:
+    import httpx as _legacy_httpx
+except ImportError:  # pragma: no cover
+    _legacy_httpx = None
+
+from ._http import create_httpx2_client
 from ._utils import run_in_executor
-from .models import create_async_http_client
 
 __all__ = ['safe_download']
 
@@ -126,6 +131,35 @@ _CLOUD_METADATA_IPV6: frozenset[ipaddress.IPv6Address] = frozenset(
 _MAX_REDIRECTS = 10
 _DEFAULT_TIMEOUT = 30  # seconds
 _SENSITIVE_HEADERS = frozenset(('authorization', 'cookie', 'proxy-authorization'))
+
+
+def _compatible_request_error_init(self: Exception, message: str, *, request: httpx2.Request | None = None) -> None:
+    Exception.__init__(self, message)
+    self.__dict__['_request'] = request
+
+
+def _compatible_http_status_error_init(
+    self: Exception, message: str, *, request: httpx2.Request, response: httpx2.Response
+) -> None:
+    Exception.__init__(self, message)
+    self.__dict__['_request'] = request
+    self.__dict__['response'] = response
+
+
+if _legacy_httpx is not None:
+    _CompatibleRequestError = type(
+        '_CompatibleRequestError',
+        (httpx2.RequestError, _legacy_httpx.RequestError),
+        {'__init__': _compatible_request_error_init},
+    )
+    _CompatibleHTTPStatusError = type(
+        '_CompatibleHTTPStatusError',
+        (httpx2.HTTPStatusError, _legacy_httpx.HTTPStatusError),
+        {'__init__': _compatible_http_status_error_init},
+    )
+else:
+    _CompatibleRequestError = httpx2.RequestError
+    _CompatibleHTTPStatusError = httpx2.HTTPStatusError
 
 
 @dataclass
@@ -483,7 +517,7 @@ async def safe_download(
     allowed_domains: list[str] | None = None,
     blocked_domains: list[str] | None = None,
     max_bytes: int | None = None,
-) -> httpx.Response:
+) -> httpx2.Response:
     """Download content from a URL with SSRF protection.
 
     This function:
@@ -516,12 +550,13 @@ async def safe_download(
                 Checked on every hop including redirects.
 
     Returns:
-        The httpx.Response object.
+        The httpx2.Response object.
 
     Raises:
         ValueError: If the URL fails SSRF validation, domain validation,
                 or too many redirects occur.
-        httpx.HTTPStatusError: If the response has an error status code.
+        httpx2.HTTPStatusError: If the response has an error status code. When legacy
+            `httpx` is installed, this also matches `httpx.HTTPStatusError` handlers.
     """
     if max_bytes is not None and max_bytes < 0:
         raise ValueError('max_bytes must be non-negative')
@@ -530,7 +565,7 @@ async def safe_download(
     redirects_followed = 0
     effective_headers: dict[str, str] = dict(headers) if headers else {}
 
-    async with create_async_http_client(timeout=timeout) as client:
+    async with create_httpx2_client(timeout=timeout) as client:
         while True:
             # Validate and resolve the current URL
             resolved = await validate_and_resolve_url(current_url, allow_local)
@@ -554,16 +589,19 @@ async def safe_download(
 
             # Make request with Host header set to original hostname. Keep the existing
             # buffered path for callers without a body limit.
-            if max_bytes is None:
-                response = await client.get(
-                    request_url,
-                    headers=request_headers,
-                    extensions=extensions,
-                    follow_redirects=False,
-                )
-            else:
-                request = client.build_request('GET', request_url, headers=request_headers, extensions=extensions)
-                response = await client.send(request, follow_redirects=False, stream=True)
+            try:
+                if max_bytes is None:
+                    response = await client.get(
+                        request_url,
+                        headers=request_headers,
+                        extensions=extensions,
+                        follow_redirects=False,
+                    )
+                else:
+                    request = client.build_request('GET', request_url, headers=request_headers, extensions=extensions)
+                    response = await client.send(request, follow_redirects=False, stream=True)
+            except httpx2.RequestError as e:
+                raise _CompatibleRequestError(str(e), request=e.request) from e
 
             # Check if we need to follow a redirect
             if response.is_redirect:
@@ -591,19 +629,22 @@ async def safe_download(
 
             # Not a redirect, we're done
             try:
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except httpx2.HTTPStatusError as e:
+                    raise _CompatibleHTTPStatusError(str(e), request=e.request, response=e.response) from e
                 if max_bytes is not None:
                     content = await _read_capped_body(response, max_bytes)
                     # Body is already decoded, so the reconstructed response must not carry
-                    # the content coding, or `httpx.Response` would run it through the decoder
+                    # the content coding, or `httpx2.Response` would run it through the decoder
                     # again. `content-length` described the encoded body and no longer applies;
-                    # httpx recomputes it from `content`.
+                    # httpx2 recomputes it from `content`.
                     decoded_headers = [
                         (key, value)
                         for key, value in response.headers.multi_items()
                         if key.lower() not in ('content-encoding', 'content-length')
                     ]
-                    return httpx.Response(
+                    return httpx2.Response(
                         response.status_code,
                         headers=decoded_headers,
                         content=content,
@@ -621,7 +662,7 @@ def _download_exceeds(max_bytes: int) -> ValueError:
     return ValueError(_DOWNLOAD_EXCEEDS_TEMPLATE.format(max_bytes=max_bytes))
 
 
-async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
+async def _read_capped_body(response: httpx2.Response, max_bytes: int) -> bytes:
     """Read a streamed response body without buffering more than `max_bytes` of decoded data.
 
     Streams the *encoded* body via `aiter_raw` so oversized wire traffic is rejected as it
@@ -632,7 +673,7 @@ async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
     size-limited while streaming are rejected; callers with `max_bytes` also send
     `Accept-Encoding: identity, gzip` so servers are not invited to use them.
 
-    Some transports (e.g. httpx mock responses built from an in-memory `content=` bytes object)
+    Some transports (e.g. httpx2 mock responses built from an in-memory `content=` bytes object)
     preload the body and mark the stream consumed; in that case the decoded body is already in
     `response.content` and we only enforce the size cap on it.
     """
@@ -659,7 +700,7 @@ async def _read_capped_body(response: httpx.Response, max_bytes: int) -> bytes:
     )
 
 
-async def _read_capped_identity(response: httpx.Response, max_bytes: int) -> bytes:
+async def _read_capped_identity(response: httpx2.Response, max_bytes: int) -> bytes:
     content = bytearray()
     async for raw in response.aiter_raw():
         if len(content) + len(raw) > max_bytes:
@@ -668,7 +709,7 @@ async def _read_capped_identity(response: httpx.Response, max_bytes: int) -> byt
     return bytes(content)
 
 
-async def _read_capped_gzip(response: httpx.Response, max_bytes: int) -> bytes:
+async def _read_capped_gzip(response: httpx2.Response, max_bytes: int) -> bytes:
     content = bytearray()
     encoded_total = 0
     decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)

--- a/pydantic_ai_slim/pydantic_ai/common_tools/web_fetch.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/web_fetch.py
@@ -10,7 +10,7 @@ import json
 import re
 from dataclasses import KW_ONLY, dataclass, field
 
-import httpx
+import httpx2
 from typing_extensions import Any, TypedDict
 
 from pydantic_ai._ssrf import safe_download
@@ -103,7 +103,7 @@ class WebFetchLocalTool:
                 blocked_domains=self.blocked_domains,
                 max_bytes=self.max_download_bytes,
             )
-        except (ValueError, httpx.HTTPStatusError, httpx.RequestError) as e:
+        except (ValueError, httpx2.HTTPStatusError, httpx2.RequestError) as e:
             raise ModelRetry(f'Failed to fetch {url}: {e}') from e
 
         media_type = response.headers.get('content-type', '')

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -129,12 +129,14 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             # Imported inside `logfire._internal.json_schema` when running `logfire.info` inside an activity with attributes to serialize
             'numpy',
             'pandas',
-            # `response.cost()` lazily imports `genai_prices` (and its `httpx2` dependency) on first call.
-            # When cost is calculated inside a workflow, the sandbox re-imports that chain and `httpx2._models`
-            # subclasses `urllib.request.Request`, which is restricted unless `genai_prices`/`httpx2` are passed
+            # `response.cost()` lazily imports `genai_prices` (and its HTTPX2 dependencies) on first call.
+            # When cost is calculated or an HTTPX2-backed model is constructed inside a workflow, the sandbox
+            # re-imports that chain and touches restricted request/lock types unless these modules are passed
             # through alongside the rest of the HTTP stack.
             'genai_prices',
             'httpx2',
+            'httpcore2',
+            'truststore',
         ),
     )
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -20,7 +20,7 @@ from functools import cache, cached_property, wraps
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar, cast, get_args, overload
 
-import httpx
+import httpx2
 from typing_extensions import Self, TypeAliasType, TypedDict, deprecated
 from typing_inspection.introspection import get_literal_values
 
@@ -80,16 +80,20 @@ from ..profiles import (
 )
 from ..providers import InterfaceClient, Provider, infer_provider, infer_provider_class
 from ..settings import ModelSettings, ThinkingLevel, merge_model_settings
-
-if TYPE_CHECKING:
-    from ..agent.abstract import AbstractAgent
 from ..tools import ToolDefinition
 from ..usage import RequestUsage
 from ._known_model_names import KnownModelName as KnownModelName
 
 if TYPE_CHECKING:
+    from httpx import AsyncClient
+
     from ..agent.abstract import AbstractAgent
     from ..usage import RunUsage
+else:
+    try:
+        from httpx import AsyncClient
+    except ImportError:
+        AsyncClient = object
 
 DEFAULT_HTTP_TIMEOUT: int = 600
 """Default HTTP timeout in seconds for API requests.
@@ -1247,7 +1251,12 @@ class StreamedResponse(ABC):
         propagate from chunk reads. Model classes that use other transports
         (for example gRPC or botocore) should override this method.
         """
-        return (httpx.StreamError, httpx.TransportError)
+        try:
+            import httpx
+        except ImportError:
+            return (httpx2.StreamError, httpx2.TransportError)
+
+        return (httpx2.StreamError, httpx2.TransportError, httpx.StreamError, httpx.TransportError)
 
     async def close_stream(self) -> None:
         """Close the underlying HTTP/gRPC connection.
@@ -1735,7 +1744,7 @@ def infer_model(  # noqa: C901
         raise UserError(f'Unknown model: {model}')  # pragma: no cover
 
 
-def create_async_http_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: int = 5) -> httpx.AsyncClient:
+def create_async_http_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: int = 5) -> AsyncClient:
     """Create an HTTPX async client.
 
     Each call creates a new client instance. When used via a [`Provider`][pydantic_ai.providers.Provider],
@@ -1744,6 +1753,8 @@ def create_async_http_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: in
     The default timeouts match those of OpenAI,
     see <https://github.com/openai/openai-python/blob/v1.54.4/src/openai/_constants.py#L9>.
     """
+    import httpx
+
     return httpx.AsyncClient(
         timeout=httpx.Timeout(timeout=timeout, connect=connect),
         headers={'User-Agent': get_user_agent()},

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -8,7 +8,6 @@ from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, timedelta
 from typing import Any, Literal, cast
 
-import httpx
 import pydantic_core
 from typing_extensions import assert_never
 
@@ -345,6 +344,11 @@ class TestModel(Model):
 
 
 @dataclass
+class _StreamCancelled(Exception):
+    pass
+
+
+@dataclass
 class TestStreamedResponse(StreamedResponse):
     """A structured response that streams test data."""
 
@@ -376,7 +380,7 @@ class TestStreamedResponse(StreamedResponse):
                     # Simulate the transport error that real providers raise
                     # when the HTTP connection is closed mid-stream by cancel().
                     if self._cancelled:
-                        raise httpx.StreamClosed()
+                        raise _StreamCancelled()
                     self._usage += _get_string_usage(word)
                     for event in self._parts_manager.handle_text_delta(vendor_part_id=i, content=word):
                         yield event
@@ -423,6 +427,9 @@ class TestStreamedResponse(StreamedResponse):
     async def close_stream(self) -> None:
         # TestModel has no underlying connection to close.
         pass
+
+    def get_stream_cancel_errors(self) -> tuple[type[BaseException], ...]:
+        return (_StreamCancelled,)
 
     @property
     def timestamp(self) -> datetime:

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -9,14 +9,21 @@ import functools
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 import anyio
-import httpx
 from typing_extensions import Self, TypeVar
 
 from ..exceptions import UserError
 from ..profiles import ModelProfile
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+else:
+    try:
+        from httpx import AsyncClient
+    except ImportError:
+        AsyncClient = object
 
 InterfaceClient = TypeVar('InterfaceClient', default=Any)
 
@@ -50,8 +57,8 @@ class Provider(ABC, Generic[InterfaceClient]):
     """
 
     _client: InterfaceClient
-    _own_http_client: httpx.AsyncClient | None = None
-    _http_client_factory: Callable[[], httpx.AsyncClient] | None = None
+    _own_http_client: AsyncClient | None = None
+    _http_client_factory: Callable[[], AsyncClient] | None = None
     _entered_count: int = 0
 
     @functools.cached_property
@@ -90,7 +97,7 @@ class Provider(ABC, Generic[InterfaceClient]):
         """The model profile for the named model, if available."""
         return None  # pragma: no cover
 
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+    def _set_http_client(self, http_client: AsyncClient) -> None:
         """Update the SDK client's internal HTTP client reference.
 
         Subclasses that manage their own HTTP client should override this to inject

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -3,16 +3,15 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -23,7 +22,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class AlibabaProvider(Provider[AsyncOpenAI]):
+class AlibabaProvider(_OpenAICompatibleProvider):
     """Provider for Alibaba Cloud Model Studio (DashScope) OpenAI-compatible API."""
 
     @property
@@ -66,7 +65,7 @@ class AlibabaProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str, base_url: str | None = None) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, base_url: str | None = None, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, base_url: str | None = None, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -77,7 +76,7 @@ class AlibabaProvider(Provider[AsyncOpenAI]):
         api_key: str | None = None,
         base_url: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         if openai_client is not None:
             self._client = openai_client
@@ -93,12 +92,4 @@ class AlibabaProvider(Provider[AsyncOpenAI]):
 
             self._base_url = base_url or 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-
-            self._client = AsyncOpenAI(base_url=self._base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self._base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -4,12 +4,10 @@ import os
 from typing import overload
 from urllib.parse import urlparse
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
@@ -17,7 +15,8 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncAzureOpenAI
@@ -28,7 +27,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class AzureProvider(Provider[AsyncOpenAI]):
+class AzureProvider(_OpenAICompatibleProvider):
     """Provider for Azure OpenAI API.
 
     See <https://azure.microsoft.com/en-us/products/ai-foundry> for more information.
@@ -102,7 +101,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
         azure_endpoint: str | None = None,
         api_version: str | None = None,
         api_key: str | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
 
     def __init__(
@@ -112,7 +111,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
         api_version: str | None = None,
         api_key: str | None = None,
         openai_client: AsyncAzureOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a new Azure provider.
 
@@ -130,7 +129,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
             openai_client: An existing
                 [`AsyncAzureOpenAI`](https://github.com/openai/openai-python#microsoft-azure-openai)
                 client to use. If provided, `base_url`, `api_key`, and `http_client` must be `None`.
-            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         if openai_client is not None:
             assert azure_endpoint is None, 'Cannot provide both `openai_client` and `azure_endpoint`'
@@ -150,10 +149,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
                     'Must provide one of the `api_key` argument or the `AZURE_OPENAI_API_KEY` environment variable'
                 )
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
+            http_client = self._get_http_client(http_client)
 
             # The Azure OpenAI v1 GA API and Azure AI Foundry serverless model
             # endpoints expose an OpenAI-compatible `/v1` API that rejects the
@@ -168,7 +164,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
                 self._client = AsyncOpenAI(
                     base_url=v1_base_url,
                     api_key=api_key or os.getenv('AZURE_OPENAI_API_KEY'),
-                    http_client=http_client,
+                    http_client=http_client,  # pyright: ignore[reportArgumentType]
                 )
                 self._base_url = str(self._client.base_url)
             else:
@@ -181,12 +177,9 @@ class AzureProvider(Provider[AsyncOpenAI]):
                     azure_endpoint=azure_endpoint,
                     api_key=api_key,
                     api_version=api_version,
-                    http_client=http_client,
+                    http_client=http_client,  # pyright: ignore[reportArgumentType]
                 )
                 self._base_url = str(self._client.base_url)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
 
 
 def _openai_compatible_v1_base_url(endpoint: str) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -3,16 +3,15 @@ from __future__ import annotations as _annotations
 import os
 from typing import Literal, overload
 
-import httpx
 from typing_extensions import assert_never
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
 from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncBedrockOpenAI, AsyncOpenAI
@@ -90,7 +89,7 @@ def _mantle_origin(base_url: str) -> str:
     return origin
 
 
-class BedrockMantleProvider(Provider[AsyncOpenAI]):
+class BedrockMantleProvider(_OpenAICompatibleProvider):
     """Provider for the Amazon Bedrock Mantle OpenAI-compatible API."""
 
     @property
@@ -137,7 +136,7 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
         aws_secret_access_key: str | None = None,
         aws_session_token: str | None = None,
         profile_name: str | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
 
     def __init__(
@@ -151,7 +150,7 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
         aws_session_token: str | None = None,
         profile_name: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a Bedrock Mantle provider.
 
@@ -169,7 +168,7 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
             openai_client: An existing OpenAI client. If provided, no other argument may be set; its base
                 URL's origin is used to derive both the `/v1` and `/openai/v1` endpoints (preserving its
                 auth and transport) so every interface routes correctly.
-            http_client: An existing `httpx.AsyncClient` used to make requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` used to make requests.
         """
         if openai_client is not None:
             assert region_name is None, 'Cannot provide both `openai_client` and `region_name`'
@@ -198,10 +197,7 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
                     'or pass `base_url` to use a Bedrock Mantle model.'
                 )
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
+            http_client = self._get_http_client(http_client)
 
             base_client = AsyncBedrockOpenAI(
                 api_key=api_key,
@@ -211,7 +207,7 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
                 aws_profile=profile_name,
                 aws_region=region_name,
                 base_url=f'{origin}/openai/v1',
-                http_client=http_client,
+                http_client=http_client,  # pyright: ignore[reportArgumentType]
             )
 
         # `_client` (the default `.client`/`.base_url`) serves the `openai-responses` interface at
@@ -222,6 +218,6 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
         self._client = base_client.with_options(base_url=f'{origin}/openai/v1')
         self._v1_client = base_client.with_options(base_url=f'{origin}/v1')
 
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+    def _set_http_client(self, http_client: _OpenAIHTTPClient) -> None:
         for client in (self._client, self._v1_client):
-            client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            client._client = http_client  # pyright: ignore[reportPrivateUsage, reportAttributeAccessIssue]

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -3,18 +3,16 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -25,7 +23,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class CerebrasProvider(Provider[AsyncOpenAI]):
+class CerebrasProvider(_OpenAICompatibleProvider):
     """Provider for Cerebras API."""
 
     @property
@@ -96,10 +94,10 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
-    def __init__(self, *, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -109,7 +107,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a new Cerebras provider.
 
@@ -117,7 +115,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             api_key: The API key to use for authentication, if not provided, the `CEREBRAS_API_KEY` environment variable
                 will be used if available.
             openai_client: An existing `AsyncOpenAI` client to use. If provided, `api_key` and `http_client` must be `None`.
-            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         api_key = api_key or os.getenv('CEREBRAS_API_KEY')
         if not api_key and openai_client is None:
@@ -130,17 +128,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
-            )
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
+            self._client = self._create_openai_client(
                 base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
             )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -3,16 +3,15 @@ from __future__ import annotations as _annotations
 import os
 from typing import Literal, overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -26,7 +25,7 @@ except ImportError as _import_error:  # pragma: no cover
 DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro']
 
 
-class DeepSeekProvider(Provider[AsyncOpenAI]):
+class DeepSeekProvider(_OpenAICompatibleProvider):
     """Provider for DeepSeek API."""
 
     @property
@@ -80,7 +79,7 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
 
     def __init__(
@@ -88,7 +87,7 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         api_key = api_key or os.getenv('DEEPSEEK_API_KEY')
         if not api_key and openai_client is None:
@@ -99,13 +98,5 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -3,12 +3,10 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -16,7 +14,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class FireworksProvider(Provider[AsyncOpenAI]):
+class FireworksProvider(_OpenAICompatibleProvider):
     """Provider for Fireworks AI API."""
 
     @property
@@ -73,7 +72,7 @@ class FireworksProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -83,7 +82,7 @@ class FireworksProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         api_key = api_key or os.getenv('FIREWORKS_API_KEY')
         if not api_key and openai_client is None:
@@ -94,13 +93,5 @@ class FireworksProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/gateway.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/gateway.py
@@ -7,7 +7,9 @@ import re
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import httpx
+import httpx2
 
+from pydantic_ai._http import create_httpx2_client
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
 
@@ -29,7 +31,7 @@ def gateway_provider(
     route: str | None = None,
     api_key: str | None = None,
     base_url: str | None = None,
-    http_client: httpx.AsyncClient | None = None,
+    http_client: httpx.AsyncClient | httpx2.AsyncClient | None = None,
 ) -> Provider[AsyncOpenAI]: ...
 
 
@@ -122,7 +124,7 @@ def gateway_provider(
     api_key: str | None = None,
     base_url: str | None = None,
     # OpenAI, Groq, Anthropic & Gemini - Only Bedrock doesn't have an HTTPX client.
-    http_client: httpx.AsyncClient | None = None,
+    http_client: httpx.AsyncClient | httpx2.AsyncClient | None = None,
 ) -> Provider[Any]:
     """Create a new Gateway provider.
 
@@ -164,6 +166,27 @@ def gateway_provider(
             region_name='pydantic-ai-gateway',  # Fake region name to avoid NoRegionError
         )
 
+    if canonical in ('openai', 'openai-chat', 'openai-responses'):
+        from .openai import OpenAIProvider
+
+        own_http_client = http_client is None
+        openai_http_client = http_client or create_httpx2_client()
+        _add_request_hook(openai_http_client, _GatewayRequestHook(api_key))
+
+        def _openai_http_client_factory() -> httpx2.AsyncClient:
+            client = create_httpx2_client()
+            _add_request_hook(client, _GatewayRequestHook(api_key))
+            return client
+
+        provider = OpenAIProvider(api_key=api_key, base_url=base_url, http_client=openai_http_client)
+        if own_http_client:
+            provider._own_http_client = openai_http_client  # pyright: ignore[reportPrivateUsage]
+            provider._http_client_factory = _openai_http_client_factory  # pyright: ignore[reportPrivateUsage]
+        return provider
+
+    if isinstance(http_client, httpx2.AsyncClient):
+        raise UserError('`httpx2.AsyncClient` is only supported for OpenAI Gateway routes.')
+
     own_http_client = http_client is None
     http_client = http_client or create_async_http_client()
     _add_request_hook(http_client, _GatewayRequestHook(api_key))
@@ -179,11 +202,7 @@ def gateway_provider(
             provider._http_client_factory = _http_client_factory  # pyright: ignore[reportPrivateUsage]
         return provider
 
-    if canonical in ('openai', 'openai-chat', 'openai-responses'):
-        from .openai import OpenAIProvider
-
-        return _with_http_client(OpenAIProvider(api_key=api_key, base_url=base_url, http_client=http_client))
-    elif canonical == 'groq':
+    if canonical == 'groq':
         from .groq import GroqProvider
 
         return _with_http_client(GroqProvider(api_key=api_key, base_url=base_url, http_client=http_client))
@@ -219,7 +238,13 @@ class _GatewayRequestHook:
     def __init__(self, api_key: str) -> None:
         self._api_key = api_key
 
-    async def __call__(self, request: httpx.Request) -> httpx.Request:
+    @overload
+    async def __call__(self, request: httpx.Request) -> httpx.Request: ...
+
+    @overload
+    async def __call__(self, request: httpx2.Request) -> httpx2.Request: ...
+
+    async def __call__(self, request: httpx.Request | httpx2.Request) -> httpx.Request | httpx2.Request:
         from opentelemetry.propagate import inject
 
         headers: dict[str, Any] = {}
@@ -232,7 +257,7 @@ class _GatewayRequestHook:
         return request
 
 
-def _add_request_hook(http_client: httpx.AsyncClient, hook: _GatewayRequestHook) -> None:
+def _add_request_hook(http_client: httpx.AsyncClient | httpx2.AsyncClient, hook: _GatewayRequestHook) -> None:
     """Add a request hook without replacing caller-provided HTTPX hooks."""
     request_hooks = [
         existing_hook

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -3,12 +3,10 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
@@ -20,7 +18,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -39,7 +38,7 @@ def _heroku_kimi_model_profile(model_name: str) -> ModelProfile | None:
     return moonshotai_model_profile(model_name)
 
 
-class HerokuProvider(Provider[AsyncOpenAI]):
+class HerokuProvider(_OpenAICompatibleProvider):
     """Provider for Heroku API."""
 
     @property
@@ -98,10 +97,10 @@ class HerokuProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str, base_url: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient, base_url: str) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient, base_url: str) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -112,7 +111,7 @@ class HerokuProvider(Provider[AsyncOpenAI]):
         base_url: str | None = None,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         if openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
@@ -130,13 +129,4 @@ class HerokuProvider(Provider[AsyncOpenAI]):
             if not base_url.endswith('/v1'):
                 base_url += '/v1'
 
-            if http_client is not None:
-                self._client = AsyncOpenAI(api_key=api_key, http_client=http_client, base_url=base_url)
-            else:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-                self._client = AsyncOpenAI(api_key=api_key, http_client=http_client, base_url=base_url)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -2,11 +2,9 @@ from __future__ import annotations as _annotations
 
 from typing import overload
 
-from httpx import AsyncClient as AsyncHTTPClient
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
@@ -20,7 +18,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -31,7 +30,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class LiteLLMProvider(Provider[AsyncOpenAI]):
+class LiteLLMProvider(_OpenAICompatibleProvider):
     """Provider for LiteLLM API."""
 
     @property
@@ -97,7 +96,7 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         api_base: str | None = None,
-        http_client: AsyncHTTPClient,
+        http_client: _OpenAIHTTPClient,
     ) -> None: ...
 
     @overload
@@ -109,7 +108,7 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
         api_key: str | None = None,
         api_base: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: AsyncHTTPClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Initialize a LiteLLM provider.
 
@@ -125,17 +124,6 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
 
         # Create OpenAI client that will be used with LiteLLM's completion function
         # The actual API calls will be intercepted and routed through LiteLLM
-        if http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=api_base, api_key=api_key or 'litellm-placeholder', http_client=http_client
-            )
-        else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
-                base_url=api_base, api_key=api_key or 'litellm-placeholder', http_client=http_client
-            )
-
-    def _set_http_client(self, http_client: AsyncHTTPClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+        self._client = self._create_openai_client(
+            base_url=api_base, api_key=api_key or 'litellm-placeholder', http_client=http_client
+        )

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-import warnings
 from collections.abc import Callable
 from typing import overload
 
@@ -9,8 +8,7 @@ import httpx
 import httpx2
 
 from pydantic_ai import ModelProfile
-from pydantic_ai._http import create_httpx2_client
-from pydantic_ai._warnings import PydanticAIDeprecationWarning
+from pydantic_ai._http import create_httpx2_client, warn_if_legacy_httpx_client
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
@@ -118,13 +116,8 @@ class MistralProvider(Provider[Mistral]):
                 http_client = create_httpx2_client()
                 self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
                 self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
-            elif isinstance(http_client, httpx.AsyncClient):
-                warnings.warn(
-                    '`httpx.AsyncClient` support for the Mistral provider is deprecated and will be removed in v3; '
-                    'use `httpx2.AsyncClient` instead.',
-                    PydanticAIDeprecationWarning,
-                    stacklevel=2,
-                )
+            else:
+                warn_if_legacy_httpx_client(http_client, consumer='the Mistral provider', stacklevel=2)
 
             # Mistral's runtime-checkable client protocol accepts HTTPX2, but its annotations name legacy HTTPX types.
             self._client = Mistral(

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -1,13 +1,17 @@
 from __future__ import annotations as _annotations
 
 import os
+import warnings
+from collections.abc import Callable
 from typing import overload
 
 import httpx
+import httpx2
 
 from pydantic_ai import ModelProfile
+from pydantic_ai._http import create_httpx2_client
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.providers import Provider
@@ -46,9 +50,14 @@ _ADJUSTABLE_REASONING_MODELS = frozenset(
     }
 )
 
+_MistralHTTPClient = httpx.AsyncClient | httpx2.AsyncClient
+
 
 class MistralProvider(Provider[Mistral]):
     """Provider for Mistral API."""
+
+    _own_http_client: _MistralHTTPClient | None = None
+    _http_client_factory: Callable[[], _MistralHTTPClient] | None = None
 
     @property
     def name(self) -> str:
@@ -73,7 +82,7 @@ class MistralProvider(Provider[Mistral]):
     def __init__(self, *, mistral_client: Mistral | None = None) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str | None = None, http_client: httpx.AsyncClient | None = None) -> None: ...
+    def __init__(self, *, api_key: str | None = None, http_client: _MistralHTTPClient | None = None) -> None: ...
 
     def __init__(
         self,
@@ -81,7 +90,7 @@ class MistralProvider(Provider[Mistral]):
         api_key: str | None = None,
         mistral_client: Mistral | None = None,
         base_url: str | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _MistralHTTPClient | None = None,
     ) -> None:
         """Create a new Mistral provider.
 
@@ -90,7 +99,7 @@ class MistralProvider(Provider[Mistral]):
                 will be used if available.
             mistral_client: An existing `Mistral` client to use, if provided, `api_key` and `http_client` must be `None`.
             base_url: The base url for the Mistral requests.
-            http_client: An existing async client to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         if mistral_client is not None:
             assert http_client is None, 'Cannot provide both `mistral_client` and `http_client`'
@@ -105,13 +114,25 @@ class MistralProvider(Provider[Mistral]):
                     'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
                     ' to use the Mistral provider.'
                 )
-            elif http_client is not None:
-                self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)
-            else:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-                self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)
+            if http_client is None:
+                http_client = create_httpx2_client()
+                self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
+                self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
+            elif isinstance(http_client, httpx.AsyncClient):
+                warnings.warn(
+                    '`httpx.AsyncClient` support for the Mistral provider is deprecated and will be removed in v3; '
+                    'use `httpx2.AsyncClient` instead.',
+                    PydanticAIDeprecationWarning,
+                    stacklevel=2,
+                )
 
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client.sdk_configuration.async_client = http_client
+            # Mistral's runtime-checkable client protocol accepts HTTPX2, but its annotations name legacy HTTPX types.
+            self._client = Mistral(
+                api_key=api_key,
+                async_client=http_client,  # pyright: ignore[reportArgumentType]
+                server_url=base_url,
+            )
+
+    # The generic Provider currently only knows the legacy HTTPX client type.
+    def _set_http_client(self, http_client: _MistralHTTPClient) -> None:
+        self._client.sdk_configuration.async_client = http_client  # pyright: ignore[reportAttributeAccessIssue]

--- a/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
@@ -3,19 +3,18 @@ from __future__ import annotations as _annotations
 import os
 from typing import Literal, overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import (
     OpenAIJsonSchemaTransformer,
     OpenAIModelProfile,
 )
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 MoonshotAIModelName = Literal[
     'moonshot-v1-8k',
@@ -36,7 +35,7 @@ MoonshotAIModelName = Literal[
 ]
 
 
-class MoonshotAIProvider(Provider[AsyncOpenAI]):
+class MoonshotAIProvider(_OpenAICompatibleProvider):
     """Provider for MoonshotAI platform (Kimi models)."""
 
     @property
@@ -88,7 +87,7 @@ class MoonshotAIProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -98,7 +97,7 @@ class MoonshotAIProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         api_key = api_key or os.getenv('MOONSHOTAI_API_KEY')
         if not api_key and openai_client is None:
@@ -109,13 +108,5 @@ class MoonshotAIProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -3,11 +3,8 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -17,7 +14,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -28,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class NebiusProvider(Provider[AsyncOpenAI]):
+class NebiusProvider(_OpenAICompatibleProvider):
     """Provider for Nebius AI Studio API."""
 
     @property
@@ -76,7 +74,7 @@ class NebiusProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -86,7 +84,7 @@ class NebiusProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         api_key = api_key or os.getenv('NEBIUS_API_KEY')
         if not api_key and openai_client is None:
@@ -97,13 +95,5 @@ class NebiusProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -2,11 +2,8 @@ from __future__ import annotations as _annotations
 
 import os
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
@@ -16,7 +13,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +25,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class OllamaProvider(Provider[AsyncOpenAI]):
+class OllamaProvider(_OpenAICompatibleProvider):
     """Provider for local or remote Ollama API."""
 
     @property
@@ -80,7 +78,7 @@ class OllamaProvider(Provider[AsyncOpenAI]):
         base_url: str | None = None,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a new Ollama provider.
 
@@ -92,7 +90,7 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             openai_client: An existing
                 [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
                 client to use. If provided, `base_url`, `api_key`, and `http_client` must be `None`.
-            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         if openai_client is not None:
             assert base_url is None, 'Cannot provide both `openai_client` and `base_url`'
@@ -111,13 +109,4 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
             api_key = api_key or os.getenv('OLLAMA_API_KEY') or 'api-key-not-set'
 
-            if http_client is not None:
-                self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
-            else:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-                self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -1,12 +1,16 @@
 from __future__ import annotations as _annotations
 
 import os
+import warnings
+from collections.abc import Callable, Mapping
 from typing import overload
 
 import httpx
+import httpx2
 
 from pydantic_ai import ModelProfile
-from pydantic_ai.models import create_async_http_client
+from pydantic_ai._http import create_httpx2_client
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.providers import Provider, missing_api_key_error
@@ -20,7 +24,54 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class OpenAIProvider(Provider[AsyncOpenAI]):
+_OpenAIHTTPClient = httpx.AsyncClient | httpx2.AsyncClient
+
+
+class _OpenAICompatibleProvider(Provider[AsyncOpenAI]):
+    """Shared HTTP client lifecycle for providers backed by the OpenAI SDK."""
+
+    _own_http_client: _OpenAIHTTPClient | None = None
+    _http_client_factory: Callable[[], _OpenAIHTTPClient] | None = None
+
+    def _get_http_client(
+        self, http_client: _OpenAIHTTPClient | None, *, warning_stacklevel: int = 3
+    ) -> _OpenAIHTTPClient:
+        if http_client is None:
+            http_client = create_httpx2_client()
+            self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
+            self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
+        elif isinstance(http_client, httpx.AsyncClient):
+            warnings.warn(
+                '`httpx.AsyncClient` support for OpenAI-compatible providers is deprecated and will be removed in v3; '
+                'use `httpx2.AsyncClient` instead.',
+                PydanticAIDeprecationWarning,
+                stacklevel=warning_stacklevel,
+            )
+        return http_client
+
+    def _create_openai_client(
+        self,
+        *,
+        base_url: str | None,
+        api_key: str | None,
+        http_client: _OpenAIHTTPClient | None,
+        default_headers: Mapping[str, str] | None = None,
+    ) -> AsyncOpenAI:
+        http_client = self._get_http_client(http_client, warning_stacklevel=4)
+        # openai-python >=2.47 accepts an httpx2 client, but its type annotations still name legacy httpx.
+        return AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+            default_headers=default_headers,
+        )
+
+    # The generic Provider currently only knows the legacy HTTPX client type.
+    def _set_http_client(self, http_client: _OpenAIHTTPClient) -> None:
+        self._client._client = http_client  # pyright: ignore[reportPrivateUsage, reportAttributeAccessIssue]
+
+
+class OpenAIProvider(_OpenAICompatibleProvider):
     """Provider for OpenAI API."""
 
     @property
@@ -62,7 +113,7 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
         base_url: str | None = None,
         api_key: str | None = None,
         openai_client: None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
 
     def __init__(
@@ -70,7 +121,7 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
         base_url: str | None = None,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a new OpenAI provider.
 
@@ -82,7 +133,7 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
             openai_client: An existing
                 [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
                 client to use. If provided, `base_url`, `api_key`, and `http_client` must be `None`.
-            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         if api_key is None and 'OPENAI_API_KEY' not in os.environ and openai_client is None:
             if base_url is None and 'OPENAI_BASE_URL' not in os.environ:
@@ -103,13 +154,5 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
             assert api_key is None, 'Cannot provide both `openai_client` and `api_key`'
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-import warnings
 from collections.abc import Callable, Mapping
 from typing import overload
 
@@ -9,8 +8,7 @@ import httpx
 import httpx2
 
 from pydantic_ai import ModelProfile
-from pydantic_ai._http import create_httpx2_client
-from pydantic_ai._warnings import PydanticAIDeprecationWarning
+from pydantic_ai._http import create_httpx2_client, warn_if_legacy_httpx_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.providers import Provider, missing_api_key_error
@@ -40,12 +38,9 @@ class _OpenAICompatibleProvider(Provider[AsyncOpenAI]):
             http_client = create_httpx2_client()
             self._own_http_client = http_client  # pyright: ignore[reportIncompatibleVariableOverride]
             self._http_client_factory = create_httpx2_client  # pyright: ignore[reportIncompatibleVariableOverride]
-        elif isinstance(http_client, httpx.AsyncClient):
-            warnings.warn(
-                '`httpx.AsyncClient` support for OpenAI-compatible providers is deprecated and will be removed in v3; '
-                'use `httpx2.AsyncClient` instead.',
-                PydanticAIDeprecationWarning,
-                stacklevel=warning_stacklevel,
+        else:
+            warn_if_legacy_httpx_client(
+                http_client, consumer='OpenAI-compatible providers', stacklevel=warning_stacklevel
             )
         return http_client
 

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -3,13 +3,11 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai._json_schema import JsonSchema, JsonSchemaTransformer
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
@@ -23,7 +21,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -121,7 +120,7 @@ def _openrouter_google_model_profile(model_name: str) -> ModelProfile | None:
     return merge_profile(profile, ModelProfile(json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer))
 
 
-class OpenRouterProvider(Provider[AsyncOpenAI]):
+class OpenRouterProvider(_OpenAICompatibleProvider):
     """Provider for OpenRouter API."""
 
     @property
@@ -230,7 +229,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         app_url: str | None = None,
         app_title: str | None = None,
         openai_client: None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
 
     def __init__(
@@ -240,7 +239,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         app_url: str | None = None,
         app_title: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Configure the provider with either an API key or prebuilt client.
 
@@ -253,7 +252,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
                 `OPENROUTER_APP_TITLE` when omitted.
             openai_client: Existing `AsyncOpenAI` client to reuse instead of
                 creating one internally.
-            http_client: Custom `httpx.AsyncClient` to pass into the
+            http_client: Custom `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to pass into the
                 `AsyncOpenAI` constructor when building a client.
 
         Raises:
@@ -275,17 +274,10 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=attribution_headers
-            )
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=attribution_headers
+            self._client = self._create_openai_client(
+                base_url=self.base_url,
+                api_key=api_key,
+                http_client=http_client,
+                default_headers=attribution_headers,
             )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -3,11 +3,8 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
@@ -15,7 +12,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -26,7 +24,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class OVHcloudProvider(Provider[AsyncOpenAI]):
+class OVHcloudProvider(_OpenAICompatibleProvider):
     """Provider for OVHcloud AI Endpoints."""
 
     @property
@@ -69,7 +67,7 @@ class OVHcloudProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -79,7 +77,7 @@ class OVHcloudProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         api_key = api_key or os.getenv('OVHCLOUD_API_KEY')
         if not api_key and openai_client is None:
@@ -90,13 +88,5 @@ class OVHcloudProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 import os
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
 __all__ = ['SambaNovaProvider']
 
 
-class SambaNovaProvider(Provider[AsyncOpenAI]):
+class SambaNovaProvider(_OpenAICompatibleProvider):
     """Provider for SambaNova AI models.
 
     SambaNova uses an OpenAI-compatible API.
@@ -81,7 +80,7 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
         api_key: str | None = None,
         base_url: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Initialize SambaNova provider.
 
@@ -89,7 +88,7 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
             api_key: SambaNova API key. If not provided, reads from SAMBANOVA_API_KEY env var.
             base_url: Custom API base URL. Defaults to https://api.sambanova.ai/v1
             openai_client: Optional pre-configured OpenAI client
-            http_client: Optional custom httpx.AsyncClient for making HTTP requests
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
 
         Raises:
             UserError: If API key is not provided and SAMBANOVA_API_KEY env var is not set
@@ -109,11 +108,4 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
             # Set base URL (default to SambaNova API endpoint)
             self._base_url = base_url or os.getenv('SAMBANOVA_BASE_URL', 'https://api.sambanova.ai/v1')
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self._base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self._base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
@@ -5,18 +5,16 @@ import re
 from collections.abc import Callable
 from typing import overload
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -44,7 +42,7 @@ class SnowflakeModelProfile(OpenAIModelProfile, total=False):
     """
 
 
-class SnowflakeProvider(Provider[AsyncOpenAI]):
+class SnowflakeProvider(_OpenAICompatibleProvider):
     """Provider for [Snowflake Cortex](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api).
 
     Routes requests through Snowflake's OpenAI-compatible Chat Completions API at
@@ -134,7 +132,7 @@ class SnowflakeProvider(Provider[AsyncOpenAI]):
         token: str | None = None,
         base_url: str | None = None,
         openai_client: None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
 
     def __init__(
@@ -144,7 +142,7 @@ class SnowflakeProvider(Provider[AsyncOpenAI]):
         token: str | None = None,
         base_url: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a new Snowflake provider.
 
@@ -160,7 +158,7 @@ class SnowflakeProvider(Provider[AsyncOpenAI]):
             openai_client: An existing `AsyncOpenAI` client to use. Its `base_url` must already
                 point at the Cortex REST API. If provided, `account`, `token`, `base_url`, and
                 `http_client` must be `None`.
-            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         if openai_client is not None:
             assert account is None, 'Cannot provide both `openai_client` and `account`'
@@ -199,13 +197,4 @@ class SnowflakeProvider(Provider[AsyncOpenAI]):
                 ' to use the Snowflake provider.'
             )
 
-        if http_client is not None:
-            self._client = AsyncOpenAI(base_url=base_url, api_key=token, http_client=http_client)
-        else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=base_url, api_key=token, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+        self._client = self._create_openai_client(base_url=base_url, api_key=token, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -3,12 +3,10 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -16,7 +14,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class TogetherProvider(Provider[AsyncOpenAI]):
+class TogetherProvider(_OpenAICompatibleProvider):
     """Provider for Together AI API."""
 
     @property
@@ -71,7 +70,7 @@ class TogetherProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -81,7 +80,7 @@ class TogetherProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         api_key = api_key or os.getenv('TOGETHER_API_KEY')
         if not api_key and openai_client is None:
@@ -92,13 +91,5 @@ class TogetherProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -3,11 +3,8 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
@@ -17,7 +14,8 @@ from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -28,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class VercelProvider(Provider[AsyncOpenAI]):
+class VercelProvider(_OpenAICompatibleProvider):
     """Provider for Vercel AI Gateway API."""
 
     @property
@@ -76,7 +74,7 @@ class VercelProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -86,7 +84,7 @@ class VercelProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         # Support Vercel AI Gateway's standard environment variables
         api_key = api_key or os.getenv('VERCEL_AI_GATEWAY_API_KEY') or os.getenv('VERCEL_OIDC_TOKEN')
@@ -101,17 +99,10 @@ class VercelProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
-            )
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
+            self._client = self._create_openai_client(
+                base_url=self.base_url,
+                api_key=api_key,
+                http_client=http_client,
+                default_headers=default_headers,
             )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/zai.py
@@ -3,15 +3,13 @@ from __future__ import annotations as _annotations
 import os
 from typing import overload
 
-import httpx
-
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.zai import zai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider, _OpenAIHTTPClient  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -22,7 +20,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class ZaiProvider(Provider[AsyncOpenAI]):
+class ZaiProvider(_OpenAICompatibleProvider):
     """Provider for Z.AI (Zhipu AI) API.
 
     Z.AI provides GLM models with support for thinking/reasoning mode
@@ -62,10 +60,10 @@ class ZaiProvider(Provider[AsyncOpenAI]):
     def __init__(self, *, api_key: str) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
-    def __init__(self, *, http_client: httpx.AsyncClient) -> None: ...
+    def __init__(self, *, http_client: _OpenAIHTTPClient) -> None: ...
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
@@ -75,7 +73,7 @@ class ZaiProvider(Provider[AsyncOpenAI]):
         *,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
     ) -> None:
         """Create a new Z.AI provider.
 
@@ -83,7 +81,7 @@ class ZaiProvider(Provider[AsyncOpenAI]):
             api_key: The API key to use for authentication, if not provided, the `ZAI_API_KEY` environment variable
                 will be used if available.
             openai_client: An existing `AsyncOpenAI` client to use. If provided, `api_key` and `http_client` must be `None`.
-            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
         """
         api_key = api_key or os.getenv('ZAI_API_KEY')
         if not api_key and openai_client is None:
@@ -94,13 +92,5 @@ class ZaiProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -6,15 +6,17 @@ used with HTTP clients that support custom transports (such as httpx), while the
 strategies can be used with any tenacity retry decorator.
 
 The module includes:
-- TenacityTransport: Synchronous HTTP transport with retry capabilities
-- AsyncTenacityTransport: Asynchronous HTTP transport with retry capabilities
+- HTTPX2TenacityTransport: Synchronous HTTPX2 transport with retry capabilities
+- AsyncHTTPX2TenacityTransport: Asynchronous HTTPX2 transport with retry capabilities
 - wait_retry_after: Wait strategy that respects HTTP Retry-After headers
 """
 
 from __future__ import annotations
 
+import warnings
 from types import TracebackType
 
+import httpx2
 from httpx import (
     AsyncBaseTransport,
     AsyncHTTPTransport,
@@ -40,13 +42,22 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import TypedDict
 
+from ._warnings import PydanticAIDeprecationWarning
+
 if TYPE_CHECKING:
     from tenacity.asyncio.retry import RetryBaseT
     from tenacity.retry import RetryBaseT as SyncRetryBaseT
     from tenacity.stop import StopBaseT
     from tenacity.wait import WaitBaseT
 
-__all__ = ['RetryConfig', 'TenacityTransport', 'AsyncTenacityTransport', 'wait_retry_after']
+__all__ = [
+    'RetryConfig',
+    'HTTPX2TenacityTransport',
+    'AsyncHTTPX2TenacityTransport',
+    'TenacityTransport',
+    'AsyncTenacityTransport',
+    'wait_retry_after',
+]
 
 
 class RetryConfig(TypedDict, total=False):
@@ -114,8 +125,96 @@ class RetryConfig(TypedDict, total=False):
     Tenacity's default for this argument is `None`."""
 
 
+class HTTPX2TenacityTransport(httpx2.BaseTransport):
+    """Synchronous HTTPX2 transport with Tenacity-based retry functionality."""
+
+    def __init__(
+        self,
+        config: RetryConfig,
+        wrapped: httpx2.BaseTransport | None = None,
+        validate_response: Callable[[httpx2.Response], object] | None = None,
+    ):
+        self.config = config
+        self.wrapped = wrapped or httpx2.HTTPTransport()
+        self.validate_response = validate_response
+
+    def handle_request(self, request: httpx2.Request) -> httpx2.Response:
+        @retry(**self.config)
+        def handle_request(req: httpx2.Request) -> httpx2.Response:
+            response = self.wrapped.handle_request(req)
+            response.request = req
+            if self.validate_response:
+                try:
+                    self.validate_response(response)
+                except Exception:
+                    response.close()
+                    raise
+            return response
+
+        return handle_request(request)
+
+    def __enter__(self) -> HTTPX2TenacityTransport:
+        self.wrapped.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self.wrapped.__exit__(exc_type, exc_value, traceback)
+
+    def close(self) -> None:
+        self.wrapped.close()
+
+
+class AsyncHTTPX2TenacityTransport(httpx2.AsyncBaseTransport):
+    """Asynchronous HTTPX2 transport with Tenacity-based retry functionality."""
+
+    def __init__(
+        self,
+        config: RetryConfig,
+        wrapped: httpx2.AsyncBaseTransport | None = None,
+        validate_response: Callable[[httpx2.Response], object] | None = None,
+    ):
+        self.config = config
+        self.wrapped = wrapped or httpx2.AsyncHTTPTransport()
+        self.validate_response = validate_response
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        @retry(**self.config)
+        async def handle_async_request(req: httpx2.Request) -> httpx2.Response:
+            response = await self.wrapped.handle_async_request(req)
+            response.request = req
+            if self.validate_response:
+                try:
+                    self.validate_response(response)
+                except Exception:
+                    await response.aclose()
+                    raise
+            return response
+
+        return await handle_async_request(request)
+
+    async def __aenter__(self) -> AsyncHTTPX2TenacityTransport:
+        await self.wrapped.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        await self.wrapped.__aexit__(exc_type, exc_value, traceback)
+
+    async def aclose(self) -> None:
+        await self.wrapped.aclose()
+
+
 class TenacityTransport(BaseTransport):
-    """Synchronous HTTP transport with tenacity-based retry functionality.
+    """Deprecated synchronous HTTPX transport with Tenacity-based retry functionality.
 
     This transport wraps another BaseTransport and adds retry capabilities using the tenacity library.
     It can be configured to retry requests based on various conditions such as specific exception types,
@@ -161,6 +260,12 @@ class TenacityTransport(BaseTransport):
         wrapped: BaseTransport | None = None,
         validate_response: Callable[[Response], Any] | None = None,
     ):
+        warnings.warn(
+            '`TenacityTransport` is deprecated and will be removed in v3; use `HTTPX2TenacityTransport` '
+            'with `httpx2.Client` instead.',
+            PydanticAIDeprecationWarning,
+            stacklevel=2,
+        )
         self.config = config
         self.wrapped = wrapped or HTTPTransport()
         self.validate_response = validate_response
@@ -213,7 +318,7 @@ class TenacityTransport(BaseTransport):
 
 
 class AsyncTenacityTransport(AsyncBaseTransport):
-    """Asynchronous HTTP transport with tenacity-based retry functionality.
+    """Deprecated asynchronous HTTPX transport with Tenacity-based retry functionality.
 
     This transport wraps another AsyncBaseTransport and adds retry capabilities using the tenacity library.
     It can be configured to retry requests based on various conditions such as specific exception types,
@@ -258,6 +363,12 @@ class AsyncTenacityTransport(AsyncBaseTransport):
         wrapped: AsyncBaseTransport | None = None,
         validate_response: Callable[[Response], Any] | None = None,
     ):
+        warnings.warn(
+            '`AsyncTenacityTransport` is deprecated and will be removed in v3; use `AsyncHTTPX2TenacityTransport` '
+            'with `httpx2.AsyncClient` instead.',
+            PydanticAIDeprecationWarning,
+            stacklevel=2,
+        )
         self.config = config
         self.wrapped = wrapped or AsyncHTTPTransport()
         self.validate_response = validate_response
@@ -314,8 +425,8 @@ def wait_retry_after(
 ) -> Callable[[RetryCallState], float]:
     """Create a tenacity-compatible wait strategy that respects HTTP Retry-After headers.
 
-    This wait strategy checks if the exception contains an HTTPStatusError with a
-    Retry-After header, and if so, waits for the time specified in the header.
+    This wait strategy checks if the exception contains an HTTPX or HTTPX2 HTTPStatusError
+    with a Retry-After header, and if so, waits for the time specified in the header.
     If no header is present or parsing fails, it falls back to the provided strategy.
 
     The Retry-After header can be in two formats:
@@ -333,12 +444,12 @@ def wait_retry_after(
 
     Example:
         ```python
-        from httpx import AsyncClient, HTTPStatusError
+        from httpx2 import AsyncClient, HTTPStatusError
         from tenacity import retry_if_exception_type, stop_after_attempt
 
-        from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
+        from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig, wait_retry_after
 
-        transport = AsyncTenacityTransport(
+        transport = AsyncHTTPX2TenacityTransport(
             RetryConfig(
                 retry=retry_if_exception_type(HTTPStatusError),
                 wait=wait_retry_after(max_wait=120),
@@ -355,7 +466,7 @@ def wait_retry_after(
 
     def wait_func(state: RetryCallState) -> float:
         exc = state.outcome.exception() if state.outcome else None
-        if isinstance(exc, HTTPStatusError):
+        if isinstance(exc, HTTPStatusError | httpx2.HTTPStatusError):
             retry_after = exc.response.headers.get('retry-after')
             if retry_after:
                 try:

--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -233,25 +233,6 @@ class TenacityTransport(BaseTransport):
             Common use case is to raise exceptions for certain HTTP status codes.
             If None, no response validation is performed.
 
-    Example:
-        ```python
-        from httpx import Client, HTTPStatusError, HTTPTransport
-        from tenacity import retry_if_exception_type, stop_after_attempt
-
-        from pydantic_ai.retries import RetryConfig, TenacityTransport, wait_retry_after
-
-        transport = TenacityTransport(
-            RetryConfig(
-                retry=retry_if_exception_type(HTTPStatusError),
-                wait=wait_retry_after(max_wait=300),
-                stop=stop_after_attempt(5),
-                reraise=True
-            ),
-            HTTPTransport(),
-            validate_response=lambda r: r.raise_for_status()
-        )
-        client = Client(transport=transport)
-        ```
     """
 
     def __init__(
@@ -337,24 +318,6 @@ class AsyncTenacityTransport(AsyncBaseTransport):
             Common use case is to raise exceptions for certain HTTP status codes.
             If None, no response validation is performed.
 
-    Example:
-        ```python
-        from httpx import AsyncClient, HTTPStatusError
-        from tenacity import retry_if_exception_type, stop_after_attempt
-
-        from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_after
-
-        transport = AsyncTenacityTransport(
-            RetryConfig(
-                retry=retry_if_exception_type(HTTPStatusError),
-                wait=wait_retry_after(max_wait=300),
-                stop=stop_after_attempt(5),
-                reraise=True
-            ),
-            validate_response=lambda r: r.raise_for_status()
-        )
-        client = AsyncClient(transport=transport)
-        ```
     """
 
     def __init__(
@@ -447,7 +410,11 @@ def wait_retry_after(
         from httpx2 import AsyncClient, HTTPStatusError
         from tenacity import retry_if_exception_type, stop_after_attempt
 
-        from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig, wait_retry_after
+        from pydantic_ai.retries import (
+            AsyncHTTPX2TenacityTransport,
+            RetryConfig,
+            wait_retry_after,
+        )
 
         transport = AsyncHTTPX2TenacityTransport(
             RetryConfig(

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
-from httpx import Timeout
 from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from httpx import Timeout
+else:
+    try:
+        from httpx import Timeout
+    except ImportError:
+        Timeout = float
 
 ThinkingEffort: TypeAlias = Literal['minimal', 'low', 'medium', 'high', 'xhigh']
 """The string effort levels for thinking/reasoning configuration."""

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, TypeVar
 
-import httpx
+import httpx2
 
 from pydantic_ai import Agent
 from pydantic_ai.native_tools import AbstractNativeTool
@@ -103,7 +103,7 @@ async def _get_ui_html(html_source: str | Path | None = None) -> bytes:
         if content := _read_cached_file(cache_file):
             return content
 
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(DEFAULT_HTML_URL)
             response.raise_for_status()
             content = response.content
@@ -127,7 +127,7 @@ async def _get_ui_html(html_source: str | Path | None = None) -> bytes:
         if content := _read_cached_file(cache_file):
             return content
 
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(html_source)
             response.raise_for_status()
             content = response.content

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -81,7 +81,6 @@ xai = ["xai-sdk>=1.14.0"]
 groq = ["groq>=0.25.0"]
 openrouter = ["openai[httpx2]>=2.47.0"]
 # `mistralai>=2.9.2` accepts `httpx2.AsyncClient` and no longer caps OpenTelemetry semantic conventions.
-# This floor also excludes `mistralai==2.4.6`, which was quarantined on PyPI due to a supply-chain attack (see #5382).
 mistral = ["mistralai>=2.9.2"]
 bedrock = ["boto3>=1.42.63"]
 # Amazon Bedrock Mantle serves OpenAI models through an OpenAI-compatible API via `AsyncBedrockOpenAI`,

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -80,10 +80,9 @@ anthropic = ["anthropic>=0.108.0"]
 xai = ["xai-sdk>=1.14.0"]
 groq = ["groq>=0.25.0"]
 openrouter = ["openai[httpx2]>=2.47.0"]
-# `mistralai>=2.4.2` is required for the `prompt_cache_key` parameter on `chat.complete_async`
-# and `chat.stream_async` (also covers the `reasoning_effort` parameter, which needed >=2.0.5).
-# `mistralai==2.4.6` was quarantined on PyPI due to a supply-chain attack (see #5382).
-mistral = ["mistralai>=2.4.2,!=2.4.6"]
+# `mistralai>=2.9.2` accepts `httpx2.AsyncClient` and no longer caps OpenTelemetry semantic conventions.
+# This floor also excludes `mistralai==2.4.6`, which was quarantined on PyPI due to a supply-chain attack (see #5382).
+mistral = ["mistralai>=2.9.2"]
 bedrock = ["boto3>=1.42.63"]
 # Amazon Bedrock Mantle serves OpenAI models through an OpenAI-compatible API via `AsyncBedrockOpenAI`,
 # which needs `openai` and (for AWS SigV4 auth) `botocore`; the bearer-token path needs `openai` alone.

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     # on 4.6.0 and below, `test_streaming_handoff_survives_absorbed_cancellation` deadlocks (#6422).
     "anyio>=4.7.0",
     "griffelib>=2.0",
-    "httpx>=0.27",
+    "httpx2>=2.7",
     "pydantic>=2.12",
     "pydantic-graph=={{ version }}",
     "exceptiongroup>=1.2.2; python_version < '3.11'",
@@ -71,15 +71,15 @@ dependencies = [
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
 # WARNING if you add optional groups, please update docs/install.md
-logfire = ["logfire[httpx]>=4.16.0"]
+logfire = ["logfire[httpx]>=4.39.0"]
 # Models
-openai = ["openai>=2.45.0", "tiktoken>=0.12.0"]
+openai = ["openai[httpx2]>=2.47.0", "tiktoken>=0.12.0"]
 cohere = ["cohere>=5.20.6; platform_system != 'Emscripten'"]
 google = ["google-genai>=1.70.0"]
 anthropic = ["anthropic>=0.108.0"]
 xai = ["xai-sdk>=1.14.0"]
 groq = ["groq>=0.25.0"]
-openrouter = ["openai>=2.45.0"]
+openrouter = ["openai[httpx2]>=2.47.0"]
 # `mistralai>=2.4.2` is required for the `prompt_cache_key` parameter on `chat.complete_async`
 # and `chat.stream_async` (also covers the `reasoning_effort` parameter, which needed >=2.0.5).
 # `mistralai==2.4.6` was quarantined on PyPI due to a supply-chain attack (see #5382).
@@ -87,9 +87,9 @@ mistral = ["mistralai>=2.4.2,!=2.4.6"]
 bedrock = ["boto3>=1.42.63"]
 # Amazon Bedrock Mantle serves OpenAI models through an OpenAI-compatible API via `AsyncBedrockOpenAI`,
 # which needs `openai` and (for AWS SigV4 auth) `botocore`; the bearer-token path needs `openai` alone.
-bedrock-mantle = ["openai>=2.45.0", "botocore>=1.42.63"]
-zai = ["openai>=2.45.0"]
-snowflake = ["openai>=2.45.0"]
+bedrock-mantle = ["openai[httpx2]>=2.47.0", "botocore>=1.42.63"]
+zai = ["openai[httpx2]>=2.47.0"]
+snowflake = ["openai[httpx2]>=2.47.0"]
 huggingface = [
     "huggingface-hub>=1.3.4,<2.0.0",
     # huggingface_hub 1.3.x still calls the deprecated hf_xet.download_files() API.
@@ -123,9 +123,9 @@ ui = ["starlette>=0.46.2"]
 # AG-UI
 ag-ui = ["ag-ui-protocol>=0.1.10", "starlette>=0.46.2"]
 # Web
-web = ["starlette>=0.46.2", "httpx>=0.27.0", "uvicorn>=0.38.0"]
+web = ["starlette>=0.46.2", "uvicorn>=0.38.0"]
 # Retries
-retries = ["tenacity>=8.2.3"]
+retries = ["tenacity>=8.2.3", "httpx>=0.27"]
 # Temporal
 temporal = ["temporalio>=1.24.0"]
 # DBOS

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
 # WARNING if you add optional groups, please update docs/install.md
-logfire = ["logfire[httpx]>=4.39.0"]
+logfire = ["logfire[httpx]>=4.39.0", "opentelemetry-instrumentation-httpx>=0.65b0"]
 # Models
 openai = ["openai[httpx2]>=2.47.0", "tiktoken>=0.12.0"]
 cohere = ["cohere>=5.20.6; platform_system != 'Emscripten'"]

--- a/pydantic_graph/pyproject.toml
+++ b/pydantic_graph/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     # `anyio>=4.7.0` is required for cancellation delivery our streaming teardown relies on:
     # on 4.6.0 and below, `test_streaming_handoff_survives_absorbed_cancellation` deadlocks (#6422).
     "anyio>=4.7.0",
-    "httpx>=0.27",
     "logfire-api>=3.14.1",
     "pydantic>=2.12",
     "typing-inspection>=0.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires-python = ">=3.10"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
-    "pydantic-ai-slim[openai,anthropic,google,cli,mcp,evals,web,retries,logfire]=={{ version }}",
+    "pydantic-ai-slim[openai,anthropic,google,cli,mcp,evals,web,logfire]=={{ version }}",
 ]
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
@@ -76,6 +76,7 @@ duckduckgo = ["pydantic-ai-slim[duckduckgo]=={{ version }}"]
 tavily = ["pydantic-ai-slim[tavily]=={{ version }}"]
 exa = ["pydantic-ai-slim[exa]=={{ version }}"]
 web-fetch = ["pydantic-ai-slim[web-fetch]=={{ version }}"]
+retries = ["pydantic-ai-slim[retries]=={{ version }}"]
 temporal = ["pydantic-ai-slim[temporal]=={{ version }}"]
 spec = ["pydantic-ai-slim[spec]=={{ version }}"]
 
@@ -157,6 +158,7 @@ logfire-api = false
 [dependency-groups]
 dev = [
     "anyio>=4.7.0",
+    "httpx>=0.27",
     "asgi-lifespan>=2.1.0",
     "devtools>=0.12.2",
     "coverage[toml]>=7.10.7",
@@ -356,6 +358,9 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
+    # mistralai constrains opentelemetry-semantic-conventions<0.61, while HTTPX2 instrumentation requires
+    # opentelemetry-instrumentation-httpx>=0.65b0. Logfire continues without HTTPX2 request spans.
+    "ignore:`httpx2` will not be instrumented because it requires `opentelemetry-instrumentation-httpx>=0.65b0`:UserWarning",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",
     # prefect has a Pydantic v2 compatibility issue in RRuleSchedule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,9 +154,6 @@ pydantic-handlebars = false
 genai-prices = false
 logfire = false
 logfire-api = false
-# TODO: Remove after 2026-08-18 07:51 UTC. https://github.com/pydantic/pydantic-ai/issues/7376
-# This admits only the reviewed HTTPX2-compatible 2.9.2 artifacts; later Mistral artifacts remain quarantined.
-mistralai = "2026-08-11T07:51:18Z"
 
 [dependency-groups]
 dev = [
@@ -361,9 +358,6 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
-    # logfire 4.40 uses the SDK logging handler deprecated by OpenTelemetry 1.44.
-    # TODO(davidsf): Remove after https://github.com/pydantic/logfire/pull/2094 is released.
-    "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",
     # prefect has a Pydantic v2 compatibility issue in RRuleSchedule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,7 +362,7 @@ filterwarnings = [
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
     # logfire 4.40 uses the SDK logging handler deprecated by OpenTelemetry 1.44.
-    # Remove after https://github.com/pydantic/logfire/pull/2094 is released.
+    # TODO(davidsf): Remove after https://github.com/pydantic/logfire/pull/2094 is released.
     "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,9 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
+    # logfire 4.40 uses the SDK logging handler deprecated by OpenTelemetry 1.44.
+    # Remove after https://github.com/pydantic/logfire/pull/2094 is released.
+    "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",
     # prefect has a Pydantic v2 compatibility issue in RRuleSchedule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,8 +358,9 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
-    # mistralai constrains opentelemetry-semantic-conventions<0.61, while HTTPX2 instrumentation requires
-    # opentelemetry-instrumentation-httpx>=0.65b0. Logfire continues without HTTPX2 request spans.
+    # Released mistralai versions constrain opentelemetry-semantic-conventions<0.61, while HTTPX2 instrumentation
+    # requires opentelemetry-instrumentation-httpx>=0.65b0. https://github.com/mistralai/client-python/pull/605
+    # removed the cap on main; re-check the latest release and remove this filter once it includes that fix.
     "ignore:`httpx2` will not be instrumented because it requires `opentelemetry-instrumentation-httpx>=0.65b0`:UserWarning",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,9 @@ pydantic-handlebars = false
 genai-prices = false
 logfire = false
 logfire-api = false
+# TODO: Remove after 2026-08-18 07:51 UTC. https://github.com/pydantic/pydantic-ai/issues/7376
+# This admits only the reviewed HTTPX2-compatible 2.9.2 artifacts; later Mistral artifacts remain quarantined.
+mistralai = "2026-08-11T07:51:18Z"
 
 [dependency-groups]
 dev = [
@@ -358,10 +361,6 @@ filterwarnings = [
     "ignore: 'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cohere",
     # This is because of google.
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
-    # Released mistralai versions constrain opentelemetry-semantic-conventions<0.61, while HTTPX2 instrumentation
-    # requires opentelemetry-instrumentation-httpx>=0.65b0. https://github.com/mistralai/client-python/pull/605
-    # removed the cap on main; re-check the latest release and remove this filter once it includes that fix.
-    "ignore:`httpx2` will not be instrumented because it requires `opentelemetry-instrumentation-httpx>=0.65b0`:UserWarning",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     "ignore: Core Pydantic V1 functionality:UserWarning",
     # prefect has a Pydantic v2 compatibility issue in RRuleSchedule

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,12 +18,14 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast, overload
 
 import httpx
+import httpx2
 import pytest
 from _pytest.assertion.rewrite import AssertionRewritingHook
 from pytest_mock import MockerFixture
 from vcr import VCR, request as vcr_request
 from vcr.record_mode import RecordMode
 
+import pydantic_ai._http
 import pydantic_ai.models
 from pydantic_ai import Agent, BinaryContent, BinaryImage, Embedder
 from pydantic_ai.messages import (
@@ -654,27 +656,39 @@ def fail_cache_prefix_violations(request: pytest.FixtureRequest, vcr: Cassette |
     check_cache_prefix_stability(request.node, cassette_path)
 
 
-_HttpClientCache: TypeAlias = 'dict[tuple[int, int], httpx.AsyncClient]'
+_HttpClient: TypeAlias = 'httpx.AsyncClient | httpx2.AsyncClient'
+_HttpClientCache: TypeAlias = 'dict[tuple[str, int, int], _HttpClient]'
 
 
 @pytest.fixture(autouse=True)
 def track_httpx_clients(monkeypatch: pytest.MonkeyPatch) -> Iterator[_HttpClientCache]:
-    """Monkeypatch `create_async_http_client` in all loaded modules and track created clients.
+    """Monkeypatch the HTTP client factories in all loaded modules and track created clients.
 
     Within a single test, calls with the same (timeout, connect) args reuse the same
-    httpx.AsyncClient. On teardown, all clients are closed — no process-global state leaks.
+    client. On teardown, all clients are closed — no process-global state leaks.
 
     This is a sync fixture so it applies to both sync and async tests. For async tests, the
     companion `close_httpx_clients` fixture handles async cleanup first.
     """
     cache: _HttpClientCache = {}
-    original = pydantic_ai.models.create_async_http_client
+    original_httpx = pydantic_ai.models.create_async_http_client
+    original_httpx2 = pydantic_ai._http.create_httpx2_client
 
     def cached_per_test(**kwargs: Any) -> httpx.AsyncClient:
-        key = (kwargs.get('timeout', DEFAULT_HTTP_TIMEOUT), kwargs.get('connect', 5))
+        key = ('httpx', kwargs.get('timeout', DEFAULT_HTTP_TIMEOUT), kwargs.get('connect', 5))
         if key not in cache or cache[key].is_closed:
-            cache[key] = original(**kwargs)
-        return cache[key]
+            cache[key] = original_httpx(**kwargs)
+        client = cache[key]
+        assert isinstance(client, httpx.AsyncClient)
+        return client
+
+    def cached_httpx2_per_test(**kwargs: Any) -> httpx2.AsyncClient:
+        key = ('httpx2', kwargs.get('timeout', DEFAULT_HTTP_TIMEOUT), kwargs.get('connect', 5))
+        if key not in cache or cache[key].is_closed:
+            cache[key] = original_httpx2(**kwargs)
+        client = cache[key]
+        assert isinstance(client, httpx2.AsyncClient)
+        return client
 
     for mod in list(sys.modules.values()):
         # Read the module's own namespace via `__dict__` rather than `getattr`: some
@@ -682,8 +696,11 @@ def track_httpx_clients(monkeypatch: pytest.MonkeyPatch) -> Iterator[_HttpClient
         # that imports submodules on attribute access, and probing every loaded module
         # with `getattr` would trigger those unrelated (and possibly failing) imports.
         mod_dict = getattr(mod, '__dict__', None)
-        if mod_dict is not None and mod_dict.get('create_async_http_client', None) is original:
-            monkeypatch.setattr(mod, 'create_async_http_client', cached_per_test)
+        if mod_dict is not None:
+            if mod_dict.get('create_async_http_client', None) is original_httpx:
+                monkeypatch.setattr(mod, 'create_async_http_client', cached_per_test)
+            if mod_dict.get('create_httpx2_client', None) is original_httpx2:
+                monkeypatch.setattr(mod, 'create_httpx2_client', cached_httpx2_per_test)
 
     yield cache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -695,12 +695,11 @@ def track_httpx_clients(monkeypatch: pytest.MonkeyPatch) -> Iterator[_HttpClient
         # modules (e.g. `transformers` submodules) define a lazy PEP 562 `__getattr__`
         # that imports submodules on attribute access, and probing every loaded module
         # with `getattr` would trigger those unrelated (and possibly failing) imports.
-        mod_dict = getattr(mod, '__dict__', None)
-        if mod_dict is not None:
-            if mod_dict.get('create_async_http_client', None) is original_httpx:
-                monkeypatch.setattr(mod, 'create_async_http_client', cached_per_test)
-            if mod_dict.get('create_httpx2_client', None) is original_httpx2:
-                monkeypatch.setattr(mod, 'create_httpx2_client', cached_httpx2_per_test)
+        mod_dict: dict[str, object] = getattr(mod, '__dict__', None) or {}
+        if mod_dict.get('create_async_http_client', None) is original_httpx:
+            monkeypatch.setattr(mod, 'create_async_http_client', cached_per_test)
+        if mod_dict.get('create_httpx2_client', None) is original_httpx2:
+            monkeypatch.setattr(mod, 'create_httpx2_client', cached_httpx2_per_test)
 
     yield cache
 

--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -6,7 +6,7 @@ DeepSeek exposes a Responses endpoint at `https://api.deepseek.com/responses`, c
 continuation is not available and is not exercised here.
 
 Each case snapshots both the resulting messages and the bodies that actually went out, captured by an
-httpx event hook so the wire assertions run against what the client built rather than what the
+HTTPX2 event hook so the wire assertions run against what the client built rather than what the
 cassette happens to hold. The request bodies are what pin the facts this pairing rests on:
 
 - the `openai_reasoning_effort` setting reaching DeepSeek as `reasoning.effort`
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any
 
-import httpx
+import httpx2
 import pytest
 from pydantic import BaseModel
 
@@ -804,10 +804,10 @@ async def test_deepseek_responses(case: Case, allow_model_requests: None, deepse
     """
     sent_bodies: list[dict[str, Any]] = []
 
-    async def capture_request(request: httpx.Request) -> None:
-        sent_bodies.append(json.loads(request.read()))
+    async def capture_request(request: httpx2.Request) -> None:
+        sent_bodies.append(json.loads(request.content))
 
-    http_client = httpx.AsyncClient(event_hooks={'request': [capture_request]})
+    http_client = httpx2.AsyncClient(event_hooks={'request': [capture_request]})
     model = OpenAIResponsesModel(
         'deepseek-v4-flash', provider=DeepSeekProvider(api_key=deepseek_api_key, http_client=http_client)
     )

--- a/tests/models/test_download_item.py
+++ b/tests/models/test_download_item.py
@@ -1,7 +1,7 @@
 import re
 from unittest.mock import patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from pydantic_ai import AudioUrl, DocumentUrl, ImageUrl, VideoUrl
@@ -76,7 +76,7 @@ async def test_download_item_rejects_oversized_body(
     def create_http_client(*, timeout: int) -> httpx.AsyncClient:
         return http_client
 
-    monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+    monkeypatch.setattr('pydantic_ai._ssrf.create_httpx2_client', create_http_client)
 
     with (
         patch('pydantic_ai.models._MAX_FILE_URL_DOWNLOAD_BYTES', 512),

--- a/tests/providers/test_alibaba_provider.py
+++ b/tests/providers/test_alibaba_provider.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai import Agent
@@ -88,7 +88,7 @@ def test_alibaba_provider_with_openai_client():
 
 
 def test_alibaba_provider_with_http_client():
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = AlibabaProvider(api_key='foo', http_client=http_client)
     assert provider.client.api_key == 'foo'
     # The line `self._client = AsyncOpenAI(..., http_client=http_client)` is executed,

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -71,9 +71,9 @@ def test_azure_provider_with_azure_openai_client():
 
 
 def test_azure_provider_with_http_client():
-    import httpx
+    import httpx2
 
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = AzureProvider(
         azure_endpoint='https://project-id.openai.azure.com/',
         api_key='1234567890',

--- a/tests/providers/test_bedrock_mantle.py
+++ b/tests/providers/test_bedrock_mantle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-import httpx
+import httpx2
 import pytest
 from inline_snapshot import snapshot
 from typing_extensions import assert_never
@@ -117,7 +117,7 @@ def test_bedrock_mantle_model_uses_interface_client() -> None:
 
 
 def test_bedrock_mantle_accepts_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = BedrockMantleProvider(http_client=http_client)
 
     assert provider.client._client is http_client  # pyright: ignore[reportPrivateUsage]

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -47,7 +47,7 @@ def test_cerebras_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_cerebras_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = CerebrasProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -38,7 +38,7 @@ def test_deep_seek_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_deep_seek_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = DeepSeekProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -49,7 +49,7 @@ def test_fireworks_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_fireworks_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = FireworksProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 from unittest.mock import patch
 from urllib.parse import urlparse
 
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai import Agent, UserError
@@ -53,6 +53,7 @@ def test_init_with_base_url(
     assert isinstance(provider, provider_cls)
     assert provider.base_url == f'https://example.com/{route}/'
     assert provider.client.api_key == 'foobar'
+    assert isinstance(provider.client._client, httpx2.AsyncClient)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_init_gateway_without_api_key_raises_error(env: TestEnv):
@@ -67,7 +68,7 @@ def test_init_gateway_without_api_key_raises_error(env: TestEnv):
 
 
 async def test_init_with_http_client():
-    async with httpx.AsyncClient() as http_client:
+    async with httpx2.AsyncClient() as http_client:
         provider = gateway_provider('openai', http_client=http_client, api_key='foobar', base_url=GATEWAY_BASE_URL)
         assert provider.client._client == http_client  # pyright: ignore[reportPrivateUsage]
 
@@ -75,13 +76,13 @@ async def test_init_with_http_client():
 async def test_init_with_http_client_preserves_existing_event_hooks():
     # Unit (not VCR): this checks local HTTPX hook merging by inspecting and invoking event hooks directly;
     # cassette playback would not exercise hook ordering or preservation.
-    async def existing_request_hook(request: httpx.Request) -> None:
+    async def existing_request_hook(request: httpx2.Request) -> None:
         request.headers['X-Existing-Request-Hook'] = 'kept'
 
-    async def existing_response_hook(response: httpx.Response) -> None:
+    async def existing_response_hook(response: httpx2.Response) -> None:
         response.headers['X-Existing-Response-Hook'] = 'kept'
 
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         event_hooks={'request': [existing_request_hook], 'response': [existing_response_hook]}
     ) as http_client:
         provider = gateway_provider('openai', http_client=http_client, api_key='foobar', base_url=GATEWAY_BASE_URL)
@@ -89,14 +90,14 @@ async def test_init_with_http_client_preserves_existing_event_hooks():
         assert existing_request_hook in http_client.event_hooks['request']
         assert existing_response_hook in http_client.event_hooks['response']
 
-        request = httpx.Request('GET', provider.base_url)
+        request = httpx2.Request('GET', provider.base_url)
         for hook in http_client.event_hooks['request']:
             await hook(request)
 
         assert request.headers['X-Existing-Request-Hook'] == 'kept'
         assert request.headers['Authorization'] == 'Bearer foobar'
 
-        response = httpx.Response(200, request=request)
+        response = httpx2.Response(200, request=request)
         for hook in http_client.event_hooks['response']:
             await hook(response)
 
@@ -106,10 +107,10 @@ async def test_init_with_http_client_preserves_existing_event_hooks():
 async def test_init_with_http_client_replaces_existing_gateway_hook():
     # Unit (not VCR): this checks local HTTPX hook replacement by inspecting and invoking event hooks directly;
     # cassette playback would not exercise Gateway hook deduplication.
-    async def existing_request_hook(request: httpx.Request) -> None:
+    async def existing_request_hook(request: httpx2.Request) -> None:
         request.headers['X-Existing-Request-Hook'] = 'kept'
 
-    async with httpx.AsyncClient(event_hooks={'request': [existing_request_hook]}) as http_client:
+    async with httpx2.AsyncClient(event_hooks={'request': [existing_request_hook]}) as http_client:
         first_provider = gateway_provider('openai', http_client=http_client, api_key='first', base_url=GATEWAY_BASE_URL)
         second_provider = gateway_provider(
             'openai', http_client=http_client, api_key='second', base_url=GATEWAY_BASE_URL
@@ -120,7 +121,7 @@ async def test_init_with_http_client_replaces_existing_gateway_hook():
         assert http_client.event_hooks['request'][0] == existing_request_hook
         assert len(http_client.event_hooks['request']) == 2
 
-        request = httpx.Request('GET', second_provider.base_url)
+        request = httpx2.Request('GET', second_provider.base_url)
         for hook in http_client.event_hooks['request']:
             await hook(request)
 

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 from unittest.mock import patch
 from urllib.parse import urlparse
 
+import httpx
 import httpx2
 import pytest
 
@@ -127,6 +128,42 @@ async def test_init_with_http_client_replaces_existing_gateway_hook():
 
         assert request.headers['X-Existing-Request-Hook'] == 'kept'
         assert request.headers['Authorization'] == 'Bearer second'
+
+
+async def test_non_openai_gateway_provider_recreates_owned_http_client():
+    provider = gateway_provider('groq', api_key='foobar', base_url=GATEWAY_BASE_URL)
+
+    async with provider:
+        pass
+    original_http_client = provider._own_http_client  # pyright: ignore[reportPrivateUsage]
+
+    async with provider:
+        pass
+
+    assert provider._own_http_client is not original_http_client  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_non_openai_gateway_provider_preserves_custom_http_client():
+    async with httpx.AsyncClient() as http_client:
+        provider = gateway_provider('groq', http_client=http_client, api_key='foobar', base_url=GATEWAY_BASE_URL)
+
+        async with provider:
+            pass
+
+        assert not http_client.is_closed
+
+
+async def test_non_openai_gateway_provider_rejects_httpx2_client():
+    async with httpx2.AsyncClient() as http_client:
+        with pytest.raises(
+            UserError, match=re.escape('`httpx2.AsyncClient` is only supported for OpenAI Gateway routes.')
+        ):
+            gateway_provider(  # pyright: ignore[reportCallIssue]
+                'groq',
+                http_client=http_client,  # pyright: ignore[reportArgumentType]
+                api_key='foobar',
+                base_url=GATEWAY_BASE_URL,
+            )
 
 
 @pytest.fixture

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai.agent import Agent
@@ -58,7 +58,7 @@ def test_heroku_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_heroku_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = HerokuProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_litellm.py
+++ b/tests/providers/test_litellm.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -121,10 +121,8 @@ def test_model_profile_with_different_models(mocker: MockerFixture):
 
 async def test_create_http_client_usage(mocker: MockerFixture):
     # Create a real AsyncClient for the mock
-    async with httpx.AsyncClient() as mock_client:
-        mock_create_func = mocker.patch(
-            'pydantic_ai.providers.litellm.create_async_http_client', return_value=mock_client
-        )
+    async with httpx2.AsyncClient() as mock_client:
+        mock_create_func = mocker.patch('pydantic_ai.providers.openai.create_httpx2_client', return_value=mock_client)
 
         provider = LiteLLMProvider(api_key='test-key')
 
@@ -135,7 +133,7 @@ async def test_create_http_client_usage(mocker: MockerFixture):
 
 
 async def test_init_with_http_client_overrides_cached():
-    async with httpx.AsyncClient() as custom_client:
+    async with httpx2.AsyncClient() as custom_client:
         provider = LiteLLMProvider(api_key='test-key', http_client=custom_client)
 
         # Verify the provider was created successfully with custom client

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -3,8 +3,10 @@ from __future__ import annotations as _annotations
 import re
 
 import httpx
+import httpx2
 import pytest
 
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.exceptions import UserError
 
 from ..conftest import TestEnv, try_import
@@ -18,12 +20,18 @@ with try_import() as imports_successful:
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='mistral not installed')
 
 
-def test_mistral_provider():
+async def test_mistral_provider():
     provider = MistralProvider(api_key='api-key')
     assert provider.name == 'mistral'
     assert provider.base_url == 'https://api.mistral.ai'
     assert isinstance(provider.client, Mistral)
     assert provider.client.sdk_configuration.security.api_key == 'api-key'  # pyright: ignore[reportFunctionMemberAccess, reportOptionalMemberAccess]
+    assert isinstance(provider.client.sdk_configuration.async_client, httpx2.AsyncClient)
+
+    async with provider:
+        pass
+
+    assert provider.client.sdk_configuration.async_client.is_closed
 
 
 def test_mistral_provider_need_api_key(env: TestEnv) -> None:
@@ -38,16 +46,43 @@ def test_mistral_provider_need_api_key(env: TestEnv) -> None:
         MistralProvider()
 
 
-def test_mistral_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = MistralProvider(http_client=http_client, api_key='api-key')
-    assert provider.client.sdk_configuration.async_client == http_client
+async def test_mistral_provider_pass_httpx2_client() -> None:
+    async with httpx2.AsyncClient() as http_client:
+        provider = MistralProvider(http_client=http_client, api_key='api-key')
+        assert provider.client.sdk_configuration.async_client is http_client
+
+        async with provider:
+            pass
+
+        assert not http_client.is_closed
 
 
-def test_mistral_provider_pass_groq_client() -> None:
-    mistral_client = Mistral(api_key='api-key')
-    provider = MistralProvider(mistral_client=mistral_client)
-    assert provider.client == mistral_client
+async def test_mistral_provider_deprecates_legacy_httpx_client() -> None:
+    async with httpx.AsyncClient() as http_client:
+        with pytest.warns(
+            PydanticAIDeprecationWarning,
+            match=r'`httpx\.AsyncClient`.*removed in v3.*`httpx2\.AsyncClient`',
+        ) as warnings:
+            provider = MistralProvider(http_client=http_client, api_key='api-key')
+
+        assert warnings[0].filename == __file__
+        assert provider.client.sdk_configuration.async_client is http_client
+        async with provider:
+            pass
+        assert not http_client.is_closed
+
+
+async def test_mistral_provider_pass_mistral_client() -> None:
+    async with httpx.AsyncClient() as http_client:
+        mistral_client = Mistral(api_key='api-key', async_client=http_client)
+        provider = MistralProvider(mistral_client=mistral_client)
+        assert provider.client is mistral_client
+
+        async with provider:
+            pass
+
+        assert provider.client.sdk_configuration.async_client is http_client
+        assert not http_client.is_closed
 
 
 def test_mistral_provider_with_base_url() -> None:

--- a/tests/providers/test_moonshotai.py
+++ b/tests/providers/test_moonshotai.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -41,7 +41,7 @@ def test_moonshotai_provider_need_api_key(env: TestEnv) -> None:
 
 def test_moonshotai_provider_pass_http_client() -> None:
     """Test passing a custom HTTP client to MoonshotAI provider."""
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = MoonshotAIProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_nebius.py
+++ b/tests/providers/test_nebius.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -57,7 +57,7 @@ def test_nebius_pass_openai_client() -> None:
 
 
 def test_nebius_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = NebiusProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -50,7 +50,7 @@ def test_ollama_provider_need_base_url(env: TestEnv) -> None:
 
 
 def test_ollama_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = OllamaProvider(http_client=http_client, base_url='http://localhost:11434/v1/')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 
 from ..conftest import TestEnv, try_import
@@ -55,6 +55,6 @@ def test_init_of_openai_with_base_url_env_var_and_without_api_key(env: TestEnv):
 
 
 async def test_init_with_http_client():
-    async with httpx.AsyncClient() as http_client:
+    async with httpx2.AsyncClient() as http_client:
         provider = OpenAIProvider(http_client=http_client, api_key='foobar')
         assert provider.client._client == http_client  # pyright: ignore[reportPrivateUsage]

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import httpx
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+
+from pydantic_ai import Agent
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
+from pydantic_ai.providers import Provider
+from pydantic_ai.providers.alibaba import AlibabaProvider
+from pydantic_ai.providers.azure import AzureProvider
+from pydantic_ai.providers.bedrock_mantle import BedrockMantleProvider
+from pydantic_ai.providers.cerebras import CerebrasProvider
+from pydantic_ai.providers.deepseek import DeepSeekProvider
+from pydantic_ai.providers.fireworks import FireworksProvider
+from pydantic_ai.providers.heroku import HerokuProvider
+from pydantic_ai.providers.litellm import LiteLLMProvider
+from pydantic_ai.providers.moonshotai import MoonshotAIProvider
+from pydantic_ai.providers.nebius import NebiusProvider
+from pydantic_ai.providers.ollama import OllamaProvider
+from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.openrouter import OpenRouterProvider
+from pydantic_ai.providers.ovhcloud import OVHcloudProvider
+from pydantic_ai.providers.sambanova import SambaNovaProvider
+from pydantic_ai.providers.snowflake import SnowflakeProvider
+from pydantic_ai.providers.together import TogetherProvider
+from pydantic_ai.providers.vercel import VercelProvider
+from pydantic_ai.providers.zai import ZaiProvider
+
+ProviderFactory = Callable[[httpx.AsyncClient | httpx2.AsyncClient | None], Provider[AsyncOpenAI]]
+
+
+@dataclass(frozen=True)
+class Case:
+    id: str
+    create: ProviderFactory
+
+
+CASES = [
+    Case('openai', lambda http_client: OpenAIProvider(api_key='test', http_client=http_client)),
+    Case(
+        'azure',
+        lambda http_client: AzureProvider(
+            azure_endpoint='https://example-resource.openai.azure.com',
+            api_version='2025-04-01-preview',
+            api_key='test',
+            http_client=http_client,
+        ),
+    ),
+    Case(
+        'bedrock-mantle',
+        lambda http_client: BedrockMantleProvider(region_name='us-east-1', api_key='test', http_client=http_client),
+    ),
+    Case(
+        'alibaba',
+        lambda http_client: AlibabaProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'cerebras',
+        lambda http_client: CerebrasProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case('deepseek', lambda http_client: DeepSeekProvider(api_key='test', http_client=http_client)),
+    Case(
+        'fireworks',
+        lambda http_client: FireworksProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'heroku',
+        lambda http_client: HerokuProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'litellm',
+        lambda http_client: LiteLLMProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'moonshotai',
+        lambda http_client: MoonshotAIProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'nebius',
+        lambda http_client: NebiusProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'ollama',
+        lambda http_client: OllamaProvider(
+            base_url='http://localhost:11434/v1', api_key='test', http_client=http_client
+        ),
+    ),
+    Case('openrouter', lambda http_client: OpenRouterProvider(api_key='test', http_client=http_client)),
+    Case(
+        'ovhcloud',
+        lambda http_client: OVHcloudProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case('sambanova', lambda http_client: SambaNovaProvider(api_key='test', http_client=http_client)),
+    Case('snowflake', lambda http_client: SnowflakeProvider(account='test', token='test', http_client=http_client)),
+    Case(
+        'together',
+        lambda http_client: TogetherProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'vercel',
+        lambda http_client: VercelProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+    Case(
+        'zai',
+        lambda http_client: ZaiProvider(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        ),
+    ),
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('case', [pytest.param(case, id=case.id) for case in CASES])
+async def test_openai_compatible_providers_default_to_httpx2(case: Case) -> None:
+    provider = case.create(None)
+
+    assert isinstance(provider.client._client, httpx2.AsyncClient)  # pyright: ignore[reportPrivateUsage]
+    async with provider:
+        pass
+
+    assert provider.client._client.is_closed  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('case', [pytest.param(case, id=case.id) for case in CASES])
+async def test_openai_compatible_providers_accept_httpx2_clients(case: Case) -> None:
+    async with httpx2.AsyncClient() as http_client:
+        provider = case.create(http_client)
+
+        assert provider.client._client is http_client  # pyright: ignore[reportPrivateUsage]
+        async with provider:
+            pass
+        assert not http_client.is_closed
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('case', [pytest.param(case, id=case.id) for case in CASES])
+async def test_openai_compatible_providers_deprecate_legacy_httpx_clients(case: Case) -> None:
+    async with httpx.AsyncClient() as http_client:
+        with pytest.warns(
+            PydanticAIDeprecationWarning,
+            match=r'`httpx\.AsyncClient`.*removed in v3.*`httpx2\.AsyncClient`',
+        ):
+            provider = case.create(http_client)
+
+        assert provider.client._client is http_client  # pyright: ignore[reportPrivateUsage]
+        async with provider:
+            pass
+        assert not http_client.is_closed
+
+
+@pytest.mark.anyio
+async def test_openai_compatible_provider_preserves_caller_owned_sdk_client() -> None:
+    async with httpx2.AsyncClient() as http_client:
+        openai_client = AsyncOpenAI(
+            api_key='test',
+            http_client=http_client,  # pyright: ignore[reportArgumentType]
+        )
+        provider = OpenAIProvider(openai_client=openai_client)
+
+        assert provider.client is openai_client
+        async with provider:
+            pass
+        assert not http_client.is_closed
+
+
+def _chat_completion() -> dict[str, object]:
+    return {
+        'id': 'chatcmpl-test',
+        'created': 1,
+        'model': 'gpt-4o',
+        'object': 'chat.completion',
+        'choices': [{'index': 0, 'finish_reason': 'stop', 'message': {'role': 'assistant', 'content': 'hello'}}],
+        'usage': {'prompt_tokens': 1, 'completion_tokens': 1, 'total_tokens': 2},
+    }
+
+
+async def test_openai_provider_uses_caller_owned_httpx2_client(allow_model_requests: None) -> None:
+    async def handle(request: httpx2.Request) -> httpx2.Response:
+        assert request.url.path == '/v1/chat/completions'
+        assert json.loads(request.content)['messages'][0]['content'] == 'hello'
+        return httpx2.Response(200, json=_chat_completion())
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handle)) as http_client:
+        provider = OpenAIProvider(api_key='test', http_client=http_client)
+        settings: OpenAIChatModelSettings = {'timeout': httpx.Timeout(1)}
+        result = await Agent(OpenAIChatModel('gpt-4o', provider=provider)).run('hello', model_settings=settings)
+
+        assert result.output == 'hello'
+        assert not http_client.is_closed
+
+
+async def test_openai_provider_uses_deprecated_caller_owned_httpx_client(allow_model_requests: None) -> None:
+    async def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == '/v1/chat/completions'
+        assert json.loads(request.content)['messages'][0]['content'] == 'hello'
+        return httpx.Response(200, json=_chat_completion())
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http_client:
+        with pytest.warns(PydanticAIDeprecationWarning, match='httpx2.AsyncClient') as warnings:
+            provider = OpenAIProvider(api_key='test', http_client=http_client)
+        assert warnings[0].filename == __file__
+        result = await Agent(OpenAIChatModel('gpt-4o', provider=provider)).run('hello')
+
+        assert result.output == 'hello'
+        assert not http_client.is_closed

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -103,7 +103,7 @@ def test_openrouter_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_openrouter_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = OpenRouterProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_ovhcloud.py
+++ b/tests/providers/test_ovhcloud.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -55,7 +55,7 @@ def test_ovhcloud_pass_openai_client() -> None:
 
 
 def test_ovhcloud_pass_http_client():
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = OVHcloudProvider(api_key='your-api-key', http_client=http_client)
     assert isinstance(provider.client, openai.AsyncOpenAI)
     assert provider.client.api_key == 'your-api-key'

--- a/tests/providers/test_sambanova_provider.py
+++ b/tests/providers/test_sambanova_provider.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -95,7 +95,7 @@ def test_sambanova_provider_with_openai_client():
 
 
 def test_sambanova_provider_with_http_client():
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = SambaNovaProvider(api_key='foo', http_client=http_client)
     assert provider.client.api_key == 'foo'
     # The line `self._client = AsyncOpenAI(..., http_client=http_client)` is executed,

--- a/tests/providers/test_snowflake.py
+++ b/tests/providers/test_snowflake.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 import re
 
-import httpx
+import httpx2
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -94,7 +94,7 @@ def test_snowflake_provider_base_url_override(env: TestEnv) -> None:
 
 
 def test_snowflake_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = SnowflakeProvider(account='myorg-myaccount', token='pat', http_client=http_client)
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -49,7 +49,7 @@ def test_together_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_together_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = TogetherProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 

--- a/tests/providers/test_vercel.py
+++ b/tests/providers/test_vercel.py
@@ -1,6 +1,6 @@
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -122,7 +122,7 @@ def test_vercel_provider_model_profile(mocker: MockerFixture):
 
 
 def test_vercel_with_http_client():
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = VercelProvider(api_key='test-key', http_client=http_client)
     assert provider.client.api_key == 'test-key'
     assert str(provider.client.base_url) == 'https://ai-gateway.vercel.sh/v1/'

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 import re
 
-import httpx
+import httpx2
 import pytest
 from pytest_mock import MockerFixture
 
@@ -57,7 +57,7 @@ def test_zai_provider_need_api_key(env: TestEnv) -> None:
 
 
 def test_zai_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx2.AsyncClient()
     provider = ZaiProvider(http_client=http_client, api_key='api-key')
     assert provider.client._client == http_client  # pyright: ignore[reportPrivateUsage]
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Literal, cast
 
+import httpx2
 import pytest
 from httpx import AsyncClient
 from pydantic import BaseModel
@@ -60,7 +61,6 @@ from pydantic_ai.models import (
     ModelRequestContext,
     ModelRequestParameters,
     ModelResolutionContext,
-    create_async_http_client,
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
@@ -132,7 +132,7 @@ pytestmark = [
 
 # We need to use a custom cached HTTP client here as the default one created for OpenAIProvider will be closed automatically
 # at the end of each test, but we need this one to live longer.
-http_client = create_async_http_client()
+http_client = httpx2.AsyncClient()
 
 
 @pytest.fixture(autouse=True, scope='module')

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -161,6 +161,10 @@ def test_docs_examples(
     mocker.patch('httpx.Client.post', side_effect=http_request)
     mocker.patch('httpx.AsyncClient.get', side_effect=async_http_request)
     mocker.patch('httpx.AsyncClient.post', side_effect=async_http_request)
+    mocker.patch('httpx2.Client.get', side_effect=http_request)
+    mocker.patch('httpx2.Client.post', side_effect=http_request)
+    mocker.patch('httpx2.AsyncClient.get', side_effect=async_http_request)
+    mocker.patch('httpx2.AsyncClient.post', side_effect=async_http_request)
     mocker.patch('random.randint', return_value=4)
     mocker.patch('rich.prompt.Prompt.ask', side_effect=rich_prompt_ask)
 

--- a/tests/test_httpx2_sdk_readiness.py
+++ b/tests/test_httpx2_sdk_readiness.py
@@ -1,0 +1,86 @@
+from __future__ import annotations as _annotations
+
+import subprocess
+import sys
+import textwrap
+
+import httpx2
+import pytest
+from anthropic import AsyncAnthropic
+from google.genai import Client as GoogleClient
+from google.genai.types import HttpOptions
+from groq import AsyncGroq
+from pydantic import ValidationError
+
+_HTTPX_FREE_CORE = """
+import sys
+
+
+class BlockHttpx:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'httpx' or fullname.startswith('httpx.'):
+            raise ImportError('httpx is not installed')
+
+
+sys.meta_path.insert(0, BlockHttpx())
+
+import asyncio
+import typing
+
+from pydantic_ai import Agent
+from pydantic_ai.agent.spec import AgentSpec
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.providers import Provider
+
+assert asyncio.run(Agent('test').run('hello')).output
+assert AgentSpec.model_json_schema_with_capabilities()
+assert typing.get_type_hints(Provider)
+
+
+async def stream_function(messages, info):
+    for word in ['hello ', 'world']:
+        yield word
+
+
+async def break_out_of_stream():
+    async with Agent(FunctionModel(stream_function=stream_function)).run_stream('hello') as result:
+        async for _ in result.stream_output():
+            break
+
+
+asyncio.run(break_out_of_stream())
+assert not any(name == 'httpx' or name.startswith('httpx.') for name in sys.modules), 'the SDK-less core imported httpx'
+"""
+
+
+def test_core_runs_without_httpx() -> None:
+    result = subprocess.run(
+        [sys.executable, '-W', 'error', '-c', textwrap.dedent(_HTTPX_FREE_CORE)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ''
+
+
+async def test_anthropic_still_rejects_httpx2_client() -> None:
+    async with httpx2.AsyncClient() as client:
+        with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
+            AsyncAnthropic(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
+
+
+async def test_groq_still_rejects_httpx2_client() -> None:
+    async with httpx2.AsyncClient() as client:
+        with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
+            AsyncGroq(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
+
+
+async def test_google_still_rejects_httpx2_client() -> None:
+    async with httpx2.AsyncClient() as client:
+        with pytest.raises(ValidationError, match='httpx_async_client'):
+            GoogleClient(
+                api_key='test',
+                http_options=HttpOptions(
+                    httpx_async_client=client,  # pyright: ignore[reportArgumentType]
+                ),
+            )

--- a/tests/test_httpx2_sdk_readiness.py
+++ b/tests/test_httpx2_sdk_readiness.py
@@ -6,10 +6,6 @@ import textwrap
 
 import httpx2
 import pytest
-from anthropic import AsyncAnthropic
-from google.genai import Client as GoogleClient
-from google.genai.types import HttpOptions
-from groq import AsyncGroq
 from pydantic import ValidationError
 
 _HTTPX_FREE_CORE = """
@@ -64,18 +60,28 @@ def test_core_runs_without_httpx() -> None:
 
 
 async def test_anthropic_still_rejects_httpx2_client() -> None:
+    pytest.importorskip('anthropic')
+    from anthropic import AsyncAnthropic
+
     async with httpx2.AsyncClient() as client:
         with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
             AsyncAnthropic(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
 
 
 async def test_groq_still_rejects_httpx2_client() -> None:
+    pytest.importorskip('groq')
+    from groq import AsyncGroq
+
     async with httpx2.AsyncClient() as client:
         with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
             AsyncGroq(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
 
 
 async def test_google_still_rejects_httpx2_client() -> None:
+    pytest.importorskip('google.genai')
+    from google.genai import Client as GoogleClient
+    from google.genai.types import HttpOptions
+
     async with httpx2.AsyncClient() as client:
         with pytest.raises(ValidationError, match='httpx_async_client'):
             GoogleClient(

--- a/tests/test_httpx2_sdk_readiness.py
+++ b/tests/test_httpx2_sdk_readiness.py
@@ -8,6 +8,21 @@ import httpx2
 import pytest
 from pydantic import ValidationError
 
+from .conftest import try_import
+
+with try_import() as anthropic_imports_successful:
+    from anthropic import AsyncAnthropic
+
+with try_import() as groq_imports_successful:
+    from groq import AsyncGroq
+
+with try_import() as google_imports_successful:
+    from google.genai import Client as GoogleClient
+    from google.genai.types import HttpOptions
+
+with try_import() as mistral_imports_successful:
+    from mistralai.client import Mistral
+
 _HTTPX_FREE_CORE = """
 import sys
 
@@ -59,29 +74,22 @@ def test_core_runs_without_httpx() -> None:
     assert result.stderr == ''
 
 
+@pytest.mark.skipif(not anthropic_imports_successful(), reason='anthropic not installed')
 async def test_anthropic_still_rejects_httpx2_client() -> None:
-    pytest.importorskip('anthropic')
-    from anthropic import AsyncAnthropic
-
     async with httpx2.AsyncClient() as client:
         with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
             AsyncAnthropic(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
 
 
+@pytest.mark.skipif(not groq_imports_successful(), reason='groq not installed')
 async def test_groq_still_rejects_httpx2_client() -> None:
-    pytest.importorskip('groq')
-    from groq import AsyncGroq
-
     async with httpx2.AsyncClient() as client:
         with pytest.raises(TypeError, match=r'Expected an instance of `httpx\.AsyncClient`'):
             AsyncGroq(api_key='test', http_client=client)  # pyright: ignore[reportArgumentType]
 
 
+@pytest.mark.skipif(not google_imports_successful(), reason='google-genai not installed')
 async def test_google_still_rejects_httpx2_client() -> None:
-    pytest.importorskip('google.genai')
-    from google.genai import Client as GoogleClient
-    from google.genai.types import HttpOptions
-
     async with httpx2.AsyncClient() as client:
         with pytest.raises(ValidationError, match='httpx_async_client'):
             GoogleClient(
@@ -92,10 +100,8 @@ async def test_google_still_rejects_httpx2_client() -> None:
             )
 
 
+@pytest.mark.skipif(not mistral_imports_successful(), reason='mistral not installed')
 async def test_mistral_accepts_httpx2_client() -> None:
-    pytest.importorskip('mistralai')
-    from mistralai.client import Mistral
-
     async with httpx2.AsyncClient() as client:
         mistral_client = Mistral(api_key='test', async_client=client)  # pyright: ignore[reportArgumentType]
 

--- a/tests/test_httpx2_sdk_readiness.py
+++ b/tests/test_httpx2_sdk_readiness.py
@@ -90,3 +90,13 @@ async def test_google_still_rejects_httpx2_client() -> None:
                     httpx_async_client=client,  # pyright: ignore[reportArgumentType]
                 ),
             )
+
+
+async def test_mistral_accepts_httpx2_client() -> None:
+    pytest.importorskip('mistralai')
+    from mistralai.client import Mistral
+
+    async with httpx2.AsyncClient() as client:
+        mistral_client = Mistral(api_key='test', async_client=client)  # pyright: ignore[reportArgumentType]
+
+        assert mistral_client.sdk_configuration.async_client is client

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
+import httpx2
 import pytest
 from pydantic import BaseModel, Field
 from pydantic.errors import PydanticUserError
@@ -63,7 +64,7 @@ from pydantic_ai.exceptions import (
     UsageLimitExceeded,
     UserError,
 )
-from pydantic_ai.models import ModelRequestParameters, ModelResolutionContext, create_async_http_client
+from pydantic_ai.models import ModelRequestParameters, ModelResolutionContext
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
@@ -139,7 +140,7 @@ pytestmark = [
 
 # We need to use a custom cached HTTP client here as the default one created for OpenAIProvider will be closed automatically
 # at the end of each test, but we need this one to live longer.
-http_client = create_async_http_client()
+http_client = httpx2.AsyncClient()
 
 
 @pytest.fixture(autouse=True, scope='module')

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import gzip
+import subprocess
+import sys
+import textwrap
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -674,6 +677,77 @@ class TestSafeDownload:
             await safe_download('https://example.com/file.txt')
 
         assert isinstance(exc_info.value, httpx.HTTPStatusError)
+
+    def test_safe_download_works_without_legacy_httpx(self) -> None:
+        """The public download boundary remains usable when only httpx2 is installed."""
+        script = """
+            import asyncio
+            import sys
+
+            import httpx2
+
+
+            class BlockHttpx:
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == 'httpx' or fullname.startswith('httpx.'):
+                        raise ImportError('httpx is not installed')
+
+
+            sys.meta_path.insert(0, BlockHttpx())
+
+            from pydantic_ai import _ssrf
+
+
+            class FailingClient:
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *args):
+                    return False
+
+                async def get(self, url, **kwargs):
+                    request = httpx2.Request('GET', url)
+                    raise httpx2.ConnectError('Connection failed', request=request)
+
+
+            async def validate_and_resolve_url(url, allow_local):
+                return _ssrf.ResolvedUrl(
+                    resolved_ip='93.184.216.34',
+                    hostname='example.com',
+                    port=80,
+                    is_https=False,
+                    path='/',
+                )
+
+
+            def create_httpx2_client(*, timeout):
+                return FailingClient()
+
+
+            _ssrf.validate_and_resolve_url = validate_and_resolve_url
+            _ssrf.create_httpx2_client = create_httpx2_client
+
+
+            async def main():
+                try:
+                    await _ssrf.safe_download('http://example.com')
+                except httpx2.RequestError as error:
+                    assert type(error) is httpx2.RequestError
+                else:
+                    raise AssertionError('safe_download did not raise the failed request')
+
+
+            asyncio.run(main())
+            assert not any(name == 'httpx' or name.startswith('httpx.') for name in sys.modules)
+        """
+        result = subprocess.run(
+            [sys.executable, '-W', 'error', '-c', textwrap.dedent(script)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == ''
 
     @pytest.fixture
     def serve_requests(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> Callable[[RequestHandler], None]:

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -7,8 +7,13 @@ from collections.abc import AsyncIterator, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import httpx
+import httpx2 as httpx
 import pytest
+
+try:
+    import httpx as legacy_httpx
+except ImportError:  # pragma: no cover
+    legacy_httpx = None
 
 from pydantic_ai import _ssrf
 from pydantic_ai._ssrf import (
@@ -52,7 +57,7 @@ def mock_ssrf_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
         client.__aenter__.return_value = client
         return client
 
-    monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', factory_wrapper)
+    monkeypatch.setattr('pydantic_ai._ssrf.create_httpx2_client', factory_wrapper)
     return mock
 
 
@@ -636,6 +641,40 @@ class TestSafeDownload:
         assert call_args[1]['headers']['Host'] == 'example.com'
         assert call_args[1]['extensions'] == {'sni_hostname': 'example.com'}
 
+    @pytest.mark.skipif(legacy_httpx is None, reason='legacy httpx is not installed')
+    async def test_request_errors_remain_compatible_with_legacy_httpx(
+        self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock
+    ) -> None:
+        """Public download errors keep matching legacy httpx request handlers when available."""
+        assert legacy_httpx is not None
+        request = httpx.Request('GET', 'https://93.184.215.14/file.txt')
+        client = AsyncMock()
+        client.get.side_effect = httpx.ConnectError('Connection failed', request=request)
+        mock_ssrf_client.return_value = client
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        with pytest.raises(legacy_httpx.RequestError) as exc_info:
+            await safe_download('https://example.com/file.txt')
+
+        assert isinstance(exc_info.value, httpx.RequestError)
+
+    @pytest.mark.skipif(legacy_httpx is None, reason='legacy httpx is not installed')
+    async def test_status_errors_remain_compatible_with_legacy_httpx(
+        self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock
+    ) -> None:
+        """Public download errors keep matching legacy httpx status handlers when available."""
+        assert legacy_httpx is not None
+        request = httpx.Request('GET', 'https://93.184.215.14/file.txt')
+        client = AsyncMock()
+        client.get.return_value = httpx.Response(404, request=request)
+        mock_ssrf_client.return_value = client
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+
+        with pytest.raises(legacy_httpx.HTTPStatusError) as exc_info:
+            await safe_download('https://example.com/file.txt')
+
+        assert isinstance(exc_info.value, httpx.HTTPStatusError)
+
     @pytest.fixture
     def serve_requests(self, mock_dns: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> Callable[[RequestHandler], None]:
         """Serves canned responses to `safe_download` through an `httpx.MockTransport`.
@@ -650,7 +689,7 @@ class TestSafeDownload:
             def create_http_client(*, timeout: int) -> httpx.AsyncClient:
                 return client
 
-            monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+            monkeypatch.setattr('pydantic_ai._ssrf.create_httpx2_client', create_http_client)
 
         return serve
 
@@ -1072,7 +1111,7 @@ class TestSafeDownload:
 
         Without proper cleanup, each call to `safe_download` leaks an unclosed
         `httpx.AsyncClient`. After switching from cached_async_http_client (which
-        reused a global) to `create_async_http_client` (new client per call),
+        reused a global) to `create_httpx2_client` (new client per call),
         the client must be explicitly closed.
 
         Regression test for PR #4421 auto-review feedback.
@@ -1093,7 +1132,7 @@ class TestSafeDownload:
             created_clients.append(client)
             return client
 
-        monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', tracking_create)
+        monkeypatch.setattr('pydantic_ai._ssrf.create_httpx2_client', tracking_create)
 
         response = await safe_download('https://example.com/file.txt')
         assert response.content == b'test content'

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -19,6 +19,7 @@ from types import TracebackType
 from typing import Any, Literal, cast
 from unittest.mock import MagicMock
 
+import httpx2
 import pytest
 from pydantic import BaseModel
 from pydantic_core import ErrorDetails
@@ -6371,6 +6372,44 @@ async def test_run_stream_cancel_guard_suppresses_transport_error():
             ),
         ]
     )
+
+
+async def test_stream_cancel_guard_suppresses_httpx2_transport_error():
+    @dataclass
+    class _HTTPX2Stream(models.StreamedResponse):
+        async def _get_event_iterator(self) -> AsyncIterator[Any]:
+            for event in self._parts_manager.handle_text_delta(vendor_part_id=0, content='x'):
+                yield event
+            if self.cancelled:
+                raise httpx2.StreamClosed()
+
+        async def close_stream(self) -> None:
+            pass
+
+        @property
+        def model_name(self) -> str:
+            return 'httpx2'
+
+        @property
+        def provider_name(self) -> str:
+            return 'httpx2'
+
+        @property
+        def provider_url(self) -> str | None:
+            return None
+
+        @property
+        def timestamp(self) -> _datetime:
+            return _datetime.now(tz=timezone.utc)
+
+    stream = _HTTPX2Stream(models.ModelRequestParameters())
+    iterator = stream.__aiter__()
+    await iterator.__anext__()
+    await stream.cancel()
+    async for _ in iterator:
+        pass
+
+    assert stream.get().state == 'interrupted'
 
 
 async def test_run_stream_cancel_after_complete():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -6380,8 +6380,8 @@ async def test_stream_cancel_guard_suppresses_httpx2_transport_error():
         async def _get_event_iterator(self) -> AsyncIterator[Any]:
             for event in self._parts_manager.handle_text_delta(vendor_part_id=0, content='x'):
                 yield event
-            if self.cancelled:
-                raise httpx2.StreamClosed()
+            assert self.cancelled
+            raise httpx2.StreamClosed()
 
         async def close_stream(self) -> None:
             pass

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import anyio
 import httpx
+import httpx2
 import pytest
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import PydanticSerializationError
@@ -104,7 +105,6 @@ from pydantic_ai.models import (
     ModelRequestContext,
     ModelRequestParameters,
     ModelResolutionContext,
-    create_async_http_client,
     infer_model,
     infer_model_profile,
 )
@@ -271,7 +271,7 @@ pytestmark = [
 
 # We need to use a custom cached HTTP client here as the default one created for OpenAIProvider will be closed automatically
 # at the end of each test, but we need this one to live longer.
-http_client = create_async_http_client()
+http_client = httpx2.AsyncClient()
 
 
 # Scoped to `session` rather than `module`: the `http_client` and the module-level agents that

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2448,7 +2448,7 @@ async def test_model_construction_in_workflow_passes_sandbox(
     assert result == expected_model_class
 
 
-# Regression test for the `genai_prices`/`httpx2` passthrough entries in `_workflow_runner`.
+# Regression test for the HTTPX2 stack passthrough entries in `_workflow_runner`.
 # `ModelResponse.cost()` lazily imports genai-prices on first call; inside a workflow that trips the
 # sandbox unless those modules are passed through (see #6215).
 @workflow.defn

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -9,6 +9,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import AsyncMock, Mock
 
 import httpx
+import httpx2
 import pytest
 
 from .conftest import try_import
@@ -21,9 +22,84 @@ with try_import() as imports_successful:
         wait_fixed,
     )
 
-    from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, TenacityTransport, wait_retry_after
+    from pydantic_ai import PydanticAIDeprecationWarning
+    from pydantic_ai.retries import (
+        AsyncHTTPX2TenacityTransport,
+        AsyncTenacityTransport,
+        HTTPX2TenacityTransport,
+        RetryConfig,
+        TenacityTransport,
+        wait_retry_after,
+    )
 
-pytestmark = pytest.mark.skipif(not imports_successful(), reason='install tenacity to run tenacity tests')
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='install tenacity to run tenacity tests'),
+    pytest.mark.filterwarnings('ignore::pydantic_ai._warnings.PydanticAIDeprecationWarning'),
+]
+
+
+class TestHTTPX2TenacityTransport:
+    """HTTPX2 retry transports use the same Tenacity configuration as their HTTPX predecessors."""
+
+    def test_sync_transport_retries_response_validator(self):
+        attempts = 0
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            nonlocal attempts
+            attempts += 1
+            return httpx2.Response(503 if attempts == 1 else 200, request=request)
+
+        transport = HTTPX2TenacityTransport(
+            config=RetryConfig(
+                retry=retry_if_exception_type(httpx2.HTTPStatusError),
+                stop=stop_after_attempt(2),
+                wait=wait_fixed(0),
+                reraise=True,
+            ),
+            wrapped=httpx2.MockTransport(handler),
+            validate_response=lambda response: response.raise_for_status(),
+        )
+
+        with httpx2.Client(transport=transport) as client:
+            response = client.get('https://example.com')
+
+        assert response.status_code == 200
+        assert attempts == 2
+
+    async def test_async_transport_exits_wrapped_transport_once(self):
+        wrapped = AsyncMock(spec=httpx2.AsyncBaseTransport)
+        transport = AsyncHTTPX2TenacityTransport(
+            config=RetryConfig(),
+            wrapped=wrapped,
+        )
+
+        async with transport:
+            pass
+
+        wrapped.__aenter__.assert_awaited_once_with()
+        wrapped.__aexit__.assert_awaited_once_with(None, None, None)
+
+
+class TestLegacyHTTPXTransports:
+    def test_sync_transport_warns_with_httpx2_replacement(self):
+        with pytest.warns(
+            PydanticAIDeprecationWarning,
+            match=(
+                r'`TenacityTransport` is deprecated and will be removed in v3; use `HTTPX2TenacityTransport` '
+                r'with `httpx2.Client` instead\.'
+            ),
+        ):
+            TenacityTransport(RetryConfig())
+
+    def test_async_transport_warns_with_httpx2_replacement(self):
+        with pytest.warns(
+            PydanticAIDeprecationWarning,
+            match=(
+                r'`AsyncTenacityTransport` is deprecated and will be removed in v3; use `AsyncHTTPX2TenacityTransport` '
+                r'with `httpx2.AsyncClient` instead\.'
+            ),
+        ):
+            AsyncTenacityTransport(RetryConfig())
 
 
 class TestTenacityTransport:
@@ -417,6 +493,23 @@ class TestWaitRetryAfter:
         result = wait_func(retry_state)
 
         assert result == 30.0
+        fallback.assert_not_called()
+
+    def test_httpx2_retry_after_seconds_format(self):
+        fallback = Mock()
+        wait_func = wait_retry_after(fallback_strategy=fallback, max_wait=300)
+
+        request = httpx2.Request('GET', 'https://example.com')
+        response = httpx2.Response(429, headers={'retry-after': '30'}, request=request)
+        with pytest.raises(httpx2.HTTPStatusError) as exc_info:
+            response.raise_for_status()
+
+        retry_state = Mock(spec=RetryCallState)
+        retry_state.outcome = Mock()
+        retry_state.outcome.failed = True
+        retry_state.outcome.exception.return_value = exc_info.value
+
+        assert wait_func(retry_state) == 30.0
         fallback.assert_not_called()
 
     @pytest.mark.parametrize('retry_after', ['120', pytest.param('1' + '0' * 309, id='huge')])

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -41,6 +41,20 @@ pytestmark = [
 class TestHTTPX2TenacityTransport:
     """HTTPX2 retry transports use the same Tenacity configuration as their HTTPX predecessors."""
 
+    def test_sync_transport_passes_response_without_validator_and_closes_wrapped_transport(self):
+        request = httpx2.Request('GET', 'https://example.com')
+        response = httpx2.Response(200, request=request)
+        wrapped = Mock(spec=httpx2.BaseTransport)
+        wrapped.handle_request.return_value = response
+        transport = HTTPX2TenacityTransport(config=RetryConfig(), wrapped=wrapped)
+
+        assert transport.handle_request(request) is response
+
+        transport.close()
+
+        wrapped.handle_request.assert_called_once_with(request)
+        wrapped.close.assert_called_once_with()
+
     def test_sync_transport_retries_response_validator(self):
         attempts = 0
 
@@ -78,6 +92,45 @@ class TestHTTPX2TenacityTransport:
 
         wrapped.__aenter__.assert_awaited_once_with()
         wrapped.__aexit__.assert_awaited_once_with(None, None, None)
+
+    async def test_async_transport_retries_response_validator(self):
+        attempts = 0
+
+        async def handler(request: httpx2.Request) -> httpx2.Response:
+            nonlocal attempts
+            attempts += 1
+            return httpx2.Response(503 if attempts == 1 else 200, request=request)
+
+        transport = AsyncHTTPX2TenacityTransport(
+            config=RetryConfig(
+                retry=retry_if_exception_type(httpx2.HTTPStatusError),
+                stop=stop_after_attempt(2),
+                wait=wait_fixed(0),
+                reraise=True,
+            ),
+            wrapped=httpx2.MockTransport(handler),
+            validate_response=lambda response: response.raise_for_status(),
+        )
+
+        async with httpx2.AsyncClient(transport=transport) as client:
+            response = await client.get('https://example.com')
+
+        assert response.status_code == 200
+        assert attempts == 2
+
+    async def test_async_transport_passes_response_without_validator_and_closes_wrapped_transport(self):
+        request = httpx2.Request('GET', 'https://example.com')
+        response = httpx2.Response(200, request=request)
+        wrapped = AsyncMock(spec=httpx2.AsyncBaseTransport)
+        wrapped.handle_async_request.return_value = response
+        transport = AsyncHTTPX2TenacityTransport(config=RetryConfig(), wrapped=wrapped)
+
+        assert await transport.handle_async_request(request) is response
+
+        await transport.aclose()
+
+        wrapped.handle_async_request.assert_awaited_once_with(request)
+        wrapped.aclose.assert_awaited_once_with()
 
 
 class TestLegacyHTTPXTransports:

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -30,7 +30,7 @@ from ._inline_snapshot import snapshot
 from .conftest import try_import
 
 with try_import() as starlette_import_successful:
-    import httpx
+    import httpx2
     from starlette.applications import Starlette
     from starlette.responses import Response
     from starlette.testclient import TestClient
@@ -255,7 +255,7 @@ def _stub_cdn_fetch(monkeypatch: pytest.MonkeyPatch, content: bytes) -> list[int
             fetch_count[0] += 1
             return MockResponse()
 
-    monkeypatch.setattr(app_module.httpx, 'AsyncClient', MockAsyncClient)
+    monkeypatch.setattr(app_module.httpx2, 'AsyncClient', MockAsyncClient)
     return fetch_count
 
 
@@ -709,7 +709,7 @@ async def test_get_ui_html_custom_url(monkeypatch: pytest.MonkeyPatch, tmp_path:
             captured_url.append(url)
             return MockResponse()
 
-    monkeypatch.setattr(app_module.httpx, 'AsyncClient', MockAsyncClient)
+    monkeypatch.setattr(app_module.httpx2, 'AsyncClient', MockAsyncClient)
 
     # URL is used directly, no version templating
     custom_url = 'https://my-internal-cdn.example.com/ui/index.html'
@@ -813,7 +813,7 @@ def test_chat_app_index_file_not_found(tmp_path: Path):
 
 
 def test_chat_app_index_http_error(monkeypatch: pytest.MonkeyPatch):
-    """Test that index endpoint raises HTTPStatusError when CDN fetch fails."""
+    """Test that index endpoint raises httpx2 HTTPStatusError when CDN fetch fails."""
 
     class MockResponse:
         status_code = 500
@@ -827,9 +827,9 @@ def test_chat_app_index_http_error(monkeypatch: pytest.MonkeyPatch):
 
         async def get(self, url: str) -> None:
             response = MockResponse()
-            raise httpx.HTTPStatusError('Server error', request=None, response=response)  # pyright: ignore[reportArgumentType]
+            raise httpx2.HTTPStatusError('Server error', request=None, response=response)  # pyright: ignore[reportArgumentType]
 
-    monkeypatch.setattr(app_module.httpx, 'AsyncClient', MockAsyncClient)
+    monkeypatch.setattr(app_module.httpx2, 'AsyncClient', MockAsyncClient)
     # Use a fresh temp dir so there's no cached file
     monkeypatch.setattr(app_module, '_get_cache_dir', lambda: Path('/tmp/nonexistent-cache-dir-for-test'))
 
@@ -837,5 +837,5 @@ def test_chat_app_index_http_error(monkeypatch: pytest.MonkeyPatch):
     app = create_web_app(agent)
 
     with TestClient(app, raise_server_exceptions=True) as client:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx2.HTTPStatusError):
             client.get('/')

--- a/tests/test_web_fetch.py
+++ b/tests/test_web_fetch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from pydantic_ai.common_tools.web_fetch import (
@@ -316,8 +316,6 @@ class TestWebFetchLocalTool:
 
     async def test_http_error_raises_model_retry(self):
         """HTTP errors are converted to ModelRetry."""
-        import httpx
-
         from pydantic_ai.exceptions import ModelRetry
 
         request = httpx.Request('GET', 'https://example.com')
@@ -503,7 +501,7 @@ class TestWebFetchLocalTool:
             def create_http_client(*, timeout: int) -> httpx.AsyncClient:
                 return client
 
-            monkeypatch.setattr('pydantic_ai._ssrf.create_async_http_client', create_http_client)
+            monkeypatch.setattr('pydantic_ai._ssrf.create_httpx2_client', create_http_client)
 
         return serve
 

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ genai-prices = false
 pydantic-extra-types = false
 pydantic-core = false
 pydantic = false
+mistralai = "2026-08-11T07:51:18Z"
 logfire-api = false
 
 [manifest]
@@ -3483,7 +3484,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.7.1"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
@@ -3495,9 +3496,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/e0/bc0188444f122083e1cd554a33440589f4c7a55bab57563333f004cf4934/mistralai-2.7.1.tar.gz", hash = "sha256:1b67a224a9387b33d8ca381d24cd8d075dbe6650af305d763d71c4cad06b2ddf", size = 530696, upload-time = "2026-07-21T13:12:51.041Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/d9/bc41311a7bd3f34f3aa508329fbaf675482643db7301efba2c3d7cdcc7c6/mistralai-2.9.2.tar.gz", hash = "sha256:50d98863aea6588d825a962aa3684361d1446d9f6f4530028705dac2799603ed", size = 537750, upload-time = "2026-08-11T07:51:17.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/1a/c502cad6ebb3363911ad30ec0318c216dcac4f5be485651b7672bdcd3ff7/mistralai-2.7.1-py3-none-any.whl", hash = "sha256:25a78835e52eb44ca8c10046dbb1635545c53c40a06397075df246c82f12b186", size = 1266550, upload-time = "2026-07-21T13:12:49.5Z" },
+    { url = "https://files.pythonhosted.org/packages/35/cf/3e90441960bfea6559cb6af5d1ca3c6ff9d39866a4fe0d19b4e85cc45786/mistralai-2.9.2-py3-none-any.whl", hash = "sha256:9d90b85b25c409e50aabe150350aa680f71e0803c0273d177a0379912f73bc45", size = 1282115, upload-time = "2026-08-11T07:51:16.005Z" },
 ]
 
 [[package]]
@@ -5734,7 +5735,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=1.3.4,<2.0.0" },
     { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.39.0" },
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
-    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.9.2" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'bedrock-mantle'", specifier = ">=2.47.0" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'openai'", specifier = ">=2.47.0" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'openrouter'", specifier = ">=2.47.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1374,7 +1374,7 @@ name = "cuda-bindings"
 version = "13.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/63/579402b642f5b9b8ceb79e456b39b5771f27e132a8af3b140e54d69790fc/cuda_bindings-13.1.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4400370a83f1538e25ed4c18c34a0e9d5fad39741e282e69ce24d1479a11017d", size = 15777291, upload-time = "2025-12-09T22:05:41.109Z" },
@@ -1409,43 +1409,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future" },
+    { name = "future", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -2532,15 +2532,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.3.0"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415", size = 80024, upload-time = "2026-06-01T13:15:00.001Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
 ]
 
 [[package]]
@@ -2581,17 +2581,18 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.3.0"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpcore2" },
     { name = "idna" },
     { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7", size = 74538, upload-time = "2026-06-01T13:15:01.566Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -2603,16 +2604,16 @@ resolution-markers = [
     "python_full_version == '3.14.*'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "shellingham" },
-    { name = "tqdm" },
-    { name = "typer-slim" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version >= '3.14'" },
+    { name = "fsspec", marker = "python_full_version >= '3.14'" },
+    { name = "hf-xet", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine == 'AMD64') or (python_full_version >= '3.14' and platform_machine == 'aarch64') or (python_full_version >= '3.14' and platform_machine == 'amd64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version >= '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.14'" },
+    { name = "shellingham", marker = "python_full_version >= '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.14'" },
+    { name = "typer-slim", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/25/74af9d16cd59ae15b12467a79a84aa0fe24be4aba68fc4da0c1864d49c17/huggingface_hub-1.3.4.tar.gz", hash = "sha256:c20d5484a611b7b7891d272e8fc9f77d5de025b0480bdacfa858efb3780b455f", size = 627683, upload-time = "2026-01-26T14:05:10.656Z" }
 wheels = [
@@ -2630,15 +2631,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", version = "1.4.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "hf-xet", version = "1.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
@@ -2665,11 +2666,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -3011,15 +3012,15 @@ name = "langchain-core"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpatch" },
-    { name = "langchain-protocol" },
-    { name = "langsmith" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "uuid-utils" },
+    { name = "jsonpatch", marker = "python_full_version < '3.14'" },
+    { name = "langchain-protocol", marker = "python_full_version < '3.14'" },
+    { name = "langsmith", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tenacity", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "uuid-utils", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
@@ -3031,7 +3032,7 @@ name = "langchain-protocol"
 version = "0.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
@@ -3043,7 +3044,7 @@ name = "langchain-text-splitters"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
+    { name = "langchain-core", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
 wheels = [
@@ -3055,20 +3056,20 @@ name = "langsmith"
 version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-    { name = "uuid-utils" },
-    { name = "websockets" },
-    { name = "xxhash" },
-    { name = "zstandard" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
+    { name = "distro", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "orjson", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "requests-toolbelt", marker = "python_full_version < '3.14'" },
+    { name = "sniffio", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "uuid-utils", marker = "python_full_version < '3.14'" },
+    { name = "websockets", marker = "python_full_version < '3.14'" },
+    { name = "xxhash", marker = "python_full_version < '3.14'" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/b7/43f80940a758ceb48714ccc10c7acb9564be4f0d4786e8ed5d46deb0be39/langsmith-0.9.3.tar.gz", hash = "sha256:868a007b3ecda002914b21212a953c77fcb1d71a8a09a94562c3b57941d3df3a", size = 4577380, upload-time = "2026-06-26T15:56:30.45Z" }
 wheels = [
@@ -3162,7 +3163,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.37.0"
+version = "4.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -3174,9 +3175,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/f2/34b8ebbd6bbd82c71055d6b881b24d8ada79a0e6692d3dd8cca5e86fadb3/logfire-4.37.0.tar.gz", hash = "sha256:7ee0cb64b59c356a41a1701fb84597037f8db1fa15df7a3715ef363e5a1de06a", size = 1212176, upload-time = "2026-06-12T20:47:06.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/71/1ed06d124bd7905f60004d60cbe14c79bda00f0604bf0cb76214f8c96348/logfire-4.40.0.tar.gz", hash = "sha256:f50f9637f9b5cc3eb5f8526e473effa1992d45056c89adc7c821ee7ab2520c75", size = 1260846, upload-time = "2026-08-05T11:26:59.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/08/1805d2f26955671115aae555d78cc4c72a6fe733f332d44d69756bc1737b/logfire-4.37.0-py3-none-any.whl", hash = "sha256:a20823e6dbb3204614a3ea5e79c91df42405c5112393ec9d8e34ef45b60d315f", size = 378930, upload-time = "2026-06-12T20:47:03.674Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/65/2ed148a656362ff3b5cce0bfae619cf57ca1df33d0c942b4c1461e57f57c/logfire-4.40.0-py3-none-any.whl", hash = "sha256:0ac2c950968812f27ee68ccec4a362230acffaffb28f04945ee07729d5866fa0", size = 409440, upload-time = "2026-08-05T11:26:56.745Z" },
 ]
 
 [package.optional-dependencies]
@@ -4119,7 +4120,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -4158,7 +4159,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -4170,7 +4171,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -4200,9 +4201,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-cusparse", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -4214,7 +4215,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4277,7 +4278,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.45.0"
+version = "2.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4289,9 +4290,16 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/4b/87a877fd987db5737e43e357ff968e2c04f21be54034507fb38de5e4af99/openai-2.52.1.tar.gz", hash = "sha256:d8f2bf9f0ec8104b171f3448e98baa59a41e26906cf53f5343346d0fa7924d98", size = 1098956, upload-time = "2026-08-03T17:16:38.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7a/45d1786760bda9ac69365b40bb3f9827e40c90938e633de8716aaab864c6/openai-2.52.1-py3-none-any.whl", hash = "sha256:49cfd53cdddfd98eeca353ee8e1f02bdb66601b6f9e6bd6dc90c754accbea958", size = 1659571, upload-time = "2026-08-03T17:16:36.675Z" },
+]
+
+[package.optional-dependencies]
+httpx2 = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx2" },
 ]
 
 [[package]]
@@ -4687,8 +4695,8 @@ name = "pendulum"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/7c/009c12b86c7cc6c403aec80f8a4308598dfc5995e5c523a5491faaa3952e/pendulum-3.1.0.tar.gz", hash = "sha256:66f96303560f41d097bee7d2dc98ffca716fbb3a832c4b3062034c2d45865015", size = 85930, upload-time = "2025-04-19T14:30:01.675Z" }
 wheels = [
@@ -5338,7 +5346,7 @@ email = [
 name = "pydantic-ai"
 source = { editable = "." }
 dependencies = [
-    { name = "pydantic-ai-slim", extra = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "retries", "web"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "web"] },
 ]
 
 [package.optional-dependencies]
@@ -5381,6 +5389,9 @@ openrouter = [
 prefect = [
     { name = "pydantic-ai-slim", extra = ["prefect"] },
 ]
+retries = [
+    { name = "pydantic-ai-slim", extra = ["retries"] },
+]
 sentence-transformers = [
     { name = "pydantic-ai-slim", extra = ["sentence-transformers"] },
 ]
@@ -5420,6 +5431,7 @@ dev = [
     { name = "exa-py" },
     { name = "fastmcp" },
     { name = "genai-prices" },
+    { name = "httpx" },
     { name = "inline-snapshot" },
     { name = "markdownify" },
     { name = "pip" },
@@ -5458,7 +5470,7 @@ lint = [
 requires-dist = [
     { name = "pydantic-ai-examples", marker = "extra == 'examples'", editable = "examples" },
     { name = "pydantic-ai-slim", extras = ["ag-ui"], marker = "extra == 'ag-ui'", editable = "pydantic_ai_slim" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "retries", "web"], editable = "pydantic_ai_slim" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "web"], editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["bedrock-mantle"], marker = "extra == 'bedrock-mantle'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["cohere"], marker = "extra == 'cohere'", editable = "pydantic_ai_slim" },
@@ -5470,6 +5482,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["mistral"], marker = "extra == 'mistral'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["openrouter"], marker = "extra == 'openrouter'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["prefect"], marker = "extra == 'prefect'", editable = "pydantic_ai_slim" },
+    { name = "pydantic-ai-slim", extras = ["retries"], marker = "extra == 'retries'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["sentence-transformers"], marker = "extra == 'sentence-transformers'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["spec"], marker = "extra == 'spec'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["tavily"], marker = "extra == 'tavily'", editable = "pydantic_ai_slim" },
@@ -5479,7 +5492,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["web-fetch"], marker = "extra == 'web-fetch'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["xai"], marker = "extra == 'xai'", editable = "pydantic_ai_slim" },
 ]
-provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "exa", "examples", "groq", "huggingface", "mistral", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
+provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "exa", "examples", "groq", "huggingface", "mistral", "openrouter", "prefect", "retries", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5495,6 +5508,7 @@ dev = [
     { name = "exa-py", specifier = ">=2.0.0" },
     { name = "fastmcp", specifier = ">=3.3.0,<4" },
     { name = "genai-prices", specifier = ">=0.1.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "inline-snapshot", specifier = ">=0.32.5" },
     { name = "markdownify", specifier = ">=1.2" },
     { name = "pip", specifier = ">=26.1" },
@@ -5581,7 +5595,7 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "genai-prices" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
@@ -5601,7 +5615,7 @@ bedrock = [
 ]
 bedrock-mantle = [
     { name = "botocore" },
-    { name = "openai" },
+    { name = "openai", extra = ["httpx2"] },
 ]
 cli = [
     { name = "argcomplete" },
@@ -5647,23 +5661,24 @@ mistral = [
     { name = "mistralai" },
 ]
 openai = [
-    { name = "openai" },
+    { name = "openai", extra = ["httpx2"] },
     { name = "tiktoken" },
 ]
 openrouter = [
-    { name = "openai" },
+    { name = "openai", extra = ["httpx2"] },
 ]
 prefect = [
     { name = "prefect" },
 ]
 retries = [
+    { name = "httpx" },
     { name = "tenacity" },
 ]
 sentence-transformers = [
     { name = "sentence-transformers", marker = "python_full_version < '3.14'" },
 ]
 snowflake = [
-    { name = "openai" },
+    { name = "openai", extra = ["httpx2"] },
 ]
 spec = [
     { name = "pydantic-handlebars" },
@@ -5682,7 +5697,6 @@ voyageai = [
     { name = "voyageai", marker = "python_full_version < '3.14'" },
 ]
 web = [
-    { name = "httpx" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -5693,7 +5707,7 @@ xai = [
     { name = "xai-sdk" },
 ]
 zai = [
-    { name = "openai" },
+    { name = "openai", extra = ["httpx2"] },
 ]
 
 [package.metadata]
@@ -5715,17 +5729,17 @@ requires-dist = [
     { name = "griffelib", specifier = ">=2.0" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=0.25.0" },
     { name = "hf-xet", marker = "(platform_machine == 'AMD64' and extra == 'huggingface') or (platform_machine == 'aarch64' and extra == 'huggingface') or (platform_machine == 'amd64' and extra == 'huggingface') or (platform_machine == 'arm64' and extra == 'huggingface') or (platform_machine == 'x86_64' and extra == 'huggingface')", specifier = "<1.5.0" },
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27.0" },
+    { name = "httpx", marker = "extra == 'retries'", specifier = ">=0.27" },
+    { name = "httpx2", specifier = ">=2.7" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=1.3.4,<2.0.0" },
-    { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.16.0" },
+    { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.39.0" },
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
-    { name = "openai", marker = "extra == 'bedrock-mantle'", specifier = ">=2.45.0" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0" },
-    { name = "openai", marker = "extra == 'openrouter'", specifier = ">=2.45.0" },
-    { name = "openai", marker = "extra == 'snowflake'", specifier = ">=2.45.0" },
-    { name = "openai", marker = "extra == 'zai'", specifier = ">=2.45.0" },
+    { name = "openai", extras = ["httpx2"], marker = "extra == 'bedrock-mantle'", specifier = ">=2.47.0" },
+    { name = "openai", extras = ["httpx2"], marker = "extra == 'openai'", specifier = ">=2.47.0" },
+    { name = "openai", extras = ["httpx2"], marker = "extra == 'openrouter'", specifier = ">=2.47.0" },
+    { name = "openai", extras = ["httpx2"], marker = "extra == 'snowflake'", specifier = ">=2.47.0" },
+    { name = "openai", extras = ["httpx2"], marker = "extra == 'zai'", specifier = ">=2.47.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.7.5" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3" },
@@ -5928,7 +5942,6 @@ name = "pydantic-graph"
 source = { editable = "pydantic_graph" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
@@ -5937,7 +5950,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.7.0" },
-    { name = "httpx", specifier = ">=0.27" },
     { name = "logfire-api", specifier = ">=3.14.1" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
@@ -6530,7 +6542,7 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -6848,10 +6860,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -6897,10 +6909,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -6950,7 +6962,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -7011,7 +7023,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -7175,16 +7187,16 @@ name = "sentence-transformers"
 version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "torch" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "transformers", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/bc/0bc9c0ec1cf83ab2ec6e6f38667d167349b950fff6dd2086b79bd360eeca/sentence_transformers-5.2.2.tar.gz", hash = "sha256:7033ee0a24bc04c664fd490abf2ef194d387b3a58a97adcc528783ff505159fa", size = 381607, upload-time = "2026-01-27T11:11:02.658Z" }
 wheels = [
@@ -7350,7 +7362,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -7375,8 +7387,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [
@@ -7615,21 +7627,21 @@ name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "cuda-bindings", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "nvidia-cudnn-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "triton", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/e7/19894fdb51c7dbaf94f5a79bb0871da0992e8e4241e579cb006da46d2e58/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", size = 111178962, upload-time = "2026-07-08T16:05:49.855Z" },
@@ -7675,15 +7687,15 @@ name = "transformers"
 version = "5.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "safetensors" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "regex", marker = "python_full_version < '3.14'" },
+    { name = "safetensors", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/418169401560cec2b61512e6bf37b0cfb4c8e27700cfa868a1de073cb65d/transformers-5.13.1.tar.gz", hash = "sha256:1e2452d6778a7482158df5d5dacf6bf775d5b2fdcfce33caaf7f6b0e5f3e3397", size = 9196891, upload-time = "2026-07-11T09:15:50.845Z" }
 wheels = [
@@ -7742,10 +7754,10 @@ resolution-markers = [
     "python_full_version == '3.14.*'",
 ]
 dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "python_full_version >= '3.14'" },
+    { name = "rich", marker = "python_full_version >= '3.14'" },
+    { name = "shellingham", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
 wheels = [
@@ -7763,10 +7775,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "python_full_version < '3.14'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "rich", marker = "python_full_version < '3.14'" },
+    { name = "shellingham", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
@@ -7964,16 +7976,16 @@ name = "voyageai"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "aiolimiter" },
-    { name = "ffmpeg-python" },
-    { name = "langchain-text-splitters" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "tenacity" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "aiolimiter", marker = "python_full_version < '3.14'" },
+    { name = "ffmpeg-python", marker = "python_full_version < '3.14'" },
+    { name = "langchain-text-splitters", marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pillow", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "tenacity", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/16/1b46b3cd401e1717a68197c1fe336d7bb4e0a1833f8105e1738f5b1add05/voyageai-0.3.7.tar.gz", hash = "sha256:826cd97f97223f42b5babc5c459c9c80f3a8215ce5c0e007b0b276550f790d24", size = 26485, upload-time = "2025-12-16T18:43:05.26Z" }
 wheels = [
@@ -8197,7 +8209,7 @@ name = "whenever"
 version = "0.8.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/67/cfc23dfe54ced1e4388826b29db9b9ab2c70a342b33b7e92cf15866f35a6/whenever-0.8.10.tar.gz", hash = "sha256:5e2a3da71527e299f98eec5bb38c4e79d9527a127107387456125005884fb235", size = 240223, upload-time = "2025-10-16T20:31:23.538Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -5653,6 +5653,7 @@ huggingface = [
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },
+    { name = "opentelemetry-instrumentation-httpx" },
 ]
 mcp = [
     { name = "fastmcp-slim", extra = ["client"] },
@@ -5741,6 +5742,7 @@ requires-dist = [
     { name = "openai", extras = ["httpx2"], marker = "extra == 'snowflake'", specifier = ">=2.47.0" },
     { name = "openai", extras = ["httpx2"], marker = "extra == 'zai'", specifier = ">=2.47.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
+    { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'logfire'", specifier = ">=0.65b0" },
     { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.7.5" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2.12" },

--- a/uv.lock
+++ b/uv.lock
@@ -2679,7 +2679,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -4317,32 +4317,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -4353,14 +4352,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4368,14 +4367,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -4384,28 +4383,28 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asyncpg"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/ec/6bd1dba7435cf54b52046d89cac1541d0cc4411f74adbcec50420025f4f5/opentelemetry_instrumentation_asyncpg-0.60b1.tar.gz", hash = "sha256:56dbafc800b83de839e8048cc0a8b76dc2d4182fce6f1fd94aa95ba3f8a2f800", size = 8725, upload-time = "2025-12-11T13:36:48.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/de/21b57f84a41385d7055547c03b491b0de0531b0fa5a03cd4a6499a57a8f8/opentelemetry_instrumentation_asyncpg-0.65b0.tar.gz", hash = "sha256:0b14338886f17c18a9899d6764117a4c163a9826f6ed1577f68ee773f95ebbc2", size = 11202, upload-time = "2026-07-16T15:25:57.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/99/04899e21a64dff4e551c63b4426c921628a73df8fbe9cd1f60b18bd9142e/opentelemetry_instrumentation_asyncpg-0.60b1-py3-none-any.whl", hash = "sha256:3d64346571822188445bef7c8219709e6ee76f9ed2583a07c503e619f6dd4169", size = 10087, upload-time = "2025-12-11T13:35:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/18/c021ac484e447fd185a968cf3b134b67c30bfbda6f0add347da1d7c109e2/opentelemetry_instrumentation_asyncpg-0.65b0-py3-none-any.whl", hash = "sha256:9156d2501021b968da0f317eb508d3efb3e7506bf50e00ee477ce0636a12772a", size = 9744, upload-time = "2026-07-16T15:25:00.172Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-dbapi"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4413,14 +4412,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/b5/1e1f0642892a2abb6e75b7009ccee946e801cded88caac3d803cf46c8c73/opentelemetry_instrumentation_dbapi-0.60b1.tar.gz", hash = "sha256:a239d328249b86fba5e42900b98bf31ee99c07092530feca18afde92c600f901", size = 16311, upload-time = "2025-12-11T13:36:55.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/97/b2e0ae6951cbf93c0c211910077cb50f9478fb4b7e89a402800b9a98151c/opentelemetry_instrumentation_dbapi-0.65b0.tar.gz", hash = "sha256:da048bb683347ddad2f47344bacfe1e111bf7bfb2e5a39796b1083679ad4f0f3", size = 20247, upload-time = "2026-07-16T15:26:02.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/08/d4c78b6e317d9975d473dd98f7854f5731ff4a1d470c65d2630fa68a1484/opentelemetry_instrumentation_dbapi-0.60b1-py3-none-any.whl", hash = "sha256:5577189f678de5b9828c930c8fb72e8f1999b304131777b60099e5c4b3948193", size = 13968, upload-time = "2025-12-11T13:35:56.316Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e3/106953cea1d7f9318a4b56827ad10839fda3d033ecea2db717c051bf6a60/opentelemetry_instrumentation_dbapi-0.65b0-py3-none-any.whl", hash = "sha256:50b662578a6903b028e09b73f604de687752f5f904aa0ca032969157b29d60f2", size = 14815, upload-time = "2026-07-16T15:25:08.361Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4429,14 +4428,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4445,71 +4444,71 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/03/a529140241addd4d0acc73bafbd6f74691651b92fc0ae9b4513cf80f07fa/opentelemetry_instrumentation_httpx-0.65b0.tar.gz", hash = "sha256:4627aa9c6bb99bf4462c8b565b0ef6aeb9ffad95c6c92868be1ef7895de112ee", size = 26309, upload-time = "2026-07-16T15:26:07.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0f/c6144096b4914bbf44b43ba21c962e8f333ff045770b50a3e79ed8bd455f/opentelemetry_instrumentation_httpx-0.65b0-py3-none-any.whl", hash = "sha256:400f1b78afa4ee2332b5debe58e1ed1b317913d58812c952576be76660aeadb1", size = 17436, upload-time = "2026-07-16T15:25:15.772Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-sqlite3"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-dbapi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/33/fafa354b529a7e9b5a5dc4155953bae1ff71622334a420d19f7e1d65e7cc/opentelemetry_instrumentation_sqlite3-0.60b1.tar.gz", hash = "sha256:d716b9d89d31dc426ccedefcdbf96cba1897dfe020d21e5e5ea82a782d03e1d6", size = 7922, upload-time = "2025-12-11T13:37:13.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/93/3716b653b0dd8f7122afe5228d77604309478378afbd4f92699a68f686e8/opentelemetry_instrumentation_sqlite3-0.65b0.tar.gz", hash = "sha256:f11fb91d159724037cadf970d5b612da720b38bd67d1c25d48c5ae09116eacc6", size = 8419, upload-time = "2026-07-16T15:26:19.834Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/64/be1c8a6d17cf2860f41206828cbabe39b71345cc95626b91c84f48e96066/opentelemetry_instrumentation_sqlite3-0.60b1-py3-none-any.whl", hash = "sha256:7666853b9df186b81e587320aaa03da3f1ce46ba9277b62d8ea20a745886031c", size = 9338, upload-time = "2025-12-11T13:36:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c9/636d87853b46228e1714063fb0c4f4fc69d85f9e06febce65620d60d3505/opentelemetry_instrumentation_sqlite3-0.65b0-py3-none-any.whl", hash = "sha256:d9ca2e3a5ab0e9f8ee1c55f4713e1b1bb626dfd57e57950e228cbd0aa9381ae1", size = 8525, upload-time = "2026-07-16T15:25:33.01Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.39.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.60b1"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

- Closes #7376

Remove the temporary Mistral seven-day cutoff and the Logfire/OpenTelemetry `LoggingHandler` deprecation-warning filter.

This PR must remain a draft until both of these conditions hold:

- Mistral 2.9.2 is admitted by the rolling seven-day cutoff around 2026-08-18 07:51 UTC.
- The fix in https://github.com/pydantic/logfire/pull/2094 has shipped in a Logfire release.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

