### PR TITLE
Fix attention triage `pydantic-ai-slim` resolution

### DIFF
--- a/.github/scripts/test_pydantic_ai_runner.py
+++ b/.github/scripts/test_pydantic_ai_runner.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+import yaml
 from pytest import LogCaptureFixture
 
 # `.github/scripts/` isn't on sys.path by default — the shim package lives
@@ -934,6 +935,34 @@ def test_attention_workflow_uses_direct_classification():
     assert 'Classify every candidate yourself' in text
     assert 'PYDANTIC_AI_DYNAMIC_WORKFLOW' not in text
     assert 'run_workflow' not in text
+
+
+def test_attention_workflow_fetches_tags_for_runner_version():
+    workflow_dir = Path(__file__).parent.parent / 'workflows'
+    source = workflow_dir / 'pydantic-ai-attention-triage.md'
+    source_steps = agentic_workflow_guard.parse_frontmatter(source)['pre-agent-steps']
+    compiled = yaml.safe_load((workflow_dir / 'pydantic-ai-attention-triage.lock.yml').read_text(encoding='utf-8'))
+    compiled_steps = compiled['jobs']['agent']['steps']
+    expected_checkout_config = {
+        'persist-credentials': False,
+        'ref': '${{ github.event.repository.default_branch }}',
+        'fetch-depth': 0,
+    }
+
+    for steps in (source_steps, compiled_steps):
+        checkout_index, checkout = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if str(step.get('uses', '')).startswith('actions/checkout@')
+            and step.get('with', {}).get('ref') == expected_checkout_config['ref']
+        )
+        prewarm_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get('name') == 'Pre-warm Pydantic AI gh-aw shim uv environment'
+        )
+        assert checkout_index < prewarm_index
+        assert checkout['with'] == expected_checkout_config
 
 
 def test_runner_drops_dynamic_workflow_dependencies():

--- a/.github/workflows/pydantic-ai-attention-triage.lock.yml
+++ b/.github/workflows/pydantic-ai-attention-triage.lock.yml
@@ -422,6 +422,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
       - name: Stage Pydantic AI gh-aw shim launcher
         run: |
           mkdir -p /tmp/gh-aw/bin

--- a/.github/workflows/pydantic-ai-attention-triage.md
+++ b/.github/workflows/pydantic-ai-attention-triage.md
@@ -93,6 +93,7 @@ pre-agent-steps:
     with:
       persist-credentials: false
       ref: ${{ github.event.repository.default_branch }}
+      fetch-depth: 0
   - name: Stage Pydantic AI gh-aw shim launcher
     run: |
       mkdir -p /tmp/gh-aw/bin


### PR DESCRIPTION
- Closes #7459

The attention-triage workflow currently checks out only one commit before pre-warming the Pydantic AI runner. Without reachable release tags, `uv-dynamic-versioning` assigns the editable workspace package a `0.0.1.dev1+...` version, which cannot satisfy `pydantic-ai-harness==0.7.0`'s `pydantic-ai-slim>=2.1.0` requirement.

This fetches the full repository history for that pre-agent checkout so the runner resolves the tag-derived version. The regression test verifies the setting in both the source and compiled workflows and confirms the checkout runs before pre-warming.

### Tests

- `uv run --with pydantic-ai-harness==0.7.0 pytest .github/scripts/test_pydantic_ai_runner.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --with pydantic-ai-harness==0.7.0 pyright .github/scripts/test_pydantic_ai_runner.py`
- `gh aw lint .github/workflows/pydantic-ai-attention-triage.lock.yml`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

