### PR TITLE
Preserve fragments in OpenAI WebRTC signaling URLs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -1024,17 +1024,21 @@ class OpenAIRealtimeModel(RealtimeModel):
         return with_realtime_query(self._realtime_ws_base(), call_id=call_id)
 
     def _webrtc_http_base(self) -> str:
-        base_url, separator, query = self._provider.base_url.partition('?')
+        base_url, _, fragment = self._provider.base_url.partition('#')
+        base_url, separator, query = base_url.partition('?')
         base_url = base_url if base_url.endswith('/') else f'{base_url}/'
-        return f'{base_url}{separator}{query}'
+        base_url = f'{base_url}{separator}{query}'
+        return f'{base_url}#{fragment}' if fragment else base_url
 
     def _webrtc_url(self, path: str, **params: str) -> str:
-        base_url, _, query = self._webrtc_http_base().partition('?')
+        base_url, _, fragment = self._webrtc_http_base().partition('#')
+        base_url, _, query = base_url.partition('?')
         for name, value in params.items():
             param = f'{name}={quote(value, safe="")}'
             query = f'{query}&{param}' if query else param
         url = f'{base_url}{path}'
-        return f'{url}?{query}' if query else url
+        url = f'{url}?{query}' if query else url
+        return f'{url}#{fragment}' if fragment else url
 
     def _webrtc_calls_url(self) -> str:
         return self._webrtc_url('realtime/calls')

--- a/tests/realtime/test_webrtc.py
+++ b/tests/realtime/test_webrtc.py
@@ -354,6 +354,26 @@ async def test_create_client_secret_through_gateway() -> None:
     assert secret.value == 'ek_gw'
 
 
+async def test_create_client_secret_with_base_url_fragment() -> None:
+    # Fragments are client-side URL state and cannot be covered by a recorded HTTP interaction.
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured['url'] = str(request.url)
+        return httpx.Response(200, json={'value': 'ek_fragment', 'expires_at': 1_700_000_060})
+
+    provider = OpenAIProvider(
+        base_url='https://example.com/v1#fragment',
+        api_key='sk-test',
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    model = OpenAIRealtimeModel('gpt-realtime', provider=provider)
+
+    await model.create_client_secret()
+
+    assert captured['url'] == 'https://example.com/v1/realtime/client_secrets#fragment'
+
+
 async def test_create_client_secret_http_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, text='invalid api key')


### PR DESCRIPTION
- Fixes #7392 (item 1: OpenAI WebRTC base URL fragments)
- Supersedes #7402, which was automatically closed before its issue reference used the required closing keyword.

## Summary

- split the provider base URL fragment before appending WebRTC signaling paths
- restore fragments after path and query construction
- add a public-API regression test through `create_client_secret()`

## Testing

- `python -m pytest tests/realtime/test_webrtc.py -q` (35 passed)
- `python -m ruff check pydantic_ai_slim/pydantic_ai/realtime/openai.py tests/realtime/test_webrtc.py`
- `python -m ruff format --check pydantic_ai_slim/pydantic_ai/realtime/openai.py tests/realtime/test_webrtc.py`
- `python -m pyright --pythonpath <env-python> pydantic_ai_slim/pydantic_ai/realtime/openai.py` (0 errors)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

