### PR TITLE
Document provider environment variables that are only in docstrings

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -92,6 +92,14 @@ Set the `PYDANTIC_AI_GATEWAY_API_KEY` environment variable to your Gateway API k
 export PYDANTIC_AI_GATEWAY_API_KEY="pylf_v..."
 ```
 
+The Gateway base URL is inferred from the region encoded in your API key, so you normally do not
+need to set it. If your key predates region-encoded keys, Pydantic AI raises a `UserError` asking
+you to generate a new key or set the URL yourself, which you do with `PYDANTIC_AI_GATEWAY_BASE_URL`:
+
+```bash
+export PYDANTIC_AI_GATEWAY_BASE_URL="https://gateway-us.pydantic.dev/proxy"
+```
+
 You can access multiple models with the same API key, as shown in the code snippet below.
 
 ```python {title="hello_world.py"}

--- a/docs/models/bedrock.md
+++ b/docs/models/bedrock.md
@@ -62,6 +62,34 @@ agent = Agent(model)
 ...
 ```
 
+### Timeouts
+
+Long generations can outlast the Bedrock client's default timeouts. Both are configurable on
+[`BedrockProvider`][pydantic_ai.providers.bedrock.BedrockProvider], and each falls back to an
+environment variable when omitted:
+
+| Argument | Environment variable | Default |
+| --- | --- | --- |
+| `aws_read_timeout` | `AWS_READ_TIMEOUT` | 300 seconds |
+| `aws_connect_timeout` | `AWS_CONNECT_TIMEOUT` | 60 seconds |
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.bedrock import BedrockConverseModel
+from pydantic_ai.providers.bedrock import BedrockProvider
+
+model = BedrockConverseModel(
+    'anthropic.claude-sonnet-4-5-20250929-v1:0',
+    provider=BedrockProvider(region_name='us-east-1', aws_read_timeout=600),
+)
+agent = Agent(model)
+...
+```
+
+These apply to clients the provider builds itself. A prebuilt `bedrock_client` is used as-is, so
+configure its timeouts on the client. See [Timeouts](../timeouts.md) for how request timeouts work
+across model classes, including why `ModelSettings['timeout']` does not reach Bedrock.
+
 ### Customizing Bedrock Runtime API
 
 You can customize the Bedrock Runtime API calls by adding additional parameters, such as [guardrail

--- a/docs/models/cohere.md
+++ b/docs/models/cohere.md
@@ -22,6 +22,12 @@ Once you have the API key, you can set it as an environment variable:
 export CO_API_KEY='your-api-key'
 ```
 
+To route requests through a different host, such as a proxy or a gateway, set `CO_BASE_URL` as well:
+
+```bash
+export CO_BASE_URL='https://your-proxy.example.com'
+```
+
 You can then use `CohereModel` by name:
 
 ```python

--- a/docs/models/groq.md
+++ b/docs/models/groq.md
@@ -22,6 +22,12 @@ Once you have the API key, you can set it as an environment variable:
 export GROQ_API_KEY='your-api-key'
 ```
 
+To route requests through a different host, such as a proxy or a gateway, set `GROQ_BASE_URL` as well:
+
+```bash
+export GROQ_BASE_URL='https://your-proxy.example.com'
+```
+
 You can then use `GroqModel` by name:
 
 ```python


### PR DESCRIPTION
Four provider settings are read from the environment but documented only in a docstring, so a user configuring through the environment cannot find them from the docs:

| Page | Variable | What reads it |
| --- | --- | --- |
| `models/groq.md` | `GROQ_BASE_URL` | `GroqProvider` falls back to it when `base_url` is omitted. The page's Environment variable section covers only `GROQ_API_KEY`. |
| `models/cohere.md` | `CO_BASE_URL` | `CohereProvider` passes it to both the v1 and v2 clients. It takes no `base_url` argument at all, so the environment is the only way to point it elsewhere. |
| `gateway.md` | `PYDANTIC_AI_GATEWAY_BASE_URL` | `_infer_base_url` raises a `UserError` telling the user to "set the `PYDANTIC_AI_GATEWAY_BASE_URL` environment variable explicitly" when the key encodes no region. The variable appeared nowhere in the Gateway docs, so that error pointed at something unsearchable. |
| `models/bedrock.md` | `AWS_READ_TIMEOUT`, `AWS_CONNECT_TIMEOUT` | `BedrockProvider` falls back to these, then to 300 and 60 seconds. Long generations are where people hit the read timeout and go looking. |

Each is verified against main: the variable is still read by its provider, and still absent from the page. The Bedrock section also notes that a prebuilt `bedrock_client` is used as-is, and links to the Timeouts page added in #7145.

This replaces #7183, #7184, #7223 and #7227, which carried these one at a time. Their descriptions cited `mkdocs build --strict` output, which stopped meaning anything when #7416 removed the MkDocs pipeline, so the evidence here is stated against the files instead. Ran `uv run pytest tests/test_examples.py -k "bedrock or gateway"`, 26 passed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. happy to drop any individual page from this if one of these is meant to stay undocumented.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

