### PR TITLE
docs: add the tagline line to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   <a href="https://github.com/pydantic/pydantic-ai/blob/main/LICENSE"><img src="https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v" alt="license"></a>
   <a href="https://logfire.pydantic.dev/docs/join-slack/"><img src="https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack" alt="Join Slack" /></a>
 </div>
+<p align="center">
+  Agents, realtime voice, image generation, embeddings. Every model, every interface, typed end to end.
+</p>
 
 ---
 


### PR DESCRIPTION
Follow-up to #7421: the centered tagline ('Agents, realtime voice, image generation, embeddings. Every model, every interface, typed end to end.') has always been index-only; the README went straight from badges to paragraph one. This adds it under the badge row, matching the docs index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

