### PR TITLE
fix: Merge remote-tracking branch 'upstream/main' into fix/response-close-on-redirect-error

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -386,11 +386,13 @@ async def safe_download(
             if response.is_redirect:
                 redirects_followed += 1
                 if redirects_followed > max_redirects:
+                    response.close()
                     raise ValueError(f'Too many redirects ({redirects_followed}). Maximum allowed: {max_redirects}')
 
                 # Get redirect location
                 location = response.headers.get('location')
                 if not location:
+                    response.close()
                     raise ValueError('Redirect response missing Location header')
 
                 current_url = resolve_redirect_url(current_url, location)

--- a/pydantic_ai_slim/pydantic_ai/format_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/format_prompt.py
@@ -158,7 +158,7 @@ class _ToXml:
         element = ElementTree.Element(tag)
         if path in self._fields_info:
             field_repr, field_info = self._fields_info[path]
-            if self.include_field_info and self.include_field_info != 'once' or field_repr not in self._included_fields:
+            if (self.include_field_info and self.include_field_info != 'once') or (self.include_field_info == 'once' and field_repr not in self._included_fields):
                 field_attributes = self._extract_attributes(field_info)
                 for k, v in field_attributes.items():
                     element.set(k, v)

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -251,7 +251,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         try:
             task = await self._graph_run.next(task)
         except StopAsyncIteration:
-            pass
+            return self._task_to_node(End(None))
         return self._task_to_node(task)
 
     async def _wrap_and_advance(


### PR DESCRIPTION
This PR addresses: Merge remote-tracking branch 'upstream/main' into fix/response-close-on-redirect-error

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

