### PR TITLE
Add four missing public symbols to the API reference

### DIFF
--- a/docs/api/output.md
+++ b/docs/api/output.md
@@ -11,3 +11,4 @@
             - TextOutput
             - StructuredDict
             - DeferredToolRequests
+            - OutputObjectDefinition

--- a/docs/api/profiles.md
+++ b/docs/api/profiles.md
@@ -5,6 +5,8 @@
       members:
         - ModelProfile
         - ModelProfileSpec
+        - JsonSchemaTransformer
+        - InlineDefsJsonSchemaTransformer
         - merge_profile
         - DEFAULT_PROFILE
         - DEFAULT_PROMPTED_OUTPUT_TEMPLATE

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -28,6 +28,8 @@
 
 ::: pydantic_ai.providers.voyageai.VoyageAIProvider
 
+::: pydantic_ai.providers.sentence_transformers.SentenceTransformersProvider
+
 ::: pydantic_ai.providers.cerebras.CerebrasProvider
 
 ::: pydantic_ai.providers.mistral.MistralProvider

--- a/docs/api/toolsets.md
+++ b/docs/api/toolsets.md
@@ -4,6 +4,7 @@
     options:
         members:
         - AbstractToolset
+        - ToolsetTool
         - CombinedToolset
         - ExternalToolset
         - ApprovalRequiredToolset


### PR DESCRIPTION
Four public symbols are missing from the `docs/api/` page that documents their module, so each is absent from the reference even though it is part of the public surface:

| Symbol | Page | Why it belongs there |
| --- | --- | --- |
| `SentenceTransformersProvider` | `api/providers.md` | Its sibling embeddings provider `VoyageAIProvider` is listed, and `api/embeddings.md` lists both `embeddings.voyageai` and `embeddings.sentence_transformers`. This page is the only place the pair is treated differently. |
| `ToolsetTool` | `api/toolsets.md` | Exported in `pydantic_ai.toolsets.__all__` and the only `__all__` entry missing from the page. The custom-toolset example in `docs/toolsets.md` has users import it and annotate `call_tool` with it. |
| `JsonSchemaTransformer`, `InlineDefsJsonSchemaTransformer` | `api/profiles.md` | `ModelProfile.json_schema_transformer` is typed `type[JsonSchemaTransformer] \| None`, and `docs/models/openai.md` already shows users importing the subclass directly. |
| `OutputObjectDefinition` | `api/output.md` | Reachable from `OutputContext.object_def`, which output hooks receive. |

Verified against `origin/main` rather than a local build: each symbol is importable from its module and appears nowhere in the corresponding page.

This replaces #7025, #7026, #7044 and #7045, which each carried one of these as its own PR. Bundling them is a better fit for your review queue, and their original descriptions cited `mkdocs build --strict` output, which stopped being meaningful once #7416 removed the MkDocs pipeline. Closing those four in favour of this.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. if any of these four are left out of the reference deliberately, say which and I will drop them from this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

