### PR TITLE
Correct the `SpanNode.duration` return contract

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -104,7 +104,7 @@ class SpanNode:
 
     @property
     def duration(self) -> timedelta:
-        """Return the span's duration as a timedelta, or None if start/end not set."""
+        """Return the span's duration as a timedelta."""
         return self.end_timestamp - self.start_timestamp
 
     @property


### PR DESCRIPTION
- Closes #7367

Corrects the `SpanNode.duration` docstring so the generated API reference matches its non-optional `timedelta` return type and required timestamps.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Validation

- `uv run ruff format --check pydantic_evals/pydantic_evals/otel/span_tree.py`
- `uv run ruff check pydantic_evals/pydantic_evals/otel/span_tree.py`
- `uv run pyright pydantic_evals/pydantic_evals/otel/span_tree.py` (`0 errors`)
- `uv run pytest -q tests/evals/test_otel.py` (`29 passed`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

