### PR TITLE
Fix inherited realtime WebRTC and Azure `for_realtime` bugs from `#6676`

### DIFF
--- a/docs/examples/realtime-webrtc.md
+++ b/docs/examples/realtime-webrtc.md
@@ -53,7 +53,7 @@ AZURE_OPENAI_API_KEY=...
 With [dependencies installed and your key set](./setup.md#usage), start the server:
 
 ```bash
-uvicorn pydantic_ai_examples.realtime_webrtc.app:app
+uv run --all-packages uvicorn pydantic_ai_examples.realtime_webrtc.app:app
 ```
 
 Open <http://localhost:8000>, click **Start call**, allow microphone access, and ask "What time is it

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -160,9 +160,11 @@ class AzureProvider(Provider[AsyncOpenAI]):
                 `openai_client` lands in.
             http_client: An existing `httpx.AsyncClient` used to construct the provider client.
         """
-        if entra_authenticated and not api_key and 'AZURE_OPENAI_API_KEY' not in os.environ:
+        if entra_authenticated and not api_key and not os.getenv('AZURE_OPENAI_API_KEY'):
             # The SDK's own placeholder for "Entra-authenticated, no key", which `__init__` normalizes
-            # back to `None` below. Satisfies the key requirement without inventing a credential.
+            # back to `None` below. Satisfies the key requirement without inventing a credential. A
+            # truthiness check (not membership) so an empty `AZURE_OPENAI_API_KEY=""` still takes the
+            # placeholder rather than resolving to an empty key that trips the key-required error.
             api_key = _api_key_sentinel
         endpoint = azure_endpoint or os.getenv('AZURE_OPENAI_ENDPOINT')
         resolved_api_version = api_version or os.getenv('OPENAI_API_VERSION')

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1924,6 +1924,13 @@ class RealtimeSession:
         events = self._finalize_lost_state()
         if lost_in_flight:
             event = replace(event, state_restored=False)
+        if not event.state_restored:
+            # The reconnect cut whatever was playing: the in-flight response (if any) is settled as
+            # interrupted above, and even a finalized response's audio won't resume on the fresh
+            # connection. End the `speak` span so it measures only what was actually audible, rather
+            # than running until session close or being merged into the next utterance
+            # (`start_playback_span` no-ops while a span is already open). No-op off a sideband.
+            self._session_instrumentation.end_playback_span()
         return [*events, event]
 
     def _finalize_lost_state(self) -> list[RealtimeEvent]:

--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -1024,17 +1024,23 @@ class OpenAIRealtimeModel(RealtimeModel):
         return with_realtime_query(self._realtime_ws_base(), call_id=call_id)
 
     def _webrtc_http_base(self) -> str:
-        base_url, separator, query = self._provider.base_url.partition('?')
+        # Split off the fragment first (like `realtime_websocket_url` / `with_realtime_query`), so the
+        # trailing slash and the appended path land before it rather than inside the client-side part.
+        base_url, _, fragment = self._provider.base_url.partition('#')
+        base_url, separator, query = base_url.partition('?')
         base_url = base_url if base_url.endswith('/') else f'{base_url}/'
-        return f'{base_url}{separator}{query}'
+        base_url = f'{base_url}{separator}{query}'
+        return f'{base_url}#{fragment}' if fragment else base_url
 
     def _webrtc_url(self, path: str, **params: str) -> str:
-        base_url, _, query = self._webrtc_http_base().partition('?')
+        base_url, _, fragment = self._webrtc_http_base().partition('#')
+        base_url, _, query = base_url.partition('?')
         for name, value in params.items():
             param = f'{name}={quote(value, safe="")}'
             query = f'{query}&{param}' if query else param
         url = f'{base_url}{path}'
-        return f'{url}?{query}' if query else url
+        url = f'{url}?{query}' if query else url
+        return f'{url}#{fragment}' if fragment else url
 
     def _webrtc_calls_url(self) -> str:
         return self._webrtc_url('realtime/calls')

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -125,7 +125,10 @@ def _zero_sdp_addresses(request: Any) -> Any:
     hand-zeroing them (as `REAL_SDP_OFFER` above was) from being a step someone has to remember.
     """
     body = request.body
-    if isinstance(body, bytes) and b'a=candidate:' in body:
+    if isinstance(body, bytes):
+        # Zero every address the regex finds, not just when an ICE candidate is present: an SDP whose
+        # only address is the `c=IN IP4/IP6` connection line (no `a=candidate:` lines) would otherwise
+        # be recorded with the recorder's real address intact.
         request.body = _SDP_ADDRESS_RE.sub(
             lambda match: match['prefix'] + (b'0.0.0.0' if b'.' in match['address'] else b'::'), body
         )
@@ -233,7 +236,7 @@ def openai_ws_sideband_cassette(
     Stored under a dedicated subdirectory so the WebSocket cassette doesn't collide with the HTTP VCR
     cassette (SDP offer relay) a WebRTC sideband test records under the module-named subdirectory.
     """
-    if not imports_successful():
+    if not openai_imports_successful():  # pragma: no cover
         pytest.skip('openai / websockets not installed')
     with _ws_cassette(request, 'openai', subdir='test_openai_ws_sideband') as cassette:
         yield OpenAIProvider(api_key=openai_api_key), cassette

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -15,11 +15,17 @@ import pytest
 from ..conftest import sanitize_filename, try_import
 from .ws_cassettes import ProviderName, RealtimeCassette, patched_ws_connect, realtime_cassette_plan
 
+# `imports_successful` gates only the `google-genai` import, so a Gemini cassette test is the only one
+# that needs it. `gateway_provider` has no optional dependency of its own, so it gets its own flag
+# rather than riding on the Google one — otherwise a gateway/OpenAI cassette test (which needs neither
+# Google) would skip whenever `google-genai` is absent.
 with try_import() as imports_successful:
-    from pydantic_ai.providers.gateway import gateway_provider
     from pydantic_ai.providers.google import GoogleProvider
 
-# Separate from the combined flag above so OpenAI cassette tests still run in an environment
+with try_import() as gateway_imports_successful:
+    from pydantic_ai.providers.gateway import gateway_provider
+
+# Separate from the flags above so OpenAI cassette tests still run in an environment
 # without `google-genai` installed.
 with try_import() as openai_imports_successful:
     from pydantic_ai.providers.openai import OpenAIProvider
@@ -289,8 +295,8 @@ def gateway_openai_ws_cassette(
     `websockets` reference) is patched; only the provider's base URL and bearer key differ. Recording
     needs a real `PYDANTIC_AI_GATEWAY_API_KEY`; offline replay never dials, so a placeholder is enough.
     """
-    if not imports_successful():  # pragma: no cover
-        pytest.skip('openai / websockets not installed')
+    if not (gateway_imports_successful() and openai_imports_successful()):  # pragma: no cover
+        pytest.skip('gateway / openai / websockets not installed')
     provider = _gateway_realtime_provider('openai', gateway_api_key)
     with _ws_cassette(request, 'openai') as cassette:
         yield provider, cassette
@@ -307,8 +313,8 @@ def gateway_gemini_ws_cassette(
     the OpenAI-shaped `/proxy/<route>/realtime` upgrade the other gateway route uses, so this fixture
     covers the second protocol the gateway relays.
     """
-    if not imports_successful():  # pragma: no cover
-        pytest.skip('google-genai / websockets not installed')
+    if not (gateway_imports_successful() and imports_successful()):  # pragma: no cover
+        pytest.skip('gateway / google-genai / websockets not installed')
     provider = _gateway_realtime_provider('google', gateway_api_key)
     with _ws_cassette(request, 'gemini') as cassette:
         yield provider, cassette

--- a/tests/realtime/test_instrumentation.py
+++ b/tests/realtime/test_instrumentation.py
@@ -62,6 +62,7 @@ from pydantic_ai.realtime import (
     RealtimeOutputSpeechEndEvent,
     RealtimeOutputSpeechStartEvent,
     RealtimeSession as _RealtimeSession,
+    RealtimeSessionReconnectEvent,
 )
 from pydantic_ai.realtime.codec import (
     AudioDelta,
@@ -286,6 +287,39 @@ async def test_no_speak_span_without_playback_reporting() -> None:
         _ = [event async for event in session]
 
     assert not [span for span in exporter.get_finished_spans() if span.name.startswith('speak')]
+
+
+async def test_reconnect_without_state_restored_ends_the_speak_span() -> None:
+    """A reconnect that didn't restore state closes the open `speak` span, so it doesn't swallow the next utterance.
+
+    The audio that was playing won't resume on the fresh connection. If the span stays open, the next
+    utterance's `RealtimeOutputSpeechStartEvent` no-ops (a span is already set) and merges into it, so
+    the two utterances land in one `speak` span that also spans the dead-air reconnect. Ending it at
+    the reconnect keeps one span per utterance. Regression for the sixth `#7392` finding.
+    """
+    settings, exporter = _settings()
+    session = RealtimeSession(
+        _Connection(
+            [
+                RealtimeOutputSpeechStartEvent(),
+                # The default connection restores in-flight state, but a `state_restored=False` reconnect
+                # is still a disruption — the playing audio is cut regardless.
+                RealtimeSessionReconnectEvent(state_restored=False),
+                RealtimeOutputSpeechStartEvent(),
+                ResponseDone(),
+                RealtimeOutputSpeechEndEvent(),
+            ]
+        ),
+        _ok_runner,
+        instrumentation=settings,
+        model_name='gpt-realtime',
+    )
+
+    async with session:
+        _ = [event async for event in session]
+
+    # Two distinct utterances bracketed a reconnect, so two `speak` spans -- not one merged across it.
+    assert len([span for span in exporter.get_finished_spans() if span.name == 'speak gpt-realtime']) == 2
 
 
 def _weather_agent(*, name: str | None = None, capabilities: list[Instrumentation] | None = None) -> Agent[None, str]:

--- a/tests/realtime/test_webrtc.py
+++ b/tests/realtime/test_webrtc.py
@@ -270,7 +270,12 @@ def test_zero_sdp_addresses_blanks_offer_addresses() -> None:
         b'a=candidate:2 1 udp 2130706431 :: 57945 typ host\r\n'
         b'c=IN IP6 ::\r\na=ice-ufrag:creB\r\n'
     )
-    # Bodies without ICE candidates — every other recorded request — are passed through untouched.
+    # An SDP whose only address is the `c=` connection line (no `a=candidate:` lines) is still zeroed:
+    # the substitution is gated on the body being bytes, not on an ICE candidate being present.
+    assert _zero_sdp_addresses(_Request(b'v=0\r\nc=IN IP4 192.168.1.5\r\na=ice-ufrag:creB\r\n')).body == (
+        b'v=0\r\nc=IN IP4 0.0.0.0\r\na=ice-ufrag:creB\r\n'
+    )
+    # Bodies with no address fields at all — every other recorded request — are unchanged.
     assert _zero_sdp_addresses(_Request(b'{"model": "gpt-realtime"}')).body == b'{"model": "gpt-realtime"}'
     assert _zero_sdp_addresses(_Request(None)).body is None
 
@@ -352,6 +357,28 @@ async def test_create_client_secret_through_gateway() -> None:
 
     assert captured['url'] == 'https://gateway.pydantic.dev/proxy/openai/realtime/client_secrets'
     assert secret.value == 'ek_gw'
+
+
+async def test_create_client_secret_preserves_base_url_fragment() -> None:
+    # A `#fragment` in the base URL is client-side URL state: the signaling path must land before it,
+    # not inside it (which would leave the request going to the fragment-truncated base). Matches the
+    # fragment handling in `realtime_websocket_url` / `with_realtime_query`.
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured['url'] = str(request.url)
+        return httpx.Response(200, json={'value': 'ek_frag', 'expires_at': 1_700_000_060})
+
+    provider = OpenAIProvider(
+        base_url='https://example.com/v1#frag',
+        api_key='sk-test',
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    model = OpenAIRealtimeModel('gpt-realtime', provider=provider)
+    secret = await model.create_client_secret()
+
+    assert captured['url'] == 'https://example.com/v1/realtime/client_secrets#frag'
+    assert secret.value == 'ek_frag'
 
 
 async def test_create_client_secret_http_error() -> None:
@@ -547,6 +574,23 @@ def test_azure_entra_credential_needs_no_resource_key(monkeypatch: pytest.Monkey
     # The SDK's Entra placeholder is never handed out as a credential: asking still reports its absence.
     with pytest.raises(UserError, match='has no API key'):
         _ = explicit._azure_provider.api_key  # pyright: ignore[reportPrivateUsage]
+
+
+def test_azure_entra_for_realtime_ignores_empty_resource_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An *empty* `AZURE_OPENAI_API_KEY` is treated as "no key", not as a key of value `''`.
+
+    Regression: the guard was a membership test (`'AZURE_OPENAI_API_KEY' not in os.environ`), so an
+    exported-but-empty variable skipped the Entra placeholder, resolved an empty key, and raised the
+    key-required error on the very path that needs no key.
+    """
+    monkeypatch.setenv('AZURE_OPENAI_API_KEY', '')
+    monkeypatch.setenv('AZURE_OPENAI_ENDPOINT', 'https://my-resource.openai.azure.com')
+    monkeypatch.delenv('OPENAI_API_VERSION', raising=False)
+
+    provider = AzureProvider.for_realtime(entra_authenticated=True)
+    # No key resolved, and asking reports its absence rather than surfacing an empty string.
+    with pytest.raises(UserError, match='has no API key'):
+        _ = provider.api_key
 
 
 def test_azure_entra_credential_survives_alongside_a_user_profile() -> None:


### PR DESCRIPTION
- Closes #7392

Six fixes for issues Macroscope surfaced while reviewing #6642 but which live in the realtime WebRTC code merged in #6676 (unrelated to Azure Voice Live), so they're fixed here in their own scoped PR. Each was verified present on `main` and, where the defect is reachable, comes with a regression test that fails without the fix.

1. **`_webrtc_http_base` dropped the URL fragment** (`realtime/openai.py`) — a base URL like `https://host/v1#frag` became `https://host/v1#frag/`, so the appended `realtime/calls` path landed inside the fragment and the client requested `/v1`. Now the fragment is split off first and restored last, matching the adjacent `realtime_websocket_url` / `with_realtime_query` helpers.
2. **`_zero_sdp_addresses` could leak the recorder's IP** (`tests/realtime/conftest.py`) — the substitution was gated on `b'a=candidate:' in body`, so an SDP with a `c=IN IP4/IP6` connection address but no ICE candidate lines recorded unchanged. Now every `c=` address is zeroed whenever the body is bytes.
3. **`openai_ws_sideband_cassette` used the wrong import guard** (`tests/realtime/conftest.py`) — it checked `imports_successful()` (which also requires `google-genai`) instead of `openai_imports_successful()`, so it silently skipped without Google installed. Now matches `openai_ws_cassette`.
4. **WebRTC example run command failed on a fresh clone** (`docs/examples/realtime-webrtc.md`) — `uvicorn ...` isn't on `PATH` after `uv sync`; the doc now uses `uv run --all-packages uvicorn ...` like the example's own README.
5. **`for_realtime(entra_authenticated=True)` mishandled an empty `AZURE_OPENAI_API_KEY`** (`providers/azure.py`) — the guard was a membership test, so an exported-but-empty `AZURE_OPENAI_API_KEY=""` skipped the SDK's Entra placeholder, resolved an empty key, and tripped the key-required error on the one path that needs no key. Now a truthiness check.
6. **Reconnect with `state_restored=False` leaked the playback span** (`realtime/_session.py`) — `_handle_reconnected` never ended the active `speak` span, so it either measured until session close or merged the next utterance into it. Now ended when the reconnect didn't restore state.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

