### PR TITLE
Scope the Code Execution Tool docs table to the OpenAI Responses API

### DIFF
--- a/docs/native-tools.md
+++ b/docs/native-tools.md
@@ -266,12 +266,13 @@ in a secure environment, making it perfect for computational tasks, data analysi
 
 | Provider | Supported | Notes |
 |----------|-----------|-------|
-| OpenAI | ✅ | To include code execution output on the [`NativeToolReturnPart`][pydantic_ai.messages.NativeToolReturnPart] that's available via [`ModelResponse.native_tool_calls`][pydantic_ai.messages.ModelResponse.native_tool_calls], enable the [`OpenAIResponsesModelSettings.openai_include_code_execution_outputs`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_include_code_execution_outputs] [model setting](agent.md#model-run-settings). If the code execution generated images, like charts, they will be available on [`ModelResponse.images`][pydantic_ai.messages.ModelResponse.images] as [`BinaryImage`][pydantic_ai.messages.BinaryImage] objects. The generated image can also be used as [image output](output.md#image-output) for the agent run. |
+| OpenAI Responses | ✅ | To include code execution output on the [`NativeToolReturnPart`][pydantic_ai.messages.NativeToolReturnPart] that's available via [`ModelResponse.native_tool_calls`][pydantic_ai.messages.ModelResponse.native_tool_calls], enable the [`OpenAIResponsesModelSettings.openai_include_code_execution_outputs`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_include_code_execution_outputs] [model setting](agent.md#model-run-settings). If the code execution generated images, like charts, they will be available on [`ModelResponse.images`][pydantic_ai.messages.ModelResponse.images] as [`BinaryImage`][pydantic_ai.messages.BinaryImage] objects. The generated image can also be used as [image output](output.md#image-output) for the agent run. |
 | Google | ✅ | See [Google tool combinations](#google-tool-combinations). |
 | Anthropic | ✅ | Available on compatible Anthropic models. Pydantic AI selects a compatible code execution tool version automatically; see [Anthropic code execution tool version](models/anthropic.md#code-execution-tool-version) to override it. |
 | xAI | ✅ | Full feature support. |
 | Groq | ❌ | |
 | Bedrock | ✅ | Only available for Nova 2.0 models. |
+| OpenAI Chat Completions | ❌ | Not supported; use [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel]. |
 | Mistral | ❌ | |
 | Cohere | ❌ | |
 | HuggingFace | ❌ | |


### PR DESCRIPTION
Documentation-only fix, so there is no linked issue under the trivial-fixes exemption in the contributing guide.

### Summary

The Code Execution Tool provider table marks an unqualified `OpenAI` row as supported. That is misleading for Chat Completions: `OpenAIChatModel.supported_native_tools()` declares only `WebSearchTool`, and model-profile filtering removes even that for models without Chat Completions web-search support. `CodeExecutionTool` is not supported by `OpenAIChatModel`, so a typical Chat Completions run fails before the request is sent:

```
UserError: Native tool(s) ['CodeExecutionTool'] not supported by this model. Supported: [].
```

By contrast, `OpenAIResponsesModel.supported_native_tools()` includes `CodeExecutionTool`, and the tool docstring already lists `OpenAI Responses`. The repository instructions ask for the docstring and provider-support table to agree.

The distinction is also consistent with the most directly comparable tables: Web Search, MCP Server, and File Search have separate `OpenAI Responses` and `OpenAI Chat Completions` rows. Image Generation uses the precise `OpenAI Responses` label without a separate Chat Completions row. Tables where OpenAI is unsupported use the generic `OpenAI` label, where the API distinction does not affect the stated support status.

### Change

Rename the supported row to `OpenAI Responses` and add an explicit unsupported `OpenAI Chat Completions` row, following the Web Search, MCP Server, and File Search tables.

The bare `openai:` prefix now resolves to the Responses API, so this correction primarily affects users who explicitly select `openai-chat:` or construct `OpenAIChatModel` directly.

### Also noticed, not included here

`XSearchTool` has a documentation section but no provider-support table. I left that out because adding one would require authoring new support claims rather than correcting the existing claim in scope here. Happy to file it as a separate issue if useful.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->