### PR TITLE
Centralize OpenAI-compatible provider HTTP client lifecycle

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
@@ -1,0 +1,43 @@
+from collections.abc import Mapping
+
+import httpx
+
+from pydantic_ai.models import create_async_http_client
+from pydantic_ai.providers import Provider
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'Please install the `openai` package to use the OpenAI provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+
+
+class OpenAICompatibleProvider(Provider[AsyncOpenAI]):
+    """Shared HTTP client lifecycle for providers backed by the OpenAI SDK."""
+
+    def _get_http_client(self, http_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
+        if http_client is None:
+            http_client = create_async_http_client()
+            self._own_http_client = http_client
+            self._http_client_factory = create_async_http_client
+        return http_client
+
+    def _create_openai_client(
+        self,
+        *,
+        base_url: str | None,
+        api_key: str | None,
+        http_client: httpx.AsyncClient | None,
+        default_headers: Mapping[str, str] | None = None,
+    ) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=self._get_http_client(http_client),
+            default_headers=default_headers,
+        )
+
+    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
@@ -1,16 +1,13 @@
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
 
 import httpx
+from openai import AsyncOpenAI
 
 from pydantic_ai.models import create_async_http_client
 from pydantic_ai.providers import Provider
 
-if TYPE_CHECKING:
-    from openai import AsyncOpenAI
 
-
-class OpenAICompatibleProvider(Provider['AsyncOpenAI']):
+class OpenAICompatibleProvider(Provider[AsyncOpenAI]):
     """Shared HTTP client lifecycle for providers backed by the OpenAI SDK."""
 
     def _get_http_client(self, http_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
@@ -27,9 +24,7 @@ class OpenAICompatibleProvider(Provider['AsyncOpenAI']):
         api_key: str | None,
         http_client: httpx.AsyncClient | None,
         default_headers: Mapping[str, str] | None = None,
-    ) -> 'AsyncOpenAI':
-        from openai import AsyncOpenAI
-
+    ) -> AsyncOpenAI:
         return AsyncOpenAI(
             base_url=base_url,
             api_key=api_key,

--- a/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
@@ -1,20 +1,16 @@
 from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 import httpx
 
 from pydantic_ai.models import create_async_http_client
 from pydantic_ai.providers import Provider
 
-try:
+if TYPE_CHECKING:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the OpenAI provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
 
 
-class OpenAICompatibleProvider(Provider[AsyncOpenAI]):
+class OpenAICompatibleProvider(Provider['AsyncOpenAI']):
     """Shared HTTP client lifecycle for providers backed by the OpenAI SDK."""
 
     def _get_http_client(self, http_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
@@ -31,7 +27,9 @@ class OpenAICompatibleProvider(Provider[AsyncOpenAI]):
         api_key: str | None,
         http_client: httpx.AsyncClient | None,
         default_headers: Mapping[str, str] | None = None,
-    ) -> AsyncOpenAI:
+    ) -> 'AsyncOpenAI':
+        from openai import AsyncOpenAI
+
         return AsyncOpenAI(
             base_url=base_url,
             api_key=api_key,

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -13,7 +13,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Alibaba provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -4,15 +4,12 @@ import os
 from typing import overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI
@@ -21,6 +18,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Alibaba provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class AlibabaProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -12,7 +12,7 @@ from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -8,11 +8,11 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -23,7 +23,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class AlibabaProvider(Provider[AsyncOpenAI]):
+class AlibabaProvider(_OpenAICompatibleProvider):
     """Provider for Alibaba Cloud Model Studio (DashScope) OpenAI-compatible API."""
 
     @property
@@ -93,12 +93,4 @@ class AlibabaProvider(Provider[AsyncOpenAI]):
 
             self._base_url = base_url or 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-
-            self._client = AsyncOpenAI(base_url=self._base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self._base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -19,7 +19,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.providers.openai import OpenAIProvider
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 if TYPE_CHECKING:
     from pydantic_ai.realtime import RealtimeModelProfile

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, overload
 from urllib.parse import urlparse
 
 import httpx
-from openai import AsyncOpenAI
 from typing_extensions import Self
 
 from pydantic_ai import ModelProfile
@@ -17,20 +16,21 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers.openai import OpenAIProvider
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 if TYPE_CHECKING:
     from pydantic_ai.realtime import RealtimeModelProfile
 
 try:
-    from openai import AsyncAzureOpenAI
+    from openai import AsyncAzureOpenAI, AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Azure provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai.lib.azure import API_KEY_SENTINEL as _api_key_sentinel

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 try:
     from openai import AsyncAzureOpenAI, AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Azure provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -10,7 +10,6 @@ from typing_extensions import Self
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
@@ -18,8 +17,9 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
 from pydantic_ai.providers.openai import OpenAIProvider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 if TYPE_CHECKING:
     from pydantic_ai.realtime import RealtimeModelProfile
@@ -45,7 +45,7 @@ _DEFAULT_VOICE_LIVE_API_VERSION = '2026-04-10'
 """Default Azure AI Voice Live API version when neither `AZURE_VOICELIVE_API_VERSION` nor an argument is set."""
 
 
-class AzureProvider(Provider[AsyncOpenAI]):
+class AzureProvider(_OpenAICompatibleProvider):
     """Provider for Azure OpenAI API.
 
     See <https://azure.microsoft.com/en-us/products/ai-foundry> for more information.
@@ -322,10 +322,7 @@ class AzureProvider(Provider[AsyncOpenAI]):
             self._api_key = None if api_key == _api_key_sentinel else api_key
             self._resolve_voice_live_credentials(voice_live_endpoint, voice_live_api_key, voice_live_api_version)
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
+            http_client = self._get_http_client(http_client)
 
             # The Azure OpenAI v1 GA API and Azure AI Foundry serverless model
             # endpoints expose an OpenAI-compatible `/v1` API that rejects the
@@ -389,9 +386,6 @@ class AzureProvider(Provider[AsyncOpenAI]):
         self._voice_live_api_version = (
             voice_live_api_version or os.getenv('AZURE_VOICELIVE_API_VERSION') or _DEFAULT_VOICE_LIVE_API_VERSION
         )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
 
 
 def _openai_compatible_v1_base_url(endpoint: str) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -14,7 +14,7 @@ from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
 
 try:
     from openai import AsyncBedrockOpenAI, AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the Bedrock Mantle dependencies to use the Bedrock Mantle provider, '
         'you can use the `bedrock-mantle` optional group — `pip install "pydantic-ai-slim[bedrock-mantle]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -19,8 +19,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the Bedrock Mantle dependencies to use the Bedrock Mantle provider, '
         'you can use the `bedrock-mantle` optional group — `pip install "pydantic-ai-slim[bedrock-mantle]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 BedrockMantleInterface = Literal['chat', 'responses', 'openai-responses']
 """The OpenAI-compatible endpoint family a Bedrock Mantle model is served on.

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -8,11 +8,11 @@ from typing_extensions import assert_never
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
 from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncBedrockOpenAI, AsyncOpenAI
@@ -90,7 +90,7 @@ def _mantle_origin(base_url: str) -> str:
     return origin
 
 
-class BedrockMantleProvider(Provider[AsyncOpenAI]):
+class BedrockMantleProvider(_OpenAICompatibleProvider):
     """Provider for the Amazon Bedrock Mantle OpenAI-compatible API."""
 
     @property
@@ -198,10 +198,7 @@ class BedrockMantleProvider(Provider[AsyncOpenAI]):
                     'or pass `base_url` to use a Bedrock Mantle model.'
                 )
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
+            http_client = self._get_http_client(http_client)
 
             base_client = AsyncBedrockOpenAI(
                 api_key=api_key,

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -12,8 +12,6 @@ from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncBedrockOpenAI, AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -21,6 +19,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the Bedrock Mantle dependencies to use the Bedrock Mantle provider, '
         'you can use the `bedrock-mantle` optional group — `pip install "pydantic-ai-slim[bedrock-mantle]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 BedrockMantleInterface = Literal['chat', 'responses', 'openai-responses']
 """The OpenAI-compatible endpoint family a Bedrock Mantle model is served on.

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock_mantle.py
@@ -12,7 +12,7 @@ from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncBedrockOpenAI, AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.zai import zai_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Cerebras provider, '
         'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -7,14 +7,14 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -25,7 +25,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class CerebrasProvider(Provider[AsyncOpenAI]):
+class CerebrasProvider(_OpenAICompatibleProvider):
     """Provider for Cerebras API."""
 
     @property
@@ -130,17 +130,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
-            )
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
+            self._client = self._create_openai_client(
                 base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
             )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -14,7 +14,7 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -14,8 +14,6 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -23,6 +21,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Cerebras provider, '
         'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class CerebrasProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -21,8 +21,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Cerebras provider, '
         'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class CerebrasProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
@@ -19,7 +19,7 @@ from pydantic_ai.profiles.zai import zai_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Crusoe provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
@@ -7,7 +7,6 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -17,7 +16,8 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -28,7 +28,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class CrusoeProvider(Provider[AsyncOpenAI]):
+class CrusoeProvider(_OpenAICompatibleProvider):
     """Provider for Crusoe Serverless Inference API."""
 
     @property
@@ -113,13 +113,5 @@ class CrusoeProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
@@ -17,8 +17,6 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.profiles.zai import zai_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -26,6 +24,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Crusoe provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class CrusoeProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/crusoe.py
@@ -24,8 +24,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Crusoe provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class CrusoeProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -13,7 +13,7 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the DeepSeek provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -12,7 +12,7 @@ from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -4,15 +4,12 @@ import os
 from typing import Literal, overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI
@@ -21,6 +18,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the DeepSeek provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro']

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -8,11 +8,11 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -26,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
 DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro']
 
 
-class DeepSeekProvider(Provider[AsyncOpenAI]):
+class DeepSeekProvider(_OpenAICompatibleProvider):
     """Provider for DeepSeek API."""
 
     @property
@@ -99,13 +99,5 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Fireworks AI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -4,7 +4,6 @@ import os
 from typing import overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
@@ -16,8 +15,6 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -25,6 +22,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Fireworks AI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class FireworksProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -8,7 +8,6 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -16,7 +15,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +27,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class FireworksProvider(Provider[AsyncOpenAI]):
+class FireworksProvider(_OpenAICompatibleProvider):
     """Provider for Fireworks AI API."""
 
     @property
@@ -94,13 +94,5 @@ class FireworksProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -4,7 +4,6 @@ import os
 from typing import overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
@@ -20,8 +19,6 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -29,6 +26,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Heroku provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 def _heroku_kimi_model_profile(model_name: str) -> ModelProfile | None:

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -20,7 +20,7 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -8,7 +8,6 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
@@ -20,7 +19,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -39,7 +39,7 @@ def _heroku_kimi_model_profile(model_name: str) -> ModelProfile | None:
     return moonshotai_model_profile(model_name)
 
 
-class HerokuProvider(Provider[AsyncOpenAI]):
+class HerokuProvider(_OpenAICompatibleProvider):
     """Provider for Heroku API."""
 
     @property
@@ -130,13 +130,4 @@ class HerokuProvider(Provider[AsyncOpenAI]):
             if not base_url.endswith('/v1'):
                 base_url += '/v1'
 
-            if http_client is not None:
-                self._client = AsyncOpenAI(api_key=api_key, http_client=http_client, base_url=base_url)
-            else:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-                self._client = AsyncOpenAI(api_key=api_key, http_client=http_client, base_url=base_url)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -21,7 +21,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Heroku provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -20,7 +20,7 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -3,7 +3,6 @@ from __future__ import annotations as _annotations
 from typing import overload
 
 from httpx import AsyncClient as AsyncHTTPClient
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.profiles import merge_profile
@@ -20,8 +19,6 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -29,6 +26,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the LiteLLM provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class LiteLLMProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -21,7 +21,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the LiteLLM provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -6,7 +6,6 @@ from httpx import AsyncClient as AsyncHTTPClient
 from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
@@ -20,7 +19,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -31,7 +31,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class LiteLLMProvider(Provider[AsyncOpenAI]):
+class LiteLLMProvider(_OpenAICompatibleProvider):
     """Provider for LiteLLM API."""
 
     @property
@@ -125,17 +125,6 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
 
         # Create OpenAI client that will be used with LiteLLM's completion function
         # The actual API calls will be intercepted and routed through LiteLLM
-        if http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=api_base, api_key=api_key or 'litellm-placeholder', http_client=http_client
-            )
-        else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
-                base_url=api_base, api_key=api_key or 'litellm-placeholder', http_client=http_client
-            )
-
-    def _set_http_client(self, http_client: AsyncHTTPClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+        self._client = self._create_openai_client(
+            base_url=api_base, api_key=api_key or 'litellm-placeholder', http_client=http_client
+        )

--- a/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.openai import (
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the MoonshotAI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
@@ -4,7 +4,6 @@ import os
 from typing import Literal, overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
@@ -15,7 +14,15 @@ from pydantic_ai.profiles.openai import (
     OpenAIModelProfile,
 )
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'Please install the `openai` package to use the MoonshotAI provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 MoonshotAIModelName = Literal[
     'moonshot-v1-8k',

--- a/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
@@ -8,14 +8,14 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import (
     OpenAIJsonSchemaTransformer,
     OpenAIModelProfile,
 )
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 MoonshotAIModelName = Literal[
     'moonshot-v1-8k',
@@ -36,7 +36,7 @@ MoonshotAIModelName = Literal[
 ]
 
 
-class MoonshotAIProvider(Provider[AsyncOpenAI]):
+class MoonshotAIProvider(_OpenAICompatibleProvider):
     """Provider for MoonshotAI platform (Kimi models)."""
 
     @property
@@ -109,13 +109,5 @@ class MoonshotAIProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
@@ -15,7 +15,7 @@ from pydantic_ai.profiles.openai import (
     OpenAIModelProfile,
 )
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 MoonshotAIModelName = Literal[
     'moonshot-v1-8k',

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -7,7 +7,6 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -17,7 +16,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -28,7 +28,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class NebiusProvider(Provider[AsyncOpenAI]):
+class NebiusProvider(_OpenAICompatibleProvider):
     """Provider for Nebius AI Studio API."""
 
     @property
@@ -97,13 +97,5 @@ class NebiusProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -17,8 +17,6 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -26,6 +24,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Nebius provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class NebiusProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -19,7 +19,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Nebius provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -24,8 +24,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Nebius provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class NebiusProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -16,8 +16,6 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -25,6 +23,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Ollama provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class OllamaProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -23,8 +23,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Ollama provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class OllamaProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -6,7 +6,6 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
@@ -16,7 +15,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +27,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class OllamaProvider(Provider[AsyncOpenAI]):
+class OllamaProvider(_OpenAICompatibleProvider):
     """Provider for local or remote Ollama API."""
 
     @property
@@ -111,13 +111,4 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
             api_key = api_key or os.getenv('OLLAMA_API_KEY') or 'api-key-not-set'
 
-            if http_client is not None:
-                self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
-            else:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-                self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -18,7 +18,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Ollama provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -1,16 +1,14 @@
 from __future__ import annotations as _annotations
 
 import os
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, overload
 
 import httpx
 
 from pydantic_ai import ModelProfile
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile, openai_realtime_model_profile
-from pydantic_ai.providers import Provider, missing_api_key_error
+from pydantic_ai.providers import missing_api_key_error
 
 if TYPE_CHECKING:
     from pydantic_ai.realtime import RealtimeModelProfile
@@ -23,34 +21,7 @@ except ImportError as _import_error:  # pragma: no cover
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
 
-
-class _OpenAICompatibleProvider(Provider[AsyncOpenAI]):
-    """Shared HTTP client lifecycle for providers backed by the OpenAI SDK."""
-
-    def _get_http_client(self, http_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
-        if http_client is None:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-        return http_client
-
-    def _create_openai_client(
-        self,
-        *,
-        base_url: str | None,
-        api_key: str | None,
-        http_client: httpx.AsyncClient | None,
-        default_headers: Mapping[str, str] | None = None,
-    ) -> AsyncOpenAI:
-        return AsyncOpenAI(
-            base_url=base_url,
-            api_key=api_key,
-            http_client=self._get_http_client(http_client),
-            default_headers=default_headers,
-        )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class OpenAIProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the OpenAI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, overload
 
 import httpx
@@ -23,7 +24,36 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class OpenAIProvider(Provider[AsyncOpenAI]):
+class _OpenAICompatibleProvider(Provider[AsyncOpenAI]):
+    """Shared HTTP client lifecycle for providers backed by the OpenAI SDK."""
+
+    def _get_http_client(self, http_client: httpx.AsyncClient | None) -> httpx.AsyncClient:
+        if http_client is None:
+            http_client = create_async_http_client()
+            self._own_http_client = http_client
+            self._http_client_factory = create_async_http_client
+        return http_client
+
+    def _create_openai_client(
+        self,
+        *,
+        base_url: str | None,
+        api_key: str | None,
+        http_client: httpx.AsyncClient | None,
+        default_headers: Mapping[str, str] | None = None,
+    ) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=self._get_http_client(http_client),
+            default_headers=default_headers,
+        )
+
+    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+
+
+class OpenAIProvider(_OpenAICompatibleProvider):
     """Provider for OpenAI API."""
 
     @property
@@ -110,13 +140,5 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
             assert api_key is None, 'Cannot provide both `openai_client` and `api_key`'
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -9,7 +9,6 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai._json_schema import JsonSchema, JsonSchemaTransformer
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
@@ -23,7 +22,8 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -121,7 +121,7 @@ def _openrouter_google_model_profile(model_name: str) -> ModelProfile | None:
     return merge_profile(profile, ModelProfile(json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer))
 
 
-class OpenRouterProvider(Provider[AsyncOpenAI]):
+class OpenRouterProvider(_OpenAICompatibleProvider):
     """Provider for OpenRouter API."""
 
     @property
@@ -275,17 +275,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=attribution_headers
-            )
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
+            self._client = self._create_openai_client(
                 base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=attribution_headers
             )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -24,7 +24,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the OpenRouter provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -4,7 +4,6 @@ import os
 from typing import overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai._json_schema import JsonSchema, JsonSchemaTransformer
@@ -23,8 +22,6 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -32,6 +29,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the OpenRouter provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class OpenRouterModelProfile(OpenAIModelProfile, total=False):

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -23,7 +23,7 @@ from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -15,8 +15,6 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -24,6 +22,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use OVHcloud AI Endpoints provider.'
         'You can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class OVHcloudProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use OVHcloud AI Endpoints provider.'
         'You can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -22,8 +22,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use OVHcloud AI Endpoints provider.'
         'You can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class OVHcloudProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -7,7 +7,6 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
@@ -15,7 +14,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -26,7 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class OVHcloudProvider(Provider[AsyncOpenAI]):
+class OVHcloudProvider(_OpenAICompatibleProvider):
     """Provider for OVHcloud AI Endpoints."""
 
     @property
@@ -90,13 +90,5 @@ class OVHcloudProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -15,7 +15,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
@@ -14,8 +13,6 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -23,6 +20,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the SambaNova provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 __all__ = ['SambaNovaProvider']
 

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -15,7 +15,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the SambaNova provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -14,7 +14,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -7,14 +7,14 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +27,7 @@ except ImportError as _import_error:  # pragma: no cover
 __all__ = ['SambaNovaProvider']
 
 
-class SambaNovaProvider(Provider[AsyncOpenAI]):
+class SambaNovaProvider(_OpenAICompatibleProvider):
     """Provider for SambaNova AI models.
 
     SambaNova uses an OpenAI-compatible API.
@@ -109,11 +109,4 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
             # Set base URL (default to SambaNova API endpoint)
             self._base_url = base_url or os.getenv('SAMBANOVA_BASE_URL', 'https://api.sambanova.ai/v1')
 
-            if http_client is None:
-                http_client = create_async_http_client()
-                self._own_http_client = http_client
-                self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self._base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self._base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
@@ -9,14 +9,14 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -44,7 +44,7 @@ class SnowflakeModelProfile(OpenAIModelProfile, total=False):
     """
 
 
-class SnowflakeProvider(Provider[AsyncOpenAI]):
+class SnowflakeProvider(_OpenAICompatibleProvider):
     """Provider for [Snowflake Cortex](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api).
 
     Routes requests through Snowflake's OpenAI-compatible Chat Completions API at
@@ -199,13 +199,4 @@ class SnowflakeProvider(Provider[AsyncOpenAI]):
                 ' to use the Snowflake provider.'
             )
 
-        if http_client is not None:
-            self._client = AsyncOpenAI(base_url=base_url, api_key=token, http_client=http_client)
-        else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=base_url, api_key=token, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+        self._client = self._create_openai_client(base_url=base_url, api_key=token, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
@@ -23,8 +23,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Snowflake provider, '
         'you can use the `snowflake` optional group — `pip install "pydantic-ai-slim[snowflake]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class SnowflakeModelProfile(OpenAIModelProfile, total=False):

--- a/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
@@ -16,8 +16,6 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -25,6 +23,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Snowflake provider, '
         'you can use the `snowflake` optional group — `pip install "pydantic-ai-slim[snowflake]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class SnowflakeModelProfile(OpenAIModelProfile, total=False):

--- a/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/snowflake.py
@@ -18,7 +18,7 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Snowflake provider, '
         'you can use the `snowflake` optional group — `pip install "pydantic-ai-slim[snowflake]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -4,7 +4,6 @@ import os
 from typing import overload
 
 import httpx
-from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
@@ -16,8 +15,6 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -25,6 +22,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Together AI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class TogetherProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -8,7 +8,6 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -16,7 +15,8 @@ from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -27,7 +27,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class TogetherProvider(Provider[AsyncOpenAI]):
+class TogetherProvider(_OpenAICompatibleProvider):
     """Provider for Together AI API."""
 
     @property
@@ -92,13 +92,5 @@ class TogetherProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Together AI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -19,7 +19,7 @@ from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModel
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Vercel provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -7,7 +7,6 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
@@ -17,7 +16,8 @@ from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -28,7 +28,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class VercelProvider(Provider[AsyncOpenAI]):
+class VercelProvider(_OpenAICompatibleProvider):
     """Provider for Vercel AI Gateway API."""
 
     @property
@@ -101,17 +101,7 @@ class VercelProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(
-                base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
-            )
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(
+            self._client = self._create_openai_client(
                 base_url=self.base_url, api_key=api_key, http_client=http_client, default_headers=default_headers
             )
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -17,8 +17,6 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -26,6 +24,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Vercel provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class VercelProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -24,8 +24,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Vercel provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class VercelProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/zai.py
@@ -11,8 +11,6 @@ from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.zai import zai_model_profile
 
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
-
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
@@ -20,6 +18,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Z.AI provider, '
         'you can use the `zai` optional group — `pip install "pydantic-ai-slim[zai]"`'
     ) from _import_error
+
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class ZaiProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/zai.py
@@ -13,7 +13,7 @@ from pydantic_ai.profiles.zai import zai_model_profile
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Z.AI provider, '
         'you can use the `zai` optional group — `pip install "pydantic-ai-slim[zai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/zai.py
@@ -18,8 +18,8 @@ except ImportError as _import_error:  # pragma: no cover
         'Please install the `openai` package to use the Z.AI provider, '
         'you can use the `zai` optional group — `pip install "pydantic-ai-slim[zai]"`'
     ) from _import_error
-
-from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
+else:
+    from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 
 class ZaiProvider(_OpenAICompatibleProvider):

--- a/pydantic_ai_slim/pydantic_ai/providers/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/zai.py
@@ -7,11 +7,11 @@ import httpx
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.zai import zai_model_profile
-from pydantic_ai.providers import Provider
+
+from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
 
 try:
     from openai import AsyncOpenAI
@@ -22,7 +22,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-class ZaiProvider(Provider[AsyncOpenAI]):
+class ZaiProvider(_OpenAICompatibleProvider):
     """Provider for Z.AI (Zhipu AI) API.
 
     Z.AI provides GLM models with support for thinking/reasoning mode
@@ -94,13 +94,5 @@ class ZaiProvider(Provider[AsyncOpenAI]):
 
         if openai_client is not None:
             self._client = openai_client
-        elif http_client is not None:
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            http_client = create_async_http_client()
-            self._own_http_client = http_client
-            self._http_client_factory = create_async_http_client
-            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
-
-    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
-        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/zai.py
@@ -11,7 +11,7 @@ from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.zai import zai_model_profile
 
-from .openai import _OpenAICompatibleProvider  # pyright: ignore[reportPrivateUsage]
+from ._openai_compatible import OpenAICompatibleProvider as _OpenAICompatibleProvider
 
 try:
     from openai import AsyncOpenAI

--- a/tests/providers/test_bedrock_mantle.py
+++ b/tests/providers/test_bedrock_mantle.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-import httpx
 import pytest
 from inline_snapshot import snapshot
 from typing_extensions import assert_never
@@ -114,13 +113,6 @@ def test_bedrock_mantle_model_uses_interface_client() -> None:
     assert chat_model.client is provider._client_for_interface('chat')  # pyright: ignore[reportPrivateUsage]
     assert responses_model.client is not gpt_oss_model.client
     assert gpt_oss_model.client is chat_model.client
-
-
-def test_bedrock_mantle_accepts_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = BedrockMantleProvider(http_client=http_client)
-
-    assert provider.client._client is http_client  # pyright: ignore[reportPrivateUsage]
 
 
 def test_bedrock_mantle_requires_region_or_base_url(env: TestEnv) -> None:

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -2,7 +2,6 @@ from __future__ import annotations as _annotations
 
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -44,12 +43,6 @@ def test_cerebras_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         CerebrasProvider()
-
-
-def test_cerebras_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = CerebrasProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_cerebras_provider_pass_openai_client() -> None:

--- a/tests/providers/test_crusoe.py
+++ b/tests/providers/test_crusoe.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -56,12 +55,6 @@ def test_crusoe_pass_openai_client() -> None:
     openai_client = openai.AsyncOpenAI(api_key='api-key')
     provider = CrusoeProvider(openai_client=openai_client)
     assert provider.client == openai_client
-
-
-def test_crusoe_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = CrusoeProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_crusoe_provider_model_profile(mocker: MockerFixture):

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -35,12 +34,6 @@ def test_deep_seek_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         DeepSeekProvider()
-
-
-def test_deep_seek_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = DeepSeekProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_deep_seek_pass_openai_client() -> None:

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -46,12 +45,6 @@ def test_fireworks_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         FireworksProvider()
-
-
-def test_fireworks_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = FireworksProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_fireworks_pass_openai_client() -> None:

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 
 from pydantic_ai.agent import Agent
@@ -55,12 +54,6 @@ def test_heroku_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         HerokuProvider()
-
-
-def test_heroku_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = HerokuProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_heroku_pass_openai_client() -> None:

--- a/tests/providers/test_litellm.py
+++ b/tests/providers/test_litellm.py
@@ -123,7 +123,7 @@ async def test_create_http_client_usage(mocker: MockerFixture):
     # Create a real AsyncClient for the mock
     async with httpx.AsyncClient() as mock_client:
         mock_create_func = mocker.patch(
-            'pydantic_ai.providers.openai.create_async_http_client', return_value=mock_client
+            'pydantic_ai.providers._openai_compatible.create_async_http_client', return_value=mock_client
         )
 
         provider = LiteLLMProvider(api_key='test-key')

--- a/tests/providers/test_litellm.py
+++ b/tests/providers/test_litellm.py
@@ -123,7 +123,7 @@ async def test_create_http_client_usage(mocker: MockerFixture):
     # Create a real AsyncClient for the mock
     async with httpx.AsyncClient() as mock_client:
         mock_create_func = mocker.patch(
-            'pydantic_ai.providers.litellm.create_async_http_client', return_value=mock_client
+            'pydantic_ai.providers.openai.create_async_http_client', return_value=mock_client
         )
 
         provider = LiteLLMProvider(api_key='test-key')

--- a/tests/providers/test_moonshotai.py
+++ b/tests/providers/test_moonshotai.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -37,13 +36,6 @@ def test_moonshotai_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         MoonshotAIProvider()
-
-
-def test_moonshotai_provider_pass_http_client() -> None:
-    """Test passing a custom HTTP client to MoonshotAI provider."""
-    http_client = httpx.AsyncClient()
-    provider = MoonshotAIProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_moonshotai_pass_openai_client() -> None:

--- a/tests/providers/test_nebius.py
+++ b/tests/providers/test_nebius.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -54,12 +53,6 @@ def test_nebius_pass_openai_client() -> None:
     openai_client = openai.AsyncOpenAI(api_key='api-key')
     provider = NebiusProvider(openai_client=openai_client)
     assert provider.client == openai_client
-
-
-def test_nebius_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = NebiusProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_nebius_provider_model_profile(mocker: MockerFixture):

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from ..conftest import TestEnv, try_import
@@ -52,9 +51,3 @@ def test_init_of_openai_with_base_url_env_var_and_without_api_key(env: TestEnv):
     env.set('OPENAI_BASE_URL', 'https://example.com/v1')
     provider = OpenAIProvider()
     assert provider.client.api_key == 'api-key-not-set'
-
-
-async def test_init_with_http_client():
-    async with httpx.AsyncClient() as http_client:
-        provider = OpenAIProvider(http_client=http_client, api_key='foobar')
-        assert provider.client._client == http_client  # pyright: ignore[reportPrivateUsage]

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from pydantic_ai.providers import Provider
+from pydantic_ai.providers.alibaba import AlibabaProvider
+from pydantic_ai.providers.azure import AzureProvider
+from pydantic_ai.providers.bedrock_mantle import BedrockMantleProvider
+from pydantic_ai.providers.cerebras import CerebrasProvider
+from pydantic_ai.providers.crusoe import CrusoeProvider
+from pydantic_ai.providers.deepseek import DeepSeekProvider
+from pydantic_ai.providers.fireworks import FireworksProvider
+from pydantic_ai.providers.heroku import HerokuProvider
+from pydantic_ai.providers.litellm import LiteLLMProvider
+from pydantic_ai.providers.moonshotai import MoonshotAIProvider
+from pydantic_ai.providers.nebius import NebiusProvider
+from pydantic_ai.providers.ollama import OllamaProvider
+from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.openrouter import OpenRouterProvider
+from pydantic_ai.providers.ovhcloud import OVHcloudProvider
+from pydantic_ai.providers.sambanova import SambaNovaProvider
+from pydantic_ai.providers.snowflake import SnowflakeProvider
+from pydantic_ai.providers.together import TogetherProvider
+from pydantic_ai.providers.vercel import VercelProvider
+from pydantic_ai.providers.zai import ZaiProvider
+
+ProviderFactory = Callable[[], Provider[AsyncOpenAI]]
+ProviderWithHTTPClientFactory = Callable[[httpx.AsyncClient], Provider[AsyncOpenAI]]
+
+
+@dataclass(frozen=True)
+class Case:
+    id: str
+    create: ProviderFactory
+    create_with_http_client: ProviderWithHTTPClientFactory
+
+
+CASES = [
+    Case(
+        'alibaba',
+        lambda: AlibabaProvider(api_key='test'),
+        lambda http_client: AlibabaProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'azure',
+        lambda: AzureProvider(
+            azure_endpoint='https://example-resource.openai.azure.com',
+            api_version='2025-04-01-preview',
+            api_key='test',
+        ),
+        lambda http_client: AzureProvider(
+            azure_endpoint='https://example-resource.openai.azure.com',
+            api_version='2025-04-01-preview',
+            api_key='test',
+            http_client=http_client,
+        ),
+    ),
+    Case(
+        'bedrock-mantle',
+        lambda: BedrockMantleProvider(region_name='us-east-1', api_key='test'),
+        lambda http_client: BedrockMantleProvider(region_name='us-east-1', api_key='test', http_client=http_client),
+    ),
+    Case(
+        'cerebras',
+        lambda: CerebrasProvider(api_key='test'),
+        lambda http_client: CerebrasProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'crusoe',
+        lambda: CrusoeProvider(api_key='test'),
+        lambda http_client: CrusoeProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'deepseek',
+        lambda: DeepSeekProvider(api_key='test'),
+        lambda http_client: DeepSeekProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'fireworks',
+        lambda: FireworksProvider(api_key='test'),
+        lambda http_client: FireworksProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'heroku',
+        lambda: HerokuProvider(api_key='test'),
+        lambda http_client: HerokuProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'litellm',
+        lambda: LiteLLMProvider(api_key='test'),
+        lambda http_client: LiteLLMProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'moonshotai',
+        lambda: MoonshotAIProvider(api_key='test'),
+        lambda http_client: MoonshotAIProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'nebius',
+        lambda: NebiusProvider(api_key='test'),
+        lambda http_client: NebiusProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'ollama',
+        lambda: OllamaProvider(base_url='http://localhost:11434/v1', api_key='test'),
+        lambda http_client: OllamaProvider(
+            base_url='http://localhost:11434/v1', api_key='test', http_client=http_client
+        ),
+    ),
+    Case(
+        'openai',
+        lambda: OpenAIProvider(api_key='test'),
+        lambda http_client: OpenAIProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'openrouter',
+        lambda: OpenRouterProvider(api_key='test'),
+        lambda http_client: OpenRouterProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'ovhcloud',
+        lambda: OVHcloudProvider(api_key='test'),
+        lambda http_client: OVHcloudProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'sambanova',
+        lambda: SambaNovaProvider(api_key='test'),
+        lambda http_client: SambaNovaProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'snowflake',
+        lambda: SnowflakeProvider(account='test', token='test'),
+        lambda http_client: SnowflakeProvider(account='test', token='test', http_client=http_client),
+    ),
+    Case(
+        'together',
+        lambda: TogetherProvider(api_key='test'),
+        lambda http_client: TogetherProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'vercel',
+        lambda: VercelProvider(api_key='test'),
+        lambda http_client: VercelProvider(api_key='test', http_client=http_client),
+    ),
+    Case(
+        'zai',
+        lambda: ZaiProvider(api_key='test'),
+        lambda http_client: ZaiProvider(api_key='test', http_client=http_client),
+    ),
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('case', [pytest.param(case, id=case.id) for case in CASES])
+async def test_openai_compatible_provider_http_client_lifecycle(case: Case) -> None:
+    provider = case.create()
+
+    first_client = provider.client._client  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(first_client, httpx.AsyncClient)
+    async with provider:
+        assert not first_client.is_closed
+    assert first_client.is_closed
+
+    async with provider:
+        second_client = provider.client._client  # pyright: ignore[reportPrivateUsage]
+        assert isinstance(second_client, httpx.AsyncClient)
+        assert second_client is not first_client
+        assert not second_client.is_closed
+    assert second_client.is_closed
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('case', [pytest.param(case, id=case.id) for case in CASES])
+async def test_openai_compatible_provider_preserves_caller_owned_http_client(case: Case) -> None:
+    async with httpx.AsyncClient() as http_client:
+        provider = case.create_with_http_client(http_client)
+
+        assert provider.client._client is http_client  # pyright: ignore[reportPrivateUsage]
+        async with provider:
+            pass
+        assert not http_client.is_closed
+
+
+@pytest.mark.anyio
+async def test_openai_compatible_provider_preserves_caller_owned_sdk_client() -> None:
+    async with httpx.AsyncClient() as http_client:
+        openai_client = AsyncOpenAI(api_key='test', http_client=http_client)
+        provider = OpenAIProvider(openai_client=openai_client)
+
+        assert provider.client is openai_client
+        async with provider:
+            pass
+        assert not http_client.is_closed

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -161,6 +163,51 @@ CASES = [
         lambda http_client: ZaiProvider(api_key='test', http_client=http_client),
     ),
 ]
+
+IMPORT_GUARD_CASES = [
+    ('alibaba', 'use the Alibaba provider'),
+    ('azure', 'use the Azure provider'),
+    ('bedrock_mantle', 'use the Bedrock Mantle provider'),
+    ('cerebras', 'use the Cerebras provider'),
+    ('crusoe', 'use the Crusoe provider'),
+    ('deepseek', 'use the DeepSeek provider'),
+    ('fireworks', 'use the Fireworks AI provider'),
+    ('heroku', 'use the Heroku provider'),
+    ('litellm', 'use the LiteLLM provider'),
+    ('moonshotai', 'use the MoonshotAI provider'),
+    ('nebius', 'use the Nebius provider'),
+    ('ollama', 'use the Ollama provider'),
+    ('openai', 'use the OpenAI provider'),
+    ('openrouter', 'use the OpenRouter provider'),
+    ('ovhcloud', 'use OVHcloud AI Endpoints provider'),
+    ('sambanova', 'use the SambaNova provider'),
+    ('snowflake', 'use the Snowflake provider'),
+    ('together', 'use the Together AI provider'),
+    ('vercel', 'use the Vercel provider'),
+    ('zai', 'use the Z.AI provider'),
+]
+
+
+@pytest.mark.parametrize(('module', 'error_hint'), IMPORT_GUARD_CASES)
+def test_openai_compatible_provider_import_guard(module: str, error_hint: str) -> None:
+    code = f"""
+import builtins
+import importlib
+
+original_import = builtins.__import__
+
+def import_without_openai(name, globals=None, locals=None, fromlist=(), level=0):
+    if level == 0 and (name == "openai" or name.startswith("openai.")):
+        raise ImportError("simulated missing OpenAI SDK")
+    return original_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = import_without_openai
+importlib.import_module("pydantic_ai.providers.{module}")
+"""
+    result = subprocess.run([sys.executable, '-c', code], text=True, capture_output=True)
+
+    assert result.returncode != 0
+    assert error_hint in result.stderr
 
 
 @pytest.mark.anyio

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -5,32 +5,40 @@ from dataclasses import dataclass
 
 import httpx
 import pytest
-from openai import AsyncOpenAI
 
 from pydantic_ai.providers import Provider
-from pydantic_ai.providers.alibaba import AlibabaProvider
-from pydantic_ai.providers.azure import AzureProvider
-from pydantic_ai.providers.bedrock_mantle import BedrockMantleProvider
-from pydantic_ai.providers.cerebras import CerebrasProvider
-from pydantic_ai.providers.crusoe import CrusoeProvider
-from pydantic_ai.providers.deepseek import DeepSeekProvider
-from pydantic_ai.providers.fireworks import FireworksProvider
-from pydantic_ai.providers.heroku import HerokuProvider
-from pydantic_ai.providers.litellm import LiteLLMProvider
-from pydantic_ai.providers.moonshotai import MoonshotAIProvider
-from pydantic_ai.providers.nebius import NebiusProvider
-from pydantic_ai.providers.ollama import OllamaProvider
-from pydantic_ai.providers.openai import OpenAIProvider
-from pydantic_ai.providers.openrouter import OpenRouterProvider
-from pydantic_ai.providers.ovhcloud import OVHcloudProvider
-from pydantic_ai.providers.sambanova import SambaNovaProvider
-from pydantic_ai.providers.snowflake import SnowflakeProvider
-from pydantic_ai.providers.together import TogetherProvider
-from pydantic_ai.providers.vercel import VercelProvider
-from pydantic_ai.providers.zai import ZaiProvider
 
-ProviderFactory = Callable[[], Provider[AsyncOpenAI]]
-ProviderWithHTTPClientFactory = Callable[[httpx.AsyncClient], Provider[AsyncOpenAI]]
+from ..conftest import try_import
+
+with try_import() as imports_successful:
+    from openai import AsyncOpenAI
+
+    from pydantic_ai.providers.alibaba import AlibabaProvider
+    from pydantic_ai.providers.azure import AzureProvider
+    from pydantic_ai.providers.bedrock_mantle import BedrockMantleProvider
+    from pydantic_ai.providers.cerebras import CerebrasProvider
+    from pydantic_ai.providers.crusoe import CrusoeProvider
+    from pydantic_ai.providers.deepseek import DeepSeekProvider
+    from pydantic_ai.providers.fireworks import FireworksProvider
+    from pydantic_ai.providers.heroku import HerokuProvider
+    from pydantic_ai.providers.litellm import LiteLLMProvider
+    from pydantic_ai.providers.moonshotai import MoonshotAIProvider
+    from pydantic_ai.providers.nebius import NebiusProvider
+    from pydantic_ai.providers.ollama import OllamaProvider
+    from pydantic_ai.providers.openai import OpenAIProvider
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+    from pydantic_ai.providers.ovhcloud import OVHcloudProvider
+    from pydantic_ai.providers.sambanova import SambaNovaProvider
+    from pydantic_ai.providers.snowflake import SnowflakeProvider
+    from pydantic_ai.providers.together import TogetherProvider
+    from pydantic_ai.providers.vercel import VercelProvider
+    from pydantic_ai.providers.zai import ZaiProvider
+
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='openai not installed')
+
+ProviderFactory = Callable[[], Provider['AsyncOpenAI']]
+ProviderWithHTTPClientFactory = Callable[[httpx.AsyncClient], Provider['AsyncOpenAI']]
 
 
 @dataclass(frozen=True)

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -100,12 +99,6 @@ def test_openrouter_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         OpenRouterProvider()
-
-
-def test_openrouter_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = OpenRouterProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_openrouter_pass_openai_client() -> None:

--- a/tests/providers/test_snowflake.py
+++ b/tests/providers/test_snowflake.py
@@ -2,7 +2,6 @@ from __future__ import annotations as _annotations
 
 import re
 
-import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
@@ -91,29 +90,6 @@ def test_snowflake_provider_base_url_override(env: TestEnv) -> None:
         base_url='https://myorg-myaccount.privatelink.snowflakecomputing.com/api/v2/cortex/v1', token='pat'
     )
     assert provider.base_url == 'https://myorg-myaccount.privatelink.snowflakecomputing.com/api/v2/cortex/v1'
-
-
-def test_snowflake_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = SnowflakeProvider(account='myorg-myaccount', token='pat', http_client=http_client)
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
-
-
-@pytest.mark.anyio
-async def test_snowflake_provider_reenter_recreates_http_client() -> None:
-    """Re-entering the provider after its own HTTP client is closed swaps in a fresh one."""
-    provider = SnowflakeProvider(account='myorg-myaccount', token='pat')
-
-    first_http_client = provider.client._client  # pyright: ignore[reportPrivateUsage]
-    async with provider:
-        assert not first_http_client.is_closed
-    assert first_http_client.is_closed
-
-    async with provider:
-        second_http_client = provider.client._client  # pyright: ignore[reportPrivateUsage]
-        assert second_http_client is not first_http_client
-        assert not second_http_client.is_closed
-    assert second_http_client.is_closed
 
 
 def test_snowflake_provider_pass_openai_client() -> None:

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -1,6 +1,5 @@
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -46,12 +45,6 @@ def test_together_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         TogetherProvider()
-
-
-def test_together_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = TogetherProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # type: ignore[reportPrivateUsage]
 
 
 def test_together_pass_openai_client() -> None:

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -2,7 +2,6 @@ from __future__ import annotations as _annotations
 
 import re
 
-import httpx
 import pytest
 from pytest_mock import MockerFixture
 
@@ -54,12 +53,6 @@ def test_zai_provider_need_api_key(env: TestEnv) -> None:
         ),
     ):
         ZaiProvider()
-
-
-def test_zai_provider_pass_http_client() -> None:
-    http_client = httpx.AsyncClient()
-    provider = ZaiProvider(http_client=http_client, api_key='api-key')
-    assert provider.client._client == http_client  # pyright: ignore[reportPrivateUsage]
 
 
 def test_zai_provider_pass_openai_client() -> None:


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

### Why we make these changes

The HTTPX2 migration in #7351 needs one lifecycle boundary for OpenAI-SDK-backed providers. This precursor extracts that boundary on current `main` without changing transports, dependencies, public annotations, or user-visible behavior.

### New public surface

None.

<details>
<summary><strong>Goal: centralize the existing HTTP client lifecycle</strong></summary>

**Before → after:** all 20 active OpenAI-compatible providers still default to `httpx.AsyncClient`, close owned clients, recreate them on re-entry, and leave caller-owned HTTPX and raw SDK clients open. The only change is that the shared construction, ownership, and reinjection code now lives in private `_OpenAICompatibleProvider` helpers.

<details>
<summary>Playground</summary>

```python
import asyncio

import httpx

from pydantic_ai.providers.openai import OpenAIProvider


async def main() -> None:
    provider = OpenAIProvider(api_key='test')
    first_client = provider.client._client
    assert isinstance(first_client, httpx.AsyncClient)

    async with provider:
        assert not first_client.is_closed
    assert first_client.is_closed

    async with provider:
        assert provider.client._client is not first_client


asyncio.run(main())
```

</details>

**Test:** `tests/providers/test_openai_compatible_http_clients.py`

**What changes for existing users: nothing.**

</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

