### PR TITLE
Set `TEMPORAL_DEBUG` and disable Prefect's task-run recorder to stop durable-execution CI flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,14 @@ jobs:
       # Rebenchmark all-extras after https://github.com/cbornet/blockbuster/pull/61 is released
       # in a compatible version; enable it if the job stays within seven minutes.
       BLOCKBUSTER_ENABLED: ${{ matrix.python-version == '3.13' && matrix.install.name != 'all-extras' }}
+      # Disables Temporal's workflow deadlock detector (temporalio reads this to set the
+      # per-activation budget to `None` instead of 2s). That budget is wall-clock, so it measures
+      # runner contention as readily as a blocking call: `tests/test_temporal.py`,
+      # `tests/test_prefect.py` and `tests/test_dbos.py` each pin an xdist group, putting three
+      # durable-execution servers on four vCPUs, and a descheduled workflow thread trips it as
+      # `TMPRL1101`. The cost: a genuine in-workflow blocking call now hangs to the job timeout
+      # instead of failing in 2s.
+      TEMPORAL_DEBUG: '1'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -331,6 +339,8 @@ jobs:
       # Blocking detection already runs in the Python 3.13 slim, evals, and standard jobs;
       # repeating its stack-inspection overhead here pushes lowest-version jobs past the CI budget.
       BLOCKBUSTER_ENABLED: false
+      # See the note on the `test` job: same runner shape, same deadlock-detector false positives.
+      TEMPORAL_DEBUG: '1'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -84,6 +84,7 @@ from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 try:
     from prefect import flow, task
     from prefect.context import FlowRunContext, TaskRunContext
+    from prefect.settings import PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_ENABLED, temporary_settings
     from prefect.testing.utilities import prefect_test_harness
 
     from pydantic_ai.durable_exec.prefect import (
@@ -169,8 +170,13 @@ def setup_logfire_instrumentation() -> Iterator[None]:
 @pytest.fixture(autouse=True, scope='session')
 def setup_prefect_test_harness() -> Iterator[None]:
     """Set up Prefect test harness for all tests."""
-    with prefect_test_harness(server_startup_timeout=60):
-        yield
+    # The task-run recorder is a background writer against the same sqlite file the flows write to.
+    # Prefect PRAGMAs a 60s `busy_timeout` onto every connection, and under CI contention the
+    # recorder's bulk inserts exhaust it, failing the flow whose state it was recording. Nothing
+    # here reads what it records: task run states reach the API through the task engine.
+    with temporary_settings({PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_ENABLED: False}):
+        with prefect_test_harness(server_startup_timeout=60):
+            yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David reviewed this lightly.

## Why we make these changes

Two CI flake classes on the durable-execution suites, both observed on `main` itself, not only on PRs.

Both `test` and `test-lowest-versions` run the suite under xdist with `--dist=loadgroup` on 4-vCPU runners (`created: 4/4 workers` in the logs). `tests/test_temporal.py`, `tests/test_prefect.py` and `tests/test_dbos.py` each pin their own `xdist_group`, so three real durable-execution servers plus a general worker share four vCPUs. Two of the budgets they run against are wall-clock latency budgets, not correctness bounds, and contention blows them:

- `[TMPRL1101] Potential deadlock detected: workflow didn't yield within 2 second(s)` — [run 31714600211](https://github.com/pydantic/pydantic-ai/actions/runs/31714600211/job/94495970744), 3.13 lowest-versions
- `sqlite3.OperationalError: database is locked` raised from `prefect.server.services.task_run_recorder` — [run 31724853556](https://github.com/pydantic/pydantic-ai/actions/runs/31724853556/job/94530564979), 3.11 lowest-versions

Each failed **exactly one test on exactly one shard**, and which test and which shard rotates between runs. That is the signature of this class. A genuine break instead fails the same tests on every shard — [run 31712382374](https://github.com/pydantic/pydantic-ai/actions/runs/31712382374) failed ~20 jobs with the same 12 tests.

## New public surface

None.

## `TEMPORAL_DEBUG` in the `test` and `test-lowest-versions` job env

temporalio reads this in exactly one place, `temporalio/worker/_workflow.py`, where it sets the per-activation deadlock budget to `None` instead of `2` seconds. One env var covers every `Worker()` call site in the suite.

It does **not** set `debug_mode` and does **not** touch `workflow_runner`. `Worker` forwards those independently, and in temporalio 1.24.0 `debug_mode` has exactly one consumer — the same deadlock-budget line — while it appears nowhere in `workflow_sandbox/` or `_workflow_instance.py`. So the `SandboxedWorkflowRunner` is unaffected and `test_model_construction_in_workflow_passes_sandbox` still exercises the sandbox on all three of its parameter variants. (The `debug_mode` docstring mentions it "may disable sandboxing"; that is not implemented in this version.)

No test asserts the detector fires. The two livelock regression tests assert a clean `TimeoutError`, which is unaffected.

**The cost, stated plainly:** a genuine in-workflow blocking regression no longer fails fast in 2 seconds — it hangs to the 20-minute job timeout. This trades a fast but currently unreliable signal for a slow but reliable one.

`test-temporal-latest` deliberately does not get the variable: it runs two config-only tests on `ubuntu-latest` with no xdist and no contention, so the detector stays armed there.

<details>
<summary>Verification</summary>

`BLOCKBUSTER_ENABLED=false TEMPORAL_DEBUG=1 uv run pytest tests/test_temporal.py -p no:randomly -q` → **266 passed, 2 skipped**. `BLOCKBUSTER_ENABLED=false` mirrors CI, which sets it for both jobs that install temporalio.

</details>

## Disabling Prefect's task-run recorder in `setup_prefect_test_harness`

That background service is the exact one that threw. It writes to the same sqlite file the flows write to, so disabling it removes a competing writer rather than extending a wait.

Raising `PREFECT_API_DATABASE_TIMEOUT` looks like the obvious knob and is a no-op, so it is deliberately not here. `AioSqliteConfiguration.engine` feeds that setting into `connect_args`, but the `setup_sqlite` connect listener then runs `PRAGMA busy_timeout = 60000` on every connection, overriding it. The failing run corroborates this: an insert timestamped `17:19:35.99` was still failing at `17:20:36` — a 60-second wait, i.e. the PRAGMA value, not the 10-second default.

<details>
<summary>Verification</summary>

`BLOCKBUSTER_ENABLED=false uv run pytest tests/test_prefect.py -p no:randomly -q` → **120 passed**, including `test_flow_retry_replays_tool_result`, the test that failed in the linked run.

</details>

## What changes for existing users

Nothing. Both changes are confined to CI configuration and the test harness; no library code is touched.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

