### PR TITLE
Record network-level `URLError` failures per item in the attention monitor instead of aborting the run

### DIFF
--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -660,7 +660,7 @@ def apply_decisions(client: GitHubClient, repo: str, output_path: str, snapshot_
                 continue
             mentions = ' '.join(f'@{login}' for login in recipients)
             lines.append(f'#{number}: requested maintainer attention from {mentions}')
-        except (urllib.error.HTTPError, RuntimeError) as exc:
+        except (urllib.error.URLError, RuntimeError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')
@@ -1063,7 +1063,7 @@ def reconcile(
                 lines.append(line)
                 if notice is not None and notices is not None:
                     notices.append(notice)
-        except (urllib.error.HTTPError, RuntimeError, ValueError) as exc:
+        except (urllib.error.URLError, RuntimeError, ValueError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')
@@ -1088,7 +1088,7 @@ def reconcile(
         try:
             if line := _sweep_escalated_item(client, repo, number):
                 lines.append(line)
-        except (urllib.error.HTTPError, RuntimeError, ValueError) as exc:
+        except (urllib.error.URLError, RuntimeError, ValueError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')
@@ -1299,7 +1299,7 @@ def finalize_notices(client: GitHubClient, repo: str, notices: Sequence[NoticeRe
         try:
             if line := _finalize_notice(client, repo, notice, now=now):
                 lines.append(line)
-        except (urllib.error.HTTPError, RuntimeError) as exc:
+        except (urllib.error.URLError, RuntimeError) as exc:
             if isinstance(exc, urllib.error.HTTPError):
                 exc.close()
             failures.append(f'#{number}: {type(exc).__name__}: {exc}')

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -61,6 +61,7 @@ class FakeClient(monitor.GitHubClient):
         self.items = items or {}
         self.calls: list[tuple[str, str, object | None]] = []
         self.fail_get: set[int] = set()
+        self.fail_get_network: set[int] = set()
         self.fail_delete_labels: set[str] = set()
         self.assignment_succeeds = True
         self.permissions: dict[str, str] = {}
@@ -113,6 +114,8 @@ class FakeClient(monitor.GitHubClient):
             number = int(path.split('/issues/')[1].split('/')[0])
             if number in self.fail_get:
                 raise urllib.error.HTTPError(path, 500, 'boom', {}, None)
+            if number in self.fail_get_network:
+                raise urllib.error.URLError(OSError('certificate verify failed'))
             return self.items[number]
         if '/comments?' in path:
             return []
@@ -1359,6 +1362,21 @@ def test_one_item_failure_does_not_block_later_items():
     assert lines == ['#2: queued channel reminder']
     assert failures and failures[0].startswith('#1: HTTPError')
     assert not any(call[0] == 'POST' and call[1].endswith('/issues/2/comments') for call in client.calls)
+
+
+def test_network_failure_on_dormant_item_does_not_abort_the_run():
+    client = FakeClient(
+        {
+            1: item(1, labels=[monitor._ACTION_LABEL]),
+            7: item(7, labels=[monitor._ESCALATED_LABEL]),
+        }
+    )
+    client.fail_get_network.add(7)
+
+    lines, failures = monitor.reconcile(client, 'pydantic/pydantic-ai', now=NOW)
+
+    assert lines == ['#1: queued channel reminder']
+    assert failures and failures[0].startswith('#7: URLError')
 
 
 def test_invalid_event_timestamp_does_not_block_later_items():


### PR DESCRIPTION
Scheduled run https://github.com/pydantic/pydantic-ai/actions/runs/31571289704 of the attention monitor crashed with exit code 1 when a single GitHub API request failed its TLS handshake mid-run (`URLError` wrapping `SSLCertVerificationError: self-signed certificate` — a transient interception on the Actions runner).

The per-item loops in `apply`, `reconcile` (active items and the dormant escalated-item sweep), and `finalize` already record per-item API failures instead of aborting, but they only catch `urllib.error.HTTPError`. A network-level failure raises its parent class `urllib.error.URLError`, which escaped the handlers and killed the whole run — in this case from `_sweep_escalated_item`.

This widens the four per-item `except` tuples from `HTTPError` to `URLError` (its parent class, so HTTP-level handling is unchanged and the `HTTPError`-only `exc.close()` guards stay as they are). A transient network blip now fails just that item and is reported in the run summary, matching how HTTP errors are already handled. The narrow `except urllib.error.HTTPError` handlers that inspect `exc.code` for 404s are deliberately untouched.

Regression test reproduces the incident: a dormant escalated item whose fetch raises a network-level `URLError` is recorded in `failures` while the rest of the sweep completes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

