### PR TITLE
fix: update internal refs in renamed schema defs and handle missing JSON Schema keywords

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -558,12 +558,20 @@ def _update_mapped_json_schema_refs(s: dict[str, Any], name_mapping: dict[str, s
         for item in prefix_items:
             _update_mapped_json_schema_refs(item, name_mapping)
 
-    # Handle unions
-    for union_type in ['anyOf', 'oneOf']:
-        if union_type in s:
-            union_items: list[dict[str, Any]] = s[union_type]
-            for item in union_items:
+    # Handle additionalProperties
+    if 'additionalProperties' in s and isinstance(s['additionalProperties'], dict):
+        _update_mapped_json_schema_refs(s['additionalProperties'], name_mapping)
+
+    # Handle unions and composition keywords
+    for keyword in ['anyOf', 'oneOf', 'allOf']:
+        if keyword in s:
+            keyword_items: list[dict[str, Any]] = s[keyword]
+            for item in keyword_items:
                 _update_mapped_json_schema_refs(item, name_mapping)
+
+    # Handle negation
+    if 'not' in s and isinstance(s['not'], dict):
+        _update_mapped_json_schema_refs(s['not'], name_mapping)
 
 
 def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
@@ -602,6 +610,13 @@ def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str
 
                 all_defs[new_name] = def_schema
                 schema_name_mapping[name] = new_name
+
+        # Update refs inside renamed definitions so internal cross-references
+        # (e.g. Outer_1 still pointing to #/$defs/Inner instead of #/$defs/Inner_1)
+        # are corrected.
+        for name, new_name in schema_name_mapping.items():
+            if name != new_name:
+                _update_mapped_json_schema_refs(all_defs[new_name], schema_name_mapping)
 
         _update_mapped_json_schema_refs(schema, schema_name_mapping)
         rewritten_schemas.append(schema)

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+import copy
 import functools
 import inspect
 import re
@@ -576,6 +577,21 @@ def _update_mapped_json_schema_refs(s: dict[str, Any], name_mapping: dict[str, s
         _update_mapped_json_schema_refs(not_schema, name_mapping)
 
 
+def _unique_def_name(name: str, schema: dict[str, Any], all_defs: dict[str, dict[str, Any]]) -> str:
+    """Generate a unique definition name by appending the schema title and/or a numeric suffix."""
+    new_name = name
+    if title := schema.get('title'):
+        new_name = f'{title}_{name}'
+
+    i = 1
+    original_new_name = new_name
+    new_name = f'{new_name}_{i}'
+    while new_name in all_defs:
+        i += 1
+        new_name = f'{original_new_name}_{i}'
+    return new_name
+
+
 def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
     """Merges the `$defs` from different JSON schemas into a single deduplicated `$defs`, handling name collisions of `$defs` that are not the same, and rewrites `$ref`s to point to the new `$defs`.
 
@@ -599,24 +615,34 @@ def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str
                 all_defs[name] = def_schema
                 schema_name_mapping[name] = name
             elif def_schema != all_defs[name]:
-                new_name = name
-                if title := schema.get('title'):
-                    new_name = f'{title}_{name}'
+                # Different def with same name — assign a unique name
+                schema_name_mapping[name] = _unique_def_name(name, schema, all_defs)
+                all_defs[schema_name_mapping[name]] = def_schema
+            # else: structurally equal — handled below
 
-                i = 1
-                original_new_name = new_name
-                new_name = f'{new_name}_{i}'
-                while new_name in all_defs:
-                    i += 1
-                    new_name = f'{original_new_name}_{i}'
-
-                all_defs[new_name] = def_schema
-                schema_name_mapping[name] = new_name
+        # Defs that are structurally equal (same dict) may still be semantically
+        # different if they contain $refs that point to defs that were renamed in
+        # this schema. E.g. both schemas have Wrapper={$ref Inner}, but their
+        # Inner defs differ, so Schema B's Inner was renamed to Inner_1. The shared
+        # Wrapper is not actually equal — Schema B needs its own copy with updated refs.
+        # Loop until stable, since creating a copy can trigger further copies
+        # in defs that reference it (transitive chains).
+        changed = True
+        while changed:
+            changed = False
+            for name, def_schema in defs.items():
+                if name not in schema_name_mapping:
+                    updated = copy.deepcopy(def_schema)
+                    _update_mapped_json_schema_refs(updated, schema_name_mapping)
+                    if updated != def_schema:
+                        schema_name_mapping[name] = _unique_def_name(name, schema, all_defs)
+                        all_defs[schema_name_mapping[name]] = updated
+                        changed = True
+                    else:
+                        schema_name_mapping[name] = name
 
         # Update refs inside definitions so internal cross-references
         # (e.g. Outer referencing Inner which was renamed to Inner_1) are corrected.
-        # This applies to all defs in the schema, not just renamed ones, since
-        # a non-renamed def can also reference a renamed def.
         for new_name in schema_name_mapping.values():
             _update_mapped_json_schema_refs(all_defs[new_name], schema_name_mapping)
 

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -560,7 +560,8 @@ def _update_mapped_json_schema_refs(s: dict[str, Any], name_mapping: dict[str, s
 
     # Handle additionalProperties
     if 'additionalProperties' in s and isinstance(s['additionalProperties'], dict):
-        _update_mapped_json_schema_refs(s['additionalProperties'], name_mapping)
+        additional_props: dict[str, Any] = s['additionalProperties']  # pyright: ignore[reportUnknownVariableType]
+        _update_mapped_json_schema_refs(additional_props, name_mapping)
 
     # Handle unions and composition keywords
     for keyword in ['anyOf', 'oneOf', 'allOf']:
@@ -571,7 +572,8 @@ def _update_mapped_json_schema_refs(s: dict[str, Any], name_mapping: dict[str, s
 
     # Handle negation
     if 'not' in s and isinstance(s['not'], dict):
-        _update_mapped_json_schema_refs(s['not'], name_mapping)
+        not_schema: dict[str, Any] = s['not']  # pyright: ignore[reportUnknownVariableType]
+        _update_mapped_json_schema_refs(not_schema, name_mapping)
 
 
 def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
@@ -611,12 +613,12 @@ def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str
                 all_defs[new_name] = def_schema
                 schema_name_mapping[name] = new_name
 
-        # Update refs inside renamed definitions so internal cross-references
-        # (e.g. Outer_1 still pointing to #/$defs/Inner instead of #/$defs/Inner_1)
-        # are corrected.
-        for name, new_name in schema_name_mapping.items():
-            if name != new_name:
-                _update_mapped_json_schema_refs(all_defs[new_name], schema_name_mapping)
+        # Update refs inside definitions so internal cross-references
+        # (e.g. Outer referencing Inner which was renamed to Inner_1) are corrected.
+        # This applies to all defs in the schema, not just renamed ones, since
+        # a non-renamed def can also reference a renamed def.
+        for new_name in schema_name_mapping.values():
+            _update_mapped_json_schema_refs(all_defs[new_name], schema_name_mapping)
 
         _update_mapped_json_schema_refs(schema, schema_name_mapping)
         rewritten_schemas.append(schema)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -564,6 +564,164 @@ def test_merge_json_schema_defs():
     )
 
 
+def test_merge_json_schema_defs_internal_refs_in_renamed_defs():
+    """When defs are renamed due to collisions, internal $refs within those defs must also be updated."""
+    schema_a = {
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+            'Outer': {
+                'type': 'object',
+                'properties': {'inner': {'$ref': '#/$defs/Inner'}, 'extra_a': {'type': 'string'}},
+            },
+        },
+        'properties': {'outer': {'$ref': '#/$defs/Outer'}},
+        'type': 'object',
+        'title': 'SchemaA',
+    }
+    schema_b = {
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'integer'}}},
+            'Outer': {
+                'type': 'object',
+                'properties': {'inner': {'$ref': '#/$defs/Inner'}, 'extra_b': {'type': 'number'}},
+            },
+        },
+        'properties': {'outer': {'$ref': '#/$defs/Outer'}},
+        'type': 'object',
+        'title': 'SchemaB',
+    }
+
+    rewritten_schemas, all_defs = merge_json_schema_defs([schema_a, schema_b])
+
+    # SchemaB's Outer was renamed to SchemaB_Outer_1, and its internal $ref to Inner
+    # must now point to SchemaB_Inner_1 (not the original Inner from SchemaA)
+    assert all_defs == snapshot(
+        {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+            'Outer': {
+                'type': 'object',
+                'properties': {'inner': {'$ref': '#/$defs/Inner'}, 'extra_a': {'type': 'string'}},
+            },
+            'SchemaB_Inner_1': {'type': 'object', 'properties': {'x': {'type': 'integer'}}},
+            'SchemaB_Outer_1': {
+                'type': 'object',
+                'properties': {'inner': {'$ref': '#/$defs/SchemaB_Inner_1'}, 'extra_b': {'type': 'number'}},
+            },
+        }
+    )
+    assert rewritten_schemas == snapshot(
+        [
+            {
+                'properties': {'outer': {'$ref': '#/$defs/Outer'}},
+                'type': 'object',
+                'title': 'SchemaA',
+            },
+            {
+                'properties': {'outer': {'$ref': '#/$defs/SchemaB_Outer_1'}},
+                'type': 'object',
+                'title': 'SchemaB',
+            },
+        ]
+    )
+
+
+def test_merge_json_schema_defs_non_renamed_def_refs_renamed_def():
+    """A non-renamed def that references a renamed def must also have its $refs updated."""
+    schema_a = {
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+        },
+        'properties': {'inner': {'$ref': '#/$defs/Inner'}},
+        'type': 'object',
+        'title': 'SchemaA',
+    }
+    schema_b = {
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'integer'}}},
+            'Wrapper': {'type': 'object', 'properties': {'inner': {'$ref': '#/$defs/Inner'}}},
+        },
+        'properties': {'wrapper': {'$ref': '#/$defs/Wrapper'}},
+        'type': 'object',
+        'title': 'SchemaB',
+    }
+
+    rewritten_schemas, all_defs = merge_json_schema_defs([schema_a, schema_b])
+
+    # Wrapper is new (no collision), but its $ref to Inner must be rewritten
+    # to SchemaB_Inner_1 because SchemaB's Inner was renamed
+    assert all_defs == snapshot(
+        {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+            'SchemaB_Inner_1': {'type': 'object', 'properties': {'x': {'type': 'integer'}}},
+            'Wrapper': {
+                'type': 'object',
+                'properties': {'inner': {'$ref': '#/$defs/SchemaB_Inner_1'}},
+            },
+        }
+    )
+    assert rewritten_schemas == snapshot(
+        [
+            {
+                'properties': {'inner': {'$ref': '#/$defs/Inner'}},
+                'type': 'object',
+                'title': 'SchemaA',
+            },
+            {
+                'properties': {'wrapper': {'$ref': '#/$defs/Wrapper'}},
+                'type': 'object',
+                'title': 'SchemaB',
+            },
+        ]
+    )
+
+
+def test_merge_json_schema_defs_additional_properties_allof_not():
+    """$refs under additionalProperties, allOf, and not must be rewritten during merge."""
+    schema_a = {
+        '$defs': {
+            'Value': {'type': 'object', 'properties': {'v': {'type': 'string'}}},
+            'Base': {'type': 'object', 'properties': {'b': {'type': 'string'}}},
+            'Excluded': {'type': 'object', 'properties': {'e': {'type': 'string'}}},
+        },
+        'properties': {
+            'map': {'type': 'object', 'additionalProperties': {'$ref': '#/$defs/Value'}},
+            'composed': {'allOf': [{'$ref': '#/$defs/Base'}, {'$ref': '#/$defs/Value'}]},
+            'excluded': {'not': {'$ref': '#/$defs/Excluded'}},
+        },
+        'type': 'object',
+        'title': 'SchemaA',
+    }
+    schema_b = {
+        '$defs': {
+            'Value': {'type': 'object', 'properties': {'v': {'type': 'integer'}}},
+            'Base': {'type': 'object', 'properties': {'b': {'type': 'integer'}}},
+            'Excluded': {'type': 'object', 'properties': {'e': {'type': 'integer'}}},
+        },
+        'properties': {
+            'map': {'type': 'object', 'additionalProperties': {'$ref': '#/$defs/Value'}},
+            'composed': {'allOf': [{'$ref': '#/$defs/Base'}, {'$ref': '#/$defs/Value'}]},
+            'excluded': {'not': {'$ref': '#/$defs/Excluded'}},
+        },
+        'type': 'object',
+        'title': 'SchemaB',
+    }
+
+    rewritten_schemas, _ = merge_json_schema_defs([schema_a, schema_b])
+
+    # SchemaB's refs should all be rewritten to the renamed defs
+    assert rewritten_schemas[1] == snapshot(
+        {
+            'properties': {
+                'map': {'type': 'object', 'additionalProperties': {'$ref': '#/$defs/SchemaB_Value_1'}},
+                'composed': {'allOf': [{'$ref': '#/$defs/SchemaB_Base_1'}, {'$ref': '#/$defs/SchemaB_Value_1'}]},
+                'excluded': {'not': {'$ref': '#/$defs/SchemaB_Excluded_1'}},
+            },
+            'type': 'object',
+            'title': 'SchemaB',
+        }
+    )
+
+
 def test_strip_markdown_fences():
     assert strip_markdown_fences('{"foo": "bar"}') == '{"foo": "bar"}'
     assert strip_markdown_fences('```json\n{"foo": "bar"}\n```') == '{"foo": "bar"}'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -722,6 +722,58 @@ def test_merge_json_schema_defs_additional_properties_allof_not():
     )
 
 
+def test_merge_json_schema_defs_structurally_equal_with_different_ref_targets():
+    """Defs that are structurally equal but whose $refs resolve to different types need separate copies."""
+    schema_a = {
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+            'Wrapper': {'type': 'object', 'properties': {'inner': {'$ref': '#/$defs/Inner'}}},
+        },
+        'properties': {'wrapper': {'$ref': '#/$defs/Wrapper'}},
+        'type': 'object',
+        'title': 'SchemaA',
+    }
+    schema_b = {
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'integer'}}},
+            'Wrapper': {'type': 'object', 'properties': {'inner': {'$ref': '#/$defs/Inner'}}},
+        },
+        'properties': {'wrapper': {'$ref': '#/$defs/Wrapper'}},
+        'type': 'object',
+        'title': 'SchemaB',
+    }
+
+    rewritten_schemas, all_defs = merge_json_schema_defs([schema_a, schema_b])
+
+    # Both Wrappers are structurally identical ({$ref: Inner}), but their Inner
+    # defs differ, so SchemaB needs its own Wrapper copy with updated refs.
+    assert all_defs == snapshot(
+        {
+            'Inner': {'type': 'object', 'properties': {'x': {'type': 'string'}}},
+            'Wrapper': {'type': 'object', 'properties': {'inner': {'$ref': '#/$defs/Inner'}}},
+            'SchemaB_Inner_1': {'type': 'object', 'properties': {'x': {'type': 'integer'}}},
+            'SchemaB_Wrapper_1': {
+                'type': 'object',
+                'properties': {'inner': {'$ref': '#/$defs/SchemaB_Inner_1'}},
+            },
+        }
+    )
+    assert rewritten_schemas == snapshot(
+        [
+            {
+                'properties': {'wrapper': {'$ref': '#/$defs/Wrapper'}},
+                'type': 'object',
+                'title': 'SchemaA',
+            },
+            {
+                'properties': {'wrapper': {'$ref': '#/$defs/SchemaB_Wrapper_1'}},
+                'type': 'object',
+                'title': 'SchemaB',
+            },
+        ]
+    )
+
+
 def test_strip_markdown_fences():
     assert strip_markdown_fences('{"foo": "bar"}') == '{"foo": "bar"}'
     assert strip_markdown_fences('```json\n{"foo": "bar"}\n```') == '{"foo": "bar"}'


### PR DESCRIPTION
This PR addresses: update internal refs in renamed schema defs and handle missing JSON Schema keywords

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

