### PR TITLE
Drop native tool calls the replayed payload has no result block for

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3535,14 +3535,15 @@ def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam])
                 # A `CachePoint` the user put on this block has to survive it. Landing it on the
                 # nearest preceding block that can carry one keeps the cacheable prefix a prefix;
                 # moving it forward would cache content the user placed outside the boundary. Nearest
-                # isn't always the block right before it: an assistant turn that reasons before calling
-                # a server tool renders `[thinking, server_tool_use]`, and a `thinking` block takes no
-                # `cache_control`.
+                # is often not the block right before it: an assistant turn that reasons before calling
+                # a server tool renders `[thinking, server_tool_use]`, and `thinking` takes no
+                # `cache_control` — nor does a replayed `BetaMCPToolResultBlock`, which is a model
+                # rather than a mapping and raises on subscript.
                 if (cache_control := block_dict.get('cache_control')) is not None:
                     carriers = [
                         param
                         for param in kept
-                        if cast(dict[str, Any], param)['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES
+                        if is_str_dict(block_param := param) and block_param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES
                     ]
                     _add_cache_control_param(
                         carriers or _last_message_content(anthropic_messages[:index]), cache_control

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3474,9 +3474,11 @@ def _result_is_still_in_flight(anthropic_messages: list[BetaMessageParam], index
     """
     for message in anthropic_messages[index + 1 :]:
         content = message['content']
-        if message['role'] != 'user' or not isinstance(content, list):  # pragma: no branch
+        if message['role'] != 'user':
             return False
-        if any(cast(dict[str, Any], block)['type'] != 'tool_result' for block in content):
+        if not isinstance(content, list):  # pragma: no cover
+            return False
+        if any(not is_str_dict(block) or block['type'] != 'tool_result' for block in content):
             return False
     return True
 
@@ -3515,7 +3517,7 @@ def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam])
             # models and the mapper appends as-is.
             if isinstance(block, BetaMCPToolResultBlock):
                 returned_ids.add(block.tool_use_id)
-            elif (tool_use_id := cast(dict[str, Any], block).get('tool_use_id')) is not None:
+            elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
                 returned_ids.add(tool_use_id)
 
     for index in range(len(anthropic_messages) - 1, -1, -1):

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1681,7 +1681,6 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         # names from it — so this changes no current behavior. It keeps the filter honest against the
         # wire regardless, rather than silently dropping a block whenever the two sets diverge.
         available_tool_names = set(model_request_parameters.declared_tool_defs)
-        orphan_tool_search_call_ids = _collect_orphan_tool_search_call_ids(messages)
         # Only the opening `SystemPromptPart`s in the first request are the run's own system prompt and
         # hoist to the top-level `system` parameter. Later ones are mid-conversation operator instructions:
         # where we support them they reach us verbatim (rather than `<system>`-tagged by `prepare_messages`)
@@ -1978,18 +1977,6 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                 _add_anthropic_caller_param(server_tool_use_block_param, response_part)
                                 assistant_content_params.append(server_tool_use_block_param)
                             elif response_part.tool_name == ToolSearchTool.kind:
-                                if tool_use_id in orphan_tool_search_call_ids:
-                                    # Anthropic occasionally emits a `tool_search_tool_*` server tool use
-                                    # in parallel with a client `tool_use` and ends the turn before
-                                    # delivering the corresponding `tool_search_tool_*_tool_result` block
-                                    # (see https://github.com/anthropics/anthropic-sdk-python/issues/1325). Direct API tolerates
-                                    # the unpaired call on resend (the result arrives in the next turn),
-                                    # but Bedrock 400s with `tool use ... was found without a corresponding
-                                    # tool_search_tool_*_tool_result block`. Drop the orphaned call from the
-                                    # wire payload — the model will re-search if it still wants to. We don't
-                                    # synthesize an empty result block because that would falsely tell the
-                                    # model the search ran and returned nothing.
-                                    continue
                                 # Round-trip the native variant (bm25/regex) so we don't
                                 # silently rewrite the algorithm. `_map_server_tool_use_block`
                                 # stashes it in `provider_details['strategy']`. Clients that don't
@@ -2174,6 +2161,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             else:
                 assert_never(m)
 
+        _drop_unpaired_native_tool_calls(anthropic_messages)
         _place_system_messages_before_generation(anthropic_messages)
         _anchor_system_messages(anthropic_messages)
 
@@ -3473,29 +3461,89 @@ def _leave_cache_boundary_behind(anthropic_messages: list[BetaMessageParam], ind
     _add_cache_control_param(_last_message_content(anthropic_messages[:index]), cache_control)
 
 
-def _collect_orphan_tool_search_call_ids(messages: list[ModelMessage]) -> set[str]:
-    """Collect `tool_call_id`s of `NativeToolSearchCallPart`s without a paired return.
+_NATIVE_TOOL_USE_PARAM_TYPES = frozenset({'server_tool_use', 'mcp_tool_use'})
+_TOOL_SEARCH_SERVER_TOOL_USE_NAMES = frozenset({'tool_search_tool_bm25', 'tool_search_tool_regex'})
 
-    Anthropic occasionally emits a `tool_search_tool_*` server tool use alongside a
-    client `tool_use` and ends the turn before delivering the corresponding result
-    block. The result may arrive in a later `ModelResponse` (direct API), or never
-    at all (Bedrock). Anything truly unpaired must be dropped from the wire payload
-    on the next request, since Bedrock rejects orphans with `tool use ... was found
-    without a corresponding tool_search_tool_*_tool_result block`.
 
-    The pair lookup is by `tool_call_id` across *all* messages — a return part may
-    sit in a later assistant turn than the call.
+def _result_is_still_in_flight(anthropic_messages: list[BetaMessageParam], index: int) -> bool:
+    """Whether the payload ends at `index`'s turn, bar a `tool_result`-only user turn answering it.
+
+    That is the one shape Anthropic accepts an unpaired native tool call in, because the result is
+    still on its way: measured on `claude-sonnet-4-5` as accepted while the request ends there and
+    rejected as soon as any further turn follows, with no other content changing.
     """
-    call_ids: set[str] = set()
-    return_ids: set[str] = set()
-    for message in messages:
-        if isinstance(message, ModelResponse):
-            for part in message.parts:
-                if isinstance(part, NativeToolSearchCallPart) and part.tool_call_id:
-                    call_ids.add(part.tool_call_id)
-                elif isinstance(part, NativeToolSearchReturnPart) and part.tool_call_id:
-                    return_ids.add(part.tool_call_id)
-    return call_ids - return_ids
+    for message in anthropic_messages[index + 1 :]:
+        content = message['content']
+        if message['role'] != 'user' or not isinstance(content, list):  # pragma: no branch
+            return False
+        if any(cast(dict[str, Any], block)['type'] != 'tool_result' for block in content):
+            return False
+    return True
+
+
+def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam]) -> None:
+    """Drop native tool-use blocks the payload delivers no result block for.
+
+    Anthropic fails a whole request with `<tool> tool use with id ... was found without a
+    corresponding <tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes
+    unpaired, unless the result is still in flight — see `_result_is_still_in_flight` for the shape
+    that buys. That exception is what lets the bug reach storage: the turn is accepted while it is the
+    live one, and then every later request replaying that history fails.
+
+    A call goes unpaired two ways. The result may never have arrived, since Anthropic can end a turn
+    before delivering it (https://github.com/anthropics/anthropic-sdk-python/issues/1325) and Bedrock may not send it
+    at all. Or it arrived and didn't render: a history processor that trims a large search payload to
+    a string leaves a `NativeToolReturnPart` whose content has no block shape here, so the result is
+    skipped and the call it answered is left dangling. Pairing is therefore read off the blocks
+    actually built rather than the parts behind them, and across the whole payload, since a result may
+    sit in a later turn than its call.
+
+    Tool-search calls drop even while the result is in flight: Bedrock rejects the shape the direct
+    API tolerates, and a search is cheap for the model to repeat. Dropping beats synthesizing an empty
+    result block either way, which would tell the model the tool ran and returned nothing.
+    """
+    returned_ids: set[str] = set()
+    for message in anthropic_messages:
+        content = message['content']
+        if not isinstance(content, list):  # pragma: no cover
+            continue
+        for block in content:
+            # Every block here is a request `*Param` TypedDict bar the MCP result, which the SDK
+            # models and the mapper appends as-is.
+            if isinstance(block, BetaMCPToolResultBlock):
+                returned_ids.add(block.tool_use_id)
+            elif (tool_use_id := cast(dict[str, Any], block).get('tool_use_id')) is not None:
+                returned_ids.add(tool_use_id)
+
+    for index in range(len(anthropic_messages) - 1, -1, -1):
+        content = anthropic_messages[index]['content']
+        if not isinstance(content, list):  # pragma: no cover
+            continue
+        in_flight = _result_is_still_in_flight(anthropic_messages, index)
+        kept: list[BetaContentBlockParam] = []
+        for block in content:
+            block_dict = cast(dict[str, Any], block)
+            unpaired = (
+                not isinstance(block, BetaMCPToolResultBlock)
+                and block_dict['type'] in _NATIVE_TOOL_USE_PARAM_TYPES
+                and block_dict['id'] not in returned_ids
+            )
+            if unpaired and not (in_flight and block_dict.get('name') not in _TOOL_SEARCH_SERVER_TOOL_USE_NAMES):
+                # A `CachePoint` the user put on this block has to survive it. Landing it on the
+                # preceding block keeps the cacheable prefix a prefix; moving it forward would cache
+                # content the user placed outside the boundary.
+                if (cache_control := block_dict.get('cache_control')) is not None:
+                    _add_cache_control_param(kept or _last_message_content(anthropic_messages[:index]), cache_control)
+                continue
+            kept.append(block)
+        if len(kept) == len(content):
+            continue
+        if kept:
+            anthropic_messages[index]['content'] = kept
+        else:
+            # Anthropic rejects a message with no content, and an assistant turn that held nothing but
+            # an unpaired call has nothing left to say.
+            del anthropic_messages[index]
 
 
 def _normalize_tool_search_args(tool_args: dict[str, Any] | None, tool_name: str) -> ToolSearchArgs:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2161,71 +2161,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             else:
                 assert_never(m)
 
-        # Pair against the rendered blocks: a result can arrive in a later response, or exist as a
-        # `NativeToolReturnPart` but fail to render. Anthropic accepts an unpaired native call only
-        # while every later message is a user turn containing only concurrent client-tool results.
-        returned_native_tool_call_ids: set[str] = set()
-        for message in anthropic_messages:
-            content = message['content']
-            assert isinstance(content, list)
-            for block in content:
-                if isinstance(block, BetaMCPToolResultBlock):
-                    returned_native_tool_call_ids.add(block.tool_use_id)
-                elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
-                    returned_native_tool_call_ids.add(tool_use_id)
-
-        suffix_is_tool_result_only = True
-        for index in range(len(anthropic_messages) - 1, -1, -1):
-            message = anthropic_messages[index]
-            content = message['content']
-            assert isinstance(content, list)
-            kept: list[BetaContentBlockParam] = []
-            for block in content:
-                block_param = block
-                if isinstance(block, BetaMCPToolResultBlock) or not is_str_dict(block):
-                    kept.append(block_param)
-                    continue
-
-                unpaired = (
-                    block['type'] in ('server_tool_use', 'mcp_tool_use')
-                    and block['id'] not in returned_native_tool_call_ids
-                )
-                tool_search = block.get('name') in ('tool_search_tool_bm25', 'tool_search_tool_regex')
-                if unpaired and (not suffix_is_tool_result_only or tool_search):
-                    # Tool search is retried instead of preserved in flight because Bedrock rejects
-                    # that shape even though the direct Anthropic API accepts other native tools there.
-                    # Keep a cache boundary on the nearest preceding cacheable block. Moving it
-                    # forward would cache content the user placed outside the boundary. If no such
-                    # block exists, the boundary disappears with the block that carried it.
-                    if (cache_control := block.get('cache_control')) is not None:
-                        carriers: list[BetaContentBlockParam] = []
-                        for preceding_content in [
-                            preceding_message['content'] for preceding_message in anthropic_messages[:index]
-                        ] + [kept]:
-                            assert isinstance(preceding_content, list)
-                            for param in preceding_content:
-                                param_value = param
-                                if is_str_dict(param) and param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
-                                    carriers.append(param_value)
-                        if carriers:
-                            _add_cache_control_param(carriers, cache_control)
-                    continue
-                kept.append(block_param)
-
-            if len(kept) != len(content):
-                if not kept:
-                    # Anthropic rejects empty messages; an assistant turn containing only the
-                    # dropped call has nothing left to send.
-                    del anthropic_messages[index]
-                    continue
-                message['content'] = kept
-
-            suffix_is_tool_result_only = (
-                suffix_is_tool_result_only
-                and message['role'] == 'user'
-                and all(is_str_dict(block) and block['type'] == 'tool_result' for block in kept)
-            )
-
+        _drop_unpaired_native_tool_calls(anthropic_messages)
         _place_system_messages_before_generation(anthropic_messages)
         _anchor_system_messages(anthropic_messages)
 
@@ -3523,6 +3459,113 @@ def _leave_cache_boundary_behind(anthropic_messages: list[BetaMessageParam], ind
     if (cache_control := last_block.pop('cache_control', None)) is None:
         return
     _add_cache_control_param(_last_message_content(anthropic_messages[:index]), cache_control)
+
+
+_NATIVE_TOOL_USE_PARAM_TYPES = frozenset({'server_tool_use', 'mcp_tool_use'})
+_TOOL_SEARCH_SERVER_TOOL_USE_NAMES = frozenset({'tool_search_tool_bm25', 'tool_search_tool_regex'})
+
+
+def _result_is_still_in_flight(anthropic_messages: list[BetaMessageParam], index: int) -> bool:
+    """Whether the payload ends at `index`'s turn, bar the `tool_result`-only user turns answering it.
+
+    That is the one shape Anthropic accepts an unpaired native tool call in, because the result is
+    still on its way. Measured on `claude-sonnet-4-5`: accepted while every later turn is a user turn
+    carrying nothing but tool results, one of them or two, and rejected as soon as a turn with any
+    other content follows. Capping it at a single turn would drop a call the API takes.
+    """
+    for message in anthropic_messages[index + 1 :]:
+        content = message['content']
+        if message['role'] != 'user':
+            return False
+        if not isinstance(content, list):  # pragma: no cover
+            return False
+        if any(not is_str_dict(block) or block['type'] != 'tool_result' for block in content):
+            return False
+    return True
+
+
+def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam]) -> None:
+    """Drop native tool-use blocks the payload delivers no result block for.
+
+    Anthropic fails a whole request with `<tool> tool use with id ... was found without a
+    corresponding <tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes
+    unpaired, unless the result is still in flight — see `_result_is_still_in_flight` for the shape
+    that buys. Both block types were measured live, against controls with the call removed that the
+    API accepts. That exception is what lets the bug reach storage: the turn is accepted while it is the
+    live one, and then every later request replaying that history fails.
+
+    A call goes unpaired two ways. The result may never have arrived, since Anthropic can end a turn
+    before delivering it (https://github.com/anthropics/anthropic-sdk-python/issues/1325) and Bedrock may not send it
+    at all. Or it arrived and didn't render: a history processor that trims a large search payload to
+    a string leaves a `NativeToolReturnPart` whose content has no block shape here, so the result is
+    skipped and the call it answered is left dangling. Pairing is therefore read off the blocks
+    actually built rather than the parts behind them, and across the whole payload, since a result may
+    sit in a later turn than its call.
+
+    Tool-search calls drop even while the result is in flight, which is what the mapper did before this
+    function existed: #5143 dropped them on the grounds that Bedrock rejects the shape the direct API
+    tolerates, a claim carried forward here rather than re-measured, and a search is cheap for the model
+    to repeat. Dropping beats synthesizing an empty result block either way, which would tell the model
+    the tool ran and returned nothing.
+    """
+    returned_ids: set[str] = set()
+    for message in anthropic_messages:
+        content = message['content']
+        if not isinstance(content, list):  # pragma: no cover
+            continue
+        for block in content:
+            # Every block here is a request `*Param` TypedDict bar the MCP result, which the SDK
+            # models and the mapper appends as-is.
+            if isinstance(block, BetaMCPToolResultBlock):
+                returned_ids.add(block.tool_use_id)
+            elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
+                returned_ids.add(tool_use_id)
+
+    for index in range(len(anthropic_messages) - 1, -1, -1):
+        content = anthropic_messages[index]['content']
+        if not isinstance(content, list):  # pragma: no cover
+            continue
+        in_flight = _result_is_still_in_flight(anthropic_messages, index)
+        kept: list[BetaContentBlockParam] = []
+        for block in content:
+            block_dict = cast(dict[str, Any], block)
+            unpaired = (
+                not isinstance(block, BetaMCPToolResultBlock)
+                and block_dict['type'] in _NATIVE_TOOL_USE_PARAM_TYPES
+                and block_dict['id'] not in returned_ids
+            )
+            if unpaired and not (in_flight and block_dict.get('name') not in _TOOL_SEARCH_SERVER_TOOL_USE_NAMES):
+                # A `CachePoint` the user put on this block has to survive it. Landing it on the
+                # nearest preceding block that can carry one keeps the cacheable prefix a prefix;
+                # moving it forward would cache content the user placed outside the boundary. Nearest
+                # is often neither the block right before it nor even in the same turn: an assistant
+                # turn that reasons before calling a server tool renders `[thinking, server_tool_use]`,
+                # and `thinking` takes no `cache_control` — nor does a replayed
+                # `BetaMCPToolResultBlock`, which is a model rather than a mapping and raises on
+                # subscript. A payload with no cacheable block before this one at all gives the
+                # breakpoint up instead of failing the request: the block that carried it is the one
+                # going away, so there is no `CachePoint` left to report a problem with.
+                if (cache_control := block_dict.get('cache_control')) is not None:
+                    preceding = [message['content'] for message in anthropic_messages[:index]] + [kept]
+                    carriers = [
+                        param
+                        for content_blocks in preceding
+                        if isinstance(content_blocks, list)
+                        for param in content_blocks
+                        if is_str_dict(block_param := param) and block_param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES
+                    ]
+                    if carriers:
+                        _add_cache_control_param(carriers, cache_control)
+                continue
+            kept.append(block)
+        if len(kept) == len(content):
+            continue
+        if kept:
+            anthropic_messages[index]['content'] = kept
+        else:
+            # Anthropic rejects a message with no content, and an assistant turn that held nothing but
+            # an unpaired call has nothing left to say.
+            del anthropic_messages[index]
 
 
 def _normalize_tool_search_args(tool_args: dict[str, Any] | None, tool_name: str) -> ToolSearchArgs:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2161,7 +2161,71 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             else:
                 assert_never(m)
 
-        _drop_unpaired_native_tool_calls(anthropic_messages)
+        # Pair against the rendered blocks: a result can arrive in a later response, or exist as a
+        # `NativeToolReturnPart` but fail to render. Anthropic accepts an unpaired native call only
+        # while every later message is a user turn containing only concurrent client-tool results.
+        returned_native_tool_call_ids: set[str] = set()
+        for message in anthropic_messages:
+            content = message['content']
+            assert isinstance(content, list)
+            for block in content:
+                if isinstance(block, BetaMCPToolResultBlock):
+                    returned_native_tool_call_ids.add(block.tool_use_id)
+                elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
+                    returned_native_tool_call_ids.add(tool_use_id)
+
+        suffix_is_tool_result_only = True
+        for index in range(len(anthropic_messages) - 1, -1, -1):
+            message = anthropic_messages[index]
+            content = message['content']
+            assert isinstance(content, list)
+            kept: list[BetaContentBlockParam] = []
+            for block in content:
+                block_param = block
+                if isinstance(block, BetaMCPToolResultBlock) or not is_str_dict(block):
+                    kept.append(block_param)
+                    continue
+
+                unpaired = (
+                    block['type'] in ('server_tool_use', 'mcp_tool_use')
+                    and block['id'] not in returned_native_tool_call_ids
+                )
+                tool_search = block.get('name') in ('tool_search_tool_bm25', 'tool_search_tool_regex')
+                if unpaired and (not suffix_is_tool_result_only or tool_search):
+                    # Tool search is retried instead of preserved in flight because Bedrock rejects
+                    # that shape even though the direct Anthropic API accepts other native tools there.
+                    # Keep a cache boundary on the nearest preceding cacheable block. Moving it
+                    # forward would cache content the user placed outside the boundary. If no such
+                    # block exists, the boundary disappears with the block that carried it.
+                    if (cache_control := block.get('cache_control')) is not None:
+                        carriers: list[BetaContentBlockParam] = []
+                        for preceding_content in [
+                            preceding_message['content'] for preceding_message in anthropic_messages[:index]
+                        ] + [kept]:
+                            assert isinstance(preceding_content, list)
+                            for param in preceding_content:
+                                param_value = param
+                                if is_str_dict(param) and param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
+                                    carriers.append(param_value)
+                        if carriers:
+                            _add_cache_control_param(carriers, cache_control)
+                    continue
+                kept.append(block_param)
+
+            if len(kept) != len(content):
+                if not kept:
+                    # Anthropic rejects empty messages; an assistant turn containing only the
+                    # dropped call has nothing left to send.
+                    del anthropic_messages[index]
+                    continue
+                message['content'] = kept
+
+            suffix_is_tool_result_only = (
+                suffix_is_tool_result_only
+                and message['role'] == 'user'
+                and all(is_str_dict(block) and block['type'] == 'tool_result' for block in kept)
+            )
+
         _place_system_messages_before_generation(anthropic_messages)
         _anchor_system_messages(anthropic_messages)
 
@@ -3459,113 +3523,6 @@ def _leave_cache_boundary_behind(anthropic_messages: list[BetaMessageParam], ind
     if (cache_control := last_block.pop('cache_control', None)) is None:
         return
     _add_cache_control_param(_last_message_content(anthropic_messages[:index]), cache_control)
-
-
-_NATIVE_TOOL_USE_PARAM_TYPES = frozenset({'server_tool_use', 'mcp_tool_use'})
-_TOOL_SEARCH_SERVER_TOOL_USE_NAMES = frozenset({'tool_search_tool_bm25', 'tool_search_tool_regex'})
-
-
-def _result_is_still_in_flight(anthropic_messages: list[BetaMessageParam], index: int) -> bool:
-    """Whether the payload ends at `index`'s turn, bar the `tool_result`-only user turns answering it.
-
-    That is the one shape Anthropic accepts an unpaired native tool call in, because the result is
-    still on its way. Measured on `claude-sonnet-4-5`: accepted while every later turn is a user turn
-    carrying nothing but tool results, one of them or two, and rejected as soon as a turn with any
-    other content follows. Capping it at a single turn would drop a call the API takes.
-    """
-    for message in anthropic_messages[index + 1 :]:
-        content = message['content']
-        if message['role'] != 'user':
-            return False
-        if not isinstance(content, list):  # pragma: no cover
-            return False
-        if any(not is_str_dict(block) or block['type'] != 'tool_result' for block in content):
-            return False
-    return True
-
-
-def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam]) -> None:
-    """Drop native tool-use blocks the payload delivers no result block for.
-
-    Anthropic fails a whole request with `<tool> tool use with id ... was found without a
-    corresponding <tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes
-    unpaired, unless the result is still in flight — see `_result_is_still_in_flight` for the shape
-    that buys. Both block types were measured live, against controls with the call removed that the
-    API accepts. That exception is what lets the bug reach storage: the turn is accepted while it is the
-    live one, and then every later request replaying that history fails.
-
-    A call goes unpaired two ways. The result may never have arrived, since Anthropic can end a turn
-    before delivering it (https://github.com/anthropics/anthropic-sdk-python/issues/1325) and Bedrock may not send it
-    at all. Or it arrived and didn't render: a history processor that trims a large search payload to
-    a string leaves a `NativeToolReturnPart` whose content has no block shape here, so the result is
-    skipped and the call it answered is left dangling. Pairing is therefore read off the blocks
-    actually built rather than the parts behind them, and across the whole payload, since a result may
-    sit in a later turn than its call.
-
-    Tool-search calls drop even while the result is in flight, which is what the mapper did before this
-    function existed: #5143 dropped them on the grounds that Bedrock rejects the shape the direct API
-    tolerates, a claim carried forward here rather than re-measured, and a search is cheap for the model
-    to repeat. Dropping beats synthesizing an empty result block either way, which would tell the model
-    the tool ran and returned nothing.
-    """
-    returned_ids: set[str] = set()
-    for message in anthropic_messages:
-        content = message['content']
-        if not isinstance(content, list):  # pragma: no cover
-            continue
-        for block in content:
-            # Every block here is a request `*Param` TypedDict bar the MCP result, which the SDK
-            # models and the mapper appends as-is.
-            if isinstance(block, BetaMCPToolResultBlock):
-                returned_ids.add(block.tool_use_id)
-            elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
-                returned_ids.add(tool_use_id)
-
-    for index in range(len(anthropic_messages) - 1, -1, -1):
-        content = anthropic_messages[index]['content']
-        if not isinstance(content, list):  # pragma: no cover
-            continue
-        in_flight = _result_is_still_in_flight(anthropic_messages, index)
-        kept: list[BetaContentBlockParam] = []
-        for block in content:
-            block_dict = cast(dict[str, Any], block)
-            unpaired = (
-                not isinstance(block, BetaMCPToolResultBlock)
-                and block_dict['type'] in _NATIVE_TOOL_USE_PARAM_TYPES
-                and block_dict['id'] not in returned_ids
-            )
-            if unpaired and not (in_flight and block_dict.get('name') not in _TOOL_SEARCH_SERVER_TOOL_USE_NAMES):
-                # A `CachePoint` the user put on this block has to survive it. Landing it on the
-                # nearest preceding block that can carry one keeps the cacheable prefix a prefix;
-                # moving it forward would cache content the user placed outside the boundary. Nearest
-                # is often neither the block right before it nor even in the same turn: an assistant
-                # turn that reasons before calling a server tool renders `[thinking, server_tool_use]`,
-                # and `thinking` takes no `cache_control` — nor does a replayed
-                # `BetaMCPToolResultBlock`, which is a model rather than a mapping and raises on
-                # subscript. A payload with no cacheable block before this one at all gives the
-                # breakpoint up instead of failing the request: the block that carried it is the one
-                # going away, so there is no `CachePoint` left to report a problem with.
-                if (cache_control := block_dict.get('cache_control')) is not None:
-                    preceding = [message['content'] for message in anthropic_messages[:index]] + [kept]
-                    carriers = [
-                        param
-                        for content_blocks in preceding
-                        if isinstance(content_blocks, list)
-                        for param in content_blocks
-                        if is_str_dict(block_param := param) and block_param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES
-                    ]
-                    if carriers:
-                        _add_cache_control_param(carriers, cache_control)
-                continue
-            kept.append(block)
-        if len(kept) == len(content):
-            continue
-        if kept:
-            anthropic_messages[index]['content'] = kept
-        else:
-            # Anthropic rejects a message with no content, and an assistant turn that held nothing but
-            # an unpaired call has nothing left to say.
-            del anthropic_messages[index]
 
 
 def _normalize_tool_search_args(tool_args: dict[str, Any] | None, tool_name: str) -> ToolSearchArgs:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2181,6 +2181,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             assert isinstance(content, list)
             kept: list[BetaContentBlockParam] = []
             for block in content:
+                # Preserve the union type before `is_str_dict` narrows `block` to `dict[str, Any]`.
                 block_param = block
                 if isinstance(block, BetaMCPToolResultBlock) or not is_str_dict(block):
                     kept.append(block_param)
@@ -2204,6 +2205,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                         ] + [kept]:
                             assert isinstance(preceding_content, list)
                             for param in preceding_content:
+                                # Preserve the union type before `is_str_dict` narrows `param`.
                                 param_value = param
                                 if is_str_dict(param) and param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
                                     carriers.append(param_value)

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2161,73 +2161,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             else:
                 assert_never(m)
 
-        # Pair against the rendered blocks: a result can arrive in a later response, or exist as a
-        # `NativeToolReturnPart` but fail to render. Anthropic accepts an unpaired native call only
-        # while every later message is a user turn containing only concurrent client-tool results.
-        returned_native_tool_call_ids: set[str] = set()
-        for message in anthropic_messages:
-            content = message['content']
-            assert isinstance(content, list)
-            for block in content:
-                if isinstance(block, BetaMCPToolResultBlock):
-                    returned_native_tool_call_ids.add(block.tool_use_id)
-                elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
-                    returned_native_tool_call_ids.add(tool_use_id)
-
-        suffix_is_tool_result_only = True
-        for index in range(len(anthropic_messages) - 1, -1, -1):
-            message = anthropic_messages[index]
-            content = message['content']
-            assert isinstance(content, list)
-            kept: list[BetaContentBlockParam] = []
-            for block in content:
-                # Preserve the union type before `is_str_dict` narrows `block` to `dict[str, Any]`.
-                block_param = block
-                if isinstance(block, BetaMCPToolResultBlock) or not is_str_dict(block):
-                    kept.append(block_param)
-                    continue
-
-                unpaired = (
-                    block['type'] in ('server_tool_use', 'mcp_tool_use')
-                    and block['id'] not in returned_native_tool_call_ids
-                )
-                tool_search = block.get('name') in ('tool_search_tool_bm25', 'tool_search_tool_regex')
-                if unpaired and (not suffix_is_tool_result_only or tool_search):
-                    # Tool search is retried instead of preserved in flight because Bedrock rejects
-                    # that shape even though the direct Anthropic API accepts other native tools there.
-                    # Keep a cache boundary on the nearest preceding cacheable block. Moving it
-                    # forward would cache content the user placed outside the boundary. If no such
-                    # block exists, the boundary disappears with the block that carried it.
-                    if (cache_control := block.get('cache_control')) is not None:
-                        carriers: list[BetaContentBlockParam] = []
-                        for preceding_content in [
-                            preceding_message['content'] for preceding_message in anthropic_messages[:index]
-                        ] + [kept]:
-                            assert isinstance(preceding_content, list)
-                            for param in preceding_content:
-                                # Preserve the union type before `is_str_dict` narrows `param`.
-                                param_value = param
-                                if is_str_dict(param) and param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
-                                    carriers.append(param_value)
-                        if carriers:
-                            _add_cache_control_param(carriers, cache_control)
-                    continue
-                kept.append(block_param)
-
-            if len(kept) != len(content):
-                if not kept:
-                    # Anthropic rejects empty messages; an assistant turn containing only the
-                    # dropped call has nothing left to send.
-                    del anthropic_messages[index]
-                    continue
-                message['content'] = kept
-
-            suffix_is_tool_result_only = (
-                suffix_is_tool_result_only
-                and message['role'] == 'user'
-                and all(is_str_dict(block) and block['type'] == 'tool_result' for block in kept)
-            )
-
+        _drop_unpaired_native_tool_calls(anthropic_messages)
         _place_system_messages_before_generation(anthropic_messages)
         _anchor_system_messages(anthropic_messages)
 
@@ -3438,6 +3372,78 @@ def _last_message_content(anthropic_messages: list[BetaMessageParam]) -> list[Be
     # Returned as-is, not copied: the caller attaches `cache_control` by mutating the block in place, so
     # it has to be the list the message actually holds.
     return content if isinstance(content, list) else []
+
+
+def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam]) -> None:  # noqa: C901
+    """Drop native tool calls that Anthropic will reject without a rendered result.
+
+    A result can arrive in a later response, or exist as a `NativeToolReturnPart` but fail to render.
+    Anthropic accepts an unpaired native call only while every later message is a user turn containing
+    only concurrent client-tool results.
+    """
+    returned_native_tool_call_ids: set[str] = set()
+    for message in anthropic_messages:
+        content = message['content']
+        assert isinstance(content, list)
+        for block in content:
+            if isinstance(block, BetaMCPToolResultBlock):
+                returned_native_tool_call_ids.add(block.tool_use_id)
+            elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
+                returned_native_tool_call_ids.add(tool_use_id)
+
+    suffix_is_tool_result_only = True
+    for index in range(len(anthropic_messages) - 1, -1, -1):
+        message = anthropic_messages[index]
+        content = message['content']
+        assert isinstance(content, list)
+        kept: list[BetaContentBlockParam] = []
+        for block in content:
+            # Preserve the union type before `is_str_dict` narrows `block` to `dict[str, Any]`.
+            block_param = block
+            if isinstance(block, BetaMCPToolResultBlock) or not is_str_dict(block):
+                kept.append(block_param)
+                continue
+
+            unpaired = (
+                block['type'] in ('server_tool_use', 'mcp_tool_use')
+                and block['id'] not in returned_native_tool_call_ids
+            )
+            tool_search = block.get('name') in ('tool_search_tool_bm25', 'tool_search_tool_regex')
+            if unpaired and (not suffix_is_tool_result_only or tool_search):
+                # Tool search is retried instead of preserved in flight because Bedrock rejects
+                # that shape even though the direct Anthropic API accepts other native tools there.
+                # Keep a cache boundary on the nearest preceding cacheable block. Moving it
+                # forward would cache content the user placed outside the boundary. If no such
+                # block exists, the boundary disappears with the block that carried it.
+                if (cache_control := block.get('cache_control')) is not None:
+                    carriers: list[BetaContentBlockParam] = []
+                    for preceding_content in [
+                        preceding_message['content'] for preceding_message in anthropic_messages[:index]
+                    ] + [kept]:
+                        assert isinstance(preceding_content, list)
+                        for param in preceding_content:
+                            # Preserve the union type before `is_str_dict` narrows `param`.
+                            param_value = param
+                            if is_str_dict(param) and param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
+                                carriers.append(param_value)
+                    if carriers:
+                        _add_cache_control_param(carriers, cache_control)
+                continue
+            kept.append(block_param)
+
+        if len(kept) != len(content):
+            if not kept:
+                # Anthropic rejects empty messages; an assistant turn containing only the
+                # dropped call has nothing left to send.
+                del anthropic_messages[index]
+                continue
+            message['content'] = kept
+
+        suffix_is_tool_result_only = (
+            suffix_is_tool_result_only
+            and message['role'] == 'user'
+            and all(is_str_dict(block) and block['type'] == 'tool_result' for block in kept)
+        )
 
 
 def _anchor_system_messages(anthropic_messages: list[BetaMessageParam]) -> None:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2161,7 +2161,71 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             else:
                 assert_never(m)
 
-        _drop_unpaired_native_tool_calls(anthropic_messages)
+        # Pair against the rendered blocks: a result can arrive in a later response, or exist as a
+        # `NativeToolReturnPart` but fail to render. Anthropic accepts an unpaired native call only
+        # while every later message is a user turn containing only concurrent client-tool results.
+        returned_native_tool_call_ids: set[str] = set()
+        for message in anthropic_messages:
+            content = message['content']
+            assert isinstance(content, list)
+            for block in content:
+                if isinstance(block, BetaMCPToolResultBlock):
+                    returned_native_tool_call_ids.add(block.tool_use_id)
+                elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
+                    returned_native_tool_call_ids.add(tool_use_id)
+
+        suffix_is_tool_result_only = True
+        for index in range(len(anthropic_messages) - 1, -1, -1):
+            message = anthropic_messages[index]
+            content = message['content']
+            assert isinstance(content, list)
+            kept: list[BetaContentBlockParam] = []
+            for block in content:
+                block_param = block
+                if isinstance(block, BetaMCPToolResultBlock) or not is_str_dict(block):
+                    kept.append(block_param)
+                    continue
+
+                unpaired = (
+                    block['type'] in ('server_tool_use', 'mcp_tool_use')
+                    and block['id'] not in returned_native_tool_call_ids
+                )
+                tool_search = block.get('name') in ('tool_search_tool_bm25', 'tool_search_tool_regex')
+                if unpaired and (not suffix_is_tool_result_only or tool_search):
+                    # Tool search is retried instead of preserved in flight because Bedrock rejects
+                    # that shape even though the direct Anthropic API accepts other native tools there.
+                    # Keep a cache boundary on the nearest preceding cacheable block. Moving it
+                    # forward would cache content the user placed outside the boundary. If no such
+                    # block exists, the boundary disappears with the block that carried it.
+                    if (cache_control := block.get('cache_control')) is not None:
+                        carriers: list[BetaContentBlockParam] = []
+                        for preceding_content in [
+                            preceding_message['content'] for preceding_message in anthropic_messages[:index]
+                        ] + [kept]:
+                            assert isinstance(preceding_content, list)
+                            for param in preceding_content:
+                                param_value = param
+                                if is_str_dict(param) and param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
+                                    carriers.append(param_value)
+                        if carriers:
+                            _add_cache_control_param(carriers, cache_control)
+                    continue
+                kept.append(block_param)
+
+            if len(kept) != len(content):
+                if not kept:
+                    # Anthropic rejects empty messages; an assistant turn containing only the
+                    # dropped call has nothing left to send.
+                    del anthropic_messages[index]
+                    continue
+                message['content'] = kept
+
+            suffix_is_tool_result_only = (
+                suffix_is_tool_result_only
+                and message['role'] == 'user'
+                and all(is_str_dict(block) and block['type'] == 'tool_result' for block in kept)
+            )
+
         _place_system_messages_before_generation(anthropic_messages)
         _anchor_system_messages(anthropic_messages)
 
@@ -3459,107 +3523,6 @@ def _leave_cache_boundary_behind(anthropic_messages: list[BetaMessageParam], ind
     if (cache_control := last_block.pop('cache_control', None)) is None:
         return
     _add_cache_control_param(_last_message_content(anthropic_messages[:index]), cache_control)
-
-
-_NATIVE_TOOL_USE_PARAM_TYPES = frozenset({'server_tool_use', 'mcp_tool_use'})
-_TOOL_SEARCH_SERVER_TOOL_USE_NAMES = frozenset({'tool_search_tool_bm25', 'tool_search_tool_regex'})
-
-
-def _result_is_still_in_flight(anthropic_messages: list[BetaMessageParam], index: int) -> bool:
-    """Whether the payload ends at `index`'s turn, bar a `tool_result`-only user turn answering it.
-
-    That is the one shape Anthropic accepts an unpaired native tool call in, because the result is
-    still on its way: measured on `claude-sonnet-4-5` as accepted while the request ends there and
-    rejected as soon as any further turn follows, with no other content changing.
-    """
-    for message in anthropic_messages[index + 1 :]:
-        content = message['content']
-        if message['role'] != 'user':
-            return False
-        if not isinstance(content, list):  # pragma: no cover
-            return False
-        if any(not is_str_dict(block) or block['type'] != 'tool_result' for block in content):
-            return False
-    return True
-
-
-def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam]) -> None:
-    """Drop native tool-use blocks the payload delivers no result block for.
-
-    Anthropic fails a whole request with `<tool> tool use with id ... was found without a
-    corresponding <tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes
-    unpaired, unless the result is still in flight — see `_result_is_still_in_flight` for the shape
-    that buys. Both block types were measured live, against controls with the call removed that the
-    API accepts. That exception is what lets the bug reach storage: the turn is accepted while it is the
-    live one, and then every later request replaying that history fails.
-
-    A call goes unpaired two ways. The result may never have arrived, since Anthropic can end a turn
-    before delivering it (https://github.com/anthropics/anthropic-sdk-python/issues/1325) and Bedrock may not send it
-    at all. Or it arrived and didn't render: a history processor that trims a large search payload to
-    a string leaves a `NativeToolReturnPart` whose content has no block shape here, so the result is
-    skipped and the call it answered is left dangling. Pairing is therefore read off the blocks
-    actually built rather than the parts behind them, and across the whole payload, since a result may
-    sit in a later turn than its call.
-
-    Tool-search calls drop even while the result is in flight, which is what the mapper did before this
-    function existed: #5143 dropped them on the grounds that Bedrock rejects the shape the direct API
-    tolerates, a claim carried forward here rather than re-measured, and a search is cheap for the model
-    to repeat. Dropping beats synthesizing an empty result block either way, which would tell the model
-    the tool ran and returned nothing.
-    """
-    returned_ids: set[str] = set()
-    for message in anthropic_messages:
-        content = message['content']
-        if not isinstance(content, list):  # pragma: no cover
-            continue
-        for block in content:
-            # Every block here is a request `*Param` TypedDict bar the MCP result, which the SDK
-            # models and the mapper appends as-is.
-            if isinstance(block, BetaMCPToolResultBlock):
-                returned_ids.add(block.tool_use_id)
-            elif is_str_dict(block) and (tool_use_id := block.get('tool_use_id')) is not None:
-                returned_ids.add(tool_use_id)
-
-    for index in range(len(anthropic_messages) - 1, -1, -1):
-        content = anthropic_messages[index]['content']
-        if not isinstance(content, list):  # pragma: no cover
-            continue
-        in_flight = _result_is_still_in_flight(anthropic_messages, index)
-        kept: list[BetaContentBlockParam] = []
-        for block in content:
-            block_dict = cast(dict[str, Any], block)
-            unpaired = (
-                not isinstance(block, BetaMCPToolResultBlock)
-                and block_dict['type'] in _NATIVE_TOOL_USE_PARAM_TYPES
-                and block_dict['id'] not in returned_ids
-            )
-            if unpaired and not (in_flight and block_dict.get('name') not in _TOOL_SEARCH_SERVER_TOOL_USE_NAMES):
-                # A `CachePoint` the user put on this block has to survive it. Landing it on the
-                # nearest preceding block that can carry one keeps the cacheable prefix a prefix;
-                # moving it forward would cache content the user placed outside the boundary. Nearest
-                # is often not the block right before it: an assistant turn that reasons before calling
-                # a server tool renders `[thinking, server_tool_use]`, and `thinking` takes no
-                # `cache_control` — nor does a replayed `BetaMCPToolResultBlock`, which is a model
-                # rather than a mapping and raises on subscript.
-                if (cache_control := block_dict.get('cache_control')) is not None:
-                    carriers = [
-                        param
-                        for param in kept
-                        if is_str_dict(block_param := param) and block_param['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES
-                    ]
-                    _add_cache_control_param(
-                        carriers or _last_message_content(anthropic_messages[:index]), cache_control
-                    )
-                continue
-            kept.append(block)
-        if len(kept) == len(content):
-            continue
-        if kept:
-            anthropic_messages[index]['content'] = kept
-        else:
-            # Anthropic rejects a message with no content, and an assistant turn that held nothing but
-            # an unpaired call has nothing left to say.
-            del anthropic_messages[index]
 
 
 def _normalize_tool_search_args(tool_args: dict[str, Any] | None, tool_name: str) -> ToolSearchArgs:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3533,10 +3533,20 @@ def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam])
             )
             if unpaired and not (in_flight and block_dict.get('name') not in _TOOL_SEARCH_SERVER_TOOL_USE_NAMES):
                 # A `CachePoint` the user put on this block has to survive it. Landing it on the
-                # preceding block keeps the cacheable prefix a prefix; moving it forward would cache
-                # content the user placed outside the boundary.
+                # nearest preceding block that can carry one keeps the cacheable prefix a prefix;
+                # moving it forward would cache content the user placed outside the boundary. Nearest
+                # isn't always the block right before it: an assistant turn that reasons before calling
+                # a server tool renders `[thinking, server_tool_use]`, and a `thinking` block takes no
+                # `cache_control`.
                 if (cache_control := block_dict.get('cache_control')) is not None:
-                    _add_cache_control_param(kept or _last_message_content(anthropic_messages[:index]), cache_control)
+                    carriers = [
+                        param
+                        for param in kept
+                        if cast(dict[str, Any], param)['type'] in _ANTHROPIC_CACHEABLE_PARAM_TYPES
+                    ]
+                    _add_cache_control_param(
+                        carriers or _last_message_content(anthropic_messages[:index]), cache_control
+                    )
                 continue
             kept.append(block)
         if len(kept) == len(content):

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3487,7 +3487,8 @@ def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam])
     Anthropic fails a whole request with `<tool> tool use with id ... was found without a
     corresponding <tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes
     unpaired, unless the result is still in flight — see `_result_is_still_in_flight` for the shape
-    that buys. That exception is what lets the bug reach storage: the turn is accepted while it is the
+    that buys. Both block types were measured live, against controls with the call removed that the
+    API accepts. That exception is what lets the bug reach storage: the turn is accepted while it is the
     live one, and then every later request replaying that history fails.
 
     A call goes unpaired two ways. The result may never have arrived, since Anthropic can end a turn
@@ -3498,9 +3499,11 @@ def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam])
     actually built rather than the parts behind them, and across the whole payload, since a result may
     sit in a later turn than its call.
 
-    Tool-search calls drop even while the result is in flight: Bedrock rejects the shape the direct
-    API tolerates, and a search is cheap for the model to repeat. Dropping beats synthesizing an empty
-    result block either way, which would tell the model the tool ran and returned nothing.
+    Tool-search calls drop even while the result is in flight, which is what the mapper did before this
+    function existed: #5143 dropped them on the grounds that Bedrock rejects the shape the direct API
+    tolerates, a claim carried forward here rather than re-measured, and a search is cheap for the model
+    to repeat. Dropping beats synthesizing an empty result block either way, which would tell the model
+    the tool ran and returned nothing.
     """
     returned_ids: set[str] = set()
     for message in anthropic_messages:

--- a/tests/models/anthropic/cassettes/test_unpaired_native_tool_calls/test_in_flight_mcp_call_history_is_accepted.yaml
+++ b/tests/models/anthropic/cassettes/test_unpaired_native_tool_calls/test_in_flight_mcp_call_history_is_accepted.yaml
@@ -1,0 +1,193 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1057'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      mcp_servers:
+      - name: deepwiki
+        type: url
+        url: https://mcp.deepwiki.com/mcp
+      messages:
+      - content:
+        - text: Look up the 10-year Treasury duration, then add 2 and 2.
+          type: text
+        role: user
+      - content:
+        - id: mcptoolu_01SAss3KEwASziHZoMR6HcZU
+          input:
+            question: What is pydantic-ai?
+            repoName: pydantic/pydantic-ai
+          name: ask_question
+          server_name: deepwiki
+          type: mcp_tool_use
+        - id: toolu_01WjXqPrN8vKsRt2YbLmZdQe
+          input:
+            a: 2
+            b: 2
+          name: add
+          type: tool_use
+        role: assistant
+      - content:
+        - content:
+          - text: '4'
+            type: text
+          is_error: false
+          tool_use_id: toolu_01WjXqPrN8vKsRt2YbLmZdQe
+          type: tool_result
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      tool_choice:
+        type: auto
+      tools:
+      - description: Add two numbers.
+        input_schema:
+          additionalProperties: false
+          properties:
+            a:
+              type: integer
+            b:
+              type: integer
+          required:
+          - a
+          - b
+          type: object
+        name: add
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '9504'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-58e4b7f40312c265860d60b18e67b44f-b6ed32f2deb68a48-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - content:
+        - text: "Pydantic AI is a Python agent framework and LLM library designed for building production-grade Generative
+            AI applications.   It aims to bring the ergonomic design of FastAPI to GenAI development, leveraging Pydantic
+            V2 for robust validation and full type safety.  The framework is model-agnostic, supporting various LLM providers
+            like OpenAI, Anthropic, and Google, and emphasizes type safety, observability, and extensibility.  \n\n## Core
+            Purpose and Features\n\nPydantic AI simplifies the development of reliable AI applications by providing a structured,
+            type-safe, and extensible framework.  It abstracts away the complexities of interacting with different LLM providers
+            and managing agent workflows. \n\nKey features include:\n*   **Type-Safe Agents**: Agents are designed with generic
+            types for compile-time validation, leveraging Pydantic for output validation and dependency injection. \n*   **Model-Agnostic
+            Design**: It supports over 15 LLM providers through a unified `Model` interface, allowing for easy switching between
+            different models and providers. \n*   **Structured Outputs**: The framework provides powerful streaming of structured
+            data with immediate Pydantic validation. \n*   **Seamless Observability**: It integrates with Pydantic Logfire
+            and OpenTelemetry for real-time debugging, tracing, and cost tracking. \n*   **Durable Execution**: Pydantic AI
+            supports preserving agent progress across restarts and handling long-running workflows via systems like Temporal
+            or DBOS. \n*   **Composable Capabilities**: You can build agents from reusable units that bundle tools, hooks,
+            instructions, and model settings. \n*   **Graph Support**: It provides a way to define graphs using type hints
+            for complex applications, managed by `pydantic-graph`.  \n\n## Monorepo Package Structure\n\nPydantic AI is organized
+            as a `uv` workspace monorepo containing several distinct Python packages. \n\n```mermaid\ngraph TD\n    subgraph
+            \"Main Packages\"\n        PYDANTIC_AI[\"pydantic-ai<br/>(Metapackage)\"]\n        SLIM[\"pydantic-ai-slim<br/>Core
+            Framework\"]\n        GRAPH[\"pydantic-graph<br/>State Machine\"]\n        EVALS[\"pydantic-evals<br/>Evaluation
+            Framework\"]\n        CLAI[\"clai<br/>CLI Tool\"]\n        EXAMPLES[\"pydantic-ai-examples<br/>Usage Examples\"]\n
+            \   end\n    \n    subgraph \"Package Relationships\"\n        PYDANTIC_AI -->|\"bundles\"| SLIM\n        PYDANTIC_AI
+            -->|\"bundles\"| GRAPH\n        PYDANTIC_AI -->|\"bundles\"| EVALS\n        PYDANTIC_AI -->|\"bundles\"| CLAI\n
+            \       PYDANTIC_AI -->|\"bundles\"| EXAMPLES\n        \n        SLIM -->|\"depends on\"| GRAPH\n        EVALS
+            -->|\"depends on\"| SLIM\n        CLAI -->|\"depends on\"| SLIM\n        EXAMPLES -->|\"depends on\"| SLIM\n        EXAMPLES
+            -->|\"depends on\"| EVALS\n    end\n    \n    subgraph \"Core Dependencies (pydantic-ai-slim)\"\n        ANYIO[\"anyio>=4.7.0\"]\n
+            \       GRIFFELIB[\"griffelib>=2.0\"]\n        HTTPX[\"httpx>=0.27\"]\n        PYDANTIC[\"pydantic>=2.12\"]\n
+            \       OPENTELEMETRY_API[\"opentelemetry-api>=1.28.0\"]\n        TYPING_INSPECTION[\"typing-inspection>=0.4.0\"]\n
+            \       GENAI_PRICES[\"genai-prices>=0.1.0\"]\n    end\n    \n    SLIM -->|\"requires\"| ANYIO\n    SLIM -->|\"requires\"|
+            GRIFFELIB\n    SLIM -->|\"requires\"| HTTPX\n    SLIM -->|\"requires\"| PYDANTIC\n    SLIM -->|\"requires\"| OPENTELEMETRY_API\n
+            \   SLIM -->|\"requires\"| TYPING_INSPECTION\n    SLIM -->|\"requires\"| GENAI_PRICES\n``` \n\n*   `pydantic-ai-slim`:
+            The core agent framework with minimal base dependencies. \n*   `pydantic-graph`: A typed graph and state machine
+            library used for agent loops and workflows. \n*   `pydantic-evals`: A framework for systematic testing and evaluation
+            of LLM performance. \n*   `clai`: A command-line interface for interacting with agents and models. \n*   `pydantic-ai-examples`:
+            A collection of examples demonstrating Pydantic AI capabilities. \n*   `pydantic-ai`: A metapackage that bundles
+            all features and common providers. \n\n## Core Architecture Components\n\nThe architecture bridges the gap between
+            high-level natural language intent and structured code execution. \n\n```mermaid\ngraph TD\n    subgraph \"Natural
+            Language Space\"\n        USER_PROMPT[(\"User Prompt\")]\n        INSTRUCTIONS[(\"Instructions\")]\n        THINKING[(\"Thinking
+            Process\")]\n        MESSAGE_HISTORY[(\"Conversation History\")]\n    end\n\n    subgraph \"Code Entity Space
+            (pydantic_ai)\"\n        AGENT_CLASS[\"Agent Class\"]\n        MODEL_ABSTRACT[\"Model (Abstract Base Class)\"]\n
+            \       TOOL_DEFINITION[\"ToolDefinition\"]\n        RUN_CONTEXT[\"RunContext\"]\n        MODEL_REQUEST_PARAMS[\"ModelRequestParameters\"]\n
+            \       MODEL_MESSAGE_TYPES[\"ModelMessage Types\"]\n        PYDANTIC_VALIDATION[\"Pydantic Validation\"]\n    end\n\n
+            \   subgraph \"Execution Flow\"\n        AGENT_EXEC_LOOP[\"Agent Execution Loop\"]\n    end\n\n    USER_PROMPT
+            -->|becomes| MODEL_MESSAGE_TYPES\n    INSTRUCTIONS -->|configures| AGENT_CLASS\n    THINKING -->|influences| MODEL_REQUEST_PARAMS\n
+            \   MESSAGE_HISTORY -->|managed by| AGENT_CLASS\n\n    AGENT_CLASS -->|orchestrates| AGENT_EXEC_LOOP\n    AGENT_EXEC_LOOP
+            -->|uses| MODEL_ABSTRACT\n    AGENT_EXEC_LOOP -->|executes| TOOL_DEFINITION\n    AGENT_EXEC_LOOP -->|provides
+            context via| RUN_CONTEXT\n    AGENT_EXEC_LOOP -->|builds| MODEL_REQUEST_PARAMS\n    MODEL_ABSTRACT -->|processes|
+            MODEL_REQUEST_PARAMS\n    MODEL_ABSTRACT -->|returns| MODEL_MESSAGE_TYPES\n    MODEL_MESSAGE_TYPES -->|validated
+            by| PYDANTIC_VALIDATION\n    TOOL_DEFINITION -->|uses| PYDANTIC_VALIDATION\n``` \n\nKey code entities include:\n*
+            \  `Agent` (`pydantic_ai.Agent`): The central orchestrator managing tools, instructions, and model interaction.
+            \n*   `Model` (`pydantic_ai.models.Model`): An abstract base class defining how to communicate with LLM providers.
+            \n*   `ModelMessage` (`pydantic_ai.messages.ModelMessage`): The core abstraction for conversation history. \n*
+            \  `RunContext` (`pydantic_ai.RunContext`): Provides access to dependencies and state within tools and dynamic
+            instructions. \n\n## Installation\n\nPydantic AI offers flexible installation options:\n*   **Standard**: `pip
+            install pydantic-ai` includes core packages and libraries for major providers like OpenAI, Anthropic, and Google.
+            \n*   **Slim**: `pip install pydantic-ai-slim` provides a minimal footprint, allowing you to add specific providers
+            or features via extras (e.g., `[openai]`). \n*   **Examples**: `pip install pydantic-ai[examples]` includes the
+            `pydantic-ai-examples` package for easy exploration. \n\n## Example Usage\n\nHere's a minimal example of using
+            Pydantic AI to create an agent:\n```python\nfrom pydantic_ai import Agent\n\nagent = Agent(\n    'anthropic:claude-sonnet-4-6',\n
+            \   instructions='Be concise, reply with one sentence.',\n)\n\nresult = agent.run_sync('Where does \"hello world\"
+            come from?')\nprint(result.output)\n``` \n\nYou can also add capabilities like `Thinking` and `WebSearch` to an
+            agent:\n```python\nfrom pydantic_ai import Agent\nfrom pydantic_ai.capabilities import Thinking, WebSearch\n\nagent
+            = Agent(\n    'anthropic:claude-sonnet-4-6',\n    instructions='Be concise, reply with one sentence.',\n    capabilities=[Thinking(),
+            WebSearch()],\n)\n\nresult = agent.run_sync('What was the mass of the largest meteorite found this year?')\nprint(result.output)\n```
+            \n\n## Notes\n\nThe `AGENTS.md` file provides insights into the project's philosophy, emphasizing modern Python,
+            type safety, and thoughtful API design.  The `SKILL.md` file in `pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md`
+            further details when to use Pydantic AI for building agents, adding tools, and handling structured output. \n\nWiki
+            pages you might want to explore:\n- [Overview (pydantic/pydantic-ai)](/wiki/pydantic/pydantic-ai#1)\n- [Additional
+            Model Providers (pydantic/pydantic-ai)](/wiki/pydantic/pydantic-ai#4.6)\n\nView this search on DeepWiki: https://deepwiki.com/search/what-is-pydanticai_008f6e73-bd1a-4a1f-9e5f-0fbee7cae4e3\n"
+          type: text
+        is_error: false
+        tool_use_id: mcptoolu_01SAss3KEwASziHZoMR6HcZU
+        type: mcp_tool_result
+      - text: |-
+          I apologize, but I don't have the ability to look up the 10-year Treasury duration. The tools available to me are limited to asking questions about GitHub repositories and performing basic mathematical operations.
+
+          However, I can tell you that **2 + 2 = 4**.
+
+          Regarding the 10-year Treasury duration, typically the duration of a 10-year U.S. Treasury bond is approximately 8-9 years (it's less than the maturity because duration accounts for the present value of all cash flows including coupon payments). However, the exact duration varies based on the current yield and coupon rate. You would need to check current financial data sources like Bloomberg, the U.S. Treasury website, or financial news outlets for the most accurate current duration figure.
+        type: text
+      id: msg_011Ce8tUPDquRYCpsqXRJWFM
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 3443
+        output_tokens: 169
+        server_tool_use:
+          web_fetch_requests: 0
+          web_search_requests: 0
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/anthropic/cassettes/test_unpaired_native_tool_calls/test_in_flight_native_tool_call_history_is_accepted.yaml
+++ b/tests/models/anthropic/cassettes/test_unpaired_native_tool_calls/test_in_flight_native_tool_call_history_is_accepted.yaml
@@ -1,0 +1,187 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1059'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: Look up the 10-year Treasury duration, then add 2 and 2.
+          type: text
+        role: user
+      - content:
+        - id: srvtoolu_01EoSNE7k4dUJyGatASCV5qs
+          input:
+            query: 10-year Treasury modified duration
+          name: web_search
+          type: server_tool_use
+        - id: toolu_01WjXqPrN8vKsRt2YbLmZdQe
+          input:
+            a: 2
+            b: 2
+          name: add
+          type: tool_use
+        role: assistant
+      - content:
+        - content:
+          - text: '4'
+            type: text
+          is_error: false
+          tool_use_id: toolu_01WjXqPrN8vKsRt2YbLmZdQe
+          type: tool_result
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      tool_choice:
+        type: auto
+      tools:
+      - description: Add two numbers.
+        input_schema:
+          additionalProperties: false
+          properties:
+            a:
+              type: integer
+            b:
+              type: integer
+          required:
+          - a
+          - b
+          type: object
+        name: add
+      - allowed_domains: null
+        blocked_domains: null
+        max_uses: null
+        name: web_search
+        type: web_search_20250305
+        user_location: null
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '25089'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-eab037cf382bed5a58d15f5fb038f9d9-1ef96f69a3212404-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - caller:
+          type: direct
+        content:
+        - encrypted_content: EuAQCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDKyudm0BEwc/bxZcOBoM9eFGil37ojZjXTMGIjAB8jK00CVJKE5q3bCxEc2tN2hRjqNp/t7O6qWwSysdyzRfUe66q/xEX970TQcDz2gq4w+9jQWqOHQ6eHMkEtoabiF+auMBnbQ+gXrq9LQ2P0J63tHwCGnRdhmWmZdy0ahfLMKKQPcaB0Qe5NSrbdNTZg0ZSmU+6KyTYPExBty6A/gqd/ONL6gITbjLvPMRpo3MCY83vJ7Xy2MBGByPrWwmGLJmt0QAg4b4AaNnf13Ank5CA2y6ZfeAKCC+ErEjXwcQkFFzWwmYisQDjnZ6Z3yHVM4W7F2saTXRBZqzL+8lqFTGb8SvU6utfZo0Hci98+8UbBu/DX8qZMG3DNjgdro57CTcF6cZncKgQ9KqeVoNGkzGFY7Dy7jAJZe7rWitoHNzgtxfvUjjvjO2pAp6XzXgHpI4cE6xAAmftnvEKXXkmHPScT4TKfMB4pI0N/+kelslYusUSXcREQNwnhQq1iPgV4ejiq9OlibOYUHk0wwVYHMkKu/8powo0dsNo8XTKNZMXp9KsN7kuaU5fELq/r2N/+X8zVSfbJjLolJzSwV+7RNdVAgXNg3VszcRiCIOBSM4eqWUlU/eAIU9Zb2wbzF+uLLEZwm6GoL1/HgurLiDBnRWkltXDxRDyNfTAEKDkJArcoRvsxRJtmYPxEwUd35JBoq31za4pQf9ZRa4KTJo/tgi8Bxcd2CEeYD7xs98rU6GheRoIeBb/5G1UBj3t0uKpUy+/DgRj9oGUQVsOIT/IcCMiUsClV7B2rZafn2wrkykl7/GWUCRQc7NeNOfft6Z/0xeaZeWZQL1KlYcqTeHGjBOhPIgkWmUNN7iYkp1YW9QOG/mEqrL/pJKCRbtZH6uxEi4wQY7W+RCv6RVkTej0DbhA/htVpj3dsjHXTNQQSCrUV6oYBzX9GgEQnWsaWUjI/tLiKEx1EnWnAtP+NbwM9ipBL3TmXYPLw7usrk68kVGIkOpW0Pdj9Ppio4msC0Qq8+6c31H6d4MlFxv2fNQaz6MY2goPhsvvT6FtTjQH69K77F1aVvN/6qUP+BDtQ0uqcLXno9W3OzhgbGVLJNNVbae1FpM7VLyfYCDPNRfZ4mDqlGmr57J8MPJNfUU6456rqVFr8IuX/IaHPqyAHNFuujIDF55w6rZ7fDQkkF7F8l39gF0xngrTYUvGjC/NocobywdQlnvY+ObvDhjldk69U+csZHa9+dmDXphytqtLbR0Bxug7qma5cU6RZkPIuvo6OMdr3RQnXXJTwts6g7jGs+3e7fGp2qE95E35fVwC/lRNoTeAnxvGtbyvTE1vymIPXYkzvrD1/MU4UyTwFs8Y/GQsm4ybVADqfSk1B8/6UCU6nJ2zn9JkBQMuCsgHLqSIzgRBEW9M6LVdCshOo4mlfJZAhTj+FkXRdNFNrps9A9etzAvis38XOtEzFquCEKIbscF4slkXxE1OIbV3zHuliQ1lhRLyI8+HlKtxsGtPNXLCrNyjSFPA3g3R4aZDBwNJR2E5dwG2SwXiZ7iOX3RJDahGPwb0XvEjhNCN20Htyeuo39xoGmW3k0ssD5IcUeBL+E0vLGLHoS590pWDB8dN7dPTh4kmGGz7lhyNc7x6VXOiVL1TSyXZbpRaZ9nsgSkNo4I1NBF4gnuTJXeoCZAdBuMhujPMeHMkUPreLdNhcXHbpB04P9ZpVll3wKm8mPykA4UKqOUa8PJKlP/vTWeW5uCAIUaYxnS9rCC17LwJKUpd7uN1lOfM+JQ9cQ4WV0QLzql1QAqel3Gw9LV+wDyd6uIiIlR24Wg40Z1O9oVK32QLBfO08PDZXPt3Dx4Jit3CKk9y4npx495OPdfKGFXROKEbgTygK56UhcowrZPz+KT8WW1Nhe99nlCUnBk7V6owDsn4S23eb5eiQkEIATwXNJUTXACaQle7VZS49XyYwNFraXUrbg/QU6OqitboxjohvYq1s4DRCqHjP4cbFrh0Ur+za4PLpsCzjIldonsNNXCA75VAjaZO7oDHNy3bqDw8VLwLEGfk9qfoocZmfGVitacDb+IPZ4pCR/pz4rcU/AVjPCvnzS+xMFkr4M7pXQYiYcdrI4GTSv0mToEbgMkuLzBzcPz8uuy0zpi0Twxx7qeFVrHClZDx8gJymtRLqfx5cxIDGJ4UdLK1ohhqH9W4w/JcIhzIw3H3zh+lczuB47WSPyOqbhlSxl9yNbD32FJV8oFwTurSdyV82eXpC+aVMxBSWNhooRBs5yi3OrGGdNMBoiJgbc8k4cEe3SH6ZwfWV7NF2TENXxyY7kqSMNwSrjfnPJPyA7fov/pTZ3VrOOxFXOV1KmShKRwIKE2mrIEgvHiwP1MwTo/3HfsCHWFTW0beVzgqNCdO/ILMlcC0RjSPuWt0z4sy6MOz6MXeu8D2uH4gWhV9d0WCA/5SZHDXFasA898caZ5vijGc8TaxkhlOWp5WB5eCvoZE0xXDe5EooUyDMUoiJhbdJJvYdtuYdzjX1Lk/nHzPHRsDaXZ032IEthsOfNV6w3MefLPBtZdpIiaO+N+rtrp+C61/CXJke6nr019zzLNfT6Ig3ovRB9Jl4BzBrf25LGT9Mjmdlt22/UKCMskiJ3Ae/Lv3oI2uFgSAJDRR5CEKPUSPPJgb0llYC0s0YFB9RKaQUlxHB4n87SwV2HWHRND3KSOFvtqS0aiyyW1meAjcVHEsnmqeE/pyujG+HUdxlQ/MNsHLuqY5J8lEwpLWsI+IRycu389JFnSEl0vJfw0sUNcVT60JaL6FKIlubYYAw==
+          page_age: null
+          title: 'Modified Duration: The Modified Duration Approach: Refining Key Rate Duration Analysis - FasterCapital'
+          type: web_search_result
+          url: https://fastercapital.com/content/Modified-Duration--The-Modified-Duration-Approach--Refining-Key-Rate-Duration-Analysis.html
+        - encrypted_content: Et8QCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDM7M+PGEiYq+NsIgchoMX1JK0tu5bfl28PZPIjAobbGRC0xZGWh/lTBSbkY+qImq5KLJfv9l7kDkQDp1gkxeMxhU4DjPOdtC8t4CaC4q4g+vWdxydCDCQDBXOunTXvnk48Vj2F4g+LcJXyh76CxtQpKZR//z9Jf9VsmtahDe7oV1CCBx1GtwElEF6q3EvSsjZOUed0ZJqZ0NYcYQ0s6+LBVlK29iErfmiWZx7VgEk65edeJ6O0pLHrwgdkY5s2BX7VJgsDyHiU4/158JiJLuSX7OSWx2J+IywNStF+2HEHyKynjJDScg9fAUz10/2lggFWeQjRWCaxgB2ZN1j6466shzT5GVjCCVlzWd9hrvjXBdYCZxERrFQ6PmhMt6vdBOgXLVcval54vyVB1jiVqw/kbthI7Qd7TkMTwV7JEcJZ5eBP/L1NwtTEg1yDXIgN+41nS3x/l7XsPkO/KfqDfjjJESfYlyvBtWXjYetTW8zWDU/UNP0vNIfPjZODQy/S7/klJp6Wxms3THyk351l7RbpgKv4ocssQyu/Z4Y6qY/LQ6o+8zvZW0fJ1p8isHmswZvby96yIWWWMM4qfOHtAeAklEQLl9LjCTQPr5pcDi21VXdoGMKY8C0X46aALbfKrZv8wrVuxoQqr1KdxC8b5CIRrtIi8jfVeggcpbhgMJ6Vzgb4CzMZ3J+o55iRvQ1W6NlsR5UCNBSftkNYY4LkQ+Cco6X4EGB0048nTUPnIYEV2BndhUGQfuWPx4CxFrDhCCeC6abuE3yJrXJzYveHP0au+ywKgNqSd+kKXhsIC0P/3+M/M24sD+P44lmDzdavEuTGNa/jRCNxcvzdTS+gzb2gsGRk76xj7Tlz+72QGZ7hCw3CQ6y/LlFCyaqpFHGxwLOv94QL7vnnlDvdTMgEQXinNvU2kxL5eSNP1D/ErCXYDYj0vMprgsd3JG4mwnWfynUn+oAEGpmnVZuixbU0iOKzyU/jKVqZhZsDDQY8SlsDB25HERgbPbS/k2OlIqcwEHFRmCTVhKuMA0URrP+0JS2WvqFE/NquFDQfydPRt7xiaaeD17YYdsBKH5ZPckObNj9Id1nSjGjgm1jyq7fkFcQCRy2p+YsQ98dkz0FnjNrHVXXPcdaW18vYGJKPozVO+gImjM5yMHZi+6uGEV2xYd8fiqNGLJhAX0PpUplIH2ougUbhHC1OP6KcSGxCUxPXrk4gLyAmSM66vG2qdkmwpNstnj9DHmMOsqlChoYJ1VOipJxKQy84Rowc/fagWI9WXqaYRYDa9X60fz8pznrCksliI84XekeNvhLUNehCGoCyJY+4VGTs/QgZsad6qvFBheapFyJCqfvORxdYjFxYAPqP0eN7z3Nz+zhh0E4lm+iy4CyZvsQ+2lDlUfBdas02AQL6zq/FGVgZ76xn/5bBiAWBrJS0DCZdjN0Pblg15YSicdMrdnX14GKLySP9xQo035gFUFq4ExEClL/Ptd1U1A2doDSdJQfJA0t5DOGZ74QUYo7Y16QR8ldnaXKSCFQq0WNK9NC8fs+iYyUOrNqtqe987FfrjVwLVjSmEymgABwggIGZ5qz/ilmb2EWhaMYF34qJO3qJyFWxkn38MqdtgxWvgYl3lpoIEzKLE7Z7GQxtMadqyZqNG18hg2FBgLr8c124ncvRGyb03kNzjjPwr1BnIs/Jncgf9QVmuAatOuUfdHbHbuIZs28QYnYWYkHLQYfzwK0AYvk4vAOgRdQd+j7g4tlUz/VrNY7szrfcn4nR7UoLlRWFPssEe6Chbises+7Ym6fiCUW14SNjFimoiQDHJJlrAqeq+m/SM8mqY5rVnxcPGLW0Dg/31/IUTtPyO6mV03GthLgQ1kl67UUMTWgLNRdzXx1lNtSicS73mIXW4A6nC66tjHRHTsBxFvSio8w3L8GWxWaXERvE4Kx3HmnzOR0kq5muz++y0Ky+Vb+yfqfzyTfABofhuKbe3g05NDPlMW9zEwrvBX/b3FNXjHmGmBSXDKzVCy6lFUE6tqnx4o1rmiQqU7PyeB8cBM1SnjyIL9sZjFo2BsAjkN1hRIQbyvoCDYCdHuXZQZeG/8kd5CX6ZHfnHXZtH92RG6FAgJ1eGimijFj25JtiR4zbBqmvj8eJYkDECpIR1caZ0+p9y0/gJ+m5jcLQUx12rssM+pfOfaRo2jhzGoCUwEX4ShF39PeUrEFJWNUf7srdZHSFHF6iANOmBGeQm/AnOjy11GFU9e9g6jWZ9Ql9qO5wVJEX+41lgOotsJ9oLIMu9WB3j9aX4BfIngQuDN+khrvAEWM/zLnDfLN0HcxlafHDeSx5Ug3VC/H9Hb8CgYiwvStOsBjJtWi6xAW8dYgMH57uvGepYDLt9Z/kwMAPxdTaaHVO479wVbf3/QaE0oT0Xx/HrwGn1O3HiJ/Rl7sPf9GRZFZmef2fZjGRQ9vrkHEJEPvEtaHlaYHNjd7CoS8+4RGzUWybN1MMilm/ixprG2GD7gp9/15Mf/mcIIXZa2SiJb2vZJfK5K1FERiUuxeoY6hZmrWH14yU6/d+VzLKG845NTqU6P0T6jn0ppF1874Nm9OtlBmIyJ9PoyEs3fG103pAKeIuS/5yoD0S15T+8awyZhY38nePjlu1K/Zm3wWmRvhVOmy7r2sB0P39zYRBfifVZ+atwRp/ThBI4ugG41vq0VSMDXJFM1+WISluKCmLLJHHUtoV0CORjSO175FllhFdFGi48S6me1zSoh6WU2zVjrQqJMwBLfM7Z7k+9ZefQ9oZEuK6eqWKn45ZCAcZ6ssEQrgRgD
+          page_age: null
+          title: A Simple Treasury Futures Duration Adjustment INTEREST RATES MAY 2020
+          type: web_search_result
+          url: https://www.cmegroup.com/trading/interest-rates/files/treasury-duration-strategy-paper.pdf
+        - encrypted_content: EpUICioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDLelMojs9EbQ5QdKmRoMQx8LrNt/qr7z8aOmIjAPUCEtkUpk3Cti4c6zTrguXsUTnFdKz+OupgdjxDtm/NyenEbC15Q+uG7yhVzqHf0qmAdxegpYmcbJJRLp/Sm5DbcBDbjB0fnCAph6FlajgPMkEjhTmimZY0RbItc5Gw/XcNNJHGuD/Z9dysWtT9poSJ++xahO4Kb2FNYTxZ+l8kOrywsxzyUqAQ6Yg88GXiRSZlm5uztj1v4bWT94hS2UK1szJj/Nkr2QU+FwH+67wlJtDRZDXnI+HdKiaGrZ0AYzTyGtY6b84zEIdzvMR7vJk6eslk6fSvVRJsNDg/FX9Z+r4X+RWTLLTcHT23g/oPy4G+BUIudw2l/pOgBW2t8PVtXQtpZ7vx/rGEZ+UT1TNdIePKnV6/1A/k94WWbZnig0pUvP9oSfN9z7jw4xBCdc58bVW2lUvtFExvZLBLCDNM3Yk8KTgdXdJXd2GlKFmh3Hz21GYIVoFAEqE1EK5HkV/gA2gHQsFSIOjaetqmy4zdbNF0aBD+lZjkK1g83ZoO3XnCg15nnzvEYHXb0ru+3sXiDChelJglHCmAteqE/NJIk9lmYUqWCKwBJtxqYDf/sysfYFvqU35/TC/Vb5H+DXdOGqlI8PR2xdbD12fUn2DgdrKsXQL5jqPduwTuoLpFu521lYsRPQoqB0uzMVRR/s839wyzMp9cx4NBa7oX57X7jhMWXIfHZBQzY+ewN5fhxyr7LG8vW7htsIUudI57HFMrNZ0mKbTnZNBTRDoE260Z1/gHHNttf2zjncEXZtVTyR8hsIR0kK9i2HyQ6c6U0KxUNAqDvxHgSaKylnm4IJYxesyHe7SC1cz4yLaStzRX9W8CmfRakcP6iPdBYgsKOolWR9+caZh6ig5+gMHMaQ+hChYSKQ30hZnItZ37v+oF+cGUkXEdKJWpsZE/NFtjTzTNbqwyiRE/E36WhUTBlZy3s66IThlhJgYq68QU8st9xYqvpYXSgTq2wL772l47OzsdpPVwsrzfFxY+uVvOcwQxdXs8rW0mjxvlxJQe13XmoBxx0wAzyMc+qj6feuYeawXuBcQreGLw74YbJAmPZ2sHkf27LMC9e7bYq+pnVh8VK7a2kVTtxE2tPAiXrlAK3dsSxS95Nv4/xP+hlvGn8A5JvdKSQVjwoG5uX97Byn4zD+1RgG334j8/n+v8KhDHMuxBrr7HTo79yTj6U691sJqMVsCBX2Nej61Ul+nQ3DVU+wP13RXx35+BaT3XFqRdJOEes0O0fOCTkAjnt9aIvb6FZEMW+1i7UAgL/ReFJdyl30RRKoOqKgXt5f/BgD
+          page_age: null
+          title: Interest Rate Research Center Tools and Analytics CALCULATING THE DOLLAR VALUE
+          type: web_search_result
+          url: https://www.cmegroup.com/trading/interest-rates/files/Calculating_the_Dollar_Value_of_a_Basis_Point_Final_Dec_4.pdf
+        - encrypted_content: ErwDCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDFv7dWe/ur5o1E1EARoME5Ia47pLK2VC9iuNIjAHCct+EtWnOZ+gcNvA72iSWEpleMgRPPqCiNp8u/wpAXYunGDsC749nhSIqTF31egqvwJ0olJD62wrstfw7sg+VApZRyeoQ3y82lC1bkQuuIff9U1HwyZ9DK3z/A0RCwe0wCECHxDxipFb3cDzE2l186ReLeKTABXdU5bc+JYA/muwiKhnKDIs2DOBeC1/1SowTv+h3v7Qax7Ug0EHBTKly7L0oZa7/53wuX6cpmmVr9Yfv8oq/J1iS4pQlHCK6Gr4zeR7kHeERqRyV7ZuLe0iB6K2uAy0QxmImB/8ZXGFS8SRuLiHicGS6Uej2/PbdIS23icL3t7QyKByLUrVWaIqyrlfIlX7JdhrlrgljIpA5siKzd+tKh2nPKxRzejiPhrItgjgfUViSqzjK/nLPRYNmoSEZTSUm7T43tPVlalb9pL/RqhbTpXa9otRr7KCzImDt81bAtfcAvLtgUSSFV98g46fWgdVExHhD1Irita83K5FGAM=
+          page_age: null
+          title: What is the duration of a 10-year treasury bond? - Quora
+          type: web_search_result
+          url: https://www.quora.com/What-is-the-duration-of-a-10-year-treasury-bond
+        - encrypted_content: EowQCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDOIp6hqTlAEi8LeGJRoMAATJQfJmAD6t4pF9IjDB2BaR0Q33Ek/zgkYnQFbp7EKKIzZ3+YXQwfoKdx9ikeCl2FeEg/8u3LmC5vA1x6Aqjw9cq79zGyQPX7Jbhp4axU/n0CnI6LHMUPMZ9cB2UYfzFybXs3R/3Xx8Tst3aACuQOYesMa1w5DThtDN6uWB30OrDQF+LLKBOsnL8VKpF53sSe8s24W3UlpbHtZ+Ox6G2niZmJWuzaYofdztAcFtmiW1OccFcpYBo1hyUnEo+JC1tBPcNjj/BqdU5evn3ajRD4tWwetF7NHVSKF4z7Vr6yg1R4xr4YmIJ475JrxlkkYEvKKY00PDVocxQ903YSgQyj7RMhQ323ojJqZO6GsEdxqj9qxWcW+UtsUgViql2a61zDqV1T26uh5kfPP8QJcZQobl83al5iDDSNWaYJU23Hdc0fsDjLgHMNBC5azSpZWFhUTsj56Vgl91Z78PVumy0vJec9v+KRgmBBXog4Dri4UH5MzyjLcpNWKv7YAGFpDtBooE4JLjNtI/EBnn2jfLxgiRTq1y9TWvvVqQLW04k/KEHO7VSbHZftfsSmurCqbfhOhviBqDBJOvE6wFS+WeYqcIONvfXZm2nFpgS48Fguw3ly8IJEbcezTcFJP5aO7Ov/8FATphmpRjSv3y0Tq3BcYgoJMVB5HIEZPTGSFTL4MfblJaWx2kFQzRzYZFRcFiJteJ1m12+BntGWRAXCvWfMqBreOC7xa7MEsID5Vinvw1l+QYVT1Q9scAvFjAltKezKpWpn76MU0ibryZEEV4+ENDIXIs19nRQg9TOhjjTtu1OKIUzws6Ipgt6I2ZLxKmL3gUirW4MUcC22dAOqxN/1I2CoV/TM2VMATzDEqEo/QztzBlYUR5AKnU4GipbU0Kftgsm1TYRQrh866ARASJ4GeCo2VCRkFMAQSC2e9fZqCimYr7udD/qGVBowJWZHTdM27MFAUX80TQIoOZWCuCesamUvmzyGy0hkq0dwCrVAWs/FoQ21cqZPdfT+RI81r1R9P/aVAmPxSe7iFZj16ZxU1TmxsyqV6KIdwIoS3+cl6nZwTfnQNY/kdhURZdA4WIeZHHTkKxhHQejIa4GdpElc5AG4ecrPJIQmX+KLJjQQITalO3F5vHGrbl+uiPFzMRY4ujR8WCRQWm7T9iXqkaeU1bqH/4xMAamf2D5kM58RQRYJZ6n68deUgiYnYP6fRuDdKP1skMZIYisPrPWQUFEpx+Utqhqnib3lP+L2Kjg/gl9GxBcur6kgmAYh8omfhKTQS6wW1V58SHx7P9nA4SqSoHl59sMAncmnkl0YXlt4gEsoJ2FxfAf/YpOFQjAmQDHqvvxSwyMW0eYOqOaD5DLYSxGbyEKdI51+fgpUyaZv7A+K5rn6OzMTibNiI0DPfP0aEw2H1nj0eOBvCvK1naEpubNeW8qpdEU/I6yySPUAlQMY8q6LLVGx+c9KoiitMpilDa5hZdn66P+ba/Hs7iOT2a+yzRMVguRl8HFjK99JmUUqw4gs5EF6iBiDaiqLwKHVOaGW4wvLWQJ6TYMtCCcFTL2+9nBlbAr44cox5XQ2xGNpGhPq0TP8f04LkF7dl6Iw6gQLOA5nJxfN9p9lFDfZasI+NuudQ/KCCr75RVdKGn2aksv7V0UNpGShvLLvrycznexiDNmQvyvlJR5IwNUilYVOTFLzkHbD8jD3sIC0khDM0c7JgolftzGb+9o54EANDDv/YrUwgmUDcfjr8AHVERggo7In26Hsy3mRCneZhcims2IJWEe5LikdS24Zir57ZZw5+tdDnyiR3hlkpuNhFD0wCUR+iSjCIpDqyX+uobha6ZtgQef/HHAn+PEP4EiRZ4wxtYjxQXRIJrx0WddgM6n1YY1WpDIPpmhclo5kGp9YbHYRNlhYEcKocRoRtrd+DV9xmc/wN07NgU0e1K9hLL3COIaJrbfwZnbPFRtUDlyG19e74ESAo3Yl7CMiX0VqHLiIFrYqxq4vAYmq5JXcGRKc4+Eh4pCOadWEMjSC4QqXLVR3YgcYMZh8inAMdssf1SDzzrYgpTcjEtyD4ipQlplWVlXQetP1/ySQxvhsJBRqv9cBkpfxAwNVXit+dL4GqhD6l00Nn/zbu3lsebR7GfAMe6auDieOeW6sLmwhiNPLVA/g3NnFyEXn1U6QRNliw21xn0ztlwAzwvrlIceR9L85++pmSf11/WokEWYDK/UTDcCq6dvu6yPsN/4884/K56FD9VIQDLRDZwVrSeot1yVLcEgZuEZlMFQ0xUAIUO9dI8ToB3761/G9y3EoSuiq6Ufwljt80tUm1+Zy2BFZ8EODMmxc46ySKeBynZUe/brghde+xkgzBk46h4sMXqAG28o+XeEn9WSX3fZ2aX2PZw54QBTMmFoKmlHoQ3lwaaujp/sF+gAh9+8kvBt1LzAZU7sWul91ut0dV4BEZ9+buPKAvLOewwlh1AfBP1r42UAuGIIWbbvh0C9y7A5/m036Xzj5QWKWEpA4V5iibF7bfjF1KF2iEEN+QIxGHIXgwouub4FSjfpX3XeyNWyri1dQlqm9zQxwEM9tN5luf5Vb8X8niE1SWgVwwErJ+vKGpu92lY3Y4IhcFB+YyPSnv9qbihcrsu2ywiUKqwMr37T3PMlQxjAzhtFISKqFpgnysYAw==
+          page_age: null
+          title: How Can You Measure Risk in Treasuries?
+          type: web_search_result
+          url: https://www.cmegroup.com/education/courses/introduction-to-treasuries/how-can-you-measure-risk-in-treasuries
+        - encrypted_content: EuAQCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDCYzHDI+zeWG4WYmCBoMFpdj9bsiEnH/ApJLIjD10lQfjHeqVHqi8spOXibmcl5NeqRaAFa5U2ou+QVIvsnOmDmq/E8Sh+Uk1SOz2IAq4w/DMxVsfDThGc1kKX+AFi/q6D5hSABFRFKkMIMFDE2xopxeAtbPUwsGphqgRogwnZVBSEIGdcylmmUJ292WqvrxepkJUGzTfUn283+Ef8Y5KQLmrMvvWYAFaSfLeoigiOuDpnA0TT1jxOOODlMdya5L/du3xCTW2BxcVHKgrEcTW34OaPXFJXdZ+SjLdaX5hkVbZlqrI3yOyrz+8FCODg4U3Di/UJxnINfXAGOAgUTtHfSPCt+GjNQbgW4OIb+iAQdAvm7LSuJbLv3jn/i/t9p4prRszKUCDFe8yDnkzcQTeDbDJuZNfN1WcS7RllGtvpGFmNH9uG+9iwQScyifx3NpFskj2v/N1GX3URAQ35jMhz8IGdsHI3dDNZO9ZUwsuSn2qey2vFm8igumGpadHShUJeCHQqWkRB+dUbHmCeLgvWgJBuw0wB4OMPhGo+WE4YWihw8yTMIhwWMZuENGzG7rmq/sBvxF2+wVQUF8jse5KafBFogys73j0UYYnZ4ixM/RHIgLa0SW87H0v7dRfRb2cNU5VMOnwKmsXbsHSU9YHrYWnMtxacqivWa3cCqwYJWUA5oXVb23IcSEeZqfi2miYFhJ1zoQt5d6GnQG6a4BV0ZPIXL1sHH3OTPL6/bCQ0AeW6e2W9WEighQYH+Y6GeFC7Tepu8j8QavKelcY2RCbWlY902ZSzBBgAGnkUNKWpjFcD7Q4y/ge5X0FXkYilCwwqR6b+iwR6jZGXDSB5IwmmCdwk9Ii/7xwBg6EZVFLnxhsN0hluoMyRJslHDlMJi6VpIDh8GO/rn1VF0OUadJHfv2KRFKp97/xeH5i0nrWcZgq+4gFesZdC0aqaSSDLb24/gC6prYe3TDLRGBU8OtWjDXVDkhlvSlxLbTiED7Qm+yF0kuUTtB87sYaVMkJmF7FzGtmYPoHr+VFaYkqaDdT2/pzVZn2ZyF2AL/tTCNuCNmwzpFHNn4Kb4oiMu7C5g9p1szW1jMBeBisctHJEtWyb4QMlZqfshzCRKUGWtPUSS6H7PwExShwWO5LRwJ84pg/r/iTgiv6cY3MNkwUcesbZ4Y4PgggYmm9TZcxSgdVIATe9RNWq2zG2hmKQHkXNgh6fWeg+IFcvs6N+w3dKSDkoEGMK7kWCgBoXpJOKGJntHiOOc64qC2b3L6wu0+FVwPHi9naEGdfXqajnoHcdBk2jFZ8clyEhqM2BMvJA5dKEh/opO9yoDS7iSbYuIq1KvM/c3Hm/utOZlTcQpQAlNnBNW+b/fek7DWgzOzz/jXsBRQXQIlFC/zNV7UeF40kwVkKL6GDmT7UsibTH170t0rhyNkgozrfyHV6KkzVZpOD8lmL6kMaM+K9rU46PJsKJJS07nwpV/GuVGxvFCweKLI7MONz/PvGPKVaz3Td46PNS8lxxq0gAUK7PFbs0SwO0pHWm+268g6u0x8D87ypWE7SQLm2ojAsHuP6ambW4ctRd9A/TF6c2k4HUZdWJm7MjxM0yXjRokXSXm3T4e4Z/3ZzFXV9qx++W8UgvCyOwDuJzdJrFhB+akioRo145tyBfJ1mi914ryIWAjqpDV/xyMrk53LRwx+66++866P6RoXv3Mc+zqPXtwnjIs7ezZQ6DDM2sfizCEvhYV1dqC23AAqgc41YhWXIVYksKyw8Wx2y3l6K5EDjmltKWuL0vykefcmHTfCjY3bgeSSk4DrLm3Phy0jz6i+fpMPuFRe9WNSz5GoZ5jEx9fYeTdqlaI06Vvt+E577jtLqhyZa8OPF4Nx5mONSxgXW2d1mphl+DDVPuaiyjcSYAwhkbFqJb0fbc5XXojh5jP3GWXBGALhyol2NIcTaJGDhUAniUIMKGRM5d+qQssJgjEX0pmQB06wmS6J99wpc+4Mck7qBKPh1Nkw7v4S4ZFcwEKLduc7J2rysOC+g2/i6SrGGK2XGQJHcA3Oj0d/RyomeRPN2Na3rXbFZBATQs08L+HvonO1vx+8Vd4FTRKP9FDPWcyTZcownjepNwl4frIRq4Xoi0jiYizx0MW1YLtD+Xrlv3NIWsnlpOLV1kpdRB6TSk+z/xhKJsku3BfZTBsnRSbUMBeozqQRFzcbdZoWTPYxTb/P2LiTYkM6viyOXehEIPfixcMsmnJAojG0cTek5u9RlCg30rRQW0W6zlpKsrMDbTjG1nJazvTn8LC4q6qbqnqoCqeqZHlYVuCcGmMX4R+Y8QTEnZAXP4Io56smS/i7dPL4PoE7L5IcB7OJe1Hou0vOSz2J6f+2P7mCGnpgF4/kuJVGxs7Mdrcj4/Zyjg/hrtv49zCbrwkIrVrocgZn/0ER3NmdVRu/4O7frY7UCWIyswxF5NcLfeCr0pQnilXummd0XPJxsx4N15InptU5zuqv12I9vun/lGTZhl5Yv7aa6vVxerFUH7t0EiyoqCJtg+f0e0KTlAmhVS6crz3/HfDac9fPkGBoBPd6n+vNe3lVV0e0jdCUsQUQ7nVaFqqoFuLpEVBetUWdnQglJafVjIXIh6So4eJtuN+XcyHnNbZHpgtTU2Pc4S7t+0GNfuua2/6f6vS+DoUjmvcXDHXY8os6LzqpouupLWPP3mbMGA0jEZi+aJ22SN9UTiDCaCiQL4CoVCRRCO7XAHw/4TK44/ttbQEmllNEHg5vzi4m8OMBO7YvFdtrKVNVZzP2qAK9f5XjWTAVBTV/FrgYAw==
+          page_age: null
+          title: US Treasury Yields & Curve | 10-Year, 2-Year & DV01 Calculator
+          type: web_search_result
+          url: https://www.sofrrate.com/treasury-rates
+        - encrypted_content: EpIQCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDAy9TRy28jT9v9WMgxoM6TFLUN3C4dGw38FKIjBbwUB48Cl3JX+YzR2OcGF+daE41CnxL5etNxu+v1Y4Ju4YrK19y0XgoLmQ0nZO0W8qlQ9aQsL9wUqCKfq1Bxp7BFko0hOCNP/ce7E1ckREvcK38I4MU3nbrJPoto9GIkZE2j70khXLiNnXlr9yLZ657lGDZjKWcUUkPsuQJCT8tLYNpT3kGAcJhUW675YPxFm+apCqpxxl1Z1os0UENhXDkc+PZvAi9t9uk/ZfNyH7RGiRThTy1IEM4XwS3L4zUO0HmgS2e6GpVW/JuVvTVl7F+4NfKqXcMMFKfFQGdtS8kQ69m+M8vjl6HcGpRorhAwYheu2ce9dk3NrxlrffqVcn3lDVD4Pt/GhfN47n212pVl2/iqvp1RrRroCyL0WuxNSPxEIRvTPOgxIFw7Y5nNxbBPD/PAUWISLfo0xYezjyjxDfFnjAFNX0o6BgRtO57omjcfGUrzlTuM4FuzyyQWtTkfaFIGaT5y//zeRg7vvChDEUvvf6ZFnz4I113HgBrgAO2Pj4AlUD9jCY7V3kI+/7fQDIVImSoxko4qDVG4zY0KLTkFxyDFFHBC2708HWQcsz98h58FeTBartB13yIFlQcE5172pGlCahW0dFLdcGIygc+EBjhvjlJVdeeCGC3xDGJ4Ic+jgAK3UNla/Mz7Iv3Os59PJfq/G5rdrbo+gqHcoVsT+6DVhyzOVe3bk/l9mWirCFjcINGVf5zPkRIq9AitJgWwRqnlZ7oCFUF/unHt8t2ebqXxEC/FlmRCcEZkiJqCrrAtr/Bo1h7/3p3oABWcbdzQfaREcFK0xWKozhM39iAp1BtB4+AJJV3/7t2Yg/pNTIozqs6ItGzBt/ZOT8n2YRrKdgRFViDWOUev33Pb7bhgeyCoKn3vhRZiVBOSnqjnCq3fn0BGNT2Imn5QUytt5PRmy4CsOz2HEAfP0CqQvg0cD+vkdfyJTB0DdIH8dWdDBOWkQV0MRF0SzSjLlx8J+3Q2ye9oUTOcareaNG24WIDke+tM3SgpRqNNRENG/rssCLy8RqVXgDeKNxd0U2P8s2/5eiCvmXMhH5+e+oO31melSa08IswG5gCjRMWORO6Hr2cRUBzcV14T2bP2ea6A5EV1X6nFbNgTHwt04Qg28SC6ebhj2Erwg90Co73hMsJoBzHpu5tJYfZAWefHa/SbKvsbL5FPkj+TJsAkDwRHHkz5/EWd/C9dXAqcYznOOh1EHBMnb412llDXjep9XqXd6K2kzZXnXLufy6TnJHwxxsSR8LFFKUi9dSJwmSgPEQo+4OCjx/zzr5Na5izBZ+54+NReE+EECfr/6Km1uVamiUKh96/AVxx2+RRtQyBobZuHuTAy28KS2lffpcmos+7uCkFHxqRK1T5QG1BNyk+h+Iz8lVKvFTNwVpHQ1QJHfyB1VLVT+2Y8Qizh6N4dCFam4GfZeC4MBXQFPBDNwGaIeE/zkl0+LL0ohe3BFIdA/3VgBtBXxZgP1Lg/qoG+hWznvsRcKH5gaHJ50fqBLNBEhVTsLMcahBNTWZd+Zfe/MPg+Ld5vllnCikUMjrTak3qq1Evs8vSSTMz8msG8ie0tlgnLEkTwUgmjgzfSSvSVdk5mPK1qTC9nh8aJrdmsnquTR/Bu2e1hcw4ygK8tk53rYvrgkMyAfZEtE2ZEKuwvfr7f2s/1S941IAb19pExQItJjbIpioMqHAGkab4V7IhaPCT5YVOnLz1vzyZfbeIpTwURueFUpL6xDsSLMiASKkbOLb/+icUz7EyrBhAEBR/a0SG06ZKE48PiAfqNcL1P/DOLiaQIlqoJGx6JbQfjzqc1gxtOPM2wLqkuigmrj2wyB95gDhjX4XDyjkska6VKmumaGXYLbXn/hDCyKrCMpv1aYf+YbsJz8HvzWjfLnXHs53YKFaBBwG9jkeazd3aXvf6E2zzqnUG3M9z7j1kfPxLwN/+BNU10Jn3DF2tigoWuvceGf602wox2UApXN4UPoYD0HlDsVtJUNYVmbXwR9AQRjrGdLAlAvZpj0SYJ7sQL8ctphY/DDOyou7718PlKwuvS8ad4SaPKRc/vi6uQSigv4YHEhL0w4ld9oTJQ4xyBuS6oGCum44IX9ce00wKSJQ9vXp2gUbiWpq0cCMYaTFc7qmpgDZQNqWuPYyoDSw3p1S1S98m/t5VkZUh6b6KRDJEgYjUutEPu+18pB/D3OY5z5mPGnfkBog8BkSx3zsM2GgEXpffWoPASs0CCwn0DTKEHZYzp7MdS9KM2YkChqyC4NvZvDqTdz+e2+Fo1NZk/MP/oHgONq6yimIUHsjZzP5VHnvAVmDE8HHWNZ4/gHE9XvjyU+1fwkAmZcYCL70NTIwkGW1ICyQsdrilvizSJK/HEzk0LVVlNHNMWSEuxMTsTpGf/5BL5rUe1WQttgbLGqStbXOci8vbOH/np6QgrmjTWikv40PrDGoVheCi3g47ViSjo/VzqJvhamXVr8SQSWWbzh99nv/0Zd+xmTUaJz7i5k9BqL3F0wXu1fdRiy32//cT2pzUexYnznSWkwmWGiO9EleOmb7teHOTzQVIyt1oWBmxp1UzMJSkCPbUZBbRXA//Jcr3L8J3Ab/JgFNomUVxttU1RdMRy4M9bd/It59tMvCYjHCWi2QMAoDsUEoyPLEll4b3wgYAw==
+          page_age: null
+          title: 'A Simple Treasury Futures Duration Adjustment INTEREST RATES:'
+          type: web_search_result
+          url: https://www.cmegroup.com/trading/interest-rates/files/Treasury_Duration_Strategy_Paper.pdf
+        - encrypted_content: EsUICioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDFPqvCZa5xpFjBzXPhoMuwi+RVxxaUl5D/5nIjC3Y70SKiNslK1cpKmkrDRfj6jxEkxloi+HgtqQ+RjHHBTFTMDzeuLIb2J8/ZBaqXUqyAeAHMFaYrFcA3krKLMgHxL6gDHT5SYe9M7KuGp0HhTBsyoqN8gDaV9LABcHmuCGKohfuYvbEBCRT1UvamZ23UmehLbzFu/rDy3E9RqQyXzFS4Jxkbb2jm5c2eEgpVO9uMHj51X1IXTu/qtz1qs0qXXaEZBs1xtVF8TtXg3BkYdn9NrRIyFkvayO5FbG6ThCFCAPOC/fTb/QEdbDstbBQm0tdWYqi+VWlmq3k3yFHg9swwECVYf2NS01UENa6ZmfJM197+PAiIs4bRht196D2HNCLXbFhwHjgLI+XwciMm/wfJF7whfGQ4JnxPwcLK4WMaX4LeygV95e3iXJVOlvEMvxC1fS0SnFhC1yULfSjIwg8sAMIGMS86o7Ydgm1l4SDNHb8j0NLq6+ztFCKM/V4EG5Z2WB2vywgsxZpGJZXDwMnlUDEhcDsnwCtvtIKBfTj8ZffTz9OABRnDl3wGgc/ZKsO7lGc7ip8bJTI567eA9/PI6nnVkBthrpFtnlaHxO48g+05Thegf30dGNy/8wMBigQao/6gQx3xlgjqwN6vPyaHP1GrXOrXaQiEEqWJXH+YmR4MunvNjvdKwInQcIac5+a1E6sjGh/0Ee/7M7onbpAAPlbaOYNcaopixSUnyTl5wf2w1WvvhdoPUtXS/WIAAxXrl2fwaOFcfmM+PXLywsMBOQwxnUjdMOjQE3T2IvaCgTipFkBKSNMO4W8bwwxd6u70AoXCz8Mi5ERar3TZS52pou5FfbbUkX7kbwUbuUSjABglDqB+tlPxSaWkcxLoKPbvC9OGgtLQHXxYVyxv7Thf8Z5ok1m5AaxdvUCbjWSU8BCB0cGSUp+rwpmxylx+WYHCabniCYfiqQVDnH9MUuCav3C9bggOO6BdwXR6eYXFSEBUXXZ5rrNd2dlEHUKYpoVicIVYTla5HgRWZOx/uBUCYRZetwtZCLaiQVUmX3rNgiJuoM92wN5T0ytA9glnHsZWBjqJIPJra9GcIIP/4NkEBpHmf148F5xDl7IZn1BBYJuT/is556SJpYeDva7MdEgA0BSvlDasItmrZzwkP2Hw7+iq9nWp8IkTlhI6KmLmRp87Eu0tZepQ2+HmJw0tAmAdg+X6ebZnLHlQ9O2OVn+AQzKOoJ2p2YhSbcuTt0BhHOxuPMkDMTiqJLGIvkgR/5fFnF/dh2+HQ6bJFIoucODdAUSiP/siNCkKJc+9M90AkEVwKCxhUognW0YdfoTZ0yiNWoQtDD8ki2H2Yi/aBpETs4870951jaYid1/EZiYNryEEtGox0zvRgD
+          page_age: 4 days ago
+          title: 10-Year T-Note Overview - CME Group
+          type: web_search_result
+          url: https://www.cmegroup.com/markets/interest-rates/us-treasury/10-year-us-treasury-note.html
+        - encrypted_content: EuAQCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDEVBABtjQxiVw2TDERoMucqb052Ke8vjW1QNIjAXQYZyhfKmcPKVsQDM3ZiITY7TN96pUrP4S7cgrSYIPwkAqV1tlDoQXWjTtKWWoXQq4w+G3lxxfZv35/h8PGh/LdACwJIzCP9MzqV8LN+ev1c8HO08EUZfInNSvk44D2juLl+P3g8w/2aDB0+Kc/pY9iRcLC5gYfTjQ21OkCZcp+NDZMQDJ8AqA7MncQnb2PyJ43evgLBDVJNUxdTJ8vvtyG4pWCiqntYzYWVRoowf6vDjk4DnR9oS/2sG9teBItzqR1RXja+GoA7XNfgvhnqkfcNlYvEWA8eohNBu5TOa2N0r+S85EuPx6Q4LX07NF+MMx79T2Tg6wYhLHq8F9kdmUqAn5mf0jl16dsdG7ypAGFQ07rClPw0EkrgerFwdFTMkgIb/NEg6x6f1d8FZt5OBaVhu0iEa7gtwS9DjfqmyUcRXBniLsFAcVQUSa6AOfMHjYEHLovbdg8Lpp9IMZ5Xc+VTltPplCx1uZgxjLAfxBR9pomJOvLKDX/pvBLTOnizMCyb9/WKalFSObSJx9y0149PQyP+mwpgIuDmNsT3y8c+1zwfByNw7+yp7jbT8KYu0SklygwNNndBF0/v7ZSy3qNqbQqgg0kgQj0DuIy6vDWbLIqtFB63zP2UbqiSl7SR5hxo4fnQXw/3b8bKs/XSso5GyVvxWM+TD4YtVB5ASG07c9hHj4AVFZZ+Wk4sf1tf3SeD1J3nNdoe+1V1TBW9x/UI2k1AAXlrqpMNao6DH9/FYZJjBphOzFfa5tmvA6yGg/tax3l0AEVMH/9+hz6quofKy2/Ql+hklFdlzreIcZE+QAc35VwHkMn9Qg+etdJgQGzXfnv6knbZyE4uttZirsRrYtsZDskziPW8jvxaZe9JwucqKmDeR8agSN3PZs32lrVJoPUbIDPwDT/0ODb1dUl4YMA9mvPSb/mTzeJrhPMqOvux+C7HL04neLN5X2Hqydwen1ywP9JQgWSzAkMrbTT4t2Kdvjhx51zZDP/+fP/CIGU9l5Ot/LA6lXzBdekqv6lroAmswEJBSK16buGSlrrQthECqNXRKaK1oeQBXaBmxU1wJ00agUwkkYjIMfmrmQxYK29n2FRsmilkC+jRl4LmUnTaPXW5uZWW5EYQ2D9J92kIug9foUyn35gv2PY6tD5Y70JLHH/XLssShJDMHbBG2m8qEM/3AeOaiBZ31M/E/N9SsnZXauoeRMuAIuShr69Ufvt2z0WaU5Kx9vqSbIKnpXFGBTg93YSPcGhBKKhk0Mf4UnDhiHUInsbdquArZn4GS0GL5UrMAnlK08adga2Uv3yWLKgMeRUFuZERuFQ2joE4OgXWHoay2N1PlGkeb8tJ3KsW9104/aPvapOT61gMmGTlAOd1vxgbcqD3NT2MJfxk6qiTgolQtjbAeP3DzUbiaj9vlcKPIQT8r2+8/tuiIo8g6vAOQE2uusk2Px4YfWz8qSkNijTGIo2Bpwe+d+mxdICVZwcC0ykKPaKZ/CzBMIO8ilWFtoGxuxLz9Tswx9X9pUV13ZGtmCVsnL15hUzSmWOSe8SzydcqgY+ZwdtRVsOqI6Em/SPgsMAqVkheRtPKEczk7bHFXXSZaSgXUgzJAYJ1i3MnUcYqvWCrDrxSuGekgTLnmuEW1SbCnJPB0Sk9g2mACRm3qtPww4NVZrJ1wJH5SVdPCxWNw7jDT/AlZsrsyp6zS1hXhhJNMKLZqKSYUqrYXLXoA6TN85UHxjH7YE1A0yYbjAG2/Y9W/5v3UYXn/oHdtnBekXtnR2/dZ6donqJiTIIo39VHg6v8CLHkChFT8Ss7MtXicQyauqhQW75dnau/upmIFFYujCIfBvqMo72OyMWVNzHGoJ+eRV+QL6ymHnmpH9c3G5PuN9MFOzmcryOxVmOBsVC85tTB/1qBfgPDodM6wbi/vk7NqsDf8blsQuxU6Bw7eBhKlSqnv3EHJJg1Pg4mbr/bXL7vbvHDeWWpU/yDCcSyKVQsI7BdxYXzN99+wL4dKrOIBF7Y+Xf1WFg0Je+QlK/SBDOozht0OePRYR1EfJ43MF9B00J9OAyQ49H5shWkjeoyKg7XtG+IEtEAcq4LMgoU1hXZ1/UQ5wNHXt9bypc7wqzowOX6JVMfUDovk7RRxSvPC4RYj0ABjeBzBvNebHAK3o1F5yhgrZh5qfAplf8hVR+4kxpAloIqPGb1VFIDjeNi26ZH8veUVWhcpwGE84EjQ5ZElODryrNL1cSOBfLzgSLADwj1cflm9kllbWS7R5Onv07Hgqm5BZsS5TIDYtcWifEATjx86pBjEFHwu2pLv5F1Ca6ps3f4NUik05T+27Iuwvfve4YORBkcDuEhpfv8Mu+rEPsMIAtBF7C7yWyilHSXeJFWv2N7MbJy0+KQ3EurdCb87BLZsS33MS9wvA4uc66kBd+oQxbWG/yBiZ6R3Wc1fP8VmfFVVEeQG9s8H81qEmnWlpUZPT1wlNbplvu2PNTIjowsw3oNxwoAHpYDqXVz1c0PlgNCSI0nE8FElelQT8XIqMTeReX4fgnMk+wEOYxqt7paW9ek+JaJmdvK+woZJOkZAQG0+dVS+JUSIabyFfPJdoajTeJMQgq5qIhRJyMpszQ78EhtBhVL9KGlxprp/kDeM2rrZk28F/YOgI4vH8uvjvnu3JSu0cq6Rf8c520OkNjaZQI+vjdJvVYBpU8lXMb6aon1Jvh/zUrw/FHdNSFshB5H6wC8Kk/st5u8OOpl065uHZH3P1Psdw011o2np1l9WGB4YAw==
+          page_age: null
+          title: 0% found this document useful (0 votes)
+          type: web_search_result
+          url: https://www.scribd.com/doc/216589390/Lecture-5-Tutorial
+        tool_use_id: srvtoolu_01EoSNE7k4dUJyGatASCV5qs
+        type: web_search_tool_result
+      - text: 'Based on the search results, '
+        type: text
+      - citations:
+        - cited_text: 'For example, consider our previously mentioned 10-Year note: if its duration was 8.95 years and yields
+            move higher from 1.30% to 2.30%, or by 1.0%, we...'
+          encrypted_index: Eo8BCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDPl+HMSEZVMZ9uSgAxoMKCCi4IsKNFxwd8NeIjCGngNWKED0BHCzs0w9S4LEHOGvyiP1Y91bNXhO3NNf4AcLcOnaXPjadIEInsvd8GsqE5YQR9kLASgeVWnE1nFAzKn45ZIYBA==
+          title: How Can You Measure Risk in Treasuries?
+          type: web_search_result_location
+          url: https://www.cmegroup.com/education/courses/introduction-to-treasuries/how-can-you-measure-risk-in-treasuries
+        - cited_text: 'For example, consider our previously mentioned 10-Year note: if its duration was 8.95 years and yields
+            move higher from 1.30% to 2.30%, or by 1.0%, we...'
+          encrypted_index: Eo8BCioIEhgCIiRmMDIyNDhmOC1jZWJhLTRlNmMtYmU3MC0yMGZkNzI5ZWM4YTESDEuM2kVS4MbFNSOyyhoMXVCRFn3yf6SMicZfIjAwRLHFVQGaF4w8N6O0WMrzpC8N4BHSIWN8YXTiEM4ZFn/Ef4vBeAElNWyTq8cH0ioqE/3e7B/+CikxRhP53+O9SsBaufQYBA==
+          title: How Can You Measure Risk in Treasuries?
+          type: web_search_result_location
+          url: https://www.cmegroup.com/education/courses/introduction-to-treasuries/how-can-you-measure-risk-in-treasuries
+        text: the duration of a 10-year Treasury note is approximately 8.95 years
+        type: text
+      - text: |2-
+           (this example was given when yields were at 1.30%). However, it's important to note that the exact duration varies depending on current market conditions, coupon rates, and yield levels.
+
+          The duration typically ranges between 7 to 9 years for 10-year Treasury securities based on the examples found in the search results.
+
+          And 2 + 2 = **4**
+        type: text
+      id: msg_011Ce8rnihPaManLmLWXsoeR
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 8606
+        output_tokens: 132
+        server_tool_use:
+          web_fetch_requests: 0
+          web_search_requests: 1
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/anthropic/cassettes/test_unpaired_native_tool_calls/test_unpaired_native_tool_call_history_is_accepted.yaml
+++ b/tests/models/anthropic/cassettes/test_unpaired_native_tool_calls/test_unpaired_native_tool_call_history_is_accepted.yaml
@@ -1,0 +1,110 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '965'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: Look up the 10-year Treasury duration, then add 2 and 2.
+          type: text
+        role: user
+      - content:
+        - id: toolu_01WjXqPrN8vKsRt2YbLmZdQe
+          input:
+            a: 2
+            b: 2
+          name: add
+          type: tool_use
+        role: assistant
+      - content:
+        - content:
+          - text: '4'
+            type: text
+          is_error: false
+          tool_use_id: toolu_01WjXqPrN8vKsRt2YbLmZdQe
+          type: tool_result
+        role: user
+      - content:
+        - text: It is 4.
+          type: text
+        role: assistant
+      - content:
+        - text: 'In one sentence: does a longer duration mean more interest-rate risk?'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      tool_choice:
+        type: auto
+      tools:
+      - description: Add two numbers.
+        input_schema:
+          additionalProperties: false
+          properties:
+            a:
+              type: integer
+            b:
+              type: integer
+          required:
+          - a
+          - b
+          type: object
+        name: add
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '625'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-39136e34dc0d6541318959d574e9135f-7482c92b04c96c8d-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - text: Yes, a longer duration means more interest-rate risk because the bond's price will be more sensitive to changes
+          in interest rates.
+        type: text
+      id: msg_011Ce7QXwgnRjsN8rb19Q7xz
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 699
+        output_tokens: 29
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -30,7 +30,7 @@ from pydantic_ai import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.messages import CachePoint, NativeToolSearchCallPart
+from pydantic_ai.messages import CachePoint, NativeToolSearchCallPart, ThinkingPart
 from pydantic_ai.models import ModelRequestParameters
 
 from ..._inline_snapshot import snapshot
@@ -266,6 +266,88 @@ async def test_dropped_call_keeps_the_cache_boundary():
                 ],
             },
             {'role': 'assistant', 'content': [{'text': 'It is 8.1.', 'type': 'text'}]},
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
+        ]
+    )
+
+
+_THINKING = ThinkingPart(content='Searching for the duration.', signature='sig', provider_name='anthropic')
+
+
+async def test_dropped_call_skips_a_block_that_cannot_carry_the_boundary():
+    """The breakpoint walks back past a `thinking` block, which takes no `cache_control`.
+
+    An assistant turn that reasons before calling a server tool renders `[thinking, server_tool_use]`,
+    so the block right before the dropped one is routinely one that would raise if handed the boundary.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+        ModelResponse(parts=[TextPart(content='Searching.'), _THINKING, _SEARCH_CALL], provider_name='anthropic'),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [{'text': 'Look up the 10-year Treasury duration, then add 2 and 2.', 'type': 'text'}],
+            },
+            {
+                'role': 'assistant',
+                'content': [
+                    {'text': 'Searching.', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                    {'thinking': 'Searching for the duration.', 'signature': 'sig', 'type': 'thinking'},
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
+        ]
+    )
+
+
+async def test_dropped_call_hands_the_boundary_back_a_message_when_its_turn_cannot_carry_it():
+    """A turn left holding only a `thinking` block passes the breakpoint to the message before it.
+
+    Nothing in the assistant turn can carry `cache_control` once the call is gone, and dropping the
+    breakpoint instead would silently re-process the whole tail on every later request.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+        ModelResponse(parts=[_THINKING, _SEARCH_CALL], provider_name='anthropic'),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': 'Look up the 10-year Treasury duration, then add 2 and 2.',
+                        'type': 'text',
+                        'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
+                    }
+                ],
+            },
+            {
+                'role': 'assistant',
+                'content': [{'thinking': 'Searching for the duration.', 'signature': 'sig', 'type': 'thinking'}],
+            },
             {
                 'role': 'user',
                 'content': [

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -2,14 +2,14 @@
 
 Anthropic fails a whole request with `<tool> tool use with id ... was found without a corresponding
 <tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes unpaired. It makes one
-exception, for the request that ends at the tool-result turn right after the call, where the result is
-still in flight. That exception is what makes the bug survivable long enough to store: the turn is
-accepted once, and every later request built from that history replays the unpaired call and fails.
+exception while every message after the call is a user turn containing only concurrent client-tool
+results, where the native result is still in flight. That exception is what makes the bug survivable
+long enough to store: the turn is accepted once, and a later non-result message makes replay fail.
 
-Measured on `claude-sonnet-4-5` — the same history is accepted while the request ends at the
-tool-result turn and rejected as soon as one more turn follows, with no reasoning or other content
-involved. `_drop_unpaired_native_tool_calls` decides pairing on the blocks actually built, so a result
-that never arrived and a result whose part didn't render both leave the call unpaired and both drop.
+Measured on `claude-sonnet-4-5` — the same history is accepted while every turn after the call
+carries nothing but tool results, and rejected as soon as a turn with any other content follows, with
+no reasoning involved. Pairing is decided on the blocks actually built, so a result that never
+arrived and a result whose part didn't render both leave the call unpaired and both drop.
 """
 
 from __future__ import annotations as _annotations
@@ -115,6 +115,7 @@ class Case:
     history: list[ModelMessage]
     expected: list[tuple[str, list[str]]]
     follow_up: bool = True
+    expected_call_ids: list[str] | None = None
 
     def __str__(self) -> str:
         return self.id
@@ -206,10 +207,41 @@ CASES = [
             ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
         ],
         follow_up=False,
+        expected_call_ids=[_SEARCH_ID, _TOOL_CALL_ID],
         expected=snapshot(
             [
                 ('user', ['text']),
                 ('assistant', ['server_tool_use', 'tool_use']),
+                ('user', ['tool_result']),
+            ]
+        ),
+    ),
+    Case(
+        # Two tool-result turns can follow the call when the model called two client tools and their
+        # results came back separately. Measured as accepted too, so the exemption reads the whole
+        # suffix rather than a single turn.
+        'in-flight-call-is-kept-behind-two-tool-result-turns',
+        [
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(
+                parts=[
+                    _SEARCH_CALL,
+                    ToolCallPart(tool_name='add', args={}, tool_call_id=_TOOL_CALL_ID),
+                    ToolCallPart(tool_name='double', args={}, tool_call_id='toolu_01DoUbLeCaLLiDeNtIfIeR00'),
+                ]
+            ),
+            ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+            ModelRequest(
+                parts=[ToolReturnPart(tool_name='double', content='8', tool_call_id='toolu_01DoUbLeCaLLiDeNtIfIeR00')]
+            ),
+        ],
+        follow_up=False,
+        expected_call_ids=[_SEARCH_ID, _TOOL_CALL_ID, 'toolu_01DoUbLeCaLLiDeNtIfIeR00'],
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['server_tool_use', 'tool_use', 'tool_use']),
+                ('user', ['tool_result']),
                 ('user', ['tool_result']),
             ]
         ),
@@ -231,6 +263,7 @@ CASES = [
             ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
         ],
         follow_up=False,
+        expected_call_ids=[_TOOL_CALL_ID],
         expected=snapshot(
             [
                 ('user', ['text']),
@@ -245,6 +278,7 @@ CASES = [
         # mcp_tool_result block`, measured live against a control with the call removed.
         'mcp-result-never-arrived-drops-the-call',
         _continued_history(_MCP_CALL),
+        expected_call_ids=[_TOOL_CALL_ID],
         expected=snapshot(
             [
                 ('user', ['text']),
@@ -263,6 +297,7 @@ CASES = [
             ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
         ],
         follow_up=False,
+        expected_call_ids=[_MCP_CALL_ID, _TOOL_CALL_ID],
         expected=snapshot(
             [
                 ('user', ['text']),
@@ -287,6 +322,15 @@ async def test_drop_unpaired_native_tool_calls(case: Case):
         history, ModelRequestParameters(), AnthropicModelSettings()
     )
     assert message_shape({'messages': [dict(message) for message in messages]}) == case.expected
+    if case.expected_call_ids is not None:
+        call_ids: list[str] = []
+        for message in messages:
+            content = message['content']
+            assert isinstance(content, list)
+            for block in content:
+                if isinstance(block, dict) and isinstance(block_id := block.get('id'), str):
+                    call_ids.append(block_id)
+        assert call_ids == case.expected_call_ids
 
 
 async def test_mcp_call_answered_by_its_replayed_result_is_kept():
@@ -323,10 +367,11 @@ async def test_mcp_call_answered_by_its_replayed_result_is_kept():
 
 
 async def test_dropped_call_keeps_the_cache_boundary():
-    """A `CachePoint` authored on the dropped block lands on the block before it.
+    """A breakpoint authored earlier in the payload stays where it is when the call's turn goes away.
 
-    Losing the breakpoint would silently re-process the tail on every later request, and moving it
-    forward would cache content the user placed outside the boundary — both are invisible at runtime.
+    The turn holding the unpaired call carries no breakpoint of its own here, so removing it must not
+    disturb one: moving the boundary forward would cache content the user placed outside it, and
+    losing it would silently re-process the tail on every later request.
     """
     model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
     history: list[ModelMessage] = [
@@ -412,6 +457,75 @@ async def test_dropped_call_hands_the_boundary_back_a_message_when_its_turn_cann
     history: list[ModelMessage] = [
         ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
         ModelResponse(parts=[_THINKING, _SEARCH_CALL], provider_name='anthropic'),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': 'Look up the 10-year Treasury duration, then add 2 and 2.',
+                        'type': 'text',
+                        'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
+                    }
+                ],
+            },
+            {
+                'role': 'assistant',
+                'content': [{'thinking': 'Searching for the duration.', 'signature': 'sig', 'type': 'thinking'}],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
+        ]
+    )
+
+
+async def test_dropped_call_that_opens_the_payload_gives_up_its_boundary():
+    """A breakpoint with nothing before it to hold it is lost rather than failing the request.
+
+    Nothing precedes the dropped block, so there is no cacheable block anywhere to walk back to. The
+    `CachePoint` that authored the boundary lived on the block going away, so a raise here would fail
+    a request over a breakpoint the user can no longer see.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelResponse(parts=[_SEARCH_CALL], provider_name='anthropic'),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            }
+        ]
+    )
+
+
+async def test_dropped_call_hands_its_boundary_across_a_turn_that_cannot_carry_it():
+    """The search for a carrier crosses message boundaries, not just the dropped block's own turn.
+
+    The message before the dropped one holds a lone `thinking` block, which takes no `cache_control`,
+    so the nearest block that can carry the boundary is two turns back.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+        ModelResponse(parts=[_THINKING], provider_name='anthropic'),
+        ModelResponse(parts=[_SEARCH_CALL], provider_name='anthropic'),
         ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
     ]
     _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
@@ -609,13 +723,41 @@ async def test_unpaired_native_tool_call_history_is_accepted(
     result = await agent.run(_FOLLOW_UP, message_history=_continued_history(_SEARCH_CALL))
 
     body = request_capture.body('/v1/messages')
-    assert message_shape(body) == snapshot(
+    assert body['messages'] == snapshot(
         [
-            ('user', ['text']),
-            ('assistant', ['tool_use']),
-            ('user', ['tool_result']),
-            ('assistant', ['text']),
-            ('user', ['text']),
+            {
+                'role': 'user',
+                'content': [{'text': 'Look up the 10-year Treasury duration, then add 2 and 2.', 'type': 'text'}],
+            },
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe',
+                        'type': 'tool_use',
+                        'name': 'add',
+                        'input': {'a': 2, 'b': 2},
+                    }
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'tool_use_id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe',
+                        'type': 'tool_result',
+                        'content': [{'text': '4', 'type': 'text'}],
+                        'is_error': False,
+                    }
+                ],
+            },
+            {'role': 'assistant', 'content': [{'text': 'It is 4.', 'type': 'text'}]},
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
         ]
     )
     assert result.output == snapshot(
@@ -670,8 +812,42 @@ async def test_in_flight_mcp_call_history_is_accepted(
     )
 
     body = request_capture.body('/v1/messages')
-    assert message_shape(body) == snapshot(
-        [('user', ['text']), ('assistant', ['mcp_tool_use', 'tool_use']), ('user', ['tool_result'])]
+    assert body['messages'] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [{'text': 'Look up the 10-year Treasury duration, then add 2 and 2.', 'type': 'text'}],
+            },
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'id': 'mcptoolu_01SAss3KEwASziHZoMR6HcZU',
+                        'type': 'mcp_tool_use',
+                        'server_name': 'deepwiki',
+                        'name': 'ask_question',
+                        'input': {'question': 'What is pydantic-ai?', 'repoName': 'pydantic/pydantic-ai'},
+                    },
+                    {
+                        'id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe',
+                        'type': 'tool_use',
+                        'name': 'add',
+                        'input': {'a': 2, 'b': 2},
+                    },
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'tool_use_id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe',
+                        'type': 'tool_result',
+                        'content': [{'text': '4', 'type': 'text'}],
+                        'is_error': False,
+                    }
+                ],
+            },
+        ]
     )
     assert result.output == snapshot("""\
 I apologize, but I don't have the ability to look up the 10-year Treasury duration. The tools available to me are limited to asking questions about GitHub repositories and performing basic mathematical operations.
@@ -716,8 +892,41 @@ async def test_in_flight_native_tool_call_history_is_accepted(
     )
 
     body = request_capture.body('/v1/messages')
-    assert message_shape(body) == snapshot(
-        [('user', ['text']), ('assistant', ['server_tool_use', 'tool_use']), ('user', ['tool_result'])]
+    assert body['messages'] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [{'text': 'Look up the 10-year Treasury duration, then add 2 and 2.', 'type': 'text'}],
+            },
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'id': 'srvtoolu_01EoSNE7k4dUJyGatASCV5qs',
+                        'type': 'server_tool_use',
+                        'name': 'web_search',
+                        'input': {'query': '10-year Treasury modified duration'},
+                    },
+                    {
+                        'id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe',
+                        'type': 'tool_use',
+                        'name': 'add',
+                        'input': {'a': 2, 'b': 2},
+                    },
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'tool_use_id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe',
+                        'type': 'tool_result',
+                        'content': [{'text': '4', 'type': 'text'}],
+                        'is_error': False,
+                    }
+                ],
+            },
+        ]
     )
     assert result.output == snapshot("""\
 Based on the search results, the duration of a 10-year Treasury note is approximately 8.95 years (this example was given when yields were at 1.30%). However, it's important to note that the exact duration varies depending on current market conditions, coupon rates, and yield levels.

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -17,7 +17,6 @@ from __future__ import annotations as _annotations
 from dataclasses import dataclass
 
 import pytest
-from anthropic.types.beta import BetaMCPToolResultBlock, BetaTextBlock
 
 from pydantic_ai import (
     Agent,
@@ -40,6 +39,8 @@ from ...conftest import try_import
 from ..conftest import AnthropicModelFactory, RequestCapture, message_shape
 
 with try_import() as imports_successful:
+    from anthropic.types.beta import BetaMCPToolResultBlock, BetaTextBlock
+
     from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
     from pydantic_ai.providers.anthropic import AnthropicProvider
 

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -17,6 +17,7 @@ from __future__ import annotations as _annotations
 from dataclasses import dataclass
 
 import pytest
+from anthropic.types.beta import BetaMCPToolResultBlock, BetaTextBlock
 
 from pydantic_ai import (
     Agent,
@@ -32,6 +33,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.messages import CachePoint, NativeToolSearchCallPart, ThinkingPart
 from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.native_tools import MCPServerTool
 
 from ..._inline_snapshot import snapshot
 from ...conftest import try_import
@@ -347,6 +349,68 @@ async def test_dropped_call_hands_the_boundary_back_a_message_when_its_turn_cann
             {
                 'role': 'assistant',
                 'content': [{'thinking': 'Searching for the duration.', 'signature': 'sig', 'type': 'thinking'}],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
+        ]
+    )
+
+
+_MCP_CALL_ID = 'mcptoolu_01AbCdEfGhIjKlMnOpQrStUv'
+
+
+async def test_dropped_call_skips_a_block_that_is_not_a_mapping():
+    """A replayed MCP result renders as a Pydantic model, which subscripting would raise on.
+
+    It shares an assistant turn with a native call whenever the model used both, so the boundary search
+    walks over blocks that aren't `dict`s at all, not just ones that can't carry `cache_control`.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+        ModelResponse(
+            parts=[
+                NativeToolReturnPart(
+                    tool_name=f'{MCPServerTool.kind}:docs',
+                    content={'content': [{'type': 'text', 'text': '8.1'}], 'is_error': False},
+                    tool_call_id=_MCP_CALL_ID,
+                    provider_name='anthropic',
+                ),
+                _SEARCH_CALL,
+            ],
+            provider_name='anthropic',
+        ),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': 'Look up the 10-year Treasury duration, then add 2 and 2.',
+                        'type': 'text',
+                        'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
+                    }
+                ],
+            },
+            {
+                'role': 'assistant',
+                'content': [
+                    BetaMCPToolResultBlock(
+                        content=[BetaTextBlock(text='8.1', type='text')],
+                        is_error=False,
+                        tool_use_id='mcptoolu_01AbCdEfGhIjKlMnOpQrStUv',
+                        type='mcp_tool_result',
+                    )
+                ],
             },
             {
                 'role': 'user',

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -30,16 +30,18 @@ from pydantic_ai import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.messages import CachePoint, NativeToolSearchCallPart, ThinkingPart
+from pydantic_ai.capabilities import NativeTool, ToolSearch
+from pydantic_ai.messages import CachePoint, ModelResponsePart, NativeToolSearchCallPart, ThinkingPart
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.native_tools import MCPServerTool
+from pydantic_ai.native_tools import MCPServerTool, WebSearchTool
 
 from ..._inline_snapshot import snapshot
 from ...conftest import try_import
 from ..conftest import AnthropicModelFactory, RequestCapture, message_shape
+from ..test_anthropic import MockAnthropic, completion_message, get_mock_chat_completion_kwargs
 
 with try_import() as imports_successful:
-    from anthropic.types.beta import BetaMCPToolResultBlock, BetaTextBlock
+    from anthropic.types.beta import BetaMCPToolResultBlock, BetaTextBlock, BetaUsage
 
     from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
     from pydantic_ai.providers.anthropic import AnthropicProvider
@@ -51,6 +53,7 @@ pytestmark = [
 
 _SEARCH_ID = 'srvtoolu_01EoSNE7k4dUJyGatASCV5qs'
 _TOOL_CALL_ID = 'toolu_01WjXqPrN8vKsRt2YbLmZdQe'
+_MCP_CALL_ID = 'mcptoolu_01AbCdEfGhIjKlMnOpQrStUv'
 _QUESTION = 'Look up the 10-year Treasury duration, then add 2 and 2.'
 _FOLLOW_UP = 'In one sentence: does a longer duration mean more interest-rate risk?'
 
@@ -70,6 +73,20 @@ _RENDERABLE_RESULT = [
 ]
 
 
+_MCP_CALL = NativeToolCallPart(
+    tool_name=f'{MCPServerTool.kind}:docs',
+    args={'tool_name': 'ask_question', 'tool_args': {'question': 'What is the 10-year Treasury duration?'}},
+    tool_call_id=_MCP_CALL_ID,
+    provider_name='anthropic',
+)
+_MCP_RETURN = NativeToolReturnPart(
+    tool_name=f'{MCPServerTool.kind}:docs',
+    content={'content': [{'type': 'text', 'text': '8.1'}], 'is_error': False},
+    tool_call_id=_MCP_CALL_ID,
+    provider_name='anthropic',
+)
+
+
 def _search_return(content: object) -> NativeToolReturnPart:
     return NativeToolReturnPart(
         tool_name='web_search', content=content, tool_call_id=_SEARCH_ID, provider_name='anthropic'
@@ -78,12 +95,12 @@ def _search_return(content: object) -> NativeToolReturnPart:
 
 # The conversation continues past the tool-result turn, which is what turns a survivable in-flight call
 # into a permanently unsendable history.
-def _continued_history(*response_parts: object) -> list[ModelMessage]:
+def _continued_history(*response_parts: ModelResponsePart) -> list[ModelMessage]:
     return [
         ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
         ModelResponse(
             parts=[
-                *response_parts,  # pyright: ignore[reportArgumentType]
+                *response_parts,
                 ToolCallPart(tool_name='add', args={'a': 2, 'b': 2}, tool_call_id=_TOOL_CALL_ID),
             ]
         ),
@@ -222,6 +239,38 @@ CASES = [
             ]
         ),
     ),
+    Case(
+        # `mcp_tool_use` is the other block type Anthropic pairs, and it fails the same way: an
+        # unpaired one is rejected with `mcp_tool_use with id ... was found without a corresponding
+        # mcp_tool_result block`, measured live against a control with the call removed.
+        'mcp-result-never-arrived-drops-the-call',
+        _continued_history(_MCP_CALL),
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['tool_use']),
+                ('user', ['tool_result']),
+                ('assistant', ['text']),
+                ('user', ['text']),
+            ]
+        ),
+    ),
+    Case(
+        'in-flight-mcp-call-is-kept',
+        [
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(parts=[_MCP_CALL, ToolCallPart(tool_name='add', args={}, tool_call_id=_TOOL_CALL_ID)]),
+            ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+        ],
+        follow_up=False,
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['mcp_tool_use', 'tool_use']),
+                ('user', ['tool_result']),
+            ]
+        ),
+    ),
 ]
 
 
@@ -238,6 +287,39 @@ async def test_drop_unpaired_native_tool_calls(case: Case):
         history, ModelRequestParameters(), AnthropicModelSettings()
     )
     assert message_shape({'messages': [dict(message) for message in messages]}) == case.expected
+
+
+async def test_mcp_call_answered_by_its_replayed_result_is_kept():
+    """A replayed MCP result pairs its call, so neither block is dropped.
+
+    Asserted whole rather than through `message_shape`, which subscripts blocks: the result comes back
+    as an SDK model, and it is the `tool_use_id` on that model that has to match the call's `id`.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        _continued_history(_MCP_CALL, _MCP_RETURN), ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages][1] == snapshot(
+        {
+            'role': 'assistant',
+            'content': [
+                {
+                    'id': 'mcptoolu_01AbCdEfGhIjKlMnOpQrStUv',
+                    'type': 'mcp_tool_use',
+                    'server_name': 'docs',
+                    'name': 'ask_question',
+                    'input': {'question': 'What is the 10-year Treasury duration?'},
+                },
+                BetaMCPToolResultBlock(
+                    content=[BetaTextBlock(text='8.1', type='text')],
+                    is_error=False,
+                    tool_use_id='mcptoolu_01AbCdEfGhIjKlMnOpQrStUv',
+                    type='mcp_tool_result',
+                ),
+                {'id': 'toolu_01WjXqPrN8vKsRt2YbLmZdQe', 'type': 'tool_use', 'name': 'add', 'input': {'a': 2, 'b': 2}},
+            ],
+        }
+    )
 
 
 async def test_dropped_call_keeps_the_cache_boundary():
@@ -361,9 +443,6 @@ async def test_dropped_call_hands_the_boundary_back_a_message_when_its_turn_cann
     )
 
 
-_MCP_CALL_ID = 'mcptoolu_01AbCdEfGhIjKlMnOpQrStUv'
-
-
 async def test_dropped_call_skips_a_block_that_is_not_a_mapping():
     """A replayed MCP result renders as a Pydantic model, which subscripting would raise on.
 
@@ -461,6 +540,51 @@ async def test_dropped_call_hands_its_cache_boundary_to_the_block_before_it():
     )
 
 
+async def test_orphaned_tool_search_call_is_dropped_through_an_agent_run(allow_model_requests: None):
+    """The tool-search drop reaches the wire through an agent run, not only through the mapper.
+
+    Anthropic occasionally emits a `tool_search_tool_*` server tool use alongside a client `tool_use`
+    and ends the turn before delivering the corresponding result block
+    (https://github.com/anthropics/anthropic-sdk-python/issues/1325), so this is the shape a
+    `ToolSearch()` run actually stores. Reported by @kclisp on PR #5143.
+    """
+    mock_client = MockAnthropic.create_mock(
+        completion_message([BetaTextBlock(text='ok', type='text')], BetaUsage(input_tokens=5, output_tokens=5))
+    )
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(model, capabilities=[ToolSearch()])
+
+    @agent.tool_plain
+    def send_status(message: str) -> str:  # pragma: no cover
+        return 'ok'
+
+    @agent.tool_plain(defer_loading=True)
+    def pay_rent() -> str:  # pragma: no cover
+        return 'paid'
+
+    history: list[ModelMessage] = [
+        ModelRequest.user_text_prompt('pay rent and send status'),
+        ModelResponse(
+            parts=[
+                NativeToolSearchCallPart(
+                    tool_call_id='srv_orphan',
+                    provider_name='anthropic',
+                    args={'queries': ['pay.*']},
+                    provider_details={'strategy': 'regex'},
+                ),
+                ToolCallPart(tool_name='send_status', args={'message': 'looking'}, tool_call_id='cl_1'),
+            ],
+            provider_name='anthropic',
+        ),
+        ModelRequest(parts=[ToolReturnPart(tool_name='send_status', content='ok', tool_call_id='cl_1')]),
+    ]
+    await agent.run('continue', message_history=history)
+
+    assert message_shape(get_mock_chat_completion_kwargs(mock_client)[0]) == snapshot(
+        [('user', ['text']), ('assistant', ['tool_use']), ('user', ['tool_result', 'text'])]
+    )
+
+
 @pytest.mark.vcr
 async def test_unpaired_native_tool_call_history_is_accepted(
     allow_model_requests: None,
@@ -497,3 +621,49 @@ async def test_unpaired_native_tool_call_history_is_accepted(
     assert result.output == snapshot(
         "Yes, a longer duration means more interest-rate risk because the bond's price will be more sensitive to changes in interest rates."
     )
+
+
+@pytest.mark.vcr
+async def test_in_flight_native_tool_call_history_is_accepted(
+    allow_model_requests: None,
+    anthropic_model: AnthropicModelFactory,
+    request_capture: RequestCapture,
+):
+    """Anthropic answers a history whose unpaired call is still in flight, so keeping it is safe.
+
+    The kept side of the same claim the drop rests on. Dropping a call here would break a pause-turn
+    resume, whose whole point is to continue it, and the payload still goes out unpaired — so the
+    recorded 200 is the assertion, with the body read off the wire pinning that the call survived.
+    """
+    model: AnthropicModel = anthropic_model('claude-sonnet-4-5', capture=True)
+    agent = Agent(model, capabilities=[NativeTool(WebSearchTool())])
+
+    @agent.tool_plain
+    def add(a: int, b: int) -> str:
+        """Add two numbers."""
+        return '4'  # pragma: no cover
+
+    result = await agent.run(
+        message_history=[
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(
+                parts=[
+                    _SEARCH_CALL,
+                    ToolCallPart(tool_name='add', args={'a': 2, 'b': 2}, tool_call_id=_TOOL_CALL_ID),
+                ]
+            ),
+            ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+        ]
+    )
+
+    body = request_capture.body('/v1/messages')
+    assert message_shape(body) == snapshot(
+        [('user', ['text']), ('assistant', ['server_tool_use', 'tool_use']), ('user', ['tool_result'])]
+    )
+    assert result.output == snapshot("""\
+Based on the search results, the duration of a 10-year Treasury note is approximately 8.95 years (this example was given when yields were at 1.30%). However, it's important to note that the exact duration varies depending on current market conditions, coupon rates, and yield levels.
+
+The duration typically ranges between 7 to 9 years for 10-year Treasury securities based on the examples found in the search results.
+
+And 2 + 2 = **4**\
+""")

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -623,6 +623,65 @@ async def test_unpaired_native_tool_call_history_is_accepted(
     )
 
 
+# The server name on the block has to match a declared MCP server, so the live call names the one
+# `test_anthropic_mcp_servers` already records against.
+_LIVE_MCP_CALL = NativeToolCallPart(
+    tool_name=f'{MCPServerTool.kind}:deepwiki',
+    args={
+        'tool_name': 'ask_question',
+        'tool_args': {'question': 'What is pydantic-ai?', 'repoName': 'pydantic/pydantic-ai'},
+    },
+    tool_call_id='mcptoolu_01SAss3KEwASziHZoMR6HcZU',
+    provider_name='anthropic',
+)
+
+
+@pytest.mark.vcr
+async def test_in_flight_mcp_call_history_is_accepted(
+    allow_model_requests: None,
+    anthropic_model: AnthropicModelFactory,
+    request_capture: RequestCapture,
+):
+    """Anthropic answers a history carrying an unpaired `mcp_tool_use` whose result is in flight.
+
+    The in-flight exemption is written against the block type rather than one tool, and a continued
+    conversation is what was measured as rejected for `mcp_tool_use`. This records the other side for
+    the same block type, so keeping it rests on a 200 rather than on the `server_tool_use` result.
+    """
+    model: AnthropicModel = anthropic_model('claude-sonnet-4-5', capture=True)
+    agent = Agent(model, capabilities=[NativeTool(MCPServerTool(id='deepwiki', url='https://mcp.deepwiki.com/mcp'))])
+
+    @agent.tool_plain
+    def add(a: int, b: int) -> str:
+        """Add two numbers."""
+        return '4'  # pragma: no cover
+
+    result = await agent.run(
+        message_history=[
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(
+                parts=[
+                    _LIVE_MCP_CALL,
+                    ToolCallPart(tool_name='add', args={'a': 2, 'b': 2}, tool_call_id=_TOOL_CALL_ID),
+                ]
+            ),
+            ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+        ]
+    )
+
+    body = request_capture.body('/v1/messages')
+    assert message_shape(body) == snapshot(
+        [('user', ['text']), ('assistant', ['mcp_tool_use', 'tool_use']), ('user', ['tool_result'])]
+    )
+    assert result.output == snapshot("""\
+I apologize, but I don't have the ability to look up the 10-year Treasury duration. The tools available to me are limited to asking questions about GitHub repositories and performing basic mathematical operations.
+
+However, I can tell you that **2 + 2 = 4**.
+
+Regarding the 10-year Treasury duration, typically the duration of a 10-year U.S. Treasury bond is approximately 8-9 years (it's less than the maturity because duration accounts for the present value of all cash flows including coupon payments). However, the exact duration varies based on the current yield and coupon rate. You would need to check current financial data sources like Bloomberg, the U.S. Treasury website, or financial news outlets for the most accurate current duration figure.\
+""")
+
+
 @pytest.mark.vcr
 async def test_in_flight_native_tool_call_history_is_accepted(
     allow_model_requests: None,

--- a/tests/models/anthropic/test_unpaired_native_tool_calls.py
+++ b/tests/models/anthropic/test_unpaired_native_tool_calls.py
@@ -1,0 +1,352 @@
+"""A native tool call with no result block is dropped from the replayed payload.
+
+Anthropic fails a whole request with `<tool> tool use with id ... was found without a corresponding
+<tool>_tool_result block` when a `server_tool_use` or `mcp_tool_use` block goes unpaired. It makes one
+exception, for the request that ends at the tool-result turn right after the call, where the result is
+still in flight. That exception is what makes the bug survivable long enough to store: the turn is
+accepted once, and every later request built from that history replays the unpaired call and fails.
+
+Measured on `claude-sonnet-4-5` — the same history is accepted while the request ends at the
+tool-result turn and rejected as soon as one more turn follows, with no reasoning or other content
+involved. `_drop_unpaired_native_tool_calls` decides pairing on the blocks actually built, so a result
+that never arrived and a result whose part didn't render both leave the call unpaired and both drop.
+"""
+
+from __future__ import annotations as _annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from pydantic_ai import (
+    Agent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    NativeToolCallPart,
+    NativeToolReturnPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.messages import CachePoint, NativeToolSearchCallPart
+from pydantic_ai.models import ModelRequestParameters
+
+from ..._inline_snapshot import snapshot
+from ...conftest import try_import
+from ..conftest import AnthropicModelFactory, RequestCapture, message_shape
+
+with try_import() as imports_successful:
+    from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='anthropic not installed'),
+    pytest.mark.anyio,
+]
+
+_SEARCH_ID = 'srvtoolu_01EoSNE7k4dUJyGatASCV5qs'
+_TOOL_CALL_ID = 'toolu_01WjXqPrN8vKsRt2YbLmZdQe'
+_QUESTION = 'Look up the 10-year Treasury duration, then add 2 and 2.'
+_FOLLOW_UP = 'In one sentence: does a longer duration mean more interest-rate risk?'
+
+_SEARCH_CALL = NativeToolCallPart(
+    tool_name='web_search',
+    args={'query': '10-year Treasury modified duration'},
+    tool_call_id=_SEARCH_ID,
+    provider_name='anthropic',
+)
+_RENDERABLE_RESULT = [
+    {
+        'type': 'web_search_result',
+        'url': 'https://example.com/treasury',
+        'title': 'Treasury duration',
+        'encrypted_content': 'encrypted',
+    }
+]
+
+
+def _search_return(content: object) -> NativeToolReturnPart:
+    return NativeToolReturnPart(
+        tool_name='web_search', content=content, tool_call_id=_SEARCH_ID, provider_name='anthropic'
+    )
+
+
+# The conversation continues past the tool-result turn, which is what turns a survivable in-flight call
+# into a permanently unsendable history.
+def _continued_history(*response_parts: object) -> list[ModelMessage]:
+    return [
+        ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+        ModelResponse(
+            parts=[
+                *response_parts,  # pyright: ignore[reportArgumentType]
+                ToolCallPart(tool_name='add', args={'a': 2, 'b': 2}, tool_call_id=_TOOL_CALL_ID),
+            ]
+        ),
+        ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+        ModelResponse(parts=[TextPart(content='It is 4.')]),
+    ]
+
+
+@dataclass
+class Case:
+    id: str
+    history: list[ModelMessage]
+    expected: list[tuple[str, list[str]]]
+    follow_up: bool = True
+
+    def __str__(self) -> str:
+        return self.id
+
+
+CASES = [
+    Case(
+        'result-never-arrived-drops-the-call',
+        _continued_history(_SEARCH_CALL),
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['tool_use']),
+                ('user', ['tool_result']),
+                ('assistant', ['text']),
+                ('user', ['text']),
+            ]
+        ),
+    ),
+    Case(
+        # A history processor that trims a large search payload to a string leaves a return part with no
+        # block shape here, so the result is silently skipped and the call is left unpaired on the wire.
+        'unrenderable-result-drops-the-call',
+        _continued_history(_SEARCH_CALL, _search_return('[search results trimmed]')),
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['tool_use']),
+                ('user', ['tool_result']),
+                ('assistant', ['text']),
+                ('user', ['text']),
+            ]
+        ),
+    ),
+    Case(
+        'paired-call-is-kept',
+        _continued_history(_SEARCH_CALL, _search_return(_RENDERABLE_RESULT)),
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['server_tool_use', 'web_search_tool_result', 'tool_use']),
+                ('user', ['tool_result']),
+                ('assistant', ['text']),
+                ('user', ['text']),
+            ]
+        ),
+    ),
+    Case(
+        # Anthropic can deliver the result in the response after the one that called the tool, so pairing
+        # is decided across the whole payload rather than within a turn.
+        'result-in-a-later-response-is-kept',
+        [
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(parts=[_SEARCH_CALL]),
+            ModelResponse(parts=[_search_return(_RENDERABLE_RESULT), TextPart(content='It is 8.1.')]),
+        ],
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['server_tool_use']),
+                ('assistant', ['web_search_tool_result', 'text']),
+                ('user', ['text']),
+            ]
+        ),
+    ),
+    Case(
+        # Nothing else was in the turn, so dropping the call leaves no assistant message to send.
+        'turn-holding-only-the-call-is-removed',
+        [
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(parts=[_SEARCH_CALL]),
+            ModelResponse(parts=[TextPart(content='It is 8.1.')]),
+        ],
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['text']),
+                ('user', ['text']),
+            ]
+        ),
+    ),
+    Case(
+        # The result is still on its way, which is the one shape Anthropic takes an unpaired call in.
+        # Dropping it here would break a pause-turn resume, whose whole point is to continue the call.
+        'in-flight-call-is-kept',
+        [
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(parts=[_SEARCH_CALL, ToolCallPart(tool_name='add', args={}, tool_call_id=_TOOL_CALL_ID)]),
+            ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+        ],
+        follow_up=False,
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['server_tool_use', 'tool_use']),
+                ('user', ['tool_result']),
+            ]
+        ),
+    ),
+    Case(
+        # Bedrock rejects the in-flight shape the direct API tolerates, and a search is cheap to redo,
+        # so tool search is the one native tool whose unpaired call drops even while in flight.
+        'in-flight-tool-search-call-drops-anyway',
+        [
+            ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+            ModelResponse(
+                parts=[
+                    NativeToolSearchCallPart(
+                        tool_call_id='srv_orphan', provider_name='anthropic', args={'queries': ['weather']}
+                    ),
+                    ToolCallPart(tool_name='add', args={}, tool_call_id=_TOOL_CALL_ID),
+                ]
+            ),
+            ModelRequest(parts=[ToolReturnPart(tool_name='add', content='4', tool_call_id=_TOOL_CALL_ID)]),
+        ],
+        follow_up=False,
+        expected=snapshot(
+            [
+                ('user', ['text']),
+                ('assistant', ['tool_use']),
+                ('user', ['tool_result']),
+            ]
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize('case', CASES, ids=str)
+async def test_drop_unpaired_native_tool_calls(case: Case):
+    """The outbound payload never carries a native tool call without its result block.
+
+    Asserted on the mapper's own output rather than through a cassette: Anthropic cassettes match on
+    method and URI only, so a recorded request plays back green whether the call was dropped or not.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history = [*case.history, *([ModelRequest(parts=[UserPromptPart(content=_FOLLOW_UP)])] if case.follow_up else [])]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert message_shape({'messages': [dict(message) for message in messages]}) == case.expected
+
+
+async def test_dropped_call_keeps_the_cache_boundary():
+    """A `CachePoint` authored on the dropped block lands on the block before it.
+
+    Losing the breakpoint would silently re-process the tail on every later request, and moving it
+    forward would cache content the user placed outside the boundary — both are invisible at runtime.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=[_QUESTION, CachePoint()])]),
+        ModelResponse(parts=[_SEARCH_CALL]),
+        ModelResponse(parts=[TextPart(content='It is 8.1.')]),
+        ModelRequest(parts=[UserPromptPart(content=_FOLLOW_UP)]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': 'Look up the 10-year Treasury duration, then add 2 and 2.',
+                        'type': 'text',
+                        'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
+                    }
+                ],
+            },
+            {'role': 'assistant', 'content': [{'text': 'It is 8.1.', 'type': 'text'}]},
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
+        ]
+    )
+
+
+async def test_dropped_call_hands_its_cache_boundary_to_the_block_before_it():
+    """A breakpoint that landed *on* the dropped block moves back one block rather than vanishing.
+
+    A `CachePoint` opening a user message has nothing to attach to there, so it attaches to the end of
+    the previous message — which is the assistant turn holding the unpaired call. Dropping that block
+    silently would take the breakpoint with it and re-process the tail on every later request.
+    """
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='x'))
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content=_QUESTION)]),
+        ModelResponse(parts=[TextPart(content='Searching.'), _SEARCH_CALL]),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), _FOLLOW_UP])]),
+    ]
+    _, messages = await model._map_message(  # pyright: ignore[reportPrivateUsage]
+        history, ModelRequestParameters(), AnthropicModelSettings()
+    )
+    assert [dict(message) for message in messages] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [{'text': 'Look up the 10-year Treasury duration, then add 2 and 2.', 'type': 'text'}],
+            },
+            {
+                'role': 'assistant',
+                'content': [
+                    {'text': 'Searching.', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}}
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'In one sentence: does a longer duration mean more interest-rate risk?', 'type': 'text'}
+                ],
+            },
+        ]
+    )
+
+
+@pytest.mark.vcr
+async def test_unpaired_native_tool_call_history_is_accepted(
+    allow_model_requests: None,
+    anthropic_model: AnthropicModelFactory,
+    request_capture: RequestCapture,
+):
+    """Anthropic answers a history that carries an unpaired native tool call.
+
+    The live half: this exact history is rejected with `web_search tool use with id ... was found
+    without a corresponding web_search_tool_result block` when the call is replayed, so the recorded
+    200 is the assertion. The body read off the wire pins that the call is what went missing and the
+    rest of the turn survived.
+    """
+    model: AnthropicModel = anthropic_model('claude-sonnet-4-5', capture=True)
+    agent = Agent(model)
+
+    @agent.tool_plain
+    def add(a: int, b: int) -> str:
+        """Add two numbers."""
+        return '4'  # pragma: no cover
+
+    result = await agent.run(_FOLLOW_UP, message_history=_continued_history(_SEARCH_CALL))
+
+    body = request_capture.body('/v1/messages')
+    assert message_shape(body) == snapshot(
+        [
+            ('user', ['text']),
+            ('assistant', ['tool_use']),
+            ('user', ['tool_result']),
+            ('assistant', ['text']),
+            ('user', ['text']),
+        ]
+    )
+    assert result.output == snapshot(
+        "Yes, a longer duration means more interest-rate risk because the bond's price will be more sensitive to changes in interest rates."
+    )

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -2227,58 +2227,6 @@ async def test_anthropic_regex_strategy_replay_preserves_variant(allow_model_req
     assert regex_inputs == snapshot([{'pattern': 'weather.*'}])
 
 
-async def test_anthropic_drops_orphaned_tool_search_call_on_replay(allow_model_requests: None) -> None:
-    """Anthropic occasionally emits a `tool_search_tool_*` server tool use alongside a client
-    `tool_use` and ends the turn without delivering the corresponding result block (see
-    anthropics/anthropic-sdk-python#1325). Bedrock then 400s on the next request:
-    `tool use ... was found without a corresponding tool_search_tool_*_tool_result block`.
-    The adapter must drop unpaired tool-search calls from the wire payload. Reported by
-    @kclisp on PR #5143.
-    """
-    pytest.importorskip('anthropic')
-
-    response = completion_message(
-        [BetaTextBlock(text='ok', type='text')],
-        BetaUsage(input_tokens=5, output_tokens=5),
-    )
-    mock_client = MockAnthropic.create_mock(response)
-    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
-    agent = Agent(model=model, capabilities=[ToolSearch()])
-
-    @agent.tool_plain
-    def send_status(message: str) -> str:  # pragma: no cover
-        return 'ok'
-
-    @agent.tool_plain(defer_loading=True)
-    def pay_rent() -> str:  # pragma: no cover
-        return 'paid'
-
-    history: list[ModelMessage] = [
-        ModelRequest.user_text_prompt('pay rent and send status'),
-        ModelResponse(
-            parts=[
-                # Orphan: server tool search emitted in parallel with a client tool, no result delivered.
-                NativeToolSearchCallPart(
-                    provider_name='anthropic',
-                    args={'queries': ['pay.*']},
-                    tool_call_id='srv_orphan',
-                    provider_details={'strategy': 'regex'},
-                ),
-                ToolCallPart(tool_name='send_status', args={'message': 'looking'}, tool_call_id='cl_1'),
-            ],
-            provider_name='anthropic',
-        ),
-        ModelRequest(parts=[ToolReturnPart(tool_name='send_status', content='ok', tool_call_id='cl_1')]),
-    ]
-    await agent.run('continue', message_history=history)
-    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
-    blocks = [
-        cast('dict[str, Any]', block) for msg in kwargs['messages'] for block in cast('list[Any]', msg['content'])
-    ]
-    server_tool_block_ids = [block.get('id') for block in blocks if block.get('type') == 'server_tool_use']
-    assert 'srv_orphan' not in server_tool_block_ids
-
-
 async def test_anthropic_cache_tool_definitions_skips_deferred_tools(allow_model_requests: None) -> None:
     """`anthropic_cache_tool_definitions=True` must apply `cache_control` to the last
     *non-deferred* tool. Anthropic rejects requests with `cache_control` and

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -137,7 +137,6 @@ with try_import() as anthropic_available:
         AnthropicModelSettings,
         _build_custom_tool_search_replay_blocks,  # pyright: ignore[reportPrivateUsage]
         _build_tool_search_replay_block,  # pyright: ignore[reportPrivateUsage]
-        _collect_orphan_tool_search_call_ids,  # pyright: ignore[reportPrivateUsage]
         _finalize_streamed_tool_search_call_part,  # pyright: ignore[reportPrivateUsage]
         _map_server_tool_use_block,  # pyright: ignore[reportPrivateUsage]
         _map_tool_search_tool_result_block,  # pyright: ignore[reportPrivateUsage]
@@ -2226,38 +2225,6 @@ async def test_anthropic_regex_strategy_replay_preserves_variant(allow_model_req
     # Regex variant must replay with `pattern` (not `query`) — Anthropic 400s otherwise.
     regex_inputs = [block['input'] for block in server_blocks if block['name'] == 'tool_search_tool_regex']
     assert regex_inputs == snapshot([{'pattern': 'weather.*'}])
-
-
-def test_collect_orphan_tool_search_call_ids_pairs_across_responses() -> None:
-    """An orphan is a `NativeToolSearchCallPart` with no matching `NativeToolSearchReturnPart`
-    *anywhere* in history. Anthropic sometimes delivers the return in a *later* `ModelResponse`
-    (deferred-result behavior on the direct API), so the pairing check must span turns."""
-    pytest.importorskip('anthropic')
-
-    history: list[ModelMessage] = [
-        ModelRequest.user_text_prompt('do the thing'),
-        # Turn 1: orphan call (paired with a client `ToolCallPart` that ate the turn)
-        ModelResponse(
-            parts=[
-                NativeToolSearchCallPart(args={'queries': ['pay.*']}, tool_call_id='srv_orphan'),
-                ToolCallPart(tool_name='send_status', args={'message': 'ok'}, tool_call_id='cl_1'),
-            ],
-        ),
-        ModelRequest(parts=[ToolReturnPart(tool_name='send_status', content='ok', tool_call_id='cl_1')]),
-        # Turn 2: deferred-result call+return *and* a fresh paired exchange
-        ModelResponse(
-            parts=[
-                # Anthropic delivers the previous turn's missing search result here.
-                NativeToolSearchReturnPart(content={'discovered_tools': []}, tool_call_id='srv_paired'),
-                # ...along with a fresh search round.
-                NativeToolSearchCallPart(args={'queries': ['weather.*']}, tool_call_id='srv_paired_2'),
-                NativeToolSearchReturnPart(content={'discovered_tools': []}, tool_call_id='srv_paired_2'),
-            ],
-        ),
-    ]
-    # `srv_orphan` has no matching return anywhere; `srv_paired_2` is paired in the same response.
-    # `srv_paired` shows up only as a return — that's not an orphan call, so it isn't reported.
-    assert _collect_orphan_tool_search_call_ids(history) == {'srv_orphan'}
 
 
 async def test_anthropic_drops_orphaned_tool_search_call_on_replay(allow_model_requests: None) -> None:


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Found while working on #6692; split out because it stands on its own and #6692 stacks on top of it.

A stored or locally transformed conversation that has continued past an unresolved native tool call becomes **permanently unsendable**. Anthropic rejects the whole request:

```
web_search tool use with id srvtoolu_01 was found without a corresponding web_search_tool_result block
```

Anthropic's current contract deliberately allows an unpaired server or MCP call while the request ends at the client-tool result turns answering the same generation. The server runs the pending native tool and returns its result at the start of the next response. This PR preserves that valid in-flight shape.

The failure begins when a replayed payload has moved beyond that point without a rendered result: for example, stale history created under older provider behavior, the Bedrock tool-search path reported in #5143, or a history processor that made a native result unrenderable. Every later request built from that history is rejected.

### Measured

`claude-sonnet-4-5`, histories differing only in what follows the call:

| shape | verdict |
|---|---|
| request **ends** at the tool-result turn | ACCEPTED |
| two `tool_result`-only user turns follow | ACCEPTED |
| a turn with any other content follows | REJECTED |
| control: same, `server_tool_use` removed | ACCEPTED |

No reasoning, tool output, or other content varies across those arms — the unpaired call alone decides it.

### The fix

`_collect_orphan_tool_search_call_ids` already dropped this shape, but only for tool search and only by pairing message *parts*. Pairing now reads the blocks the mapper actually **built**, across the whole payload. That also covers a second way a call goes unpaired: the result arrived but didn't render. A history processor that trims a large search payload to a string leaves a `NativeToolReturnPart` whose content has no block shape here, so the result is skipped and the call it answered is left dangling.

Three behaviors are deliberate:

1. **In-flight calls are kept.** A dangling advisor call on a pause-turn resume has to replay — dropping it would break the resume. `test_anthropic_advisor_dangling_call_replayed_when_active` pins this and caught an earlier, broader version of this change.
2. **Tool search drops even in flight**, preserving the behavior introduced in #5143 after a Bedrock user reported the orphan 400. The direct API tolerates the shape and a search is cheap for the model to repeat.
3. **A cache breakpoint that landed on the dropped block walks back** rather than vanishing. A leading `CachePoint` attaches to the end of the previous message, which can be the assistant turn holding the unpaired call; losing it would silently re-process the tail on every later request. The search runs over every block ahead of the dropped one, since the nearest is often neither the block before it nor even in the same turn — `thinking` takes no `cache_control`, and a replayed MCP result is a model rather than a mapping. A payload holding no carrier at all gives the breakpoint up instead of failing the request.

Dropping beats synthesizing an empty result block, which would tell the model the tool ran and returned nothing.

<details>
<summary>Behavior change worth a look</summary>

For non-tool-search server tools, an unpaired call that is *not* in flight was previously sent and is now dropped. That request was rejected by Anthropic, so no working call changes — but if a reviewer knows a provider path where such a call was meaningful, that's the thing to flag.

</details>

### Tests

`tests/models/anthropic/test_unpaired_native_tool_calls.py` — ten mapper-level cases (result absent, unrenderable result, paired kept, result in a later response, turn emptied, in-flight kept, in-flight kept behind two tool-result turns, in-flight tool search dropped, and the `mcp_tool_use` drop and in-flight pair), five cache-boundary tests, the tool-search drop through an agent run, and three VCR tests.

Each recording pins a claim about what the API accepts: that the previously rejected history is answered once the call is dropped, and that keeping an in-flight `server_tool_use` and an in-flight `mcp_tool_use` are both safe. Everything else is asserted on the mapper's own output, because Anthropic cassettes match on method and URI, so a recording replays green whether or not the call was dropped.

Removed `test_collect_orphan_tool_search_call_ids_pairs_across_responses`, a unit test on the deleted private helper; its cross-response pairing invariant is now a case in the new file.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
