### PR TITLE
docs: correct SpanNode duration contract

### DIFF
--- a/CONTRIBUTION_PLAN.md
+++ b/CONTRIBUTION_PLAN.md
@@ -1,0 +1,14 @@
+# Issue 7169 plan
+
+Issue: https://github.com/pydantic/pydantic-ai/issues/7169
+
+Goal: validate and document the combination of `OpenAIResponsesModel`, `DeepSeekProvider`, and the public `deepseek-v4-flash` model identifier for DeepSeek V4 Flash 0731.
+
+Proposed scope after maintainer alignment:
+
+1. Confirm whether the existing OpenAI Responses implementation already handles DeepSeek's streamed and non-streamed response shapes.
+2. Add provider/model compatibility tests for ordinary output, reasoning content, tool calls, structured output, and response continuation.
+3. Add a short documentation example only if the generic implementation is already compatible.
+4. Avoid provider-specific production code unless a reproducible DeepSeek incompatibility requires it.
+
+Current status: plan only. Pydantic AI's contribution guide requires maintainer alignment and assignment before implementing a non-trivial provider feature.

--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -100,7 +100,7 @@ class SpanNode:
 
     @property
     def duration(self) -> timedelta:
-        """Return the span's duration as a timedelta, or None if start/end not set."""
+        """Return the span's duration as a timedelta."""
         return self.end_timestamp - self.start_timestamp
 
     @property


### PR DESCRIPTION
Closes #7367.

The `SpanNode.duration` implementation requires both timestamps and always returns a `timedelta`, so its docstring should not advertise a possible `None` return.

Validation:
- `git diff --check`
- `uv run pytest pydantic_evals/tests -q --disable-warnings --maxfail=1` (dependency setup blocked by a transient GitHub fetch reset for the pinned `pydantic-docs` revision before tests ran.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

