### PR TITLE
Prevent forced tool choices for Together `deepseek-v4-*` models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -60,6 +60,9 @@ class TogetherProvider(Provider[AsyncOpenAI]):
             if provider in provider_to_profile:
                 profile = provider_to_profile[provider](model_name)
 
+            if provider == 'deepseek-ai' and model_name.startswith('deepseek-v4-'):
+                profile = merge_profile(profile, OpenAIModelProfile(openai_supports_tool_choice_required=False))
+
         # As the Together API is OpenAI-compatible, let's assume we also need OpenAIJsonSchemaTransformer,
         # unless json_schema_transformer is set explicitly
         return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -74,6 +74,12 @@ def test_together_provider_model_profile(mocker: MockerFixture):
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
     assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('openai_supports_tool_choice_required', True) is True
+
+    deepseek_v4_profile = provider.model_profile('deepseek-ai/DeepSeek-V4-Flash-0731')
+    deepseek_model_profile_mock.assert_called_with('deepseek-v4-flash-0731')
+    assert deepseek_v4_profile is not None
+    assert deepseek_v4_profile.get('openai_supports_tool_choice_required', True) is False
 
     meta_profile = provider.model_profile('meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8')
     meta_model_profile_mock.assert_called_with('llama-4-maverick-17b-128e-instruct-fp8')


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

- Closes #7406

### What

Together-hosted DeepSeek V4 models do not support forced `tool_choice=required`, but `TogetherProvider` inherited the default capability flag and advertised support. Add a provider-level profile override for `deepseek-ai/deepseek-v4-*` models while preserving the existing behavior for ordinary DeepSeek models.

### Testing

- `uv run --frozen pytest tests/providers/test_together.py tests/profiles/test_resolution_matrix.py -q` (106 passed, 34 skipped)
- `uv run --frozen ruff format --check pydantic_ai_slim/pydantic_ai/providers/together.py tests/providers/test_together.py`
- `uv run --frozen ruff check pydantic_ai_slim/pydantic_ai/providers/together.py tests/providers/test_together.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --frozen pyright pydantic_ai_slim/pydantic_ai/providers/together.py`
- `git diff --check`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

