### PR TITLE
Fail the workflow on `UnexpectedModelBehavior` and `FallbackExceptionGroup` under the deprecated `TemporalAgent`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -10,10 +10,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from pydantic import ConfigDict, with_config
-from pydantic.errors import PydanticUserError
 from pydantic_core import PydanticSerializationError
 from temporalio import activity, workflow
-from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityConfig
 from typing_extensions import deprecated
 
@@ -57,7 +55,6 @@ from ._durability import serialization_user_error
 from ._model import TemporalModel, TemporalProviderFactory
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import (
-    PAYLOAD_SIZE_ERROR_TYPE,
     temporalize_toolset,
     toolset_temporal_activities,
     with_non_retryable_errors,
@@ -190,16 +187,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             else ActivityConfig(start_to_close_timeout=timedelta(seconds=60))
         )
 
-        # `pydantic_ai.exceptions.UserError` and `pydantic.errors.PydanticUserError` are not retryable,
-        # and neither is an over-limit payload, which would otherwise be resent forever (#7110).
-        retry_policy = copy.copy(activity_config.get('retry_policy') or RetryPolicy())
-        retry_policy.non_retryable_error_types = [
-            *(retry_policy.non_retryable_error_types or []),
-            UserError.__name__,
-            PydanticUserError.__name__,
-            PAYLOAD_SIZE_ERROR_TYPE,
-        ]
-        activity_config['retry_policy'] = retry_policy
+        activity_config['retry_policy'] = with_non_retryable_errors(activity_config.get('retry_policy'))
         self.activity_config = activity_config
 
         model_activity_config = model_activity_config or {}

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -7296,13 +7296,7 @@ def test_durability_activity_config_not_mutated():
 
 
 def test_temporal_agent_retry_policy_non_retryable_errors():
-    """The deprecated wrapper's base config carries the same non-retryable errors as the capability.
-
-    `TemporalAgent` used to build this list by hand, and it drifted: it never picked up the
-    `UnexpectedModelBehavior` and `FallbackExceptionGroup` entries #6978 added to
-    `with_non_retryable_errors`, so a continuation-ceiling error retried the whole (paid) model
-    request forever instead of failing the workflow (#7163).
-    """
+    """The deprecated wrapper normalizes its base activity retry policy with `with_non_retryable_errors`."""
     temporal_agent = TemporalAgent(  # pyright: ignore[reportDeprecated]
         Agent(TestModel(), name='retry_policy_probe_agent'),
     )

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -7296,11 +7296,12 @@ def test_durability_activity_config_not_mutated():
 
 
 def test_temporal_agent_retry_policy_non_retryable_errors():
-    """The deprecated wrapper builds its own list, so its entries need their own assertion.
+    """The deprecated wrapper's base config carries the same non-retryable errors as the capability.
 
-    `TemporalAgent` doesn't go through `with_non_retryable_errors`, and every line of its
-    inline list runs on any construction — so without this, dropping `PayloadSizeError`
-    would leave coverage at 100% while restoring the infinite retry of #7110.
+    `TemporalAgent` used to build this list by hand, and it drifted: it never picked up the
+    `UnexpectedModelBehavior` and `FallbackExceptionGroup` entries #6978 added to
+    `with_non_retryable_errors`, so a continuation-ceiling error retried the whole (paid) model
+    request forever instead of failing the workflow (#7163).
     """
     temporal_agent = TemporalAgent(  # pyright: ignore[reportDeprecated]
         Agent(TestModel(), name='retry_policy_probe_agent'),
@@ -7311,6 +7312,8 @@ def test_temporal_agent_retry_policy_non_retryable_errors():
     assert retry_policy.non_retryable_error_types == [
         'UserError',
         'PydanticUserError',
+        'UnexpectedModelBehavior',
+        'FallbackExceptionGroup',
         'PayloadSizeError',
     ]
 


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

- Closes #7163

`TemporalAgent` built its base `non_retryable_error_types` inline, so it missed `UnexpectedModelBehavior` and `FallbackExceptionGroup` when those exceptions were added to `with_non_retryable_errors()` in #6978. Under the default unlimited Temporal retry policy, either exception could leave the workflow retrying indefinitely instead of failing.

This change uses `with_non_retryable_errors()` for the deprecated wrapper too, keeping its retry policy aligned with `TemporalDurability` and eliminating the duplicated list.

The other behavior reported in #7163 — a custom model or toolset `retry_policy` replacing the normalized base policy — is already fixed on `main` by `_merge_activity_config` and covered by `test_temporal_agent_custom_retry_policy_keeps_non_retryable_errors`.

### New public surface

None.

### Test plan

- `test_temporal_agent_retry_policy_non_retryable_errors`
- Full CI and coverage

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->