### PR TITLE
Preserve `output_tool_return_content` in `AgentRun` JSON histories

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -164,9 +164,14 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
     def all_messages_json(self, *, output_tool_return_content: str | None = None) -> bytes:
         """Return all messages from [`all_messages`][pydantic_ai.agent.AgentRun.all_messages] as JSON bytes.
 
+        Args:
+            output_tool_return_content: The return content of the output tool call to set in the last message once the run has ended.
+
         Returns:
             JSON bytes representing the messages.
         """
+        if output_tool_return_content is not None and (result := self.result) is not None:
+            return result.all_messages_json(output_tool_return_content=output_tool_return_content)
         return _messages.ModelMessagesTypeAdapter.dump_json(self.all_messages())
 
     def new_messages(self) -> list[_messages.ModelMessage]:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1261,6 +1261,32 @@ def test_plain_response_then_tuple():
     )
 
 
+async def test_iter_run_all_messages_json_output_tool_return_content():
+    """AgentRun JSON should mirror AgentRunResult's output-tool acknowledgement override."""
+    agent = Agent('test', output_type=int)
+
+    async with agent.iter('Hello') as run:
+        async for _ in run:
+            pass
+
+    assert run.result is not None
+    expected_content = 'custom acknowledgement'
+
+    for result in (run, run.result):
+        assert (
+            ModelMessagesTypeAdapter.validate_json(result.all_messages_json())[-1].parts[0].content
+            == 'Final result processed.'
+        )
+        assert (
+            ModelMessagesTypeAdapter.validate_json(
+                result.all_messages_json(output_tool_return_content=expected_content)
+            )[-1]
+            .parts[0]
+            .content
+            == expected_content
+        )
+
+
 def test_output_tool_return_content_str_return():
     agent = Agent('test')
 


### PR DESCRIPTION
## Summary
- forward a completed `AgentRun` JSON acknowledgement override to its `AgentRunResult` serializer
- preserve default and in-progress serialization behavior
- add a tokenless iterative-run regression test covering `AgentRun`/`AgentRunResult` parity

## Test Plan
- [x] `uv run pytest tests/test_agent.py::test_iter_run_all_messages_json_output_tool_return_content -q`
- [x] `uv run pytest tests/test_agent.py -q`
- [x] `uv run ruff check pydantic_ai_slim/pydantic_ai/run.py tests/test_agent.py`
- [x] `uv run ruff format --check pydantic_ai_slim/pydantic_ai/run.py tests/test_agent.py`
- [x] `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/run.py`

Fixes #7317

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

