### PR TITLE
Exempt `pytest-examples`' print capture from BlockBuster in `tests/conftest.py`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -348,6 +348,11 @@ BLOCKBUSTER_EXEMPTIONS: list[tuple[str, str, str | tuple[str, ...]]] = [
     # https://github.com/cbornet/blockbuster/pull/63 is released in a compatible version.
     ('os.stat', 'coverage/python.py', 'get_python_source'),
     ('io.BufferedReader.read', 'coverage/python.py', 'read_python_source'),
+    # pytest-examples locates the source line of a captured `print()` with `Path.samefile`, so an
+    # example printing from inside a running event loop trips the detector on the harness's own
+    # `os.stat`. Exempting the capture entry point keeps `os.stat` calls from example and library
+    # code detectable.
+    ('os.stat', 'pytest_examples/run_code.py', '__call__'),
     # `load_mcp_toolsets` is a sync config-file loader; reading the file is its documented job.
     ('os.stat', 'pydantic_ai/mcp.py', 'load_mcp_toolsets'),
     ('io.BufferedReader.read', 'pydantic_ai/mcp.py', 'load_mcp_toolsets'),


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David reviewed this lightly.

- Closes #7476

## Why we make these changes

Two `docs/capabilities/custom.md` examples failed `tests/test_examples.py` with `blockbuster.blockbuster.BlockingError: Blocking call to os.stat`, raised inside async hooks whose bodies only call `print()`.

The blocking call is the test harness's, not ours. `pytest_examples/run_code.py` `MockPrintFunction.__call__` locates the source line of a captured `print()` via `Path.samefile`, which calls `os.stat`. These examples print from inside an async hook while `agent.run_sync()` is still running, so BlockBuster sees a running event loop plus `pydantic_ai` frames on the stack and flags pytest-examples' `os.stat`.

Diagnosis credit to @Vedant-Git-dev, who traced the failure to `MockPrintFunction.__call__` on the issue and proposed exactly this harness-level approach.

The fix is one entry in `BLOCKBUSTER_EXEMPTIONS` in `tests/conftest.py`, rather than a third per-example `blockbuster_enabled = False` override alongside the existing `voyageai_embeddings.py` one. Exempting at the harness boundary is narrower: `blockbuster_enabled = False` switches detection off for the whole example, while the exemption is pinned to the `(os.stat, pytest_examples/run_code.py, __call__)` triple, so real `os.stat` calls from example and library code stay detectable. It also covers future examples that print from a running loop without adding a per-example case each time.

## New public surface

None — test-suite configuration only.

## Verification

<details>
<summary>Reproduced, fixed, and confirmed detection is not broadened</summary>

Before, `uv run pytest tests/test_examples.py -k custom`:

```
docs/capabilities/custom.md:89: BlockingError
E   blockbuster.blockbuster.BlockingError: Blocking call to os.stat

docs/capabilities/custom.md:1111: BlockingError
E   blockbuster.blockbuster.BlockingError: Blocking call to os.stat
```

After: all pass.

To confirm the exemption doesn't switch detection off more broadly, a genuine `Path('pyproject.toml').stat()` was temporarily added to the `typed_capability.py` example's `before_model_request` hook. It still raises `BlockingError: Blocking call to os.stat`, so example-code blocking calls remain detected. The temporary edit was reverted.

</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

