### PR TITLE
fix: isolate cached MCP listing results

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1282,11 +1282,11 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         `__aexit__`.
         """
         if self.cache_tools and self._cached_tools is not None:
-            return self._cached_tools
+            return list(self._cached_tools)
         async with self:
             tools = await self.client.list_tools()
             if self.cache_tools:
-                self._cached_tools = tools
+                self._cached_tools = list(tools)
             return tools
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
@@ -1486,7 +1486,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server returns an error.
         """
         if self.cache_prompts and self._cached_prompts is not None:
-            return self._cached_prompts
+            return list(self._cached_prompts)
         async with self:
             if not self.capabilities.prompts:
                 return []
@@ -1496,7 +1496,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 raise MCPError.from_mcp_sdk(e) from e
             prompts = [Prompt.from_mcp_sdk(p) for p in mcp_prompts]
             if self.cache_prompts:
-                self._cached_prompts = prompts
+                self._cached_prompts = list(prompts)
             return prompts
 
     async def get_prompt(self, name: str, arguments: dict[str, str] | None = None) -> PromptResult:
@@ -1541,7 +1541,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server returns an error.
         """
         if self.cache_resources and self._cached_resources is not None:
-            return self._cached_resources
+            return list(self._cached_resources)
         async with self:
             if not self.capabilities.resources:
                 return []
@@ -1551,7 +1551,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 raise MCPError.from_mcp_sdk(e) from e
             resources = [Resource.from_mcp_sdk(r) for r in mcp_resources]
             if self.cache_resources:
-                self._cached_resources = resources
+                self._cached_resources = list(resources)
             return resources
 
     async def list_resource_templates(self) -> list[ResourceTemplate]:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1028,14 +1028,22 @@ class TestMCPToolsetIntegration:
         async with toolset:
             first = await toolset.list_prompts()
             assert toolset._cached_prompts is not None  # pyright: ignore[reportPrivateUsage]
+            first.clear()
             second = await toolset.list_prompts()
-        assert first == second
+        assert second
 
     async def test_list_prompts_no_caching_when_disabled(self, fastmcp_server: FastMCP[None]):
         toolset = MCPToolset(fastmcp_server, cache_prompts=False)
         async with toolset:
             await toolset.list_prompts()
             assert toolset._cached_prompts is None  # pyright: ignore[reportPrivateUsage]
+
+    async def test_list_prompts_cache_returns_new_list(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(fastmcp_server)
+        async with toolset:
+            first = await toolset.list_prompts()
+            second = await toolset.list_prompts()
+        assert first is not second
 
     async def test_prompts_cache_invalidation_on_notification(self, fastmcp_server: FastMCP[None]):
         from pydantic_ai.mcp import _build_message_handler  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Fixes #7477.

`MCPToolset.list_tools()`, `list_prompts()`, and `list_resources()` previously exposed the mutable list used internally for caching. A caller could mutate a returned list and corrupt later results.

## Changes

- Store shallow copies when populating the three caches.
- Return shallow copies on cache hits.
- Extend the prompt-cache regression test to mutate the first result and verify the cached result remains available.

The MCP item objects themselves are unchanged, and notification/session-exit invalidation behavior is unchanged.

## Verification

- `python -m py_compile mcp.py test_mcp.py`
- Full test suite not run: the repository checkout could not be completed in the available environment because the large GitHub transfer repeatedly disconnected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

