### PR TITLE
Sort OpenAI embedding responses by index to preserve input order

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -143,7 +143,9 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e
 
-        embeddings = [item.embedding for item in response.data]
+        # Sort by `index`: the API returns one item per input carrying its position, and
+        # OpenAI-compatible servers are not guaranteed to return them in request order.
+        embeddings = [item.embedding for item in sorted(response.data, key=lambda item: item.index)]
 
         return EmbeddingResult(
             embeddings=embeddings,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -376,6 +376,28 @@ class TestOpenAI:
         with pytest.raises(ModelHTTPError, match='model_not_found'):
             await embedder.embed_query('Hello, world!')
 
+    async def test_out_of_order_batch_response(self):
+        """Embeddings are returned in input order even when the response items are not.
+
+        Mocked rather than recorded: OpenAI itself returns items in order today, so no cassette
+        reproduces the reordering that OpenAI-compatible servers are free to do.
+        """
+        mock_client = AsyncMock()
+        second, first = MagicMock(), MagicMock()
+        second.embedding, second.index = [0.9, 0.9], 1
+        first.embedding, first.index = [0.1, 0.1], 0
+
+        mock_response = MagicMock()
+        mock_response.data = [second, first]
+        mock_response.usage = None
+        mock_response.model = 'test-model'
+        mock_client.embeddings.create.return_value = mock_response
+
+        model = OpenAIEmbeddingModel('test-model', provider=OpenAIProvider(openai_client=mock_client))
+
+        result = await model.embed(['first', 'second'], input_type='document')
+        assert result.embeddings == [[0.1, 0.1], [0.9, 0.9]]
+
     async def test_response_with_no_usage(self):
         mock_client = AsyncMock()
         mock_embedding_item = MagicMock()


### PR DESCRIPTION
- Fixes #7284

`OpenAIEmbeddingModel.embed()` built its result straight from `response.data`:

```python
embeddings = [item.embedding for item in response.data]
```

Every item in that response carries an `index` giving its position in the request, and that field only needs to exist because response order is not guaranteed to match input order. If a server returns them out of order, `EmbeddingResult.embeddings` is silently misaligned with `inputs`, so every vector is attributed to the wrong text. Nothing raises, and the `EmbeddingResult['text']` lookup returns confidently wrong data.

OpenAI itself appears to return items in order today, so this is not an active break against their API. It matters because this same class serves every OpenAI-compatible provider and proxy in the repo, where that ordering is not promised by anyone. `litellm` sorts by `index` for the same reason, and the legacy `openai-python` client did too.

The fix sorts by `index` before building the list. The regression test mocks an out-of-order response, since no cassette can reproduce a reordering that OpenAI does not currently do. Confirmed it fails without the change and passes with it.

Ran `uv run pytest tests/test_embeddings.py` (110 passed, 20 skipped), plus ruff on both files. Pyright reports the same 15 pre-existing errors on this test file with and without my change, all from unresolved `torch` and `sentence_transformers` imports in the local environment.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. if you would rather not carry a defensive sort for something the OpenAI API does not currently do, say so and I will close this.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

