### PR TITLE
Document the `realtime` extras in install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -68,6 +68,10 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `ui` - installs [UI Event Streams](ui/overview.md) dependency `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"}
 * `web` - installs [Web UI](ui/overview.md) dependencies `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"}, `httpx` [PyPI ↗](https://pypi.org/project/httpx){:target="_blank"}, and `uvicorn` [PyPI ↗](https://pypi.org/project/uvicorn){:target="_blank"}
 * `ag-ui` - installs [AG-UI Event Stream Protocol](ui/ag-ui.md) dependencies `ag-ui-protocol` [PyPI ↗](https://pypi.org/project/ag-ui-protocol){:target="_blank"} and `starlette` [PyPI ↗](https://pypi.org/project/starlette){:target="_blank"}
+* `realtime` - installs [Realtime Agents](realtime/overview.md) dependency `websockets` [PyPI ↗](https://pypi.org/project/websockets){:target="_blank"}
+* `openai-realtime` - installs [OpenAI Realtime](realtime/openai.md) dependencies `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"} and `websockets` [PyPI ↗](https://pypi.org/project/websockets){:target="_blank"}
+* `google-realtime` - installs [Gemini Live](realtime/gemini.md) dependencies `google-genai` [PyPI ↗](https://pypi.org/project/google-genai){:target="_blank"} and `websockets` [PyPI ↗](https://pypi.org/project/websockets){:target="_blank"}
+* `xai-realtime` - installs [xAI Realtime](realtime/xai.md) dependencies `xai-sdk` [PyPI ↗](https://pypi.org/project/xai-sdk){:target="_blank"}, `openai` [PyPI ↗](https://pypi.org/project/openai){:target="_blank"}, and `websockets` [PyPI ↗](https://pypi.org/project/websockets){:target="_blank"}
 * `retries` - installs [HTTP Retries](models/http-request-retries.md) dependency `tenacity` [PyPI ↗](https://pypi.org/project/tenacity){:target="_blank"}
 * `temporal` - installs [Temporal Durable Execution](durable_execution/temporal.md) dependency `temporalio` [PyPI ↗](https://pypi.org/project/temporalio){:target="_blank"}
 * `dbos` - installs [DBOS Durable Execution](durable_execution/dbos.md) dependency `dbos` [PyPI ↗](https://pypi.org/project/dbos){:target="_blank"}


### PR DESCRIPTION
- Relates to #7524

### What

`pydantic_ai_slim/pyproject.toml` defines four realtime optional groups that are missing from the canonical slim-install list in `docs/install.md`:

- `realtime`
- `openai-realtime`
- `google-realtime`
- `xai-realtime`

This adds one entry for each group using the existing dependency-list format and links each entry to its corresponding Realtime documentation.

The missing groups were recorded as a deferred follow-up in #7524 and #7526. The separate `mcp-tasks` documentation change remains scoped to #7526.

### Validation

- Compared every group and its transitive dependencies with `pydantic_ai_slim/pyproject.toml`.
- Checked all internal documentation targets.
- `git diff --check`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] **PR title** is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

