### PR TITLE
Preserve DeepSeek prompt cache hits in `cache_read_tokens`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -5011,6 +5011,13 @@ def _map_usage(
         cache_write_tokens = input_tokens_details.get('cache_write_tokens')
         if isinstance(cache_write_tokens, int):
             request_usage.cache_write_tokens = cache_write_tokens
+    prompt_cache_hit_tokens = usage_data.get('prompt_cache_hit_tokens')
+    if (
+        request_usage.cache_read_tokens == 0
+        and isinstance(prompt_cache_hit_tokens, int)
+        and not isinstance(prompt_cache_hit_tokens, bool)
+    ):
+        request_usage.cache_read_tokens = prompt_cache_hit_tokens
     return request_usage
 
 

--- a/tests/models/test_deepseek.py
+++ b/tests/models/test_deepseek.py
@@ -23,8 +23,13 @@ from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsStr, try_import
 
 with try_import() as imports_successful:
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+    from openai.types.completion_usage import CompletionUsage
+
     from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.deepseek import DeepSeekProvider
+
+    from .mock_openai import MockOpenAI, completion_message
 
 
 pytestmark = [
@@ -45,6 +50,30 @@ def freeze_deepseek_off_peak_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
             return timestamp if tz is not None else timestamp.replace(tzinfo=None)
 
     monkeypatch.setattr('pydantic_ai._utils.datetime', FrozenDatetime)
+
+
+async def test_deepseek_chat_prompt_cache_hits_are_first_class(allow_model_requests: None):
+    completion = completion_message(
+        ChatCompletionMessage(content='cached response', role='assistant'),
+        usage=CompletionUsage.model_construct(
+            completion_tokens=5,
+            prompt_tokens=20,
+            total_tokens=25,
+            prompt_cache_hit_tokens=12,
+            prompt_cache_miss_tokens=8,
+        ),
+    )
+    mock_client = MockOpenAI.create_mock(completion)
+    model = OpenAIChatModel('deepseek-chat', provider=DeepSeekProvider(openai_client=mock_client))
+    agent = Agent(model)
+
+    result = await agent.run('Hello')
+
+    assert result.usage.input_tokens == 20
+    assert result.usage.cache_read_tokens == 12
+    assert result.usage.output_tokens == 5
+    assert result.usage.details['prompt_cache_hit_tokens'] == 12
+    assert result.usage.details['prompt_cache_miss_tokens'] == 8
 
 
 @pytest.mark.moves_cache_prefix(reason='dynamic tool disclosure after ToolSearch discovery')


### PR DESCRIPTION
- Closes #7470

### Summary

- lift DeepSeek top-level `prompt_cache_hit_tokens` into normalized `RequestUsage.cache_read_tokens` when nested OpenAI cache details have not already populated it
- keep raw `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` values in `RequestUsage.details`
- add a deterministic DeepSeek Chat regression test

### Tests

- `uv run pytest tests/models/test_deepseek.py -q`
- `uv run pytest tests/models/test_openai.py::test_request_simple_usage tests/models/test_openai_prompt_cache.py::test_openai_chat_stream_maps_cache_write_usage tests/models/test_openai_prompt_cache.py::test_openai_chat_usage_without_cache_write_tokens tests/models/test_deepseek.py::test_deepseek_chat_prompt_cache_hits_are_first_class -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_deepseek.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_deepseek.py`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

