### PR TITLE
Surface OpenRouter web-search sources in `provider_details["annotations"]`

### DIFF
--- a/docs/models/openrouter.md
+++ b/docs/models/openrouter.md
@@ -208,6 +208,18 @@ Pass the prompt list to `agent.run_sync(prompt)`. Everything before the `CachePo
 
 OpenRouter supports web search through its [Beta server tool](https://openrouter.ai/docs/guides/features/server-tools/web-search). Enable it with [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool]. The model decides whether to search and may make zero or multiple searches for a request.
 
+Pydantic AI previously enabled OpenRouter's `web` plugin, which searched on every request and billed a flat fee for each one, whether or not the question needed the web. If you want that always-on grounding, OpenRouter's plugin is deprecated but still reachable by passing it yourself:
+
+```python {title="web_search_openrouter_plugin.py" test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
+
+model = OpenRouterModel('openai/gpt-4.1')
+settings = OpenRouterModelSettings(extra_body={'plugins': [{'id': 'web'}]})
+agent = Agent(model, model_settings=settings)
+result = agent.run_sync('What is the latest news in AI?')
+```
+
 ### Web Search Parameters
 
 You can configure search context, approximate user location, domain filters, and a limit on searches with [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool]:
@@ -233,6 +245,26 @@ result = agent.run_sync('What is the latest news in AI?')
 ```
 
 Pydantic AI surfaces the per-request web-search count under [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details] `['server_tool_use']['web_search_requests']`.
+
+### Search Sources
+
+When OpenRouter runs the search itself rather than delegating to the downstream provider's own search, it attaches the sources it used to the message as `url_citation` annotations. Pydantic AI surfaces them verbatim under [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details] `['annotations']`, each carrying the result's `url`, `title` and the excerpt that was given to the model:
+
+```python {title="web_search_openrouter_sources.py" test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import WebSearch
+from pydantic_ai.models.openrouter import OpenRouterModel
+
+agent = Agent(OpenRouterModel('deepseek/deepseek-chat'), capabilities=[WebSearch()])
+result = agent.run_sync('What is the latest news in AI?')
+
+annotations = (result.response.provider_details or {}).get('annotations', [])
+for annotation in annotations:
+    print(annotation['url_citation']['url'])
+```
+
+!!! note "Only non-native search reports its sources"
+    Models whose downstream provider runs the search natively — OpenAI and Anthropic among them — return no annotations at all, so `provider_details` carries only the search count for those. Which engine OpenRouter picks is not currently configurable from Pydantic AI.
 
 !!! note "Engine-specific parameters"
     A recorded request verifies only that OpenRouter accepts these parameter names. The per-engine effects below come from OpenRouter's [Beta server-tool documentation](https://openrouter.ai/docs/guides/features/server-tools/web-search), not from responses recorded in this project: native provider search ignores `search_context_size`; `user_location` works only with native search; and domain-filter support varies (native OpenAI ignores `excluded_domains`). The server tool can make zero or several searches when it is available to the model. `max_uses` caps a request when OpenRouter uses a non-native search engine or Anthropic's native search; other native providers, including the OpenAI model in this example, ignore it. OpenRouter does not support [`WebSearchTool.external_web_access`][pydantic_ai.native_tools.WebSearchTool.external_web_access].

--- a/docs/models/openrouter.md
+++ b/docs/models/openrouter.md
@@ -214,7 +214,7 @@ Pydantic AI previously enabled OpenRouter's `web` plugin, which searched on ever
 from pydantic_ai import Agent
 from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
 
-model = OpenRouterModel('openai/gpt-4.1')
+model = OpenRouterModel('openai/gpt-5.2')
 settings = OpenRouterModelSettings(extra_body={'plugins': [{'id': 'web'}]})
 agent = Agent(model, model_settings=settings)
 result = agent.run_sync('What is the latest news in AI?')
@@ -264,7 +264,7 @@ for annotation in annotations:
 ```
 
 !!! note "Only non-native search reports its sources"
-    Models whose downstream provider runs the search natively — OpenAI and Anthropic among them — return no annotations at all, so `provider_details` carries only the search count for those. Which engine OpenRouter picks is not currently configurable from Pydantic AI.
+    Models whose downstream provider runs the search natively — OpenAI and Anthropic among them — return no annotations at all, so `provider_details` has no `annotations` entry for those. The normal OpenRouter provider details remain available. Which engine OpenRouter picks is not currently configurable from Pydantic AI.
 
 !!! note "Engine-specific parameters"
     A recorded request verifies only that OpenRouter accepts these parameter names. The per-engine effects below come from OpenRouter's [Beta server-tool documentation](https://openrouter.ai/docs/guides/features/server-tools/web-search), not from responses recorded in this project: native provider search ignores `search_context_size`; `user_location` works only with native search; and domain-filter support varies (native OpenAI ignores `excluded_domains`). The server tool can make zero or several searches when it is available to the model. `max_uses` caps a request when OpenRouter uses a non-native search engine or Anthropic's native search; other native providers, including the OpenAI model in this example, ignore it. OpenRouter does not support [`WebSearchTool.external_web_access`][pydantic_ai.native_tools.WebSearchTool.external_web_access].

--- a/docs/models/openrouter.md
+++ b/docs/models/openrouter.md
@@ -208,9 +208,9 @@ Pass the prompt list to `agent.run_sync(prompt)`. Everything before the `CachePo
 
 OpenRouter supports web search through its [Beta server tool](https://openrouter.ai/docs/guides/features/server-tools/web-search). Enable it with [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool]. The model decides whether to search and may make zero or multiple searches for a request.
 
-Pydantic AI previously enabled OpenRouter's `web` plugin, which searched on every request and billed a flat fee for each one, whether or not the question needed the web. If you want that always-on grounding, OpenRouter's plugin is deprecated but still reachable by passing it yourself:
+Before Pydantic AI v2.30.0, [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool] enabled OpenRouter's `web` plugin, which searched on every request and billed a flat fee for each one, whether or not the question needed the web. If you want that always-on grounding, OpenRouter's plugin is deprecated but still reachable by passing it yourself:
 
-```python {title="web_search_openrouter_plugin.py" test="skip"}
+```python {title="web_search_openrouter_plugin.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.openrouter import OpenRouterModel, OpenRouterModelSettings
 
@@ -250,7 +250,7 @@ Pydantic AI surfaces the per-request web-search count under [`ModelResponse.prov
 
 When OpenRouter runs the search itself rather than delegating to the downstream provider's own search, it attaches the sources it used to the message as `url_citation` annotations. Pydantic AI surfaces them verbatim under [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details] `['annotations']`, each carrying the result's `url`, `title` and the excerpt that was given to the model:
 
-```python {title="web_search_openrouter_sources.py" test="skip"}
+```python {title="web_search_openrouter_sources.py"}
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import WebSearch
 from pydantic_ai.models.openrouter import OpenRouterModel
@@ -260,7 +260,8 @@ result = agent.run_sync('What is the latest news in AI?')
 
 annotations = (result.response.provider_details or {}).get('annotations', [])
 for annotation in annotations:
-    print(annotation['url_citation']['url'])
+    if annotation['type'] == 'url_citation':
+        print(annotation['url_citation']['url'])
 ```
 
 !!! note "Only non-native search reports its sources"

--- a/docs/native-tools.md
+++ b/docs/native-tools.md
@@ -89,7 +89,7 @@ making it ideal for queries that require up-to-date data.
 | Google | ✅ | No parameter support. No [`NativeToolCallPart`][pydantic_ai.messages.NativeToolCallPart] or [`NativeToolReturnPart`][pydantic_ai.messages.NativeToolReturnPart] is generated when streaming. See [Google tool combinations](#google-tool-combinations). |
 | xAI | ✅ | Supports `blocked_domains`, `allowed_domains`, and `user_location` parameters. |
 | Groq | ✅ | Limited parameter support. To use web search capabilities with Groq, you need to use the [compound models](https://console.groq.com/docs/compound). |
-| OpenRouter | ✅ | Uses OpenRouter's [Beta web-search server tool](https://openrouter.ai/docs/guides/features/server-tools/web-search). The model can make 0–N searches. Recorded requests verify only that OpenRouter accepts the parameter names; the per-engine effects below are per OpenRouter's docs: native search ignores `search_context_size`; `user_location` is native-only; native OpenAI ignores `blocked_domains`; and `max_uses` works with non-native or Anthropic native search. |
+| OpenRouter | ✅ | Uses OpenRouter's [Beta web-search server tool](https://openrouter.ai/docs/guides/features/server-tools/web-search). The model can make 0–N searches. Recorded requests verify only that OpenRouter accepts the parameter names; the per-engine effects below are per OpenRouter's docs: native search ignores `search_context_size`; `user_location` is native-only; native OpenAI ignores `blocked_domains`; and `max_uses` works with non-native or Anthropic native search. Search sources surface in `provider_details['annotations']`, but only when a non-native engine ran the search. |
 | OpenAI Chat Completions | ❌ | Not supported |
 | Bedrock | ❌ | Not supported |
 | Mistral | ❌ | Not supported |

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1281,9 +1281,7 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
         provider_details.update(_map_openrouter_provider_details(chunk))
         if annotations := chunk.choices[0].delta.annotations:
             self._annotations.extend(_dump_openrouter_annotations(annotations))
-        if self._annotations:
-            # Streamed provider details are shallow-merged per chunk, and OpenRouter spreads
-            # annotations over several deltas, so the running list is re-published whole.
+            # Provider details are shallow-merged across chunks, so publish the running list.
             provider_details['annotations'] = list(self._annotations)
         return provider_details or None
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -589,6 +589,11 @@ def _map_openrouter_provider_details(
     return provider_details
 
 
+def _dump_openrouter_annotations(annotations: list[_OpenRouterAnnotation]) -> list[dict[str, Any]]:
+    """Dump the `url_citation` search sources and file citations OpenRouter attaches to a message."""
+    return [annotation.model_dump(mode='json') for annotation in annotations]
+
+
 def _map_openrouter_usage(
     response: _OpenRouterChatCompletion | _OpenRouterChatCompletionChunk,
     provider: str,
@@ -1074,6 +1079,8 @@ class OpenRouterModel(OpenAIChatModel):
 
         provider_details = super()._process_provider_details(response) or {}
         provider_details.update(_map_openrouter_provider_details(response))
+        if annotations := response.choices[0].message.annotations:
+            provider_details['annotations'] = _dump_openrouter_annotations(annotations)
         return provider_details or None
 
     @override
@@ -1212,6 +1219,8 @@ class _OpenRouterChatCompletionChunk(_ChatCompletionChunk):
 class OpenRouterStreamedResponse(OpenAIStreamedResponse):
     """Implementation of `StreamedResponse` for OpenRouter models."""
 
+    _annotations: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]], init=False)
+
     @override
     async def _validate_response(self):
         try:
@@ -1270,6 +1279,12 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
 
         provider_details = super()._map_provider_details(chunk) or {}
         provider_details.update(_map_openrouter_provider_details(chunk))
+        if annotations := chunk.choices[0].delta.annotations:
+            self._annotations.extend(_dump_openrouter_annotations(annotations))
+        if self._annotations:
+            # Streamed provider details are shallow-merged per chunk, and OpenRouter spreads
+            # annotations over several deltas, so the running list is re-published whole.
+            provider_details['annotations'] = list(self._annotations)
         return provider_details or None
 
     @override

--- a/tests/models/cassettes/test_openrouter/test_openrouter_web_search_annotations.yaml
+++ b/tests/models/cassettes/test_openrouter/test_openrouter_web_search_annotations.yaml
@@ -1,0 +1,297 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '293'
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+    method: POST
+    parsed_body:
+      messages:
+      - content: Use web search to find Pydantic AI's GitHub repository and answer with its URL only.
+        role: user
+      model: deepseek/deepseek-chat
+      stream: false
+      tools:
+      - parameters:
+          max_uses: 1
+          search_context_size: medium
+        type: openrouter:web_search
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      connection:
+      - keep-alive
+      content-length:
+      - '4800'
+      content-type:
+      - application/json
+      permissions-policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com" "https://js.stripe.com" "https://*.js.stripe.com"
+        "https://hooks.stripe.com")
+      referrer-policy:
+      - no-referrer, strict-origin-when-cross-origin
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations:
+          - type: url_citation
+            url_citation:
+              content: |-
+                # pydantic/pydantic-ai
+
+                ...
+
+                - Stars: 19265
+                - Forks: 2514
+                - Watchers: 19265
+                - Open issues: 702
+                - License: MIT License
+                - Homepage: https://pydantic.dev/pydantic-ai
+                - Default branch: main
+                - Created: 2024-06-21T15:55:04Z
+
+                ...
+
+                AI Agent Framework, the Pydantic way
+
+                ...
+
+                ### Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.
+              end_index: 0
+              start_index: 0
+              title: AI Agent Framework, the Pydantic way
+              url: https://github.com/pydantic/pydantic-ai
+          - type: url_citation
+            url_citation:
+              content: |-
+                Get started: https://pydantic.dev/docs/ai/overview/ · GitHub: https://github.com/pydantic/pydantic-ai
+
+                ...
+
+                Type-safe Python framework for building agents and LLM applications. Model-agnostic with built-in validation, structured outputs, and seamless observability. Open source under the MIT license.
+
+                ...
+
+                ```bash
+                uv add pydantic-ai
+
+                ...
+
+                Open source (MIT license). Install with uv (or pip) and start building production-grade AI applications today.
+
+                ...
+
+                -
+
+                ...
+
+                uv add p
+
+                ...
+
+                -
+
+                ...
+
+                applications with Generative AI
+
+                ...
+
+                -
+
+                ...
+
+                : https://github
+
+                ...
+
+                # Production
+
+                ...
+
+                )
+
+                ...
+
+                .
+
+                ...
+
+                : https://p
+
+                ...
+
+                Gateway pricing
+
+                ...
+
+                /pydantic-ai
+
+                ...
+
+                bash
+
+                ...
+
+                -ai
+
+                ...
+
+                /
+
+                ...
+
+                : https://p
+
+                ...
+
+                ://pyd
+
+                ...
+
+                fire and
+
+                ...
+
+                free;
+
+                ...
+
+                .
+
+                ...
+
+                /pyd
+
+                ...
+
+                pyd
+
+                ...
+
+                .
+
+                ...
+
+                antic.
+
+                ...
+
+                /
+
+                ...
+
+                ```
+              end_index: 0
+              start_index: 0
+              title: ''
+              url: https://pydantic.dev/pydantic-ai
+          - type: url_citation
+            url_citation:
+              content: "- Tag: v2.0.0\n- Repository: pydantic/pydantic-ai\n- Published: 2026-06-23T15:38:17Z\n- Author: dsfaccini\n\n...\n\n#
+                v2.0.0 (2026-06-23)\n\n...\n\nAfter seven betas, **Pydantic AI V2 is now stable.** V2 leans into a harness-first
+                design with capabilities as a core primitive -- a single composable unit that bundles an agent's tools, hooks,
+                instructions, and model settings, reaching every layer of the agent through one concept.\n\n...\n\n# \U0001F389
+                Pydantic AI V2.0 is here!\n\n...\n\nuv add pydantic-ai\n\n...\n\nInstall it with:\n\n...\n\n```bash"
+              end_index: 0
+              start_index: 0
+              title: v2.0.0 (2026-06-23)
+              url: https://github.com/pydantic/pydantic-ai/releases/tag/v2.0.0
+          - type: url_citation
+            url_citation:
+              content: |-
+                # Pydantic AI
+
+                ...
+
+                Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.
+
+                ...
+
+                ,
+
+                ...
+
+                ydantic AI Harness is our official library of ready-made capabilities -- code
+
+                ...
+
+                access, guardrails, sub-agent orchestration, and more -- that you pick and choose to build coding agents, research assistants, and anything in between.
+
+                ...
+
+                Pydantic AI ships the agent loop, a composable capabilities system
+
+                ...
+
+                and built-in capabilities for thinking, web search, web fetch, image generation, MCP, tool search, and more;
+              end_index: 0
+              start_index: 0
+              title: Pydantic AI | Pydantic Docs
+              url: https://pydantic.dev/docs/ai/overview/
+          - type: url_citation
+            url_citation:
+              content: |-
+                GitHub - pydantic/pydantic-ai at refs/tags/v1.44.0 · GitHub
+                ...
+                ### Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.
+              end_index: 0
+              start_index: 0
+              title: GitHub - pydantic/pydantic-ai at refs/tags/v1.44.0 · GitHub
+              url: https://github.com/pydantic/pydantic-ai/tree/refs/tags/v1.44.0
+          content: https://github.com/pydantic/pydantic-ai
+          reasoning: null
+          refusal: null
+          role: assistant
+        native_finish_reason: stop
+      created: 1786680756
+      id: gen-1786680756-Fmq0SbiQ50hlHCCn30d5
+      model: deepseek/deepseek-chat
+      object: chat.completion
+      provider: OpenAI
+      service_tier: null
+      system_fingerprint: null
+      usage:
+        completion_tokens: 40
+        completion_tokens_details:
+          audio_tokens: 0
+          image_tokens: 0
+          reasoning_tokens: 0
+        cost: 0.007637029
+        cost_details:
+          upstream_inference_completions_cost: 4.1148e-05
+          upstream_inference_cost: 0.000637029
+          upstream_inference_prompt_cost: 0.000595881
+        prompt_tokens: 2315
+        prompt_tokens_details:
+          audio_tokens: 0
+          cache_write_tokens: 0
+          cached_tokens: 0
+          video_tokens: 0
+        server_tool_use_details:
+          tool_calls_executed: 1
+          tool_calls_requested: 1
+          web_search_requests: 1
+        total_tokens: 2355
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openrouter/test_openrouter_web_search_annotations_stream.yaml
+++ b/tests/models/cassettes/test_openrouter/test_openrouter_web_search_annotations_stream.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '335'
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+    method: POST
+    parsed_body:
+      messages:
+      - content: Use web search to find Pydantic AI's GitHub repository and answer with its URL only.
+        role: user
+      model: deepseek/deepseek-chat
+      stream: true
+      stream_options:
+        include_usage: true
+      tools:
+      - parameters:
+          max_uses: 1
+          search_context_size: medium
+        type: openrouter:web_search
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: ": OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n:
+        OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER
+        PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n:
+        OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER
+        PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\n:
+        OPENROUTER PROCESSING\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://github.com/pydantic/pydantic-ai\",\"title\":\"AI
+        Agent Framework, the Pydantic way - GitHub\",\"start_index\":0,\"end_index\":0,\"content\":\"# pydantic/pydantic-ai\\n\\n...\\n\\n-
+        Stars: 19265\\n- Forks: 2514\\n- Watchers: 19265\\n- Open issues: 702\\n- License: MIT License\\n- Homepage: https://pydantic.dev/pydantic-ai\\n-
+        Default branch: main\\n- Created: 2024-06-21T15:55:04Z\\n\\n...\\n\\nAI Agent Framework, the Pydantic way\\n\\n...\\n\\n###
+        Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production
+        grade applications and workflows with Generative AI.\"}}]},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://pydantic.dev/pydantic-ai\",\"title\":\"\",\"start_index\":0,\"end_index\":0,\"content\":\"Get
+        started: https://pydantic.dev/docs/ai/overview/ · GitHub: https://github.com/pydantic/pydantic-ai\\n\\n...\\n\\nType-safe
+        Python framework for building agents and LLM applications. Model-agnostic with built-in validation, structured outputs,
+        and seamless observability. Open source under the MIT license.\\n\\n...\\n\\n```bash\\nuv add pydantic-ai\\n\\n...\\n\\nOpen
+        source (MIT license). Install with uv (or pip) and start building production-grade AI applications today.\\n\\n...\\n\\n-\\n\\n...\\n\\nuv
+        add p\\n\\n...\\n\\n-\\n\\n...\\n\\napplications with Generative AI\\n\\n...\\n\\n-\\n\\n...\\n\\n: https://github\\n\\n...\\n\\n#
+        Production\\n\\n...\\n\\n)\\n\\n...\\n\\n.\\n\\n...\\n\\n: https://p\\n\\n...\\n\\nGateway pricing\\n\\n...\\n\\n/pydantic-ai\\n\\n...\\n\\nbash\\n\\n...\\n\\n-ai\\n\\n...\\n\\n/\\n\\n...\\n\\n:
+        https://p\\n\\n...\\n\\n://pyd\\n\\n...\\n\\nfire and\\n\\n...\\n\\nfree;\\n\\n...\\n\\n.\\n\\n...\\n\\n/pyd\\n\\n...\\n\\npyd\\n\\n...\\n\\n.\\n\\n...\\n\\nantic.\\n\\n...\\n\\n/\\n\\n...\\n\\n```\"}}]},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://github.com/pydantic/pydantic-ai/releases/tag/v2.0.0\",\"title\":\"v2.0.0
+        (2026-06-23)\",\"start_index\":0,\"end_index\":0,\"content\":\"- Tag: v2.0.0\\n- Repository: pydantic/pydantic-ai\\n-
+        Published: 2026-06-23T15:38:17Z\\n- Author: dsfaccini\\n\\n...\\n\\n# v2.0.0 (2026-06-23)\\n\\n...\\n\\nAfter seven
+        betas, **Pydantic AI V2 is now stable.** V2 leans into a harness-first design with capabilities as a core primitive
+        — a single composable unit that bundles an agent's tools, hooks, instructions, and model settings, reaching every
+        layer of the agent through one concept.\\n\\n...\\n\\n# \U0001F389 Pydantic AI V2.0 is here!\\n\\n...\\n\\nuv add
+        pydantic-ai\\n\\n...\\n\\nInstall it with:\\n\\n...\\n\\n```bash\"}}]},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://pydantic.dev/docs/ai/overview/\",\"title\":\"Pydantic
+        AI | Pydantic Docs\",\"start_index\":0,\"end_index\":0,\"content\":\"# Pydantic AI\\n\\n...\\n\\nPydantic AI is a
+        Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications
+        and workflows with Generative AI.\\n\\n...\\n\\n,\\n\\n...\\n\\nydantic AI Harness is our official library of ready-made
+        capabilities -- code\\n\\n...\\n\\naccess, guardrails, sub-agent orchestration, and more -- that you pick and choose
+        to build coding agents, research assistants, and anything in between.\\n\\n...\\n\\nPydantic AI ships the agent loop,
+        a composable capabilities system\\n\\n...\\n\\nand built-in capabilities for thinking, web search, web fetch, image
+        generation, MCP, tool search, and more;\"}}]},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://github.com/pydantic/pydantic-ai/tree/refs/tags/v1.44.0\",\"title\":\"GitHub
+        - pydantic/pydantic-ai at refs/tags/v1.44.0 · GitHub\",\"start_index\":0,\"end_index\":0,\"content\":\"GitHub - pydantic/pydantic-ai
+        at refs/tags/v1.44.0 · GitHub\\n...\\n### Pydantic AI is a Python agent framework designed to help you quickly, confidently,
+        and painlessly build production grade applications and workflows with Generative AI.\"}}]},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        URL\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        for P\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"yd\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"antic
+        AI\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"'s
+        GitHub repository\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        is:  \\n\\n\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata: {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"https://github.com\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"/pyd\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"antic/pyd\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"antic-\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ai\",\"role\":\"assistant\"},\"finish_reason\":null,\"native_finish_reason\":null}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":\"stop\",\"native_finish_reason\":\"stop\"}]}\n\ndata:
+        {\"id\":\"gen-1786680764-gY2YTdjLLLQA6Cd1Wa6J\",\"object\":\"chat.completion.chunk\",\"created\":1786680764,\"model\":\"deepseek/deepseek-chat\",\"provider\":\"OpenAI\",\"service_tier\":null,\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":\"stop\",\"native_finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":2317,\"completion_tokens\":53,\"total_tokens\":2370,\"cost\":0.0076509169000000005,\"prompt_tokens_details\":{\"cached_tokens\":0,\"cache_write_tokens\":0,\"audio_tokens\":0,\"video_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"image_tokens\":0,\"audio_tokens\":0},\"cost_details\":{\"upstream_inference_cost\":0.0006509169,\"upstream_inference_prompt_cost\":0.0005963957999999999,\"upstream_inference_completions_cost\":0.0000545211},\"server_tool_use_details\":{\"web_search_requests\":1,\"tool_calls_requested\":1,\"tool_calls_executed\":1}}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      cache-control:
+      - no-cache
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream
+      permissions-policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com" "https://js.stripe.com" "https://*.js.stripe.com"
+        "https://hooks.stripe.com")
+      referrer-policy:
+      - no-referrer, strict-origin-when-cross-origin
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -960,34 +960,10 @@ async def test_openrouter_file_annotation_validation(openrouter_api_key: str) ->
     result = model._process_response(response)  # type: ignore[reportPrivateUsage]
     text_part = cast(TextPart, result.parts[0])
     assert text_part.content == 'Here is the summary of your file.'
-
-
-async def test_openrouter_url_citation_annotation_validation(openrouter_api_key: str) -> None:
-    """Test that url_citation annotations from OpenRouter are correctly validated."""
-    from openai.types.chat.chat_completion_message import ChatCompletionMessage
-
-    provider = OpenRouterProvider(api_key=openrouter_api_key)
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
-
-    message = ChatCompletionMessage.model_construct(
-        role='assistant',
-        content='According to the source, this is the answer.',
-        annotations=[
-            {
-                'type': 'url_citation',
-                'url_citation': {'url': 'https://example.com', 'title': 'Example', 'start_index': 0, 'end_index': 10},
-            },
-        ],
+    assert result.provider_details is not None
+    assert result.provider_details['annotations'] == snapshot(
+        [{'type': 'file', 'file': {'filename': 'test.pdf', 'file_id': 'file-123'}}]
     )
-    choice = Choice.model_construct(index=0, message=message, finish_reason='stop', native_finish_reason='stop')
-    response = ChatCompletion.model_construct(
-        id='test', choices=[choice], created=0, object='chat.completion', model='test', provider='test'
-    )
-
-    # This should not raise a validation error
-    result = model._process_response(response)  # type: ignore[reportPrivateUsage]
-    text_part = cast(TextPart, result.parts[0])
-    assert text_part.content == 'According to the source, this is the answer.'
 
 
 async def test_openrouter_service_tier_completion(openrouter_api_key: str) -> None:
@@ -1605,6 +1581,7 @@ async def test_openrouter_web_search_tool_usage(
     raw_response = json.loads(vcr.responses[0]['body']['string'])  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
     assert raw_response['usage']['server_tool_use_details'] == {'web_search_requests': 1}
     assert response.provider_details['server_tool_use'] == {'web_search_requests': 1}
+    assert 'annotations' not in response.provider_details
 
 
 _OPENROUTER_WEB_SEARCH_FULL_PARAMS_CASSETTE = (
@@ -1686,6 +1663,7 @@ async def test_openrouter_web_search_tool_usage_stream(allow_model_requests: Non
 
     assert stream.response.provider_details is not None
     assert stream.response.provider_details['server_tool_use'] == {'web_search_requests': 1}
+    assert 'annotations' not in stream.response.provider_details
 
 
 async def test_openrouter_web_search_annotations(allow_model_requests: None, openrouter_api_key: str) -> None:
@@ -1704,10 +1682,48 @@ async def test_openrouter_web_search_annotations(allow_model_requests: None, ope
     assert isinstance(response, ModelResponse)
     assert response.provider_details is not None
     annotations = response.provider_details['annotations']
-    assert [annotation['type'] for annotation in annotations] == snapshot(
-        ['url_citation', 'url_citation', 'url_citation', 'url_citation', 'url_citation']
+    assert annotations[0] == snapshot(
+        {
+            'type': 'url_citation',
+            'url_citation': {
+                'end_index': 0,
+                'start_index': 0,
+                'title': 'AI Agent Framework, the Pydantic way',
+                'url': 'https://github.com/pydantic/pydantic-ai',
+                'content': """\
+# pydantic/pydantic-ai
+
+...
+
+- Stars: 19265
+- Forks: 2514
+- Watchers: 19265
+- Open issues: 702
+- License: MIT License
+- Homepage: https://pydantic.dev/pydantic-ai
+- Default branch: main
+- Created: 2024-06-21T15:55:04Z
+
+...
+
+AI Agent Framework, the Pydantic way
+
+...
+
+### Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.\
+""",
+            },
+        }
     )
-    assert annotations[0]['url_citation']['url'] == snapshot('https://github.com/pydantic/pydantic-ai')
+    assert [annotation['url_citation']['url'] for annotation in annotations] == snapshot(
+        [
+            'https://github.com/pydantic/pydantic-ai',
+            'https://pydantic.dev/pydantic-ai',
+            'https://github.com/pydantic/pydantic-ai/releases/tag/v2.0.0',
+            'https://pydantic.dev/docs/ai/overview/',
+            'https://github.com/pydantic/pydantic-ai/tree/refs/tags/v1.44.0',
+        ]
+    )
 
 
 async def test_openrouter_web_search_annotations_stream(allow_model_requests: None, openrouter_api_key: str) -> None:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1688,6 +1688,52 @@ async def test_openrouter_web_search_tool_usage_stream(allow_model_requests: Non
     assert stream.response.provider_details['server_tool_use'] == {'web_search_requests': 1}
 
 
+async def test_openrouter_web_search_annotations(allow_model_requests: None, openrouter_api_key: str) -> None:
+    """OpenRouter's `url_citation` annotations surface as the response's `annotations` provider detail.
+
+    Uses a model whose downstream provider has no native search, because OpenRouter only returns
+    annotations when a non-native search engine ran; native provider search returns none.
+    """
+    provider = OpenRouterProvider(api_key=openrouter_api_key)
+    model = OpenRouterModel('deepseek/deepseek-chat', provider=provider)
+    agent = Agent(model, capabilities=[NativeTool(WebSearchTool(max_uses=1))])
+
+    result = await agent.run("Use web search to find Pydantic AI's GitHub repository and answer with its URL only.")
+
+    response = result.all_messages()[-1]
+    assert isinstance(response, ModelResponse)
+    assert response.provider_details is not None
+    annotations = response.provider_details['annotations']
+    assert [annotation['type'] for annotation in annotations] == snapshot(
+        ['url_citation', 'url_citation', 'url_citation', 'url_citation', 'url_citation']
+    )
+    assert annotations[0]['url_citation']['url'] == snapshot('https://github.com/pydantic/pydantic-ai')
+
+
+async def test_openrouter_web_search_annotations_stream(allow_model_requests: None, openrouter_api_key: str) -> None:
+    """Streaming accumulates annotations across deltas rather than keeping only the last chunk's."""
+    provider = OpenRouterProvider(api_key=openrouter_api_key)
+    model = OpenRouterModel('deepseek/deepseek-chat', provider=provider)
+    agent = Agent(model, capabilities=[NativeTool(WebSearchTool(max_uses=1))])
+
+    async with agent.run_stream(
+        "Use web search to find Pydantic AI's GitHub repository and answer with its URL only."
+    ) as stream:
+        assert await stream.get_output()
+
+    assert stream.response.provider_details is not None
+    annotations = stream.response.provider_details['annotations']
+    assert [annotation['url_citation']['url'] for annotation in annotations] == snapshot(
+        [
+            'https://github.com/pydantic/pydantic-ai',
+            'https://pydantic.dev/pydantic-ai',
+            'https://github.com/pydantic/pydantic-ai/releases/tag/v2.0.0',
+            'https://pydantic.dev/docs/ai/overview/',
+            'https://github.com/pydantic/pydantic-ai/tree/refs/tags/v1.44.0',
+        ]
+    )
+
+
 def test_openrouter_nested_provider_response() -> None:
     """OpenRouter sometimes nests the real response inside the 'provider' dict.
 


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David has not reviewed this code yet.

- Part of #7338

### Why we make these changes

#7378 migrated OpenRouter web search to the `openrouter:web_search` server tool, which reports a search count and nothing else. When OpenRouter runs the search itself rather than delegating to the downstream provider's native search, it attaches the sources it used to the message as `url_citation` annotations — `_OpenRouterChatCompletionMessage.annotations` has always validated them, but nothing ever read them, so users got a count and no sources.

### New public surface

- `ModelResponse.provider_details['annotations']` on OpenRouter — the raw `url_citation` / file annotations, verbatim. No new symbols.

<details>
<summary><b>Goal:</b> search sources reach the caller</summary>

Before → after, same agent, `deepseek/deepseek-chat` with `WebSearch()`:

```python
result.response.provider_details
# before -> {'server_tool_use': {'web_search_requests': 1, ...}, ...}
# after  -> {'server_tool_use': {...}, 'annotations': [{'type': 'url_citation', 'url_citation': {'url': 'https://github.com/pydantic/pydantic-ai', 'title': ..., 'content': ...}}, ...], ...}
```

<details>
<summary>Playground</summary>

```python
from pydantic_ai import Agent
from pydantic_ai.capabilities import WebSearch
from pydantic_ai.models.openrouter import OpenRouterModel

agent = Agent(OpenRouterModel('deepseek/deepseek-chat'), capabilities=[WebSearch()])
result = agent.run_sync('What is the latest news in AI?')

for annotation in (result.response.provider_details or {}).get('annotations', []):
    print(annotation['url_citation']['url'])
```
</details>

Test: `test_openrouter_web_search_annotations` in `tests/models/test_openrouter.py`, against a live cassette.

**What changes for existing users:** an extra `annotations` key appears in `provider_details` on OpenRouter responses whose search ran on a non-native engine. Nothing is removed or renamed.
</details>

<details>
<summary><b>Goal:</b> streaming reports the same sources as the standard path</summary>

OpenRouter spreads annotations over several deltas, and `OpenAIStreamedResponse` shallow-merges each chunk's provider details, so a naive mapping keeps only the last chunk's annotations — and the final usage chunk carries none, which drops them entirely. `OpenRouterStreamedResponse` accumulates them and re-publishes the whole list.

```python
# recorded run, 5 sources arriving across 5 separate deltas
stream.response.provider_details['annotations']
# naive per-chunk mapping -> KeyError (final usage chunk has no annotations)
# accumulated             -> 5 entries, matching the non-streamed response
```

Test: `test_openrouter_web_search_annotations_stream` in `tests/models/test_openrouter.py`, whose snapshot pins all five URLs.

**What changes for existing users:** nothing beyond the same additive `annotations` key.
</details>

### Deliberate scope decisions

- **Surfaced in `provider_details`, not as `NativeToolCallPart` / `NativeToolReturnPart`.** Google synthesizes those parts from response-level grounding metadata, so there is precedent for the richer shape. Not doing it here: OpenRouter's Chat Completions responses carry no server-tool call items at all (the advisor tool has the same shape), `provider_details` is where this model already puts every OpenRouter extra, and the parts shape would need a matching streaming-event path. Easy to overrule — say the word and I'll switch it.
- **Always on, unlike OpenAI's opt-in `openai_include_raw_annotations`.** `OpenAIChatModel._process_response` takes no `model_settings`, so gating the standard path on a per-request setting means changing that shared signature. Worth knowing: annotations include the excerpt handed to the model, so they are not tiny, and they persist into serialized message history.
- **Engine selection is not addressed here.** Models whose downstream provider searches natively (OpenAI, Anthropic) return no annotations at all, and OpenRouter's `engine` parameter is unreachable from Pydantic AI. That is deliverable 1 of #7338, awaiting a design decision on [provider-specific native-tool parameters](https://github.com/pydantic/pydantic-ai/issues/7338#issuecomment-5289343779).

### Validation

Live-recorded both cassettes against OpenRouter. Confirmed against the API that native-search providers (`openai/gpt-4.1-mini`, `anthropic/claude-sonnet-4.6`) return no annotations while non-native ones (`deepseek`, `mistralai`, `qwen`, `z-ai`) return five, standard and streamed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

