### PR TITLE
Add realtime, Crusoe, and TwelveLabs pages to the pydantic.dev nav manifests `docs/navigation.yml` and `docs/nav.json`

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -21,6 +21,71 @@
     ]
   },
   {
+    "label": "Realtime (speech-to-speech)",
+    "items": [
+      {
+        "label": "Overview",
+        "slug": "realtime/overview"
+      },
+      {
+        "label": "Audio, images, and transcripts",
+        "slug": "realtime/audio"
+      },
+      {
+        "label": "Events",
+        "slug": "realtime/events"
+      },
+      {
+        "label": "Turns and interruptions",
+        "slug": "realtime/turns"
+      },
+      {
+        "label": "Tools",
+        "slug": "realtime/tools"
+      },
+      {
+        "label": "Capabilities and hooks",
+        "slug": "realtime/capabilities"
+      },
+      {
+        "label": "History and handoff",
+        "slug": "realtime/history"
+      },
+      {
+        "label": "Connecting a frontend",
+        "slug": "realtime/deployment"
+      },
+      {
+        "label": "Connection lifecycle",
+        "slug": "realtime/lifecycle"
+      },
+      {
+        "label": "Usage and observability",
+        "slug": "realtime/observability"
+      },
+      {
+        "label": "Troubleshooting",
+        "slug": "realtime/troubleshooting"
+      },
+      {
+        "label": "OpenAI",
+        "slug": "realtime/openai"
+      },
+      {
+        "label": "Azure",
+        "slug": "realtime/azure"
+      },
+      {
+        "label": "Google Gemini",
+        "slug": "realtime/gemini"
+      },
+      {
+        "label": "xAI",
+        "slug": "realtime/xai"
+      }
+    ]
+  },
+  {
     "label": "Core Concepts",
     "items": [
       {
@@ -71,7 +136,7 @@
       "models/bedrock",
       "models/cerebras",
       "models/cohere",
-    "models/crusoe",
+      "models/crusoe",
       "models/groq",
       "models/huggingface",
       "models/mistral",
@@ -303,6 +368,10 @@
             "slug": "evals/evaluators/llm-judge"
           },
           {
+            "label": "Standard Quality Metrics",
+            "slug": "evals/evaluators/standard-quality-metrics"
+          },
+          {
             "label": "Third-Party Integrations",
             "slug": "evals/evaluators/framework-integrations"
           },
@@ -317,6 +386,10 @@
           {
             "label": "Span-Based",
             "slug": "evals/evaluators/span-based"
+          },
+          {
+            "label": "Agentic",
+            "slug": "evals/evaluators/agentic"
           }
         ]
       },
@@ -462,7 +535,8 @@
         "items": [
           "examples/sql-gen",
           "examples/data-analyst",
-          "examples/rag"
+          "examples/rag",
+          "examples/twelvelabs-video-agent"
         ]
       },
       {
@@ -470,6 +544,16 @@
         "items": [
           "examples/stream-markdown",
           "examples/stream-whales"
+        ]
+      },
+      {
+        "label": "Realtime",
+        "items": [
+          "examples/realtime-voice",
+          "examples/realtime-text-to-audio",
+          "examples/realtime-handoff",
+          "examples/realtime-camera",
+          "examples/realtime-webrtc"
         ]
       },
       {
@@ -522,6 +606,7 @@
               "api/models/bedrock_mantle",
               "api/models/cerebras",
               "api/models/cohere",
+              "api/models/crusoe",
               "api/models/fallback",
               "api/models/function",
               "api/models/google",
@@ -543,6 +628,17 @@
           "api/output",
           "api/profiles",
           "api/providers",
+          "api/realtime",
+          {
+            "label": "realtime",
+            "items": [
+              "api/realtime/codec",
+              "api/realtime/openai",
+              "api/realtime/google",
+              "api/realtime/xai",
+              "api/realtime/azure"
+            ]
+          },
           "api/result",
           "api/retries",
           "api/run",

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -41,6 +41,84 @@ navigation:
         slug: "overview/gateway"
         aliases:
           - "gateway"
+  - section: "Realtime (speech-to-speech)"
+    slug: ""
+    contents:
+      - page: "Overview"
+        path: "realtime/overview.md"
+        slug: "overview/realtime/overview"
+        aliases:
+          - "realtime/overview"
+      - page: "Audio, images, and transcripts"
+        path: "realtime/audio.md"
+        slug: "overview/realtime/audio"
+        aliases:
+          - "realtime/audio"
+      - page: "Events"
+        path: "realtime/events.md"
+        slug: "overview/realtime/events"
+        aliases:
+          - "realtime/events"
+      - page: "Turns and interruptions"
+        path: "realtime/turns.md"
+        slug: "overview/realtime/turns"
+        aliases:
+          - "realtime/turns"
+      - page: "Tools"
+        path: "realtime/tools.md"
+        slug: "overview/realtime/tools"
+        aliases:
+          - "realtime/tools"
+      - page: "Capabilities and hooks"
+        path: "realtime/capabilities.md"
+        slug: "overview/realtime/capabilities"
+        aliases:
+          - "realtime/capabilities"
+      - page: "History and handoff"
+        path: "realtime/history.md"
+        slug: "overview/realtime/history"
+        aliases:
+          - "realtime/history"
+      - page: "Connecting a frontend"
+        path: "realtime/deployment.md"
+        slug: "overview/realtime/deployment"
+        aliases:
+          - "realtime/deployment"
+      - page: "Connection lifecycle"
+        path: "realtime/lifecycle.md"
+        slug: "overview/realtime/lifecycle"
+        aliases:
+          - "realtime/lifecycle"
+      - page: "Usage and observability"
+        path: "realtime/observability.md"
+        slug: "overview/realtime/observability"
+        aliases:
+          - "realtime/observability"
+      - page: "Troubleshooting"
+        path: "realtime/troubleshooting.md"
+        slug: "overview/realtime/troubleshooting"
+        aliases:
+          - "realtime/troubleshooting"
+      - page: "OpenAI"
+        path: "realtime/openai.md"
+        slug: "overview/realtime/openai"
+        aliases:
+          - "realtime/openai"
+      - page: "Azure"
+        path: "realtime/azure.md"
+        slug: "overview/realtime/azure"
+        aliases:
+          - "realtime/azure"
+      - page: "Google Gemini"
+        path: "realtime/gemini.md"
+        slug: "overview/realtime/gemini"
+        aliases:
+          - "realtime/gemini"
+      - page: "xAI"
+        path: "realtime/xai.md"
+        slug: "overview/realtime/xai"
+        aliases:
+          - "realtime/xai"
   - section: "Core Concepts"
     slug: ""
     contents:
@@ -679,6 +757,9 @@ navigation:
             slug: "examples/data-analytics/rag"
             aliases:
               - "examples/rag"
+          - page: "TwelveLabs Video Agent"
+            path: "examples/twelvelabs-video-agent.md"
+            slug: "examples/data-analytics/twelvelabs-video-agent"
       - section: "Streaming"
         slug: ""
         contents:
@@ -692,6 +773,34 @@ navigation:
             slug: "examples/streaming/stream-whales"
             aliases:
               - "examples/stream-whales"
+      - section: "Realtime"
+        slug: ""
+        contents:
+          - page: "Voice Assistant"
+            path: "examples/realtime-voice.md"
+            slug: "examples/realtime/realtime-voice"
+            aliases:
+              - "examples/realtime-voice"
+          - page: "Text to Audio"
+            path: "examples/realtime-text-to-audio.md"
+            slug: "examples/realtime/realtime-text-to-audio"
+            aliases:
+              - "examples/realtime-text-to-audio"
+          - page: "Agent Handoff"
+            path: "examples/realtime-handoff.md"
+            slug: "examples/realtime/realtime-handoff"
+            aliases:
+              - "examples/realtime-handoff"
+          - page: "Camera Agent"
+            path: "examples/realtime-camera.md"
+            slug: "examples/realtime/realtime-camera"
+            aliases:
+              - "examples/realtime-camera"
+          - page: "Browser WebRTC"
+            path: "examples/realtime-webrtc.md"
+            slug: "examples/realtime/realtime-webrtc"
+            aliases:
+              - "examples/realtime-webrtc"
       - section: "Complex Workflows"
         slug: ""
         contents:
@@ -876,6 +985,29 @@ navigation:
             slug: "api/pydantic-ai/providers"
             aliases:
               - "api/providers"
+          - page: "realtime"
+            path: "api/realtime.md"
+            slug: "api/pydantic-ai/realtime"
+            aliases:
+              - "api/realtime"
+          - section: "realtime"
+            slug: ""
+            contents:
+              - page: "codec"
+                path: "api/realtime/codec.md"
+                slug: "api/realtime/codec"
+              - page: "openai"
+                path: "api/realtime/openai.md"
+                slug: "api/realtime/openai"
+              - page: "google"
+                path: "api/realtime/google.md"
+                slug: "api/realtime/google"
+              - page: "xai"
+                path: "api/realtime/xai.md"
+                slug: "api/realtime/xai"
+              - page: "azure"
+                path: "api/realtime/azure.md"
+                slug: "api/realtime/azure"
           - page: "result"
             path: "api/result.md"
             slug: "api/pydantic-ai/result"
@@ -1022,6 +1154,9 @@ navigation:
           - "version-policy"
 redirects:
   # Section roots without their own landing page.
+  - from: "overview/realtime"
+    to: "overview/realtime/overview"
+    status: 302
   - from: "core-concepts"
     to: "core-concepts/agent"
     status: 302

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -46,79 +46,49 @@ navigation:
     contents:
       - page: "Overview"
         path: "realtime/overview.md"
-        slug: "overview/realtime/overview"
-        aliases:
-          - "realtime/overview"
+        slug: "realtime/overview"
       - page: "Audio, images, and transcripts"
         path: "realtime/audio.md"
-        slug: "overview/realtime/audio"
-        aliases:
-          - "realtime/audio"
+        slug: "realtime/audio"
       - page: "Events"
         path: "realtime/events.md"
-        slug: "overview/realtime/events"
-        aliases:
-          - "realtime/events"
+        slug: "realtime/events"
       - page: "Turns and interruptions"
         path: "realtime/turns.md"
-        slug: "overview/realtime/turns"
-        aliases:
-          - "realtime/turns"
+        slug: "realtime/turns"
       - page: "Tools"
         path: "realtime/tools.md"
-        slug: "overview/realtime/tools"
-        aliases:
-          - "realtime/tools"
+        slug: "realtime/tools"
       - page: "Capabilities and hooks"
         path: "realtime/capabilities.md"
-        slug: "overview/realtime/capabilities"
-        aliases:
-          - "realtime/capabilities"
+        slug: "realtime/capabilities"
       - page: "History and handoff"
         path: "realtime/history.md"
-        slug: "overview/realtime/history"
-        aliases:
-          - "realtime/history"
+        slug: "realtime/history"
       - page: "Connecting a frontend"
         path: "realtime/deployment.md"
-        slug: "overview/realtime/deployment"
-        aliases:
-          - "realtime/deployment"
+        slug: "realtime/deployment"
       - page: "Connection lifecycle"
         path: "realtime/lifecycle.md"
-        slug: "overview/realtime/lifecycle"
-        aliases:
-          - "realtime/lifecycle"
+        slug: "realtime/lifecycle"
       - page: "Usage and observability"
         path: "realtime/observability.md"
-        slug: "overview/realtime/observability"
-        aliases:
-          - "realtime/observability"
+        slug: "realtime/observability"
       - page: "Troubleshooting"
         path: "realtime/troubleshooting.md"
-        slug: "overview/realtime/troubleshooting"
-        aliases:
-          - "realtime/troubleshooting"
+        slug: "realtime/troubleshooting"
       - page: "OpenAI"
         path: "realtime/openai.md"
-        slug: "overview/realtime/openai"
-        aliases:
-          - "realtime/openai"
+        slug: "realtime/openai"
       - page: "Azure"
         path: "realtime/azure.md"
-        slug: "overview/realtime/azure"
-        aliases:
-          - "realtime/azure"
+        slug: "realtime/azure"
       - page: "Google Gemini"
         path: "realtime/gemini.md"
-        slug: "overview/realtime/gemini"
-        aliases:
-          - "realtime/gemini"
+        slug: "realtime/gemini"
       - page: "xAI"
         path: "realtime/xai.md"
-        slug: "overview/realtime/xai"
-        aliases:
-          - "realtime/xai"
+        slug: "realtime/xai"
   - section: "Core Concepts"
     slug: ""
     contents:
@@ -760,6 +730,8 @@ navigation:
           - page: "TwelveLabs Video Agent"
             path: "examples/twelvelabs-video-agent.md"
             slug: "examples/data-analytics/twelvelabs-video-agent"
+            aliases:
+              - "examples/twelvelabs-video-agent"
       - section: "Streaming"
         slug: ""
         contents:
@@ -1154,8 +1126,8 @@ navigation:
           - "version-policy"
 redirects:
   # Section roots without their own landing page.
-  - from: "overview/realtime"
-    to: "overview/realtime/overview"
+  - from: "realtime"
+    to: "realtime/overview"
     status: 302
   - from: "core-concepts"
     to: "core-concepts/agent"


### PR DESCRIPTION
<!-- Trivial docs-manifest fix discussed on Slack (realtime pages 404ing on pydantic.dev); no issue. -->

Pydantic AI v2.28 added the realtime documentation to `mkdocs.yml` but not to the two manifests that [pydantic/unified-docs](https://github.com/pydantic/unified-docs) reads from the latest release tag to publish these docs on https://pydantic.dev/docs/ai. The realtime guide therefore linked pages that were never published and they 404ed (worked around consumer-side in pydantic/unified-docs#178). This updates both manifests:

### `docs/navigation.yml` (canonical manifest from #7361, pre-cutover)

- adds the 15-page realtime guide as a `Realtime (speech-to-speech)` section at the canonical `realtime/*` routes so old-site redirects like `ai.pydantic.dev/realtime/overview/` resolve after the cutover
- adds the 5 realtime examples as a `Realtime` section (`examples/realtime/*` canonical, current flat routes kept as aliases, matching the existing group pattern) and `examples/twelvelabs-video-agent` under Data & Analytics with its flat route retained as an alias
- adds `api/realtime` under `pydantic_ai` (canonical `api/pydantic-ai/realtime`, alias `api/realtime` — same shape as every sibling) and the 5 `api/realtime/*` submodule pages at their current routes
- adds the `realtime` section-root 302 to the realtime overview

Validated against the repository-navigation JSON schema; page set now exactly matches the `mkdocs.yml` nav (no missing/extra pages, no duplicate slugs, no alias/slug or redirect/slug collisions).

### `docs/nav.json` (release-compatibility manifest, consumed until the cutover)

Brings it back to exact page parity with `mkdocs.yml` (225 pages each), following `mkdocs.yml` labels and order: the realtime guide section (labeled `Realtime (speech-to-speech)` to match the unified-docs section it mounts under), the realtime examples group, `examples/twelvelabs-video-agent`, `api/realtime` + `api/realtime/*`, `api/models/crusoe`, and the `Standard Quality Metrics` / `Agentic` evaluator pages missing since v2.17 (unified-docs carries workarounds for those too). Also fixes a stray mis-indentation on the `models/crusoe` line.

### Notes for reviewers (@strawgate)

- Takes effect on pydantic.dev at the next release tag. The unified-docs workarounds from #178 (and the older evaluator one) then become removable, and the navigation baseline needs a refresh: the realtime example/API pages are currently published but unlisted, and via `nav.json` groups their canonical routes become `examples/realtime/*` and `api/pydantic-ai/realtime` (consistent with all grouped siblings), with the current flat routes covered by `navigation.yml` aliases post-cutover.
- Example page titles (`Voice Assistant`, `Text to Audio`, `Agent Handoff`, `Camera Agent`, `Browser WebRTC`, `TwelveLabs Video Agent`) are curated since the example files have no headings — rename freely.
- Until the cutover retires `nav.json`, docs PRs touching the `mkdocs.yml` nav need the same change mirrored in **both** `docs/navigation.yml` and `docs/nav.json`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

