### PR TITLE
fix: add missing space in MistralProvider error message

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -72,8 +72,8 @@ class MistralProvider(Provider[Mistral]):
 
             if not api_key:
                 raise UserError(
-                    'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
-                    ' to use the Mistral provider.'
+                    'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)` '
+                    'to use the Mistral provider.'
                 )
             elif http_client is not None:
                 self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)


### PR DESCRIPTION
This PR addresses: add missing space in MistralProvider error message

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

