### PR TITLE
Update `NebiusProvider` to the Token Factory endpoint

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -941,16 +941,16 @@ print(result.output)
     [Models that accept only one leading system message](#models-that-accept-only-one-leading-system-message)
     for details.
 
-### Nebius AI Studio
+### Nebius Token Factory
 
-Go to [Nebius AI Studio](https://studio.nebius.com/) and create an API key.
+Go to [Nebius Token Factory](https://tokenfactory.nebius.com/) and create an API key.
 
 You can set the `NEBIUS_API_KEY` environment variable and use [`NebiusProvider`][pydantic_ai.providers.nebius.NebiusProvider] by name:
 
 ```python
 from pydantic_ai import Agent
 
-agent = Agent('nebius:Qwen/Qwen3-32B-fast')
+agent = Agent('nebius:openai/gpt-oss-120b')
 result = agent.run_sync('What is the capital of France?')
 print(result.output)
 #> The capital of France is Paris.
@@ -964,7 +964,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.nebius import NebiusProvider
 
 model = OpenAIChatModel(
-    'Qwen/Qwen3-32B-fast',
+    'openai/gpt-oss-120b',
     provider=NebiusProvider(api_key='your-nebius-api-key'),
 )
 agent = Agent(model)

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -29,7 +29,7 @@ except ImportError as _import_error:  # pragma: no cover
 
 
 class NebiusProvider(Provider[AsyncOpenAI]):
-    """Provider for Nebius AI Studio API."""
+    """Provider for the Nebius Token Factory API."""
 
     @property
     def name(self) -> str:
@@ -37,7 +37,7 @@ class NebiusProvider(Provider[AsyncOpenAI]):
 
     @property
     def base_url(self) -> str:
-        return 'https://api.studio.nebius.com/v1'
+        return 'https://api.tokenfactory.nebius.com/v1'
 
     @property
     def client(self) -> AsyncOpenAI:
@@ -92,7 +92,7 @@ class NebiusProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `NEBIUS_API_KEY` environment variable or pass it via '
-                '`NebiusProvider(api_key=...)` to use the Nebius AI Studio provider.'
+                '`NebiusProvider(api_key=...)` to use the Nebius Token Factory provider.'
             )
 
         if openai_client is not None:

--- a/tests/providers/test_nebius.py
+++ b/tests/providers/test_nebius.py
@@ -33,8 +33,9 @@ pytestmark = [
 def test_nebius_provider():
     provider = NebiusProvider(api_key='api-key')
     assert provider.name == 'nebius'
-    assert provider.base_url == 'https://api.studio.nebius.com/v1'
+    assert provider.base_url == 'https://api.tokenfactory.nebius.com/v1'
     assert isinstance(provider.client, openai.AsyncOpenAI)
+    assert str(provider.client.base_url) == 'https://api.tokenfactory.nebius.com/v1/'
     assert provider.client.api_key == 'api-key'
 
 
@@ -44,7 +45,7 @@ def test_nebius_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `NEBIUS_API_KEY` environment variable or pass it via '
-            '`NebiusProvider(api_key=...)` to use the Nebius AI Studio provider.'
+            '`NebiusProvider(api_key=...)` to use the Nebius Token Factory provider.'
         ),
     ):
         NebiusProvider()


### PR DESCRIPTION
The built-in `NebiusProvider` still targeted the retired Nebius AI Studio hostname while Nebius now documents Token Factory as the public OpenAI-compatible API.

This updates the provider to `https://api.tokenfactory.nebius.com/v1`, updates its user-facing terminology, and replaces the documentation sample with the current Token Factory `openai/gpt-oss-120b` model. The provider remains an `OpenAIChatModel` provider; this PR does not change its API behavior or add Responses API support.

The provider URL regression assertion verifies that the canonical endpoint reaches the constructed `AsyncOpenAI` client. The branch has also been refreshed onto current `main` and now uses the repository's shared `OpenAICompatibleProvider` client-lifecycle base.

I searched open issues and pull requests for Nebius endpoint and naming changes before opening this PR and found no duplicate. Because this is an atomic correction of a stale URL and its matching documentation, I treated it as a trivial fix and did not open a separate issue.

Validation on current `main`:

- `uv run pytest tests/providers/test_nebius.py -q` — 5 passed
- `uv run --group lint ruff check pydantic_ai_slim/pydantic_ai/providers/nebius.py tests/providers/test_nebius.py`
- `uv run --group lint ruff format --check pydantic_ai_slim/pydantic_ai/providers/nebius.py tests/providers/test_nebius.py`
- `uv run --group lint pyright pydantic_ai_slim/pydantic_ai/providers/nebius.py` — 0 errors

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
