### PR TITLE
ci: validate build artifacts with `twine check` on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
 
       - run: uv build --all-packages
       - run: ls -lh dist/
+      - run: uvx twine check --strict dist/*
 
   # mypy and lint are a bit slower than other jobs, so we run them separately
   mypy:


### PR DESCRIPTION
- Closes #7397

`uv build --all-packages` already runs in the `lint` job on every PR, but nothing validates the resulting artifact metadata — that only happens inside `gh-action-pypi-publish` at tag-push time. That's why last night's `hatchling` 1.32 metadata-version bump (fixed in #7394/#7395) was only caught on release night instead of on the PR that would have introduced the drift.

This adds `uvx twine check --strict dist/*` right after the existing build step, so the same validation `gh-action-pypi-publish` relies on runs on every PR/push.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).