### PR TITLE
fix(mcp): return a copy of cached lists to prevent caller mutation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1282,7 +1282,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         `__aexit__`.
         """
         if self.cache_tools and self._cached_tools is not None:
-            return self._cached_tools
+            return list(self._cached_tools)
         async with self:
             tools = await self.client.list_tools()
             if self.cache_tools:
@@ -1486,7 +1486,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server returns an error.
         """
         if self.cache_prompts and self._cached_prompts is not None:
-            return self._cached_prompts
+            return list(self._cached_prompts)
         async with self:
             if not self.capabilities.prompts:
                 return []
@@ -1541,7 +1541,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server returns an error.
         """
         if self.cache_resources and self._cached_resources is not None:
-            return self._cached_resources
+            return list(self._cached_resources)
         async with self:
             if not self.capabilities.resources:
                 return []


### PR DESCRIPTION
When `cache_tools`, `cache_prompts`, or `cache_resources` is enabled (all enabled by default), `list_tools()`, `list_prompts()`, and `list_resources()` return the internal cached `list` directly. A caller that clears, appends to, or filters the returned list silently corrupts subsequent cached results even though the server has not sent a list-changed notification.

### Changes
- `list_tools()`: `return self._cached_tools` → `return list(self._cached_tools)`
- `list_prompts()`: `return self._cached_prompts` → `return list(self._cached_prompts)`
- `list_resources()`: `return self._cached_resources` → `return list(self._cached_resources)`

Each change wraps the cached list in `list()` to give callers a fresh copy, so mutations by external code never affect the cache.

Fixes #7477

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

