### PR TITLE
fix: preserve all conditions in pruned span queries

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -351,7 +351,9 @@ class SpanNode:
         def pruned_descendants():
             stop_recursing_when = query.get('stop_recursing_when')
             return (
-                self._filter_descendants(lambda _: True, stop_recursing_when) if stop_recursing_when else descendants()
+                list(self._filter_descendants(lambda _: True, stop_recursing_when))
+                if stop_recursing_when
+                else descendants()
             )
 
         if (min_descendant_count := query.get('min_descendant_count')) and len(descendants()) < min_descendant_count:
@@ -380,7 +382,11 @@ class SpanNode:
         @cache
         def pruned_ancestors():
             stop_recursing_when = query.get('stop_recursing_when')
-            return self._filter_ancestors(lambda _: True, stop_recursing_when) if stop_recursing_when else ancestors()
+            return (
+                list(self._filter_ancestors(lambda _: True, stop_recursing_when))
+                if stop_recursing_when
+                else ancestors()
+            )
 
         if (min_depth := query.get('min_depth')) and len(ancestors()) < min_depth:
             return False

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -463,6 +463,16 @@ async def test_span_tree_ancestors_methods():
         {'no_ancestor_has': {'name_matches_regex': 'root'}, 'stop_recursing_when': {'name_equals': 'level1'}}
     )
 
+    # Pruned results are reused by each recursive condition and must be reusable
+    # collections rather than one-shot generators.
+    assert not leaf_node.matches(
+        {
+            'all_ancestors_have': {'name_matches_regex': 'level|root'},
+            'no_ancestor_has': {'name_equals': 'root'},
+            'stop_recursing_when': {'name_equals': 'never'},
+        }
+    )
+
 
 async def test_span_tree_descendants_methods():
     """Test the descendant traversal methods in SpanNode."""


### PR DESCRIPTION
Closes #7484

## Summary

`SpanNode._matches_query` cached the generator returned by the pruned ancestor/descendant traversal helpers. After the first recursive condition consumed it, later conditions saw an exhausted iterator and could pass or fail vacuously.

This change materializes pruned traversal results once so all conditions evaluate the same snapshot. It adds regression coverage combining multiple ancestor conditions with `stop_recursing_when`.

## Compatibility

No public API changes. Traversal order, pruning behavior, and non-pruned query behavior are unchanged.

## Verification

- Not run: the repository could not be fully cloned in this environment because GitHub transport was extremely slow/intermittent. The focused test was added alongside the implementation and should be run by CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

