### PR TITLE
Support `minLength`/`maxLength` in OpenAI strict mode via opt-in `strict_supports_length_constraints`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from .._json_schema import JsonSchema, JsonSchemaTransformer
 from ..exceptions import UserError
@@ -375,7 +375,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
     # `default_structured_output_mode` is `'tool'`, so `native` is only used when the user specifically uses
     # the `NativeOutput` marker, so an error from the API is acceptable.
     return OpenAIModelProfile(
-        json_schema_transformer=OpenAIJsonSchemaTransformer,
+        json_schema_transformer=OpenAINativeJsonSchemaTransformer,
         supports_json_schema_output=True,
         supports_json_object_output=True,
         supports_image_output=supports_image_output,
@@ -484,6 +484,11 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
     * all fields in properties must be marked as required
     """
 
+    strict_supports_length_constraints: ClassVar[bool] = False
+    """Whether the API accepts `minLength`/`maxLength` in strict mode. OpenAI itself does, but this
+    transformer is shared by OpenAI-compatible APIs that may not (e.g. DeepSeek documents them as
+    unsupported), so it's opt-in."""
+
     def __init__(self, schema: JsonSchema, *, strict: bool | None = None):
         super().__init__(schema, strict=strict)
         self.root_ref = schema.get('$ref')
@@ -529,6 +534,8 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
         # Track strict-incompatible keys
         incompatible_values: dict[str, Any] = {}
         for key in _STRICT_INCOMPATIBLE_KEYS:
+            if self.strict_supports_length_constraints and key in ('minLength', 'maxLength'):
+                continue
             value = schema.get(key, _sentinel)
             if value is not _sentinel:
                 incompatible_values[key] = value
@@ -605,3 +612,9 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                 elif self.strict is None:  # pragma: no branch
                     self.is_strict_compatible = False
         return schema
+
+
+class OpenAINativeJsonSchemaTransformer(OpenAIJsonSchemaTransformer):
+    """For OpenAI's own API, which supports `minLength`/`maxLength` in strict mode."""
+
+    strict_supports_length_constraints = True

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -103,7 +103,11 @@ with try_import() as imports_successful:
         OpenAIResponsesModelSettings,
         _resolve_openai_image_generation_size,  # pyright: ignore[reportPrivateUsage]
     )
-    from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAISystemPromptRole
+    from pydantic_ai.profiles.openai import (
+        OpenAIJsonSchemaTransformer,
+        OpenAINativeJsonSchemaTransformer,
+        OpenAISystemPromptRole,
+    )
     from pydantic_ai.providers.azure import AzureProvider
     from pydantic_ai.providers.cerebras import CerebrasProvider
     from pydantic_ai.providers.google import GoogleProvider
@@ -2942,6 +2946,10 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
     return f'{x} {y}'  # pragma: no cover
 
 
+def tool_with_length_constraints(x: Annotated[str, Field(min_length=2, max_length=10)]) -> str:
+    return x  # pragma: no cover
+
+
 @pytest.mark.parametrize(
     'tool,tool_strict,expected_params,expected_strict',
     [
@@ -3048,7 +3056,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
             snapshot(
                 {
                     'additionalProperties': False,
-                    'properties': {'x': {'type': 'string', 'description': 'minLength=1, format=uri'}},
+                    'properties': {'x': {'minLength': 1, 'type': 'string', 'description': 'format=uri'}},
                     'required': ['x'],
                     'type': 'object',
                 }
@@ -3445,6 +3453,19 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                         'y': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'string'}], 'type': 'array'},
                     },
                     'required': ['x', 'y'],
+                    'type': 'object',
+                }
+            ),
+            snapshot(True),
+        ),
+        (
+            tool_with_length_constraints,
+            None,
+            snapshot(
+                {
+                    'additionalProperties': False,
+                    'properties': {'x': {'maxLength': 10, 'minLength': 2, 'type': 'string'}},
+                    'required': ['x'],
                     'type': 'object',
                 }
             ),
@@ -6131,6 +6152,41 @@ async def test_openai_chat_tool_choice_list_unsupported_raises_error(allow_model
             model_settings=settings,
             model_request_parameters=mrp,
         )
+
+
+def test_transformer_length_constraints_default_not_strict_compatible():
+    """By default `minLength`/`maxLength` downgrade to non-strict, since OpenAI-compatible APIs
+    sharing this transformer may not support them in strict mode (e.g. DeepSeek)."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': {'type': 'string', 'minLength': 2, 'maxLength': 10}},
+        'required': ['value'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is False
+
+    schema = {
+        'type': 'object',
+        'properties': {'value': {'type': 'string', 'minLength': 2, 'maxLength': 10}},
+        'required': ['value'],
+    }
+    result = OpenAIJsonSchemaTransformer(schema, strict=True).walk()
+    assert result['properties']['value'] == {'type': 'string', 'description': 'minLength=2, maxLength=10'}
+
+
+def test_transformer_length_constraints_native_openai_strict_compatible():
+    """OpenAI itself accepts `minLength`/`maxLength` in strict mode, so its transformer keeps them."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': {'type': 'string', 'minLength': 2, 'maxLength': 10}},
+        'required': ['value'],
+    }
+    transformer = OpenAINativeJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['value'] == {'type': 'string', 'minLength': 2, 'maxLength': 10}
+    assert transformer.is_strict_compatible is True
 
 
 def test_transformer_adds_properties_to_object_schemas():

--- a/uv.lock
+++ b/uv.lock
@@ -62,6 +62,7 @@ constraints = [
     { name = "vcrpy", specifier = ">=8.2.1" },
     { name = "xgrammar", specifier = ">=0.1.32" },
 ]
+build-constraints = [{ name = "hatchling", specifier = "<1.32" }]
 
 [[package]]
 name = "ag-ui-protocol"


### PR DESCRIPTION
- Closes #7315 (the `minLength`/`maxLength` half; the `prefixItems` half is #7333)

OpenAI accepts `minLength`/`maxLength` in strict mode (live-probed: 200 with the constraints enforced), but `OpenAIJsonSchemaTransformer` treats them as strict-incompatible, silently downgrading models like

```python
class WithMin(BaseModel):
    name: str = Field(min_length=2)
```

to `strict: false`, losing the schema guarantee with no visible signal.

The transformer is shared by ~20 OpenAI-compatible providers, and at least one (DeepSeek) documents these keywords as unsupported, so the fix cannot change the shared default. Instead:

- `OpenAIJsonSchemaTransformer` gains `strict_supports_length_constraints: ClassVar[bool] = False`. Default off: every provider keeps today's behavior byte for byte.
- New `OpenAINativeJsonSchemaTransformer` subclass sets it to `True`, and `openai_model_profile()` now uses it, so OpenAI itself (and providers resolving through that profile, e.g. Azure) keep the constraints and stay strict.
- A provider whose backend does support the keywords can opt in with the same three-line subclass.

Public API added (flag + subclass); naming open to bikeshedding. No behavior change for any provider using the base transformer.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

