### PR TITLE
Fix prompted output template rejecting literal JSON braces

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -717,7 +717,7 @@ class StructuredTextOutputSchema(OutputSchema[OutputDataT], ABC):
         if '{schema}' not in template:
             template = '\n\n'.join([template, '{schema}'])
 
-        return template.format(schema=json.dumps(schema))
+        return template.replace('{schema}', json.dumps(schema))
 
 
 class NativeOutputSchema(StructuredTextOutputSchema[OutputDataT]):

--- a/tests/test_native_output_schema.py
+++ b/tests/test_native_output_schema.py
@@ -119,6 +119,21 @@ async def test_prompted_output_template_false():
     assert params.prompted_output_instructions is None
 
 
+async def test_prompted_output_template_with_literal_braces():
+    """Test that literal JSON braces in a template are preserved, not interpreted as format fields."""
+    model = TestModel(custom_output_text='{"name": "Paris", "population": 9000000}')
+    template = 'Return JSON like {"name": "x"} matching {schema}'
+    agent = Agent(model, output_type=PromptedOutput(City, template=template))
+
+    await agent.run('Paris')
+
+    params = model.last_model_request_parameters
+    assert params
+    assert params.prompted_output_instructions is not None
+    assert '{"name": "x"}' in params.prompted_output_instructions
+    assert 'City' in params.prompted_output_instructions
+
+
 async def test_native_output_template_false():
     """Test that `template=False` on `NativeOutput` disables the schema prompt,
     even when the profile would normally inject one."""


### PR DESCRIPTION
## Summary

- Replaces `str.format(schema=...)` with `str.replace('{schema}', ...)` in `StructuredTextOutputSchema.build_instructions()` so that only the documented `{schema}` placeholder is substituted
- Templates containing literal braces (e.g. JSON examples like `{"name": "x"}`) no longer raise `KeyError`

## Related issue

Fixes #7485

## Changes

- **`pydantic_ai_slim/pydantic_ai/_output.py`** — One-line fix: `template.format(schema=...)` → `template.replace('{schema}', ...)`
- **`tests/test_native_output_schema.py`** — Added regression test with literal JSON braces in the template

## Verification

- New test `test_prompted_output_template_with_literal_braces` reproduces the exact `KeyError` from the issue before the fix, and passes after
- Existing tests remain unchanged — `{schema}` substitution behavior is identical for templates without extra braces

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

