### PR TITLE
Fast-path the ToolReturnContent discriminator for plain JSON-decoded …

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1161,6 +1161,21 @@ _MULTIMODAL_KINDS: frozenset[str] = frozenset(t.__dataclass_fields__['kind'].def
 # (every dumped item), `file_id` (`UploadedFile`).
 _MULTIMODAL_FIELDS: frozenset[str] = frozenset({'url', 'media_type', 'file_id'})
 
+# Leaf types `json.loads`/pydantic-core's JSON parser ever produces, plus the builtin scalars a
+# `validate_python` caller would pass. Checked with `type(value) in ...` rather than `isinstance`
+# in the fast path below, since none of them can be subclassed away from a matching `kind`/`Mapping`
+# ABC registration the slow path still needs to catch.
+_JSON_LEAF_TYPES: frozenset[type] = frozenset({str, int, float, bool, type(None)})
+
+
+def _is_multimodal_dict(value: Any) -> bool:
+    return (
+        'kind' in value
+        and isinstance(value['kind'], str)
+        and value['kind'] in _MULTIMODAL_KINDS
+        and any(field in value for field in _MULTIMODAL_FIELDS)
+    )
+
 
 def _tool_return_content_discriminator(value: Any) -> str:
     """Route a `ToolReturnContent` value to one of the tagged union branches.
@@ -1176,18 +1191,26 @@ def _tool_return_content_discriminator(value: Any) -> str:
     (carried by every dumped `MultiModalContent`), or `file_id` for `UploadedFile` — so a user
     dict that merely reuses one of our `kind` values (e.g. `{'kind': 'binary', 'label': 'foo'}`)
     stays a plain mapping instead of being forced through multimodal validation.
+
+    Because `ToolReturnContent` is recursive, this runs once per JSON node on `validate_json`
+    (see https://github.com/pydantic/pydantic-ai/issues/7472), so the exact-type fast path below
+    matters: it skips the `MULTI_MODAL_CONTENT_TYPES` tuple check and the `Mapping`/`Sequence` ABC
+    `isinstance` checks for the plain `dict`/`list`/scalar nodes that make up the bulk of any
+    JSON-decoded tree, falling back to the general (slower but exhaustive) checks for everything
+    else, e.g. real `MultiModalContent` instances or custom `Mapping`/`Sequence` implementations
+    passed via `validate_python`.
     """
+    if type(value) is dict:
+        return 'multimodal' if _is_multimodal_dict(value) else 'mapping'
+    if type(value) is list:
+        return 'sequence'
+    if type(value) in _JSON_LEAF_TYPES:
+        return 'any'
+
     if isinstance(value, MULTI_MODAL_CONTENT_TYPES):
         return 'multimodal'
     if isinstance(value, Mapping):
-        if (
-            'kind' in value
-            and isinstance(value['kind'], str)
-            and value['kind'] in _MULTIMODAL_KINDS
-            and any(field in value for field in _MULTIMODAL_FIELDS)
-        ):
-            return 'multimodal'
-        return 'mapping'
+        return 'multimodal' if _is_multimodal_dict(value) else 'mapping'
     if isinstance(value, (str, bytes, bytearray)):
         return 'any'
     if isinstance(value, Sequence):


### PR DESCRIPTION
Fixes #7472.

## What this does

`_tool_return_content_discriminator` runs once per node on every `validate_json` of a recursive `ToolReturnContent` tree, so its cost is O(nodes). The `isinstance` checks against `MULTI_MODAL_CONTENT_TYPES` and the `Mapping`/`Sequence` ABCs dominate that per-node cost, even though the overwhelming majority of nodes in a JSON-decoded tree are plain `dict`/`list`/`str`/`int`/`float`/`bool`/`None`.

This adds an exact-type fast path (`type(value) is dict`, etc.) ahead of the existing `isinstance` checks. The original checks stay as the fallback, unchanged, for real `MultiModalContent` instances and custom `Mapping`/`Sequence` subclasses passed via `validate_python`. Behavior and the wire format are unchanged — same classification for every input.

## Benchmark

Using the MRE from #7472 (37KB payload, `CallToolResult.validate_json`):

- Before: 0.672 ms/validate
- After: 0.205 ms/validate — **3.3x faster**

Isolating the discriminator function itself: 0.365ms → 0.039ms (9.4x), confirming the function body — not the Rust↔Python FFI crossing — was the dominant cost.

## Scope

This is a local, non-breaking optimization, not the wire-format redesign discussed on #7472 for eliminating the O(nodes) Python calls entirely. Posting this as a concrete, benchmarked partial win for discussion — happy to adjust the approach based on maintainer feedback before this is considered for merge.

## Verification

- `ruff check`, `ruff format --check`, `pyright` (strict) all clean
- Full `test_messages.py`, `test_vercel_ai.py`, `test_ag_ui.py` suites pass (467 passed)

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

