### PR TITLE
fix: forward supported Cerebras model settings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -63,11 +63,6 @@ class CerebrasProvider(_OpenAICompatibleProvider):
         # Cerebras doesn't support some model settings.
         # openai_chat_supports_web_search=False is default, so not required here
         unsupported_model_settings = (
-            'frequency_penalty',
-            'logit_bias',
-            'presence_penalty',
-            'parallel_tool_calls',
-            'service_tier',
             'openai_service_tier',
         )
         is_reasoning = model_name_lower.startswith(reasoning_prefixes)

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -227,6 +227,7 @@ class ModelSettings(TypedDict, total=False):
     * Groq
     * Mistral
     * xAI
+    * Cerebras
     * Crusoe
     * Ollama
     * OpenRouter
@@ -310,6 +311,7 @@ class ModelSettings(TypedDict, total=False):
     * Mistral
     * xAI
     * HuggingFace
+    * Cerebras
     * Crusoe
     * Ollama
     * OpenRouter
@@ -330,6 +332,7 @@ class ModelSettings(TypedDict, total=False):
     * Mistral
     * xAI
     * HuggingFace
+    * Cerebras
     * Crusoe
     * Ollama
     * OpenRouter
@@ -346,6 +349,7 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI Chat Completions
     * Groq
     * HuggingFace
+    * Cerebras
     * Crusoe
     * Ollama (sent, but Ollama documents `logit_bias` as unsupported)
     * OpenRouter
@@ -394,6 +398,7 @@ class ModelSettings(TypedDict, total=False):
     * OpenRouter
     * Snowflake
     * Z.AI
+    * Cerebras
     * Bedrock Mantle
     """
 

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -99,14 +99,14 @@ def test_cerebras_provider_model_profile(mocker: MockerFixture):
     assert isinstance(unknown_profile, dict)
     assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
-    # Verify unsupported model settings are set for all profiles
+    # Verify only the still-unsupported model settings are filtered for all profiles
     for profile in [meta_profile, qwen_profile, harmony_profile, zai_profile, unknown_profile]:
         assert isinstance(profile, dict)
-        assert 'frequency_penalty' in profile.get('openai_unsupported_model_settings', ())
-        assert 'logit_bias' in profile.get('openai_unsupported_model_settings', ())
-        assert 'presence_penalty' in profile.get('openai_unsupported_model_settings', ())
-        assert 'parallel_tool_calls' in profile.get('openai_unsupported_model_settings', ())
-        assert 'service_tier' in profile.get('openai_unsupported_model_settings', ())
+        assert 'frequency_penalty' not in profile.get('openai_unsupported_model_settings', ())
+        assert 'logit_bias' not in profile.get('openai_unsupported_model_settings', ())
+        assert 'presence_penalty' not in profile.get('openai_unsupported_model_settings', ())
+        assert 'parallel_tool_calls' not in profile.get('openai_unsupported_model_settings', ())
+        assert 'service_tier' not in profile.get('openai_unsupported_model_settings', ())
         assert 'openai_service_tier' in profile.get('openai_unsupported_model_settings', ())
 
 


### PR DESCRIPTION
## Summary

Fixes #7444.

Cerebras now documents frequency_penalty, logit_bias, presence_penalty, parallel_tool_calls, and service_tier as supported. Stop filtering those settings from Cerebras requests, keep openai_service_tier filtered, and update the ModelSettings support lists and provider regression test.

## Validation

- PYTHONUTF8=1 uv run pytest tests/providers/test_cerebras.py -q — 5 passed.
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

