### PR TITLE
Add `allowed_hosts` to `Agent.to_web()` and `clai web` (v1 backport)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -189,6 +189,7 @@ clai web --agent my_module:my_agent -i 'Always respond in Spanish'
 | `--host` | Host to bind server (default: 127.0.0.1) |
 | `--port` | Port to bind server (default: 7932) |
 | `--html-source` | URL or file path for the chat UI HTML. |
+| `--allowed-host` | Hostname to answer to in addition to IP addresses and `localhost` (repeatable). See [Reaching the UI under a hostname](web.md#reaching-the-ui-under-a-hostname). |
 
 When using `--agent`, the agent's configured model becomes the default. CLI models (`-m`) are additional options. Without `--agent`, the first `-m` model is the default.
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -94,9 +94,36 @@ agent = Agent('openai:gpt-5.2')
 app = agent.to_web(instructions='Always respond in a friendly tone.')
 ```
 
+## Reaching the UI under a hostname
+
+The app answers only to requests whose `Host` header is an IP address (`127.0.0.1`, `[::1]`, or a LAN address like `192.168.1.5`) or `localhost` — including names under it, like `my-app.localhost`. Any other `Host` gets a `421 Misdirected Request`. Hostnames are compared in ASCII form, so an internationalized name goes in the list as punycode (`xn--bcher-kva.example`), which is what the browser sends.
+
+This is what stops a website from reaching the UI on your machine by pointing a hostname it controls at `127.0.0.1` — a DNS rebinding attack, which makes the browser treat that website and the UI as the same origin, so the endpoint's `Content-Type: application/json` requirement no longer applies. An IP address can't be rebound that way, because rebinding works by pointing a *name* at an address.
+
+If you serve the UI under a real hostname — behind a reverse proxy, or through a tunnel like ngrok — name that hostname in `allowed_hosts`:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+app = agent.to_web(allowed_hosts=['ui.example.com'])
+
+# `*.example.com` matches subdomains only; list the apex separately if you serve it too
+app = agent.to_web(allowed_hosts=['example.com', '*.example.com'])
+```
+
+Or with the CLI:
+
+```bash
+clai web -m openai:gpt-5.2 --allowed-host ui.example.com
+```
+
+Pass `allowed_hosts=['*']` to answer to any host, but only if something in front of the app already authenticates requests.
+
 ## Reserved Routes
 
-The web UI app uses the following routes which should not be overwritten:
+All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). The web UI app uses the following routes which should not be overwritten:
 
 - `/` and `/{id}` - Serves the chat UI
 - `/api/chat` - Chat endpoint (POST, OPTIONS). Requires `Content-Type: application/json`; other content types are rejected with `415`.

--- a/docs/web.md
+++ b/docs/web.md
@@ -119,7 +119,11 @@ Or with the CLI:
 clai web -m openai:gpt-5.2 --allowed-host ui.example.com
 ```
 
-Pass `allowed_hosts=['*']` to answer to any host, but only if something in front of the app already authenticates requests.
+`clai web --host <name>` adds that name for you, so the URL it prints always works.
+
+Every route is checked, including `/api/health`. A health check or container probe that sends a DNS name in its `Host` header gets the same `421`, and monitoring systems often record only the status code or swap in their own error page, so the explanation may never reach you — point probes at the bound IP address or `localhost`, or add their hostname here.
+
+Pass `allowed_hosts=['*']` to answer to any host, but only if something in front of the app already authenticates requests. Only list domains whose subdomains you control: a wildcard for a domain where anyone can obtain a subdomain re-opens the problem.
 
 ## Reserved Routes
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -195,6 +195,14 @@ def _cli_web(args_list: list[str], prog_name: str, default_model: str, qualified
     )
     parser.add_argument('--host', default='127.0.0.1', help='Host to bind server (default: 127.0.0.1)')
     parser.add_argument('--port', type=int, default=7932, help='Port to bind server (default: 7932)')
+    parser.add_argument(
+        '--allowed-host',
+        action='append',
+        dest='allowed_hosts',
+        help='Hostname to answer to in addition to IP addresses and localhost, which are always '
+        'allowed (can be repeated). Needed only when reaching the UI through a name, e.g. behind a '
+        'reverse proxy or a tunnel. Supports "*.example.com" and "*" for any host.',
+    )
     argcomplete.autocomplete(parser)
     args = parser.parse_args(args_list)
 
@@ -209,6 +217,7 @@ def _cli_web(args_list: list[str], prog_name: str, default_model: str, qualified
         instructions=args.instructions,
         default_model=default_model,
         html_source=args.html_source,
+        allowed_hosts=args.allowed_hosts or [],
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/web.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/web.py
@@ -69,7 +69,10 @@ def run_web_command(
         native_tools=tool_instances,
         instructions=instructions,
         html_source=html_source,
-        allowed_hosts=allowed_hosts,
+        # `--host` is both where we bind and the URL printed below, so answering to it is implied —
+        # making the user repeat it in `--allowed-host` would have the CLI advertise a URL it then
+        # refuses. Only meaningful when binding to a name; an IP address is always allowed anyway.
+        allowed_hosts=[*allowed_hosts, host],
     )
 
     agent_desc = agent_path or 'generic agent'

--- a/pydantic_ai_slim/pydantic_ai/_cli/web.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/web.py
@@ -18,6 +18,7 @@ def run_web_command(
     instructions: str | None = None,
     default_model: str = 'openai-chat:gpt-5',
     html_source: str | None = None,
+    allowed_hosts: list[str] = [],
 ) -> int:
     """Run the web command to serve an agent via web UI.
 
@@ -33,6 +34,7 @@ def run_web_command(
         instructions: System instructions passed as extra instructions to each agent run.
         default_model: Default model to use when no agent or models are specified.
         html_source: URL or file path for the chat UI HTML.
+        allowed_hosts: Hostnames to answer to in addition to IP addresses and localhost.
     """
     console = Console()
 
@@ -67,6 +69,7 @@ def run_web_command(
         native_tools=tool_instances,
         instructions=instructions,
         html_source=html_source,
+        allowed_hosts=allowed_hosts,
     )
 
     agent_desc = agent_path or 'generic agent'

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2776,6 +2776,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         model_settings: ModelSettings | None = None,
         instructions: str | None = None,
         html_source: str | Path | None = None,
+        allowed_hosts: Sequence[str] | None = None,
         **_deprecated_kwargs: Any,
     ) -> Starlette:
         """Create a Starlette app that serves a web chat UI for this agent.
@@ -2809,6 +2810,12 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 - A Path instance: Reads from the local file
                 - A URL string (http:// or https://): Fetches from the URL
                 - A file path string: Reads from the local file
+            allowed_hosts: Additional hostnames to answer to, e.g. `['ui.example.com']` or
+                `['*.example.com']` (subdomains only, so list the apex separately if you serve it).
+                IP addresses and `localhost` are always allowed; any other `Host` header is refused
+                with a `421`, so that a website cannot reach the UI on your machine by pointing a
+                hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host,
+                only if something in front of the app already authenticates requests.
 
         Returns:
             A configured Starlette application ready to be served (e.g., with uvicorn)
@@ -2847,6 +2854,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             model_settings=model_settings,
             instructions=instructions,
             html_source=html_source,
+            allowed_hosts=allowed_hosts,
         )
 
     @asynccontextmanager

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/_hosts.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/_hosts.py
@@ -1,0 +1,150 @@
+"""`Host` header validation for the web chat UI, to defeat DNS rebinding.
+
+Binding the UI to loopback keeps other machines out, but not other *websites*: a page the developer
+visits can make their browser send requests to `http://127.0.0.1:7932`. The chat endpoint's
+`application/json` requirement stops that, because a browser can't send a non-safelisted content
+type cross-origin without a preflight the server refuses.
+
+DNS rebinding gets around all of it. The attacker points a name they control at `127.0.0.1`, so the
+browser believes `http://evil.example:7932` and the web UI are the *same* origin: no preflight, no
+CORS, and a CSRF token wouldn't help either, since a same-origin page can simply read it. The one
+thing the attacker cannot change is the `Host` header the browser sends, which still carries their
+name. Checking it is therefore the control available at this layer — putting an authenticating proxy
+in front of the app is the other answer, and the one to reach for outside local development.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Sequence
+from urllib.parse import urlsplit
+
+from starlette.datastructures import Headers
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+ANY_HOST = '*'
+"""`allowed_hosts` entry that accepts every `Host` header, turning the protection off."""
+
+LOCALHOST = 'localhost'
+
+# Characters that make `urlsplit` read part of the value as userinfo, a path, a query or a fragment.
+# None of them may appear in a `Host` header, and treating them as a parse failure is what keeps
+# `evil.example@127.0.0.1` from being read as loopback.
+_ILLEGAL_HOST_CHARS = frozenset('@/?#')
+
+
+def _hostname(host_header: str) -> str | None:
+    """Return the lowercased hostname in a `Host` header value, or `None` if it isn't parsable.
+
+    The port is dropped: only one server is listening on the port the request arrived at, so the
+    port identifies nothing. Note that it can't be dropped by slicing at the first `:` — which is
+    what Starlette's own `TrustedHostMiddleware` does — because that mangles the bracketed IPv6
+    form `[::1]:7932` into `[`.
+
+    A single trailing dot is dropped as well. `http://localhost./` names the same host as
+    `http://localhost/`, and a browser keeps that dot in the `Host` header, so without this
+    `localhost.` would be turned away. Exactly one dot, so `localhost..`, which denotes no host at
+    all, stays rejected.
+    """
+    if _ILLEGAL_HOST_CHARS & set(host_header):
+        return None
+    try:
+        hostname = urlsplit(f'//{host_header}').hostname
+    except ValueError:
+        return None
+    if not hostname:
+        # `urlsplit('//')` yields `None`, which is how an absent or empty `Host` lands here.
+        return None
+    return hostname.removesuffix('.') or None
+
+
+def _is_ip_address(hostname: str) -> bool:
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return True
+
+
+def _matches(hostname: str, pattern: str) -> bool:
+    if pattern.startswith('*.'):
+        # Subdomains only, not the apex — `*.example.com` means exactly what it means in Starlette's
+        # `TrustedHostMiddleware`, which this parameter is named after. A deployment that serves the
+        # apex too lists it separately; over-matching an allowlist is the worse way to be wrong.
+        # Note this compares against `.example.com`, so `a.example.com.evil` doesn't slip through on
+        # a bare substring.
+        return hostname.endswith(pattern[1:])
+    return hostname == pattern
+
+
+def is_allowed_host(host_header: str, allowed_hosts: Sequence[str]) -> bool:
+    """Whether a request's `Host` header names a server this app is willing to answer as.
+
+    `allowed_hosts` entries must already be normalized the way `HostValidationMiddleware` normalizes
+    them: lowercased, with any trailing dot removed. Hostnames are compared in their ASCII form, so
+    an internationalized name has to be given as punycode (`xn--bcher-kva.example`), which is what a
+    browser puts in the header anyway.
+    """
+    if ANY_HOST in allowed_hosts:
+        return True
+
+    hostname = _hostname(host_header)
+    if hostname is None:
+        return False
+
+    # An IP literal can't be the product of DNS rebinding: rebinding works by pointing a *name* the
+    # attacker controls at the server's address, and a name is exactly what an IP literal is not. A
+    # page that navigates straight to `http://127.0.0.1:7932` is an ordinary cross-origin request,
+    # which the chat endpoint's `application/json` requirement already turns away. Accepting every
+    # IP literal rather than just the loopback ones is deliberate: reaching a dev server over the
+    # LAN or through a forwarded port is a normal thing to do, and none of it is rebindable.
+    if _is_ip_address(hostname):
+        return True
+
+    # RFC 6761 reserves `localhost` and everything under it for the loopback interface, and browsers
+    # resolve those names locally instead of over DNS, so they can't be rebound either.
+    if hostname == LOCALHOST or hostname.endswith(f'.{LOCALHOST}'):
+        return True
+
+    return any(_matches(hostname, pattern) for pattern in allowed_hosts)
+
+
+class HostValidationMiddleware:
+    """Turn away requests whose `Host` header names a server other than a local one.
+
+    Deliberately reads only the `Host` header, never `X-Forwarded-Host` or `Forwarded`: those are
+    just request headers, so a client talking to the app directly can set them to anything. A
+    deployment behind a proxy names the public hostname in `allowed_hosts` instead.
+    """
+
+    def __init__(self, app: ASGIApp, allowed_hosts: Sequence[str]) -> None:
+        self.app = app
+        self.allowed_hosts = [pattern.lower().removesuffix('.') for pattern in allowed_hosts]
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope['type'] not in ('http', 'websocket'):
+            await self.app(scope, receive, send)
+            return
+
+        host_header = Headers(scope=scope).get('host', '')
+        if is_allowed_host(host_header, self.allowed_hosts):
+            await self.app(scope, receive, send)
+            return
+
+        if scope['type'] == 'websocket':
+            await send({'type': 'websocket.close', 'code': 1008})
+            return
+
+        response = PlainTextResponse(
+            f'Host {host_header!r} is not allowed.\n\n'
+            'The web chat UI only answers requests whose `Host` header is an IP address or '
+            '`localhost`, so that a website cannot reach it on your machine by pointing a hostname '
+            'it controls at you (DNS rebinding).\n\n'
+            'To serve the UI under a hostname, pass it in `allowed_hosts`.\n',
+            status_code=421,
+            # The message quotes the client's own `Host` header back at it. `text/plain` is enough
+            # to keep a browser from rendering that as markup, as long as it isn't sniffed.
+            headers={'x-content-type-options': 'nosniff'},
+        )
+        await response(scope, receive, send)

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/_hosts.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/_hosts.py
@@ -141,7 +141,8 @@ class HostValidationMiddleware:
             'The web chat UI only answers requests whose `Host` header is an IP address or '
             '`localhost`, so that a website cannot reach it on your machine by pointing a hostname '
             'it controls at you (DNS rebinding).\n\n'
-            'To serve the UI under a hostname, pass it in `allowed_hosts`.\n',
+            'To serve the UI under a hostname, pass it in `allowed_hosts`, or run `clai web` with '
+            '`--allowed-host`.\n',
             status_code=421,
             # The message quotes the client's own `Host` header back at it. `text/plain` is enough
             # to keep a browser from rendering that as markup, as long as it isn't sniffed.

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/_hosts.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/_hosts.py
@@ -23,6 +23,8 @@ from starlette.datastructures import Headers
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from pydantic_ai.exceptions import UserError
+
 ANY_HOST = '*'
 """`allowed_hosts` entry that accepts every `Host` header, turning the protection off."""
 
@@ -65,6 +67,24 @@ def _is_ip_address(hostname: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def normalized_pattern(pattern: str) -> str:
+    """Normalize an `allowed_hosts` entry the way `_hostname` normalizes an incoming header.
+
+    Raises `UserError` on a wildcard naming no domain. `'*.'` is the one that matters: it reads like
+    a wildcard for something, but dropping its root dot would leave `'*'` — the sentinel that accepts
+    every host — so a typo would silently turn the check off rather than fail. A wildcard that isn't
+    `*.`-prefixed (`'*example.com'`) is rejected in the same pass; it can only ever match a literal
+    host of that name, which is to say never.
+    """
+    lowered = pattern.lower()
+    if lowered != ANY_HOST and lowered.startswith('*') and not (lowered.startswith('*.') and lowered[2:].strip('.')):
+        raise UserError(
+            f'Invalid `allowed_hosts` pattern {pattern!r}. '
+            f'Use a hostname, `*.example.com` to match its subdomains, or `{ANY_HOST}` to allow any host.'
+        )
+    return lowered.removesuffix('.')
 
 
 def _matches(hostname: str, pattern: str) -> bool:
@@ -120,7 +140,7 @@ class HostValidationMiddleware:
 
     def __init__(self, app: ASGIApp, allowed_hosts: Sequence[str]) -> None:
         self.app = app
-        self.allowed_hosts = [pattern.lower().removesuffix('.') for pattern in allowed_hosts]
+        self.allowed_hosts = [normalized_pattern(pattern) for pattern in allowed_hosts]
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope['type'] not in ('http', 'websocket'):
@@ -138,9 +158,9 @@ class HostValidationMiddleware:
 
         response = PlainTextResponse(
             f'Host {host_header!r} is not allowed.\n\n'
-            'The web chat UI only answers requests whose `Host` header is an IP address or '
-            '`localhost`, so that a website cannot reach it on your machine by pointing a hostname '
-            'it controls at you (DNS rebinding).\n\n'
+            'The web chat UI only answers requests whose `Host` header is an IP address, '
+            '`localhost`, or a name under `.localhost`, so that a website cannot reach it on your '
+            'machine by pointing a hostname it controls at you (DNS rebinding).\n\n'
             'To serve the UI under a hostname, pass it in `allowed_hosts`, or run `clai web` with '
             '`--allowed-host`.\n',
             status_code=421,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -103,6 +103,11 @@ def create_api_app(
 ) -> Starlette:
     """Create API app for the web chat UI.
 
+    This sub-app carries no `Host` validation of its own: `create_web_app()` applies
+    `HostValidationMiddleware` to the outer app it mounts this into. Serving it directly, or
+    re-mounting `create_web_app(...).router` (which drops application middleware), exposes the chat
+    endpoint to any `Host` — mount the app `create_web_app()` returns instead.
+
     Args:
         agent: Agent instance.
         models: Models to make available in the UI. Can be:

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -12,10 +12,12 @@ from pydantic_ai import Agent
 from pydantic_ai.native_tools import AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 
+from ._hosts import HostValidationMiddleware
 from .api import ModelsParam, create_api_app
 
 try:
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
     from starlette.requests import Request
     from starlette.responses import HTMLResponse, Response
     from starlette.routing import Mount
@@ -115,6 +117,7 @@ def create_web_app(
     model_settings: ModelSettings | None = None,
     instructions: str | None = None,
     html_source: str | Path | None = None,
+    allowed_hosts: Sequence[str] | None = None,
     **_deprecated_kwargs: object,
 ) -> Starlette:
     """Create a Starlette app that serves a web chat UI for the given agent.
@@ -140,6 +143,12 @@ def create_web_app(
             - A Path instance: Reads from the local file
             - A URL string (http:// or https://): Fetches from the URL
             - A file path string: Reads from the local file
+        allowed_hosts: Additional hostnames to answer to, e.g. `['ui.example.com']` or
+            `['*.example.com']` (subdomains only, so list the apex separately if you serve it).
+            IP addresses and `localhost` are always allowed; any other `Host` header is refused
+            with a `421`, so that a website cannot reach the UI on your machine by pointing a
+            hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host, only
+            if something in front of the app already authenticates requests.
 
     Returns:
         A configured Starlette application ready to be served
@@ -159,7 +168,11 @@ def create_web_app(
     )
 
     routes = [Mount('/api', app=api_app)]
-    app = Starlette(routes=routes)
+    # Applied to the whole app rather than just `/api/chat`: a request that reaches us under a
+    # hostname we don't answer to is misdirected whatever it asks for, and guarding every route
+    # means a route added later is covered without anyone having to remember to opt it in.
+    middleware = [Middleware(HostValidationMiddleware, allowed_hosts=allowed_hosts or ())]
+    app = Starlette(routes=routes, middleware=middleware)
 
     async def index(request: Request) -> Response:
         """Serve the chat UI from filesystem cache or CDN."""

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -12,7 +12,7 @@ from pydantic_ai import Agent
 from pydantic_ai.native_tools import AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 
-from ._hosts import HostValidationMiddleware
+from ._hosts import HostValidationMiddleware, normalized_pattern
 from .api import ModelsParam, create_api_app
 
 try:
@@ -152,11 +152,19 @@ def create_web_app(
 
     Returns:
         A configured Starlette application ready to be served
+
+    Raises:
+        UserError: If an `allowed_hosts` entry is not a hostname, `*.example.com`, or `*`.
     """
     from ... import _utils
 
     native_tools = _utils.consume_deprecated_builtin_tools(_deprecated_kwargs, native_tools)
     _utils.validate_empty_kwargs(_deprecated_kwargs)
+
+    # Normalized here rather than left to the middleware so a bad pattern is reported from this call
+    # instead of from the first request: Starlette builds its middleware stack lazily. Normalizing is
+    # idempotent, so the middleware doing it again over the same list is a no-op.
+    allowed_hosts = [normalized_pattern(pattern) for pattern in allowed_hosts or ()]
 
     api_app = create_api_app(
         agent=agent,
@@ -171,7 +179,7 @@ def create_web_app(
     # Applied to the whole app rather than just `/api/chat`: a request that reaches us under a
     # hostname we don't answer to is misdirected whatever it asks for, and guarding every route
     # means a route added later is covered without anyone having to remember to opt it in.
-    middleware = [Middleware(HostValidationMiddleware, allowed_hosts=allowed_hosts or ())]
+    middleware = [Middleware(HostValidationMiddleware, allowed_hosts=allowed_hosts)]
     app = Starlette(routes=routes, middleware=middleware)
 
     async def index(request: Request) -> Response:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,3 +809,19 @@ def test_clai_web_with_allowed_hosts(mocker: MockerFixture, env: TestEnv):
         html_source=None,
         allowed_hosts=['ui.example.com', '*.corp.example'],
     )
+
+
+def test_clai_web_answers_to_the_host_it_binds_to(mocker: MockerFixture, env: TestEnv):
+    """`--host <name>` implies answering to that name, so the URL the CLI prints actually works.
+
+    Without this the CLI contradicts itself: it prints `Open your browser at: http://devbox.example:7932`
+    and then rejects that exact `Host` with a `421`.
+    """
+    env.set('OPENAI_API_KEY', 'test')
+    mock_uvicorn = mocker.patch('uvicorn.run')
+    mock_create = mocker.patch('pydantic_ai._cli.web.create_web_app')
+
+    assert cli(['web', '-m', 'openai:gpt-5', '--host', 'devbox.example'], prog_name='clai') == 0
+
+    assert mock_create.call_args.kwargs['allowed_hosts'] == ['devbox.example']
+    assert mock_uvicorn.call_args.kwargs['host'] == 'devbox.example'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,6 +425,7 @@ def test_clai_web_generic_agent(mocker: MockerFixture, env: TestEnv):
         instructions=None,
         default_model='openai-chat:gpt-5',
         html_source=None,
+        allowed_hosts=[],
     )
 
 
@@ -447,6 +448,7 @@ def test_clai_web_success(mocker: MockerFixture, create_test_module: Callable[..
         instructions=None,
         default_model='openai-chat:gpt-5',
         html_source=None,
+        allowed_hosts=[],
     )
 
 
@@ -484,6 +486,7 @@ def test_clai_web_with_models(mocker: MockerFixture, create_test_module: Callabl
         instructions=None,
         default_model='openai-chat:gpt-5',
         html_source=None,
+        allowed_hosts=[],
     )
 
 
@@ -512,6 +515,7 @@ def test_clai_web_with_tools(mocker: MockerFixture, create_test_module: Callable
         instructions=None,
         default_model='openai-chat:gpt-5',
         html_source=None,
+        allowed_hosts=[],
     )
 
 
@@ -532,6 +536,7 @@ def test_clai_web_generic_with_instructions(mocker: MockerFixture, env: TestEnv)
         instructions='You are a helpful coding assistant',
         default_model='openai-chat:gpt-5',
         html_source=None,
+        allowed_hosts=[],
     )
 
 
@@ -558,6 +563,7 @@ def test_clai_web_with_custom_port(mocker: MockerFixture, create_test_module: Ca
         instructions=None,
         default_model='openai-chat:gpt-5',
         html_source=None,
+        allowed_hosts=[],
     )
 
 
@@ -780,4 +786,26 @@ def test_clai_web_with_html_source(mocker: MockerFixture, env: TestEnv):
         instructions=None,
         default_model='openai-chat:gpt-5',
         html_source=custom_url,
+        allowed_hosts=[],
+    )
+
+
+def test_clai_web_with_allowed_hosts(mocker: MockerFixture, env: TestEnv):
+    """`--allowed-host` is repeatable, for serving the UI under a name behind a proxy or a tunnel."""
+    env.set('OPENAI_API_KEY', 'test')
+    mock_run_web = mocker.patch('pydantic_ai._cli.web.run_web_command', return_value=0)
+
+    args = ['web', '-m', 'openai:gpt-5', '--allowed-host', 'ui.example.com', '--allowed-host', '*.corp.example']
+    assert cli(args, prog_name='clai') == 0
+
+    mock_run_web.assert_called_once_with(
+        agent_path=None,
+        host='127.0.0.1',
+        port=7932,
+        models=['openai:gpt-5'],
+        tools=[],
+        instructions=None,
+        default_model='openai-chat:gpt-5',
+        html_source=None,
+        allowed_hosts=['ui.example.com', '*.corp.example'],
     )

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -241,6 +241,20 @@ def test_chat_app_index_endpoint(isolated_ui_cache: None):
         assert len(response.content) > 0
 
 
+def test_get_cache_dir_uses_xdg_cache_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """`_get_cache_dir` derives its path from `XDG_CACHE_HOME` and creates the directory.
+
+    Every other test monkeypatches `_get_cache_dir` for isolation, so this is the only test that
+    exercises its real body.
+    """
+    monkeypatch.setenv('XDG_CACHE_HOME', str(tmp_path))
+
+    cache_dir = app_module._get_cache_dir()  # pyright: ignore[reportPrivateUsage]
+
+    assert cache_dir == tmp_path / 'pydantic-ai' / 'web-ui'
+    assert cache_dir.is_dir()
+
+
 @pytest.mark.anyio
 async def test_get_ui_html_cdn_fetch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Test that _get_ui_html fetches from CDN when filesystem cache misses."""

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from pydantic_ai import Agent, ModelSettings
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.native_tools import AbstractNativeTool, MCPServerTool
 from pydantic_ai.profiles import ModelProfile
@@ -527,6 +528,24 @@ def test_host_validation_normalizes_configured_hosts(host: str):
         response = client.get('/api/health', headers={'host': host})
 
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    'pattern',
+    [
+        # The dangerous one: normalizing away the root dot would leave `*`, the sentinel that
+        # accepts every host, so a typo would silently turn the whole check off.
+        pytest.param('*.', id='wildcard-with-no-domain'),
+        pytest.param('*..', id='wildcard-with-only-dots'),
+        # Matches nothing, since a `Host` header can't contain `*` — accepting it would leave the
+        # user believing they had allowlisted something.
+        pytest.param('*example.com', id='wildcard-without-a-label-boundary'),
+    ],
+)
+def test_host_validation_rejects_malformed_patterns(pattern: str):
+    """A malformed `allowed_hosts` entry fails loudly instead of quietly meaning something else."""
+    with pytest.raises(UserError, match='Invalid `allowed_hosts` pattern'):
+        create_web_app(Agent('test'), allowed_hosts=[pattern])
 
 
 def test_host_validation_can_be_turned_off():

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -27,6 +27,7 @@ with try_import() as starlette_import_successful:
     from starlette.applications import Starlette
     from starlette.responses import Response
     from starlette.testclient import TestClient
+    from starlette.websockets import WebSocket, WebSocketDisconnect
 
     import pydantic_ai.ui._web.app as app_module
     from pydantic_ai.native_tools import WebSearchTool
@@ -40,6 +41,11 @@ with try_import() as openai_import_successful:
 pytestmark = [
     pytest.mark.skipif(not starlette_import_successful(), reason='starlette not installed'),
 ]
+
+# The app only answers to a `Host` header that is an IP address or `localhost`, so `TestClient`'s
+# default `http://testserver` gets a `421`. Every client below stands in for a browser pointed at
+# the loopback address the UI actually runs on; `test_host_validation` covers the rest.
+LOCAL_BASE_URL = 'http://127.0.0.1:7932'
 
 
 def test_agent_to_web():
@@ -75,7 +81,7 @@ async def test_model_instance_preserved_in_dispatch(monkeypatch: pytest.MonkeyPa
     mock_dispatch = AsyncMock(return_value=Response(content=b'', status_code=200))
     monkeypatch.setattr(VercelAIAdapter, 'dispatch_request', mock_dispatch)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         client.post(
             '/api/chat',
             json={
@@ -127,7 +133,7 @@ def test_chat_app_health_endpoint():
     agent = Agent('test')
     app = create_web_app(agent)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.get('/api/health')
         assert response.status_code == 200
         assert response.json() == {'ok': True}
@@ -143,7 +149,7 @@ def test_chat_app_configure_endpoint():
         native_tools=[WebSearchTool()],
     )
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.get('/api/configure')
         assert response.status_code == 200
         assert response.json() == snapshot(
@@ -162,7 +168,7 @@ def test_chat_app_configure_endpoint_empty():
     agent = Agent('test')
     app = create_web_app(agent)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.get('/api/configure')
         assert response.status_code == 200
         assert response.json() == snapshot(
@@ -181,7 +187,7 @@ def test_chat_app_configure_preserves_chat_vs_responses(monkeypatch: pytest.Monk
         models=['openai-chat:gpt-4o', 'openai-responses:gpt-4o'],
     )
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.get('/api/configure')
         assert response.status_code == 200
         data = response.json()
@@ -196,7 +202,7 @@ def test_chat_app_index_endpoint():
     agent = Agent('test')
     app = create_web_app(agent)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.get('/')
         assert response.status_code == 200
         assert response.headers['content-type'] == 'text/html; charset=utf-8'
@@ -257,7 +263,7 @@ def test_chat_app_index_caching():
     agent = Agent('test')
     app = create_web_app(agent)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response1 = client.get('/')
         response2 = client.get('/')
 
@@ -272,7 +278,7 @@ async def test_post_chat_endpoint():
     agent = Agent(TestModel(custom_output_text='Hello from test!'))
     app = create_web_app(agent)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.post(
             '/api/chat',
             json={
@@ -304,7 +310,7 @@ def test_chat_app_options_endpoint():
     agent = Agent('test')
     app = create_web_app(agent)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.options('/api/chat')
         assert response.status_code == 200
         assert not any(name.lower().startswith('access-control-') for name in response.headers)
@@ -346,7 +352,7 @@ def test_chat_rejects_non_json_content_type(content_type: str | None, monkeypatc
     )
     headers = {'content-type': content_type} if content_type is not None else {}
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.post('/api/chat', content=body, headers=headers)
 
     assert response.status_code == 415
@@ -375,10 +381,197 @@ def test_chat_accepts_json_content_type(content_type: str):
         }
     )
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.post('/api/chat', content=body, headers={'content-type': content_type})
 
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    'host',
+    [
+        pytest.param('127.0.0.1:7932', id='loopback-ipv4'),
+        pytest.param('[::1]:7932', id='loopback-ipv6'),
+        # Bracketed IPv6 is the case a `host.split(':')[0]` check mangles into `[`.
+        pytest.param('[2001:db8::1]', id='ipv6-no-port'),
+        # Any IP literal, not just a loopback one: reaching a dev server over the LAN or a forwarded
+        # port is normal, and no IP literal can be the product of DNS rebinding.
+        pytest.param('192.168.1.5:7932', id='lan-ipv4'),
+        pytest.param('localhost:7932', id='localhost'),
+        # RFC 6761 reserves everything under `.localhost` for the loopback interface too.
+        pytest.param('my-app.localhost:7932', id='localhost-subdomain'),
+        # A browser navigating to `http://localhost./` keeps the root dot in the `Host` header, so
+        # the fully-qualified spelling of every accepted name has to be accepted as well.
+        pytest.param('localhost.:7932', id='localhost-fully-qualified'),
+        pytest.param('my-app.localhost.:7932', id='localhost-subdomain-fully-qualified'),
+        pytest.param('127.0.0.1.:7932', id='ipv4-fully-qualified'),
+    ],
+)
+def test_host_validation_accepts_local_hosts(host: str):
+    """The ways a developer actually reaches the UI all still work."""
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/api/health', headers={'host': host})
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    'host',
+    [
+        # What a browser sends once `evil.example` has been rebound to 127.0.0.1.
+        pytest.param('evil.example:7932', id='rebound-hostname'),
+        pytest.param('EVIL.EXAMPLE', id='uppercase-hostname'),
+        # Registrable names that contain `localhost` without being under it. These are what a
+        # substring test would wave through where the label-boundary test doesn't, so they pin the
+        # `.localhost` suffix check against being loosened.
+        pytest.param('localhost.evil.example', id='localhost-as-leading-label'),
+        pytest.param('evil-localhost.example', id='localhost-inside-a-label'),
+        # `localhost..` denotes no host at all; only one root dot is stripped.
+        pytest.param('localhost..', id='localhost-double-root-dot'),
+        # `urlsplit` reads userinfo and a path, so without rejecting these outright they would parse
+        # as the loopback address that follows the delimiter.
+        pytest.param('evil.example@127.0.0.1', id='userinfo-smuggled'),
+        pytest.param('127.0.0.1/evil.example', id='path-smuggled'),
+        pytest.param('127.0.0.1?evil.example', id='query-smuggled'),
+        pytest.param('127.0.0.1#evil.example', id='fragment-smuggled'),
+        # Not parsable as a host at all: `urlsplit` raises on both.
+        pytest.param('[::1', id='unterminated-ipv6'),
+        pytest.param('[not-an-address]', id='bracketed-non-address'),
+        pytest.param('', id='no-host-header'),
+    ],
+)
+def test_host_validation_rejects_foreign_hosts(host: str):
+    """Anything that isn't demonstrably local is refused, including near-misses that parse loosely."""
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/api/health', headers={'host': host})
+
+    assert response.status_code == 421
+    assert 'is not allowed' in response.text
+    # The message quotes the client's `Host` back at it, so it must not be sniffable as markup.
+    assert response.headers['x-content-type-options'] == 'nosniff'
+
+
+def test_host_validation_blocks_the_rebinding_attack_before_the_agent_runs(monkeypatch: pytest.MonkeyPatch):
+    """A fully browser-legal rebound request never reaches the agent.
+
+    This is the whole point of the check. DNS rebinding makes the browser treat the attacker's page
+    and the local UI as the same origin, so the request carries `Content-Type: application/json`
+    and a matching `Origin` — everything the CSRF defence looks at is satisfied, and only the `Host`
+    header still names the attacker. Asserting the status alone would be too weak: the attacker
+    never needs to read the response, so what matters is that nothing runs.
+
+    A unit test rather than a VCR one because the check runs before any model request, so there is
+    no HTTP traffic to record.
+    """
+    mock_from_request = AsyncMock(side_effect=AssertionError('adapter should not be built'))
+    monkeypatch.setattr(VercelAIAdapter, 'from_request', mock_from_request)
+    app = create_web_app(Agent(TestModel()))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.post(
+            '/api/chat',
+            json={
+                'trigger': 'submit-message',
+                'id': 'test-id',
+                'messages': [{'id': 'msg-1', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Hello'}]}],
+            },
+            headers={'host': 'evil.example:7932', 'origin': 'http://evil.example:7932'},
+        )
+
+    assert response.status_code == 421
+    assert mock_from_request.call_count == 0
+
+
+@pytest.mark.parametrize(
+    ('host', 'allowed'),
+    [
+        pytest.param('ui.example.com', True, id='exact'),
+        pytest.param('UI.EXAMPLE.COM', True, id='exact-uppercase'),
+        pytest.param('ui.example.com.', True, id='exact-fully-qualified'),
+        pytest.param('a.corp.example', True, id='wildcard-subdomain'),
+        pytest.param('a.b.corp.example', True, id='wildcard-nested-subdomain'),
+        # `*.corp.example` means subdomains only, as it does in Starlette's `TrustedHostMiddleware`.
+        # A deployment that serves the apex lists it separately.
+        pytest.param('corp.example', False, id='wildcard-does-not-cover-apex'),
+        pytest.param('notcorp.example', False, id='wildcard-suffix-not-a-subdomain'),
+        # The allowlisted domain appears in the middle of an attacker-registrable name. Only a
+        # suffix test rejects this; a substring test would not.
+        pytest.param('a.corp.example.evil', False, id='wildcard-domain-not-at-the-end'),
+        pytest.param('evil.example', False, id='not-listed'),
+    ],
+)
+def test_host_validation_honours_allowed_hosts(host: str, allowed: bool):
+    """`allowed_hosts` is what a deployment behind a proxy or a tunnel reaches for."""
+    app = create_web_app(Agent('test'), allowed_hosts=['ui.example.com', '*.corp.example'])
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/api/health', headers={'host': host})
+
+    assert response.status_code == (200 if allowed else 421)
+
+
+@pytest.mark.parametrize('host', ['ui.example.com', 'a.corp.example'])
+def test_host_validation_normalizes_configured_hosts(host: str):
+    """Entries are normalized the same way an incoming `Host` is, so casing and a root dot don't matter.
+
+    Without this, `allowed_hosts=['UI.Example.COM.']` would silently never match: the header is
+    lowercased and stripped of its root dot before comparison, and the configured value wasn't.
+    """
+    app = create_web_app(Agent('test'), allowed_hosts=['UI.Example.COM.', '*.CORP.example.'])
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/api/health', headers={'host': host})
+
+    assert response.status_code == 200
+
+
+def test_host_validation_can_be_turned_off():
+    """`['*']` is the documented escape hatch for someone who has their own authentication."""
+    app = create_web_app(Agent('test'), allowed_hosts=['*'])
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/api/health', headers={'host': 'evil.example'})
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(('host', 'accepted'), [('127.0.0.1:7932', True), ('evil.example:7932', False)])
+def test_host_validation_covers_websocket_routes(host: str, accepted: bool):
+    """A WebSocket route added to the app is guarded too, rather than bypassing the check.
+
+    The app ships no WebSocket routes today, so this adds one: the middleware wraps the whole app,
+    and a route that silently escaped the check would be a hole the day one is added.
+    """
+
+    reached_endpoint = False
+
+    async def endpoint(websocket: WebSocket) -> None:
+        nonlocal reached_endpoint
+        reached_endpoint = True
+        await websocket.accept()
+        await websocket.close()
+
+    app = create_web_app(Agent('test'))
+    app.router.add_websocket_route('/ws', endpoint)
+
+    disconnect_code: int | None = None
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        try:
+            with client.websocket_connect('/ws', headers={'host': host}):
+                pass
+        except WebSocketDisconnect as exc:
+            disconnect_code = exc.code
+
+    assert reached_endpoint is accepted
+    # `disconnect_code` is the ASGI `websocket.close` message the middleware sends, which `TestClient`
+    # surfaces directly. It is not what a client sees: closing before accepting means the handshake
+    # never completes, so a real ASGI server refuses it at the HTTP layer instead (uvicorn: `403`).
+    # What this pins is that the connection is refused and the endpoint never runs.
+    assert disconnect_code == (None if accepted else 1008)
 
 
 def test_mcp_server_tool_label():
@@ -416,7 +609,7 @@ def test_post_chat_invalid_model():
     # Use 'test' as the allowed model, then send a different model in the request
     app = create_web_app(agent, models=['test'])
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.post(
             '/api/chat',
             json={
@@ -443,7 +636,7 @@ def test_post_chat_invalid_builtin_tool():
     agent = Agent(TestModel(custom_output_text='Hello'))
     app = create_web_app(agent, native_tools=[WebSearchTool()])
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.post(
             '/api/chat',
             json={
@@ -490,7 +683,7 @@ async def test_instructions_passed_to_dispatch(monkeypatch: pytest.MonkeyPatch):
     mock_dispatch = AsyncMock(return_value=Response(content=b'', status_code=200))
     monkeypatch.setattr(VercelAIAdapter, 'dispatch_request', mock_dispatch)
 
-    with TestClient(app) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         client.post(
             '/api/chat',
             json={
@@ -657,7 +850,7 @@ def test_chat_app_index_file_not_found(tmp_path: Path):
     nonexistent_file = tmp_path / 'nonexistent-ui.html'
     app = create_web_app(agent, html_source=str(nonexistent_file))
 
-    with TestClient(app, raise_server_exceptions=True) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL, raise_server_exceptions=True) as client:
         with pytest.raises(FileNotFoundError, match='Local UI file not found'):
             client.get('/')
 
@@ -686,6 +879,6 @@ def test_chat_app_index_http_error(monkeypatch: pytest.MonkeyPatch):
     agent = Agent('test')
     app = create_web_app(agent)
 
-    with TestClient(app, raise_server_exceptions=True) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL, raise_server_exceptions=True) as client:
         with pytest.raises(httpx.HTTPStatusError):
             client.get('/')

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -198,7 +198,36 @@ def test_chat_app_configure_preserves_chat_vs_responses(monkeypatch: pytest.Monk
         assert len([m for m in model_ids if 'gpt-4o' in m]) == 2
 
 
-def test_chat_app_index_endpoint():
+@pytest.fixture
+def isolated_ui_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Isolate the index route's HTML cache to a temp dir and stub the CDN fetch.
+
+    The index route caches the default UI HTML under the shared user cache dir; without
+    per-test isolation, tests that serve `/` race on the same file across xdist workers
+    (a non-atomic write being read mid-write), and miss the cache into a real CDN request.
+    """
+
+    class MockResponse:
+        content = b'<html>Test UI</html>'
+
+        def raise_for_status(self) -> None:
+            pass
+
+    class MockAsyncClient:
+        async def __aenter__(self) -> MockAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            pass
+
+        async def get(self, url: str) -> MockResponse:
+            return MockResponse()
+
+    monkeypatch.setattr(app_module, '_get_cache_dir', lambda: tmp_path)
+    monkeypatch.setattr(app_module.httpx, 'AsyncClient', MockAsyncClient)
+
+
+def test_chat_app_index_endpoint(isolated_ui_cache: None):
     """Test that the index endpoint serves HTML with proper caching headers."""
     agent = Agent('test')
     app = create_web_app(agent)
@@ -259,7 +288,7 @@ async def test_get_ui_html_filesystem_cache_hit(monkeypatch: pytest.MonkeyPatch,
     assert result == test_content
 
 
-def test_chat_app_index_caching():
+def test_chat_app_index_caching(isolated_ui_cache: None):
     """Test that the UI HTML is cached after first fetch."""
     agent = Agent('test')
     app = create_web_app(agent)


### PR DESCRIPTION
Backport of #7437 to `v1`.

Adds an `allowed_hosts` argument to `create_web_app()` and `Agent.to_web()`, and a repeatable `--allowed-host` flag to `clai web`, controlling which `Host` headers the development chat UI answers to.

By default the app answers to IP addresses (`127.0.0.1`, `[::1]`, or a LAN address like `192.168.1.5`) and `localhost`, including names under it like `my-app.localhost`. Any other `Host` gets a `421 Misdirected Request`.

That covers how the UI is normally reached — `to_web()` under uvicorn, `clai web`, LAN access, container or SSH port forwarding — but a deployment that serves the UI under a real hostname, behind a reverse proxy or through a tunnel, now has to name it:

```python
app = agent.to_web(allowed_hosts=['ui.example.com'])
```

`*.example.com` matches subdomains, the same way that pattern works in Starlette's `TrustedHostMiddleware`. `['*']` accepts anything, for a deployment that already authenticates in front of the app.

Re-derived against `v1` rather than cherry-picked: `v1` has no `sdk_version` parameter, keeps the deprecated-kwargs shim, and its `docs/web.md` has no tool approval section. The new `_hosts.py` is byte-identical to the `main` version.

### Implementation notes

- Raw ASGI middleware rather than `BaseHTTPMiddleware`, which buffers and would break the chat SSE stream. It wraps the whole app, so the `/api` mount, both index routes, and any route added later are covered.
- Not `TrustedHostMiddleware`: its `host.split(':')[0]` turns `[::1]:7932` into `[`, so IPv6 loopback can't be expressed at all.
- A single trailing dot is stripped from both the header and the configured patterns, because a browser navigating to `http://localhost./` keeps the DNS root dot and `localhost.` names the same host as `localhost`.
- Hostnames compare in ASCII, so an internationalized name goes in the list as punycode — which is what the browser sends.

### Tests

Cover the accepted and rejected forms (including bracketed IPv6 and label-boundary near-misses), wildcard semantics, normalization of configured entries, and WebSocket routes. Every mutation of the matcher I tried now fails at least one test.

Existing `TestClient(app)` call sites now pass an explicit `base_url`: `TestClient`'s default `Host: testserver` is not an accepted host.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

