### PR TITLE
Keep `OpenAIResponsesModel` function calls with their outputs during history replay

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3210,8 +3210,9 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         # parts may name the same revealed tool (duplicated deltas from a UI round-trip, a delta
         # plus a replayed search return), and one declaration per request is enough.
         rendered_additional_tools: set[str] = set()
+
         openai_messages: list[responses.ResponseInputItemParam] = []
-        for message in messages:
+        for message_index, message in enumerate(messages):
             if isinstance(message, ModelRequest):
                 for part in message.parts:
                     if isinstance(part, SystemPromptPart):
@@ -3303,7 +3304,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                 web_search_item: responses.ResponseFunctionWebSearchParam | None = None
                 file_search_item: responses.ResponseFileSearchToolCallParam | None = None
                 code_interpreter_item: responses.ResponseCodeInterpreterToolCallParam | None = None
-                for item in message.parts:
+                for item in _responses_replay_parts(messages, message_index, message):
                     from_same_provider = item.provider_name == self.system or (
                         item.provider_name is None and message.provider_name == self.system
                     )
@@ -5006,6 +5007,47 @@ def _map_provider_details(
         provider_details['finish_reason'] = raw_finish_reason
 
     return provider_details or None
+
+
+def _responses_replay_parts(
+    messages: list[ModelMessage], message_index: int, message: ModelResponse
+) -> Sequence[ModelResponsePart]:
+    """Group settled portable function calls after other response parts for Responses replay."""
+    parts = message.parts
+    first_tool_call_index = next((index for index, part in enumerate(parts) if isinstance(part, ToolCallPart)), None)
+    if (
+        first_tool_call_index is None
+        or not any(not isinstance(part, ToolCallPart) for part in parts[first_tool_call_index + 1 :])
+        or any(isinstance(part, NativeToolCallPart | NativeToolReturnPart) for part in parts)
+        # Provider item IDs describe the exact prior Responses output sequence, which must be
+        # replayed verbatim rather than normalized like portable cross-provider history.
+        or any(
+            (isinstance(part, TextPart | ThinkingPart) and part.id is not None)
+            or (
+                isinstance(part, ToolCallPart)
+                and (part.id is not None or _split_combined_tool_call_id(part.tool_call_id)[1] is not None)
+            )
+            for part in parts
+        )
+    ):
+        return parts
+
+    pending_call_ids = [part.tool_call_id for part in parts if isinstance(part, ToolCallPart)]
+    for next_index in range(message_index + 1, len(messages)):
+        following_message = messages[next_index]
+        if isinstance(following_message, ModelResponse):
+            break
+        for part in following_message.parts:
+            if (
+                isinstance(part, ToolReturnPart) or (isinstance(part, RetryPromptPart) and part.tool_name is not None)
+            ) and part.tool_call_id in pending_call_ids:
+                pending_call_ids.remove(part.tool_call_id)
+    if pending_call_ids:
+        return parts
+
+    # An assistant item after a function call starts a new output group for strict
+    # Responses-compatible providers. Stable sorting keeps relative order within both partitions.
+    return sorted(parts, key=lambda part: isinstance(part, ToolCallPart))
 
 
 def _split_combined_tool_call_id(combined_id: str) -> tuple[str, str | None]:

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4,6 +4,7 @@ import re
 import warnings
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -55,7 +56,7 @@ from pydantic_ai.agent import Agent
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.direct import model_request as direct_model_request
 from pydantic_ai.exceptions import ContentFilterError, ModelHTTPError, ModelRetry, SuspendedResponseExpired
-from pydantic_ai.messages import INVALID_JSON_KEY, sanitize_messages
+from pydantic_ai.messages import INVALID_JSON_KEY, ToolSearchCallPart, ToolSearchReturnPart, sanitize_messages
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAspectRatio, MCPServerTool, WebSearchTool
 from pydantic_ai.native_tools._tool_search import ToolSearchTool
@@ -15687,6 +15688,256 @@ async def test_openai_responses_web_search_tool_external_web_access_default_omit
     response_kwargs = get_mock_responses_kwargs(mock_client)[0]
     assert len(response_kwargs['tools']) == 1
     assert response_kwargs['tools'] == snapshot([{'type': 'web_search', 'search_context_size': 'medium'}])
+
+
+async def test_openai_responses_replay_groups_settled_interleaved_function_calls(
+    allow_model_requests: None,
+) -> None:
+    """Portable calls are grouped on the wire after the assistant items they were interleaved with.
+
+    This is a direct wire-shape test rather than a VCR test because no real OpenAI response
+    produces this cross-provider persisted history, and a cassette would not match on `input`.
+    """
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.6', provider=OpenAIProvider(openai_client=mock_client))
+    history = [
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='inspect inputs'),
+                ToolCallPart('read', {'path': 'a'}, tool_call_id='call-read-a'),
+                ToolCallPart('read', {'path': 'b'}, tool_call_id='call-read-b'),
+                ThinkingPart(content='inspect views'),
+                ToolCallPart('view', {'path': 'c'}, tool_call_id='call-view-c'),
+                ToolCallPart('view', {'path': 'd'}, tool_call_id='call-view-d'),
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                RetryPromptPart('read failed', tool_name='read', tool_call_id='call-read-a'),
+                RetryPromptPart('read failed', tool_name='read', tool_call_id='call-read-b'),
+                ToolReturnPart('view', 'c contents', tool_call_id='call-view-c'),
+                ToolReturnPart('view', 'd contents', tool_call_id='call-view-d'),
+            ]
+        ),
+    ]
+    original_history = deepcopy(history)
+
+    await model.request(history, None, ModelRequestParameters())
+
+    assert history == original_history
+    assert get_mock_responses_kwargs(mock_client)[0]['input'] == snapshot(
+        [
+            {'role': 'assistant', 'content': '<think>\ninspect inputs\n</think>'},
+            {'role': 'assistant', 'content': '<think>\ninspect views\n</think>'},
+            {'name': 'read', 'arguments': '{"path":"a"}', 'call_id': 'call-read-a', 'type': 'function_call'},
+            {'name': 'read', 'arguments': '{"path":"b"}', 'call_id': 'call-read-b', 'type': 'function_call'},
+            {'name': 'view', 'arguments': '{"path":"c"}', 'call_id': 'call-view-c', 'type': 'function_call'},
+            {'name': 'view', 'arguments': '{"path":"d"}', 'call_id': 'call-view-d', 'type': 'function_call'},
+            {
+                'type': 'function_call_output',
+                'call_id': 'call-read-a',
+                'output': 'read failed\n\nFix the errors and try again.',
+            },
+            {
+                'type': 'function_call_output',
+                'call_id': 'call-read-b',
+                'output': 'read failed\n\nFix the errors and try again.',
+            },
+            {'type': 'function_call_output', 'call_id': 'call-view-c', 'output': 'c contents'},
+            {'type': 'function_call_output', 'call_id': 'call-view-d', 'output': 'd contents'},
+        ]
+    )
+
+
+async def test_openai_responses_replay_does_not_reorder_unsettled_or_native_responses(
+    allow_model_requests: None,
+) -> None:
+    """Live frontiers and responses containing native tool parts keep ordinary-part order."""
+    response = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock([response, response])
+    model = OpenAIResponsesModel('gpt-5.6', provider=OpenAIProvider(openai_client=mock_client))
+
+    await model.request(
+        [
+            ModelResponse(
+                parts=[
+                    ToolCallPart('read', {'path': 'a'}, tool_call_id='call-read'),
+                    ThinkingPart(content='keep after the unsettled call'),
+                ]
+            ),
+            ModelRequest.user_text_prompt('continue without a tool result'),
+        ],
+        None,
+        ModelRequestParameters(),
+    )
+    await model.request(
+        [
+            ModelResponse(
+                parts=[
+                    ToolCallPart('read', {'path': 'a'}, tool_call_id='call-read'),
+                    ThinkingPart(content='keep after the portable call'),
+                    NativeToolCallPart(
+                        'web_search',
+                        {'query': 'pydantic ai'},
+                        tool_call_id='native-search',
+                        provider_name='other',
+                    ),
+                ]
+            ),
+            ModelRequest(parts=[ToolReturnPart('read', 'contents', tool_call_id='call-read')]),
+        ],
+        None,
+        ModelRequestParameters(),
+    )
+
+    requests = get_mock_responses_kwargs(mock_client)
+    assert requests[0]['input'] == snapshot(
+        [
+            {'name': 'read', 'arguments': '{"path":"a"}', 'call_id': 'call-read', 'type': 'function_call'},
+            {'role': 'assistant', 'content': '<think>\nkeep after the unsettled call\n</think>'},
+            {'role': 'user', 'content': 'continue without a tool result'},
+        ]
+    )
+    assert requests[1]['input'] == snapshot(
+        [
+            {'name': 'read', 'arguments': '{"path":"a"}', 'call_id': 'call-read', 'type': 'function_call'},
+            {'role': 'assistant', 'content': '<think>\nkeep after the portable call\n</think>'},
+            {'type': 'function_call_output', 'call_id': 'call-read', 'output': 'contents'},
+        ]
+    )
+
+
+@pytest.mark.parametrize('legacy_combined_id', [False, True])
+async def test_openai_responses_replay_preserves_provider_item_id_order(
+    allow_model_requests: None, legacy_combined_id: bool
+) -> None:
+    """Provider-owned Responses items are replayed in their exact original order."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.6', provider=OpenAIProvider(openai_client=mock_client))
+
+    await model.request(
+        [
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        'read',
+                        {'path': 'a'},
+                        tool_call_id='call-read|fc_read' if legacy_combined_id else 'call-read',
+                        id=None if legacy_combined_id else 'fc_read',
+                        provider_name='openai',
+                    ),
+                    ThinkingPart(content='keep after the provider call'),
+                ],
+                provider_name='openai',
+            ),
+            ModelRequest(parts=[ToolReturnPart('read', 'contents', tool_call_id='call-read')]),
+        ],
+        OpenAIResponsesModelSettings(openai_send_reasoning_ids=True),
+        ModelRequestParameters(),
+    )
+
+    assert get_mock_responses_kwargs(mock_client)[0]['input'] == snapshot(
+        [
+            {
+                'name': 'read',
+                'arguments': '{"path":"a"}',
+                'call_id': 'call-read',
+                'type': 'function_call',
+                'id': 'fc_read',
+            },
+            {'role': 'assistant', 'content': '<think>\nkeep after the provider call\n</think>'},
+            {'type': 'function_call_output', 'call_id': 'call-read', 'output': 'contents'},
+        ]
+    )
+
+
+async def test_openai_responses_replay_groups_settled_local_tool_search_call(
+    allow_model_requests: None,
+) -> None:
+    """Typed local tool-search calls follow ordinary function-call grouping."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.6', provider=OpenAIProvider(openai_client=mock_client))
+
+    await model.request(
+        [
+            ModelResponse(
+                parts=[
+                    ToolSearchCallPart(args={'queries': ['weather']}, tool_call_id='search-1'),
+                    ThinkingPart(content='search first'),
+                ]
+            ),
+            ModelRequest(
+                parts=[
+                    ToolSearchReturnPart(
+                        content={'discovered_tools': []},
+                        tool_call_id='search-1',
+                    )
+                ]
+            ),
+        ],
+        None,
+        ModelRequestParameters(),
+    )
+
+    assert get_mock_responses_kwargs(mock_client)[0]['input'] == snapshot(
+        [
+            {'role': 'assistant', 'content': '<think>\nsearch first\n</think>'},
+            {
+                'name': 'search_tools',
+                'arguments': '{"queries":["weather"]}',
+                'call_id': 'search-1',
+                'type': 'function_call',
+            },
+            {
+                'type': 'function_call_output',
+                'call_id': 'search-1',
+                'output': '{"discovered_tools":[]}',
+            },
+        ]
+    )
 
 
 async def test_openai_responses_malformed_tool_args_degraded_on_the_wire(allow_model_requests: None):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -15775,7 +15775,7 @@ async def test_openai_responses_replay_does_not_reorder_unsettled_or_native_resp
             )
         ]
     )
-    mock_client = MockOpenAIResponses.create_mock([response, response])
+    mock_client = MockOpenAIResponses.create_mock([response, response, response])
     model = OpenAIResponsesModel('gpt-5.6', provider=OpenAIProvider(openai_client=mock_client))
 
     await model.request(
@@ -15810,6 +15810,20 @@ async def test_openai_responses_replay_does_not_reorder_unsettled_or_native_resp
         None,
         ModelRequestParameters(),
     )
+    await model.request(
+        [
+            ModelResponse(
+                parts=[
+                    ToolCallPart('read', {'path': 'a'}, tool_call_id='call-read'),
+                    ThinkingPart(content='keep before the next response'),
+                ]
+            ),
+            ModelRequest.user_text_prompt('continue without a tool result'),
+            ModelResponse(parts=[TextPart(content='already continued')]),
+        ],
+        None,
+        ModelRequestParameters(),
+    )
 
     requests = get_mock_responses_kwargs(mock_client)
     assert requests[0]['input'] == snapshot(
@@ -15824,6 +15838,14 @@ async def test_openai_responses_replay_does_not_reorder_unsettled_or_native_resp
             {'name': 'read', 'arguments': '{"path":"a"}', 'call_id': 'call-read', 'type': 'function_call'},
             {'role': 'assistant', 'content': '<think>\nkeep after the portable call\n</think>'},
             {'type': 'function_call_output', 'call_id': 'call-read', 'output': 'contents'},
+        ]
+    )
+    assert requests[2]['input'] == snapshot(
+        [
+            {'name': 'read', 'arguments': '{"path":"a"}', 'call_id': 'call-read', 'type': 'function_call'},
+            {'role': 'assistant', 'content': '<think>\nkeep before the next response\n</think>'},
+            {'role': 'user', 'content': 'continue without a tool result'},
+            {'role': 'assistant', 'content': 'already continued'},
         ]
     )
 


### PR DESCRIPTION
- Closes #7430

`OpenAIResponsesModel` currently serializes an interleaved `ModelResponse` part by part. For a settled portable function-call batch, that can put a later assistant/reasoning item between the first calls and their outputs, which strict Responses-compatible providers reject.

This change keeps the normalized typed history untouched and only adjusts the Responses wire projection:

- stable-groups settled ordinary function calls after the response's other assistant parts;
- treats both `ToolReturnPart` and tool-bound `RetryPromptPart` as matching results;
- leaves unsettled live frontiers, responses containing native tool parts, and provider-owned item-ID transcripts in their original order;
- preserves typed local tool-call subclasses such as `ToolSearchCallPart` as ordinary function calls.

### Tests

- `uv run pytest tests/models/test_openai_responses.py -q` (236 passed)
- `make typecheck`
- pre-commit hooks: format, lint, typecheck, cassette checks

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

