### PR TITLE
fix(openai): disallow function tools with reasoning on OpenAIChatModel for GPT-5.4

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1012,6 +1012,26 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                 f'WebSearchTool is not supported with `OpenAIChatModel` and model {self.model_name!r}. '
                 f'Please use `OpenAIResponsesModel` instead.'
             )
+
+        if not self.profile.get('openai_chat_supports_function_tools_with_reasoning', True) and (
+            model_request_parameters.function_tools or model_request_parameters.output_mode == 'tool'
+        ):
+            reasoning_effort = (
+                model_settings.get('openai_reasoning_effort') if isinstance(model_settings, dict) else None
+            )
+            thinking = model_request_parameters.thinking
+            if reasoning_effort is not None:
+                reasoning_active = reasoning_effort != 'none'
+            elif thinking is not None:
+                reasoning_active = thinking is not False
+            else:
+                reasoning_active = self.profile.get('openai_reasoning_enabled_by_default', False)
+            if reasoning_active:
+                raise UserError(
+                    f'Function tools with reasoning are not supported with `OpenAIChatModel` and model {self.model_name!r}. '
+                    f'Please use `OpenAIResponsesModel` instead.'
+                )
+
         return super().prepare_request(model_settings, model_request_parameters)
 
     async def request(

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -217,6 +217,9 @@ class OpenAIModelProfile(ModelProfile, total=False):
     openai_chat_supports_web_search: bool
     """Whether the model supports web search in Chat Completions API. Default: `False`."""
 
+    openai_chat_supports_function_tools_with_reasoning: bool
+    """Whether the Chat Completions API supports function tools when reasoning is enabled for this model. Default: `True`."""
+
     openai_chat_audio_input_encoding: Literal['base64', 'uri']
     """The encoding to use for audio input in Chat Completions requests. Default: `'base64'`.
 
@@ -370,6 +373,10 @@ def openai_model_profile(model_name: str) -> ModelProfile:
     # known versions rather than matching open-endedly.
     # See https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints.
     supports_prompt_cache_breakpoints = model_name.startswith('gpt-5.6')
+    # Function tools with reasoning are not supported on the Chat Completions API for GPT-5.4 models
+    # (requests must use the Responses API instead).
+    supports_chat_tools_with_reasoning = not model_name.startswith('gpt-5.4')
+
     # Structured Outputs (output mode 'native') is only supported with the gpt-4o-mini, gpt-4o-mini-2024-07-18,
     # and gpt-4o-2024-08-06 model snapshots and later. We leave it in here for all models because the
     # `default_structured_output_mode` is `'tool'`, so `native` is only used when the user specifically uses
@@ -384,6 +391,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
         thinking_always_enabled=reasoning.always_enabled,
         openai_system_prompt_role=openai_system_prompt_role,
         openai_chat_supports_web_search=supports_web_search,
+        openai_chat_supports_function_tools_with_reasoning=supports_chat_tools_with_reasoning,
         openai_supports_encrypted_reasoning_content=reasoning.supported,
         openai_supports_reasoning=reasoning.supported,
         openai_reasoning_enabled_by_default=reasoning.enabled_by_default,

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -6478,3 +6478,58 @@ def test_model_construction_preloads_lazy_dependencies():
     env = {key: value for key, value in os.environ.items() if not key.startswith('COVERAGE_')}
     process = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True, timeout=120, env=env)
     assert process.returncode == 0, f'lazy-dependency preload check failed:\n{process.stderr}'
+
+
+async def test_openai_gpt_5_4_chat_model_rejects_tools_with_reasoning(allow_model_requests: None):
+    """GPT-5.4 rejects function tools with reasoning on OpenAIChatModel."""
+    c = completion_message(ChatCompletionMessage(content='Paris.', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-5.4', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    @agent.tool_plain
+    async def get_capital(country: str) -> str:
+        return 'Paris'
+
+    with pytest.raises(
+        UserError,
+        match=r"Function tools with reasoning are not supported with `OpenAIChatModel` and model 'gpt-5.4'.*OpenAIResponsesModel",
+    ):
+        await agent.run(
+            'What is the capital of France?',
+            model_settings=OpenAIChatModelSettings(openai_reasoning_effort='medium'),
+        )
+
+
+async def test_openai_gpt_5_4_chat_model_allows_tools_when_reasoning_disabled(allow_model_requests: None):
+    """GPT-5.4 allows function tools on OpenAIChatModel when reasoning_effort is 'none'."""
+    c = completion_message(ChatCompletionMessage(content='Paris.', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-5.4', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    @agent.tool_plain
+    async def get_capital(country: str) -> str:
+        return 'Paris'
+
+    result = await agent.run(
+        'What is the capital of France?',
+        model_settings=OpenAIChatModelSettings(openai_reasoning_effort='none'),
+    )
+    assert result.output == 'Paris.'
+    assert len(get_mock_chat_completion_kwargs(mock_client)) == 1
+
+
+async def test_openai_gpt_5_4_chat_model_allows_reasoning_when_no_tools(allow_model_requests: None):
+    """GPT-5.4 allows reasoning on OpenAIChatModel when no tools are present."""
+    c = completion_message(ChatCompletionMessage(content='Paris.', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-5.4', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run(
+        'What is the capital of France?',
+        model_settings=OpenAIChatModelSettings(openai_reasoning_effort='medium'),
+    )
+    assert result.output == 'Paris.'
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['reasoning_effort'] == 'medium'

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -50,6 +50,9 @@ class ReasoningCase:
     supports_context: bool = False
     """The Responses API accepts `reasoning.context='all_turns'`."""
 
+    supports_chat_tools_with_reasoning: bool = True
+    """The Chat Completions API accepts function tools with reasoning enabled."""
+
 
 # The `enabled_by_default` and `can_be_disabled` cells were verified against the live Responses API
 # (2026-07): "enabled by default" = sampling params rejected with no `reasoning.effort` set;
@@ -76,14 +79,34 @@ REASONING_CASES = [
     ReasoningCase(model='gpt-5.3-codex', can_be_disabled=True),
     ReasoningCase(model='gpt-5.3-mini', can_be_disabled=True),
     # gpt-5.4 family: opt-in reasoning, and accepts `reasoning.context='all_turns'`
-    ReasoningCase(model='gpt-5.4', can_be_disabled=True, supports_context=True),
-    ReasoningCase(model='gpt-5.4-mini', can_be_disabled=True, supports_context=True),
-    ReasoningCase(model='gpt-5.4-nano', can_be_disabled=True, supports_context=True),
+    ReasoningCase(
+        model='gpt-5.4',
+        can_be_disabled=True,
+        supports_context=True,
+        supports_chat_tools_with_reasoning=False,
+    ),
+    ReasoningCase(
+        model='gpt-5.4-mini',
+        can_be_disabled=True,
+        supports_context=True,
+        supports_chat_tools_with_reasoning=False,
+    ),
+    ReasoningCase(
+        model='gpt-5.4-nano',
+        can_be_disabled=True,
+        supports_context=True,
+        supports_chat_tools_with_reasoning=False,
+    ),
     # -pro and gpt-5.1 codex variants: always reason, no `effort='none'`
     ReasoningCase(model='gpt-5.1-codex', enabled_by_default=True),
     ReasoningCase(model='gpt-5.1-codex-max', enabled_by_default=True),
     ReasoningCase(model='gpt-5.2-pro', enabled_by_default=True),
-    ReasoningCase(model='gpt-5.4-pro', enabled_by_default=True, supports_context=True),
+    ReasoningCase(
+        model='gpt-5.4-pro',
+        enabled_by_default=True,
+        supports_context=True,
+        supports_chat_tools_with_reasoning=False,
+    ),
     ReasoningCase(model='gpt-5.5-pro', enabled_by_default=True, supports_context=True),
     # gpt-5.1+ chat variants: always reason at a fixed 'medium' effort (sampling params rejected)
     ReasoningCase(model='gpt-5.1-chat-latest', enabled_by_default=True),
@@ -140,6 +163,10 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('openai_supports_minimal_reasoning_effort', True) is case.supports_minimal_reasoning_effort
     assert profile.get('openai_responses_supports_reasoning_mode', False) is case.supports_mode
     assert profile.get('openai_responses_supports_reasoning_context', False) is case.supports_context
+    assert (
+        profile.get('openai_chat_supports_function_tools_with_reasoning', True)
+        is case.supports_chat_tools_with_reasoning
+    )
     assert profile.get('supports_thinking', False) is supports_reasoning
     assert profile.get('thinking_always_enabled', False) is (case.enabled_by_default and not case.can_be_disabled)
 


### PR DESCRIPTION
- Closes #4667

### Description
On OpenAI's Chat Completions API (`/v1/chat/completions`), GPT-5.4 models (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`) reject function tools when reasoning effort is active. Such requests must be directed to the Responses API (`/v1/responses`, i.e. `OpenAIResponsesModel`).

This PR:
1. Adds `openai_chat_supports_function_tools_with_reasoning` to `OpenAIModelProfile`, evaluating to `False` for `gpt-5.4*` models.
2. In `OpenAIChatModel.prepare_request`, checks if the model does not support function tools with reasoning on Chat Completions and reasoning is active, raising a helpful `UserError` instructing users to use `OpenAIResponsesModel` instead.
3. Adds unit tests and regression tests in `tests/models/test_openai.py` and `tests/profiles/test_openai.py` covering:
   - GPT-5.4 + tools + reasoning effort -> raises `UserError` with guidance to `OpenAIResponsesModel`
   - GPT-5.4 + tools without reasoning (reasoning_effort='none') -> succeeds on `OpenAIChatModel`
   - GPT-5.4 + reasoning effort without tools -> succeeds on `OpenAIChatModel`
   - Full reasoning profile matrix verification for `gpt-5.4*`

### Checklist
- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

