### PR TITLE
Add Live Tennis agent example

### DIFF
--- a/docs/examples/live-tennis-agent.md
+++ b/docs/examples/live-tennis-agent.md
@@ -1,0 +1,32 @@
+Example of a Pydantic AI agent that answers questions about professional tennis using the [Live Tennis API](https://livetennisapi.com).
+
+Demonstrates:
+
+- [tools](../tools.md)
+- [agent dependencies](../dependencies.md)
+- wrapping a plain REST API as tools with `httpx`
+
+In this case the idea is a "live tennis" agent — the user asks what's happening on the
+ATP/WTA tours, and the agent uses the `get_live_matches`, `get_upcoming_fixtures` and
+`search_players` tools to look up matches in progress (including who is serving and
+whether there's a break point), upcoming fixtures, and player rankings. Each tool makes
+one HTTP call and returns a trimmed-down JSON summary so the LLM sees only the fields
+it needs.
+
+## Running the Example
+
+You'll need a Live Tennis API key set via `LIVETENNIS_API_KEY`. The free tier
+(30 requests/minute, 100/day, no card required) is enough for this example — grab a key
+at [livetennisapi.com/subscribe/free](https://livetennisapi.com/subscribe/free).
+
+The example agent runs on `openai:gpt-5-mini`, so you'll also need an OpenAI API key set
+via `OPENAI_API_KEY`.
+
+With [dependencies installed and environment variables set](./setup.md#usage), run:
+
+```bash
+python/uv-run -m pydantic_ai_examples.live_tennis_agent
+```
+
+## Example Code
+```snippet {path="/examples/pydantic_ai_examples/live_tennis_agent.py"}```

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -781,6 +781,11 @@ navigation:
             slug: "examples/data-analytics/twelvelabs-video-agent"
             aliases:
               - "examples/twelvelabs-video-agent"
+          - page: "Live Tennis Agent"
+            path: "examples/live-tennis-agent.md"
+            slug: "examples/data-analytics/live-tennis-agent"
+            aliases:
+              - "examples/live-tennis-agent"
       - section: "Streaming"
         slug: ""
         contents:

--- a/examples/pydantic_ai_examples/live_tennis_agent.py
+++ b/examples/pydantic_ai_examples/live_tennis_agent.py
@@ -1,0 +1,201 @@
+"""Example of a Pydantic AI agent that answers questions about professional tennis.
+
+In this case the idea is a "live tennis" agent — the user can ask what's happening on
+the ATP/WTA tours right now, and the agent uses the [Live Tennis
+API](https://livetennisapi.com) to look up matches in progress (including who is
+serving and whether there's a break point), upcoming fixtures, and player rankings.
+
+This shows how to wrap a plain REST API as Pydantic AI tools using `httpx`: each tool
+makes one HTTP call and returns a trimmed-down JSON summary so the LLM sees only the
+fields it needs.
+
+The API's free tier (30 requests/minute, 100/day, no card required) is enough to run
+this example; set `LIVETENNIS_API_KEY` to your key.
+
+Run with:
+
+    uv run -m pydantic_ai_examples.live_tennis_agent
+"""
+
+from __future__ import annotations as _annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import logfire
+from httpx import AsyncClient
+
+from pydantic_ai import Agent, RunContext
+
+# 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
+logfire.configure(send_to_logfire='if-token-present')
+logfire.instrument_pydantic_ai()
+
+BASE_URL = 'https://api.livetennisapi.com/api/public/v1'
+
+
+@dataclass
+class Deps:
+    client: AsyncClient
+
+
+tennis_agent = Agent(
+    'openai:gpt-5-mini',
+    instructions=(
+        'You are a tennis assistant. Use the tools to look up live matches, '
+        'upcoming fixtures and player rankings, then answer concisely. '
+        "If there are no live matches, say so and check what's coming up instead."
+    ),
+    deps_type=Deps,
+    retries=2,
+)
+
+
+def _player_label(player: dict[str, Any]) -> str:
+    """Format a player as 'Name (#ranking)', or just the name if unranked."""
+    name: str = player['name']
+    ranking: int | None = player.get('ranking')
+    return f'{name} (#{ranking})' if ranking is not None else name
+
+
+def _is_break_point(score: dict[str, Any]) -> bool:
+    """Whether the returner is one point from breaking serve (never in a tiebreak)."""
+    server = score.get('server')
+    points: list[str | None] = score.get('points') or []
+    if score.get('is_tiebreak') or server not in (1, 2) or len(points) != 2:
+        return False
+    server_points, returner_points = points[server - 1], points[2 - server]
+    return returner_points == 'AD' or (
+        returner_points == '40' and server_points not in ('40', 'AD')
+    )
+
+
+def _summarize_match(match: dict[str, Any]) -> dict[str, Any]:
+    """Trim a match object down to the fields the LLM needs."""
+    p1, p2 = match['players']['p1'], match['players']['p2']
+    summary: dict[str, Any] = {
+        'match_id': match['id'],
+        'tournament': match['tournament'],
+        'tour': match['tour'],
+        'round': match['round'],
+        'players': [_player_label(p1), _player_label(p2)],
+    }
+    score = match.get('score')
+    if score is not None:
+        # games is [games_p1, games_p2], each a per-set list; points are tennis
+        # strings like '0', '15', '40', 'AD'.
+        summary['sets'] = score['sets']
+        summary['games'] = score['games']
+        summary['points'] = score['points']
+        server = score.get('server')
+        if server in (1, 2):
+            summary['serving'] = _player_label(p1 if server == 1 else p2)
+        if score.get('is_tiebreak'):
+            summary['tiebreak'] = True
+        elif _is_break_point(score):
+            summary['break_point'] = True
+    return summary
+
+
+@tennis_agent.tool
+async def get_live_matches(
+    ctx: RunContext[Deps], tour: str | None = None
+) -> list[dict[str, Any]]:
+    """Get tennis matches that are in progress right now, with their current score.
+
+    Each match includes who is serving and whether the returner has a break point.
+
+    Args:
+        ctx: The context.
+        tour: Optionally restrict to one tour: "atp", "wta", "challenger", "itf"
+            or "juniors". Omit for all tours.
+    """
+    params: dict[str, Any] = {'status': 'live'}
+    if tour is not None:
+        params['tour'] = tour
+    r = await ctx.deps.client.get(f'{BASE_URL}/matches', params=params)
+    r.raise_for_status()
+    return [_summarize_match(match) for match in r.json()['data']]
+
+
+@tennis_agent.tool
+async def get_upcoming_fixtures(
+    ctx: RunContext[Deps], tour: str | None = None, limit: int = 10
+) -> list[dict[str, Any]]:
+    """Get upcoming scheduled fixtures, earliest first.
+
+    Args:
+        ctx: The context.
+        tour: Optionally restrict to one tour: "atp", "wta", "challenger", "itf"
+            or "juniors". Omit for all tours.
+        limit: Maximum number of fixtures to return.
+    """
+    params: dict[str, Any] = {'limit': limit}
+    if tour is not None:
+        params['tour'] = tour
+    r = await ctx.deps.client.get(f'{BASE_URL}/fixtures', params=params)
+    r.raise_for_status()
+    return [
+        {
+            'tournament': fixture['tournament'],
+            'round': fixture['round'],
+            'players': [fixture['player1_name'], fixture['player2_name']],
+            # Scheduled start in UTC; null until the order of play assigns a time.
+            'start_time': fixture['start_time'],
+        }
+        for fixture in r.json()['data']
+    ]
+
+
+@tennis_agent.tool
+async def search_players(ctx: RunContext[Deps], name: str) -> list[dict[str, Any]]:
+    """Search players by name and return their current ranking.
+
+    Args:
+        ctx: The context.
+        name: Full or partial player name, e.g. "Alcaraz".
+    """
+    r = await ctx.deps.client.get(
+        f'{BASE_URL}/players', params={'search': name, 'limit': 5}
+    )
+    r.raise_for_status()
+    return [
+        {
+            'player_id': player['id'],
+            'name': player['name'],
+            'country': player['country'],
+            'ranking': player['ranking'],
+            'ranking_points': player['ranking_points'],
+            'ranking_movement': player['ranking_movement'],
+        }
+        for player in r.json()['data']
+    ]
+
+
+async def main():
+    api_key = os.environ.get('LIVETENNIS_API_KEY')
+    if not api_key:
+        print(
+            'Set LIVETENNIS_API_KEY to run this example — the free tier '
+            '(30 requests/minute, 100/day, no card required) is enough: '
+            'https://livetennisapi.com/subscribe/free'
+        )
+        return
+
+    headers = {'Authorization': f'Bearer {api_key}'}
+    async with AsyncClient(headers=headers) as client:
+        logfire.instrument_httpx(client, capture_all=True)
+        deps = Deps(client=client)
+        result = await tennis_agent.run(
+            'Is there any ATP or WTA tennis on right now? If so, who is serving '
+            'and are there any break points? If not, what are the next few '
+            "fixtures, and what is Carlos Alcaraz's current ranking?",
+            deps=deps,
+        )
+        print('Response:', result.output)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
Hi! Disclosure up front: I work on the [Live Tennis API](https://livetennisapi.com) (@bensynapse).

### What this adds

A new example, `live_tennis_agent.py`, plus its docs page and navigation entry, showing how to
wrap a plain REST API as Pydantic AI tools with `httpx`. The agent answers "what's happening in
tennis right now?" using three tools over the API's free tier: live matches (with who's serving
and whether there's a break point), upcoming fixtures, and player search with current rankings.

It follows the existing `weather_agent.py` pattern exactly: an `Agent` with `@tool`s, a typed
`Deps` dataclass holding the `httpx.AsyncClient`, `logfire` wiring, and an async `main()`. It's
structured the same way as the TwelveLabs example that landed in #6061, but with no SDK — each
tool is one `httpx` GET plus a small summarizer that trims the JSON down to what the LLM needs.

### Why it helps

The existing tool examples call either mock endpoints (`weather_agent.py`) or a vendor SDK
(#6061). This one is a copy-paste-able template for the most common real-world case: a plain
keyed REST API wrapped as tools, including deriving state the LLM can reason about (break
points) from raw fields (server + points). The free tier (30 req/min, 100/day, no card) is
enough to run it.

### Opt-in / non-breaking

Pure addition: one example file, one docs page, one `docs/navigation.yml` entry. No new
dependencies — `httpx` is already in the workspace — so `uv.lock` is unchanged
(`uv lock --check` passes). No core code or existing examples touched.

### How it was tested

- `ruff format --check` and `ruff check` pass repo-wide; `pyright` clean on `examples/`.
- `tests/test_examples.py` passes (914 passed, 188 skipped).
- The module imports cleanly and all three tools register on the agent; the break-point
  derivation is verified against a table of score states (deuce, AD-in/out, tiebreak, nulls).
- Endpoint paths and field names are taken verbatim from the published OpenAPI spec
  (https://docs.livetennisapi.com/openapi.yaml); the base URL was verified live via `/health`.

### A note on process

Per CONTRIBUTING, features normally start with an issue and maintainer alignment. This is
scoped as a docs **example** (no core code, no new dependency), following the shape of #6061,
so I'm opening it directly for your consideration — happy to convert to an issue first if
you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

