### PR TITLE
Pass `openai` through Temporal workflow sandboxes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -117,6 +117,12 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             # e.g. a `gateway/anthropic:` or `anthropic:` model resolved lazily via `infer_model`.
             # Safe to pass through: a deterministic, read-only config lookup.
             'anthropic',
+            # The OpenAI SDK defers importing its large generated resource tree until a model constructor
+            # accesses `client.chat.completions` or `client.responses`. Without passthrough, Temporal reloads
+            # that tree in every isolated workflow sandbox. Pass through the whole SDK so resource classes and
+            # their base classes come from one coherent module graph. Pydantic AI does not use the SDK's global
+            # client configuration: it creates per-model clients and invokes their request methods in activities.
+            'openai',
             # The `google-genai` SDK lazily imports `google.auth` submodules (e.g.
             # `google.auth.aio.credentials`) while constructing its client, which Temporal flags as
             # "imported after initial workflow load" when a `gateway/google-cloud:` (or `google-*:`)


### PR DESCRIPTION
- Closes #7463

PR #7408 moved the OpenAI SDK's deferred resource imports from the first request to model construction. Temporal reconstructs module-level models in isolated workflow sandboxes, so that change repeated the large OpenAI resource import tree for every sandbox.

This change passes `openai` through Pydantic AI's Temporal sandbox configuration. The constructor preload from #7408 remains unchanged, but Temporal now imports the SDK once in the worker host and shares the same module graph with each workflow sandbox.

The whole SDK is passed through rather than only `openai.resources`. Resource classes inherit from base classes elsewhere in the package; passing through only the resource subtree creates incompatible host and sandbox class identities. Pydantic AI creates per-model clients rather than using the SDK's global client configuration, and request methods execute in Temporal activities.

Validation:

- The existing, unchanged Temporal test suite passes with `TEMPORAL_DEBUG=1`: 268 passed, 2 skipped.
- Diagnostic sandbox timings changed from roughly 0.5 to 1.0 seconds on every sandbox to one roughly 0.4-second host import followed by roughly 3 to 4 ms per later sandbox.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
