### PR TITLE
Fix diff rendering pointing the wrong way for negative baselines

### DIFF
--- a/pydantic_evals/pydantic_evals/reporting/render_numbers.py
+++ b/pydantic_evals/pydantic_evals/reporting/render_numbers.py
@@ -140,15 +140,20 @@ def _render_relative(new: float, base: float, small_base_threshold: float) -> st
     if abs(base) < small_base_threshold and abs(delta) > MULTIPLIER_DROP_FACTOR * abs(base):
         return None
 
-    # Compute the relative change as a percentage.
-    rel_change = (delta / base) * 100
+    # Compute the relative change as a percentage of the base's magnitude. Dividing by the
+    # signed base would invert the sign for negative bases, so an improvement from -2.0 to
+    # -1.0 would render as '-50.0%' next to an absolute diff of '+1.0'.
+    rel_change = (delta / abs(base)) * 100
     perc_str = f'{rel_change:+.{PERC_DECIMALS}f}%'
     # If the percentage rounds to 0.0%, return only the absolute difference.
     if perc_str in ('+0.0%', '-0.0%'):
         return None
 
-    # Decide whether to use percentage style or multiplier style.
-    if abs(delta) / abs(base) <= 1:
+    # Decide whether to use percentage style or multiplier style. A multiplier is only used
+    # for positive bases: for a negative base, `new / base` is arithmetically true but reads
+    # backwards (-1.0 -> -3.0 would render as '3.0x'), so percentages above 100% are used
+    # there instead.
+    if abs(delta) / abs(base) <= 1 or base < 0:
         # Percentage style.
         return perc_str
     else:

--- a/tests/evals/test_render_numbers.py
+++ b/tests/evals/test_render_numbers.py
@@ -56,10 +56,34 @@ def test_default_render_number(value: float | int, expected: str):
         (0.02, -25.0, snapshot('-25.0 / -1,250x')),
         (0.001, 25.0, snapshot('+25.0')),
         (0.0, 25.0, snapshot('+25.0')),
+        # Negative baselines: the relative indicator's sign must match the direction of the
+        # change, and multipliers (which read backwards for negative bases) are not used.
+        (-2.0, -1.0, snapshot('+1.0 / +50.0%')),
+        (-1.0, -2.0, snapshot('-1.0 / -100.0%')),
+        (-1.0, -3.0, snapshot('-2.0 / -200.0%')),
+        (-1.0, 3.0, snapshot('+4.0 / +400.0%')),
+        (-0.5, -0.25, snapshot('+0.25 / +50.0%')),
     ],
 )
 def test_default_render_number_diff(old: int | float, new: int | float, expected: str | None):
     assert default_render_number_diff(old, new) == expected
+
+
+def test_negative_base_diff_sign_matches_direction():
+    """The absolute and relative halves of a diff cell must never point in opposite directions.
+
+    With a signed-base denominator, an improvement from -2.0 to -1.0 rendered as
+    '+1.0 / -50.0%', and -1.0 to -3.0 rendered as '-2.0 / 3.0x'.
+    """
+    for old, new in [(-2.0, -1.0), (-1.0, -3.0), (-1.0, 3.0), (-0.5, -0.25), (-2.0, 1.0)]:
+        rendered = default_render_number_diff(old, new)
+        assert rendered is not None
+        abs_part, _, rel_part = rendered.partition(' / ')
+        if not rel_part:
+            continue
+        assert abs_part[0] == rel_part[0], (
+            f'{old} -> {new} rendered as {rendered!r}: absolute and relative signs disagree'
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #7496

## The wrong number

`default_render_number_diff` renders the relative half of a diff cell with an inverted sign whenever the baseline is negative, because `_render_relative` divides the delta by the signed base:

| old | new | true direction | rendered on main |
|---|---|---|---|
| -2.0 | -1.0 | improved | `+1.0 / -50.0%` |
| -1.0 | -3.0 | regressed | `-2.0 / 3.0x` |
| -1.0 | +3.0 | improved | `+4.0 / -3.0x` |

In the first row the absolute and relative halves of one cell point in opposite directions. In the second, a regression renders as a threefold multiplier with no sign at all, since `new / base` is `-3 / -1 = 3`. These cells feed the report diff via `diff_formatter = default_render_number_diff`, which is exactly the view someone reads to decide whether a run regressed, and scores and metrics can legitimately be negative (reward margins, deltas, signed log-scores).

## The fix

The relative change is now computed against `abs(base)`, so its sign always matches the direction of the change. For negative bases the multiplier style is not used, because `new / base` is arithmetically true but reads backwards there; percentages above 100% are used instead:

| old | new | rendered with this change |
|---|---|---|
| -2.0 | -1.0 | `+1.0 / +50.0%` |
| -1.0 | -3.0 | `-2.0 / -200.0%` |
| -1.0 | +3.0 | `+4.0 / +400.0%` |

Behaviour for positive baselines is unchanged: every existing snapshot in `tests/evals/test_render_numbers.py` still passes, including the sign-crossing cases with positive bases such as `(2.0, -25.0) -> '-27.0 / -12.5x'`.

## Tests

Five parametrized negative-baseline cases are added to `test_default_render_number_diff`, plus `test_negative_base_diff_sign_matches_direction`, which asserts the absolute and relative halves of a rendered cell never disagree in sign. The added cases fail on `main` and pass with this change; the full `test_render_numbers.py` module passes (66 tests).

## What this does not change

Zero bases (relative indicator already dropped), the small-base drop heuristic, integer diffs, and duration diffs are untouched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



