### PR TITLE
Fix diff rendering pointing the wrong way for negative baselines

### DIFF
--- a/pydantic_evals/pydantic_evals/reporting/render_numbers.py
+++ b/pydantic_evals/pydantic_evals/reporting/render_numbers.py
@@ -68,12 +68,15 @@ def default_render_number_diff(old: float | int, new: float | int) -> str | None
             _default_format_number_diff(3, 4) -> '+1'
       - For floats (or a mix of float and int):
           * Compute the raw delta = new - old and format it with ABS_SIG_FIGS significant figures.
-          * If `old` is nonzero, compute a relative change:
+          * If `old` is nonzero, compute a relative change against |old|, so that its sign
+            tracks the direction of the change rather than the sign of the baseline:
               - If |delta|/|old| ≤ 1, render the relative change as a percentage with
                 PERC_DECIMALS decimal places, e.g. '+0.7 / +70.0%'.
-              - If |delta|/|old| > 1, render a multiplier (new/old). Use one decimal place
-                if the absolute multiplier is less than MULTIPLIER_ONE_DECIMAL_THRESHOLD,
-                otherwise no decimals.
+              - If |delta|/|old| > 1 and `old` is positive, render a multiplier (new/old).
+                Use one decimal place if the absolute multiplier is less than
+                MULTIPLIER_ONE_DECIMAL_THRESHOLD, otherwise no decimals.
+              - If `old` is negative, keep the percentage form: a multiplier over a negative
+                base reads backwards, e.g. -1.0 -> -3.0 would show as '3.0x'.
           * However, if the percentage rounds to 0.0% (e.g. '+0.0%'), return only the absolute diff.
           * Also, if |old| is below BASE_THRESHOLD and |delta| exceeds MULTIPLIER_DROP_FACTOR×|old|,
             drop the relative change indicator.

--- a/pydantic_evals/pydantic_evals/reporting/render_numbers.py
+++ b/pydantic_evals/pydantic_evals/reporting/render_numbers.py
@@ -140,15 +140,20 @@ def _render_relative(new: float, base: float, small_base_threshold: float) -> st
     if abs(base) < small_base_threshold and abs(delta) > MULTIPLIER_DROP_FACTOR * abs(base):
         return None
 
-    # Compute the relative change as a percentage.
-    rel_change = (delta / base) * 100
+    # Compute the relative change as a percentage of the base's magnitude. Dividing by the
+    # signed base would invert the sign for negative bases, so an improvement from -2.0 to
+    # -1.0 would render as '-50.0%' next to an absolute diff of '+1.0'.
+    rel_change = (delta / abs(base)) * 100
     perc_str = f'{rel_change:+.{PERC_DECIMALS}f}%'
     # If the percentage rounds to 0.0%, return only the absolute difference.
     if perc_str in ('+0.0%', '-0.0%'):
         return None
 
-    # Decide whether to use percentage style or multiplier style.
-    if abs(delta) / abs(base) <= 1:
+    # Decide whether to use percentage style or multiplier style. A multiplier is only used
+    # for positive bases: for a negative base, `new / base` is arithmetically true but reads
+    # backwards (-1.0 -> -3.0 would render as '3.0x'), so percentages above 100% are used
+    # there instead.
+    if abs(delta) / abs(base) <= 1 or base < 0:
         # Percentage style.
         return perc_str
     else:

--- a/tests/evals/test_render_numbers.py
+++ b/tests/evals/test_render_numbers.py
@@ -56,10 +56,34 @@ def test_default_render_number(value: float | int, expected: str):
         (0.02, -25.0, snapshot('-25.0 / -1,250x')),
         (0.001, 25.0, snapshot('+25.0')),
         (0.0, 25.0, snapshot('+25.0')),
+        # Negative baselines: the relative indicator's sign must match the direction of the
+        # change, and multipliers (which read backwards for negative bases) are not used.
+        (-2.0, -1.0, snapshot('+1.0 / +50.0%')),
+        (-1.0, -2.0, snapshot('-1.0 / -100.0%')),
+        (-1.0, -3.0, snapshot('-2.0 / -200.0%')),
+        (-1.0, 3.0, snapshot('+4.0 / +400.0%')),
+        (-0.5, -0.25, snapshot('+0.25 / +50.0%')),
     ],
 )
 def test_default_render_number_diff(old: int | float, new: int | float, expected: str | None):
     assert default_render_number_diff(old, new) == expected
+
+
+def test_negative_base_diff_sign_matches_direction():
+    """The absolute and relative halves of a diff cell must never point in opposite directions.
+
+    With a signed-base denominator, an improvement from -2.0 to -1.0 rendered as
+    '+1.0 / -50.0%', and -1.0 to -3.0 rendered as '-2.0 / 3.0x'.
+    """
+    for old, new in [(-2.0, -1.0), (-1.0, -3.0), (-1.0, 3.0), (-0.5, -0.25), (-2.0, 1.0)]:
+        rendered = default_render_number_diff(old, new)
+        assert rendered is not None
+        abs_part, _, rel_part = rendered.partition(' / ')
+        if not rel_part:
+            continue
+        assert abs_part[0] == rel_part[0], (
+            f'{old} -> {new} rendered as {rendered!r}: absolute and relative signs disagree'
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/evals/test_render_numbers.py
+++ b/tests/evals/test_render_numbers.py
@@ -79,8 +79,7 @@ def test_negative_base_diff_sign_matches_direction():
         rendered = default_render_number_diff(old, new)
         assert rendered is not None
         abs_part, _, rel_part = rendered.partition(' / ')
-        if not rel_part:
-            continue
+        assert rel_part, f'{old} -> {new} rendered as {rendered!r}: no relative part'
         assert abs_part[0] == rel_part[0], (
             f'{old} -> {new} rendered as {rendered!r}: absolute and relative signs disagree'
         )


### PR DESCRIPTION
Fixes #7496

`_render_relative` divides by the signed base, so when the base is negative the sign of the
relative change is inverted with respect to the absolute change. The two halves of the same
diff cell then point in opposite directions:

- `-2.0 -> -1.0` renders as `+1.0 / -50.0%`. The value improved, and the percentage says it got worse.
- `-1.0 -> -3.0` renders as `-2.0 / 3.0x`. The value got worse, and the multiplier reads as growth.

The multiplier branch has the same root cause seen from a different angle: `new / base` is
arithmetically true for a negative base but cannot be read the way a multiplier is meant to be
read.

## Change

- Compute the relative change against `abs(base)`, so the percentage sign tracks the direction
  of the change rather than the sign of the baseline.
- Use percentage style rather than multiplier style when the base is negative.

## Tests

Added parametrised cases covering negative baselines, plus an assertion that the absolute and
relative halves of a diff never disagree in sign. Both describe behaviour that `main` does not
satisfy today.

## Scope

Only `_render_relative` changes. Positive-base behaviour, the zero-base guard, the small-base
multiplier drop and the `+0.0%` suppression are all untouched.

This replaces #7495, which was closed automatically for not referencing an issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

