### PR TITLE
Add `E2BSandbox` and `ModalSandbox` provider backends on top of the sandbox abstraction

### DIFF
--- a/docs/api/sandboxes.md
+++ b/docs/api/sandboxes.md
@@ -22,3 +22,5 @@
             - SandboxResult
 
 ::: pydantic_ai.sandboxes.e2b
+
+::: pydantic_ai.sandboxes.modal

--- a/docs/api/sandboxes.md
+++ b/docs/api/sandboxes.md
@@ -20,3 +20,5 @@
             - SandboxProcess
             - SandboxOutputChunk
             - SandboxResult
+
+::: pydantic_ai.sandboxes.e2b

--- a/docs/install.md
+++ b/docs/install.md
@@ -71,6 +71,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `dbos` - installs [DBOS Durable Execution](durable_execution/dbos.md) dependency `dbos` [PyPI ↗](https://pypi.org/project/dbos){:target="_blank"}
 * `prefect` - installs [Prefect Durable Execution](durable_execution/prefect.md) dependency `prefect` [PyPI ↗](https://pypi.org/project/prefect){:target="_blank"}
 * `e2b` - installs the [E2B Sandbox](sandbox.md#provider-backends) dependency `e2b` [PyPI ↗](https://pypi.org/project/e2b){:target="_blank"}
+* `modal` - installs the [Modal Sandbox](sandbox.md#provider-backends) dependency `modal` [PyPI ↗](https://pypi.org/project/modal){:target="_blank"}
 * `spec` - installs [AgentSpec](agent-spec.md) dependencies `pyyaml` [PyPI ↗](https://pypi.org/project/PyYAML){:target="_blank"} and `pydantic-handlebars` [PyPI ↗](https://pypi.org/project/pydantic-handlebars){:target="_blank"}
 
 You can also install dependencies for multiple models and use cases, for example:

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,6 +70,7 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `temporal` - installs [Temporal Durable Execution](durable_execution/temporal.md) dependency `temporalio` [PyPI ↗](https://pypi.org/project/temporalio){:target="_blank"}
 * `dbos` - installs [DBOS Durable Execution](durable_execution/dbos.md) dependency `dbos` [PyPI ↗](https://pypi.org/project/dbos){:target="_blank"}
 * `prefect` - installs [Prefect Durable Execution](durable_execution/prefect.md) dependency `prefect` [PyPI ↗](https://pypi.org/project/prefect){:target="_blank"}
+* `e2b` - installs the [E2B Sandbox](sandbox.md#provider-backends) dependency `e2b` [PyPI ↗](https://pypi.org/project/e2b){:target="_blank"}
 * `spec` - installs [AgentSpec](agent-spec.md) dependencies `pyyaml` [PyPI ↗](https://pypi.org/project/PyYAML){:target="_blank"} and `pydantic-handlebars` [PyPI ↗](https://pypi.org/project/pydantic-handlebars){:target="_blank"}
 
 You can also install dependencies for multiple models and use cases, for example:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -108,7 +108,10 @@ async def main() -> None:
 ```
 
 [`connect()`][pydantic_ai.sandboxes.e2b.E2BSandbox.connect] attaches to an environment that
-already exists without taking over its teardown, which is exactly what a capability's
+already exists without taking over its destruction — though not without touching it: E2B has no
+passive look, so connecting resumes a paused sandbox and sets its keep-alive `timeout=` (E2B's own
+default of 300 seconds when you omit it), never shortening one that already has longer to live.
+That is exactly what a capability's
 [`get_sandbox`][pydantic_ai.capabilities.AbstractCapability.get_sandbox] hook needs to turn a
 [`SandboxRef`][pydantic_ai.sandboxes.SandboxRef] back into a live backend, including
 [under durable execution](#durable-execution):
@@ -140,7 +143,9 @@ pip/uv-add "pydantic-ai-slim[modal]"
 
 Its [`create()`][pydantic_ai.sandboxes.modal.ModalSandbox.create] terminates the environment when
 the block ends, and [`connect()`][pydantic_ai.sandboxes.modal.ModalSandbox.connect] attaches to an
-existing one for a capability's `get_sandbox`, exactly as above. Every Modal sandbox belongs to an
+existing one for a capability's `get_sandbox`, exactly as above — Modal's is a genuine look-up,
+though it does not prove the environment is alive: a sandbox Modal still knows about but has
+terminated surfaces at the first command rather than at `connect()`. Every Modal sandbox belongs to an
 app, so `app=` takes either a `modal.App` you already hold or a name to look up (creating it if it
 doesn't exist). It authenticates with the ambient Modal credentials — `modal token new`, or the
 `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` environment variables — unless you pass `client=`.
@@ -170,9 +175,12 @@ members. Only `ModalSandbox` adds live output
 ([`SupportsStream`][pydantic_ai.sandboxes.SupportsStream]): Modal's SDK hands a command's output
 back as async-iterable streams it keeps drained itself, while E2B's delivers output through
 callbacks its own event pump awaits, so bridging those into an iterator would either buffer
-without bound or stall the pump. In exchange, Modal has no API for killing a single command, so
+without bound or stall the pump. Modal's streams take one consumer each, so a started command can
+be streamed once — [`wait()`][pydantic_ai.sandboxes.SandboxProcess.wait] asks Modal for the whole
+output separately, and reports it in full whether you streamed all of it, some of it, or none.
+In exchange, Modal has no API for killing a single command, so
 [`kill()`][pydantic_ai.sandboxes.SandboxProcess.kill] raises `NotImplementedError` there and
-`timeout=`, which Modal enforces itself, is how a command is bounded. Neither backend supports
+`timeout=`, which Modal enforces itself in whole seconds, is how a command is bounded. Neither backend supports
 `output_limit=`, for the same honesty reason `LocalSandbox` doesn't: bound the output in-command
 instead, e.g. `| tail -c 10000`.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -72,6 +72,72 @@ when the read was served without reaching EOF. For strict text decoding and writ
 [`Sandbox.read_text()`][pydantic_ai.sandboxes.Sandbox.read_text] and
 [`Sandbox.write_text()`][pydantic_ai.sandboxes.Sandbox.write_text].
 
+## Provider backends
+
+Anything a model can reach with untrusted input needs a real environment rather than
+`LocalSandbox`. [`E2BSandbox`][pydantic_ai.sandboxes.e2b.E2BSandbox] runs commands and file
+operations inside an [E2B](https://e2b.dev) cloud microVM. Install the `e2b` optional group and
+import it from its own module, so the SDK is only loaded by applications that use it:
+
+```bash
+pip/uv-add "pydantic-ai-slim[e2b]"
+```
+
+The supplier of a sandbox owns its lifecycle, so
+[`create()`][pydantic_ai.sandboxes.e2b.E2BSandbox.create] is an async context manager: it
+provisions an environment on entry and kills it when the block ends, including on failure. It
+authenticates with the `E2B_API_KEY` environment variable unless you pass `api_key=`.
+
+```python {title="e2b_sandbox.py" test="skip"}
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.sandboxes.e2b import E2BSandbox
+
+agent = Agent('anthropic:claude-sonnet-5')
+
+
+@agent.tool
+async def execute(ctx: RunContext[None], command: str) -> str:
+    result = await ctx.sandbox.run(command, shell=True, timeout=60)
+    return result.stdout if result.exit_code == 0 else f'[exit {result.exit_code}] {result.stderr}'
+
+
+async def main() -> None:
+    async with E2BSandbox.create(timeout=600) as sandbox:
+        result = await agent.run('Profile the script and fix the hot spot.', sandbox=sandbox)
+        print(result.output)
+```
+
+[`connect()`][pydantic_ai.sandboxes.e2b.E2BSandbox.connect] attaches to an environment that
+already exists without taking over its teardown, which is exactly what a capability's
+[`get_sandbox`][pydantic_ai.capabilities.AbstractCapability.get_sandbox] hook needs to turn a
+[`SandboxRef`][pydantic_ai.sandboxes.SandboxRef] back into a live backend, including
+[under durable execution](#durable-execution):
+
+```python {title="e2b_capability.py" test="skip"}
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.sandboxes import SandboxBackend, SandboxRef
+from pydantic_ai.sandboxes.e2b import E2BSandbox
+
+
+class E2BCapability(AbstractCapability[Any]):
+    async def get_sandbox(
+        self, ctx: RunContext[Any], ref: SandboxRef
+    ) -> SandboxBackend | None:
+        if ref.provider != 'e2b':
+            return None
+        return await E2BSandbox.connect(ref.sandbox_id)
+```
+
+Backends implement exactly what their platform supports. `E2BSandbox` adds native background
+processes ([`start()`][pydantic_ai.sandboxes.Sandbox.start]) on top of the required members, but
+not live output streaming — E2B's async SDK delivers output through callbacks its own event pump
+awaits, so bridging them into an iterator would either buffer without bound or stall the pump.
+`output_limit=` is unsupported for the same honesty reason it is on `LocalSandbox`: bound the
+output in-command instead, e.g. `| tail -c 10000`.
+
 ## Attaching a sandbox
 
 ### Directly, per run

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -131,12 +131,50 @@ class E2BCapability(AbstractCapability[Any]):
         return await E2BSandbox.connect(ref.sandbox_id)
 ```
 
-Backends implement exactly what their platform supports. `E2BSandbox` adds native background
-processes ([`start()`][pydantic_ai.sandboxes.Sandbox.start]) on top of the required members, but
-not live output streaming — E2B's async SDK delivers output through callbacks its own event pump
-awaits, so bridging them into an iterator would either buffer without bound or stall the pump.
-`output_limit=` is unsupported for the same honesty reason it is on `LocalSandbox`: bound the
-output in-command instead, e.g. `| tail -c 10000`.
+[`ModalSandbox`][pydantic_ai.sandboxes.modal.ModalSandbox] is the same story on
+[Modal](https://modal.com), from the `modal` optional group:
+
+```bash
+pip/uv-add "pydantic-ai-slim[modal]"
+```
+
+Its [`create()`][pydantic_ai.sandboxes.modal.ModalSandbox.create] terminates the environment when
+the block ends, and [`connect()`][pydantic_ai.sandboxes.modal.ModalSandbox.connect] attaches to an
+existing one for a capability's `get_sandbox`, exactly as above. Every Modal sandbox belongs to an
+app, so `app=` takes either a `modal.App` you already hold or a name to look up (creating it if it
+doesn't exist). It authenticates with the ambient Modal credentials — `modal token new`, or the
+`MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` environment variables — unless you pass `client=`.
+
+```python {title="modal_sandbox.py" test="skip"}
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.sandboxes.modal import ModalSandbox
+
+agent = Agent('anthropic:claude-sonnet-5')
+
+
+@agent.tool
+async def execute(ctx: RunContext[None], command: str) -> str:
+    result = await ctx.sandbox.run(command, shell=True, timeout=60)
+    return result.stdout if result.exit_code == 0 else f'[exit {result.exit_code}] {result.stderr}'
+
+
+async def main() -> None:
+    async with ModalSandbox.create(app='my-agent', timeout=600) as sandbox:
+        result = await agent.run('Profile the script and fix the hot spot.', sandbox=sandbox)
+        print(result.output)
+```
+
+Backends implement exactly what their platform supports, and these two differ. Both add native
+background processes ([`start()`][pydantic_ai.sandboxes.Sandbox.start]) on top of the required
+members. Only `ModalSandbox` adds live output
+([`SupportsStream`][pydantic_ai.sandboxes.SupportsStream]): Modal's SDK hands a command's output
+back as async-iterable streams it keeps drained itself, while E2B's delivers output through
+callbacks its own event pump awaits, so bridging those into an iterator would either buffer
+without bound or stall the pump. In exchange, Modal has no API for killing a single command, so
+[`kill()`][pydantic_ai.sandboxes.SandboxProcess.kill] raises `NotImplementedError` there and
+`timeout=`, which Modal enforces itself, is how a command is bounded. Neither backend supports
+`output_limit=`, for the same honesty reason `LocalSandbox` doesn't: bound the output in-command
+instead, e.g. `| tail -c 10000`.
 
 ## Attaching a sandbox
 

--- a/examples/pydantic_ai_examples/slack_lead_qualifier/modal.py
+++ b/examples/pydantic_ai_examples/slack_lead_qualifier/modal.py
@@ -31,7 +31,7 @@ def setup_logfire():
 
 
 ### [web_app]
-@app.function(min_containers=1)
+@app.function(min_containers=1)  # pyright: ignore[reportUnknownMemberType]
 @modal.asgi_app()  # pyright: ignore[reportUnknownMemberType]
 def web_app():
     setup_logfire()
@@ -42,7 +42,7 @@ def web_app():
 
 
 ### [process_slack_member]
-@app.function()
+@app.function()  # pyright: ignore[reportUnknownMemberType]
 async def process_slack_member(profile_raw: dict[str, Any], logfire_ctx: Any):
     setup_logfire()
 
@@ -57,7 +57,8 @@ async def process_slack_member(profile_raw: dict[str, Any], logfire_ctx: Any):
 
 
 ### [send_daily_summary]
-@app.function(schedule=modal.Cron('0 8 * * *'))  # Every day at 8am UTC
+# Every day at 8am UTC
+@app.function(schedule=modal.Cron('0 8 * * *'))  # pyright: ignore[reportUnknownMemberType]
 async def send_daily_summary():
     setup_logfire()
 

--- a/examples/pydantic_ai_examples/slack_lead_qualifier/store.py
+++ b/examples/pydantic_ai_examples/slack_lead_qualifier/store.py
@@ -28,4 +28,6 @@ class AnalysisStore:
 
     @classmethod
     def _get_store(cls) -> modal.Dict:
-        return modal.Dict.from_name('analyses', create_if_missing=True)  # pyright: ignore[reportUnknownMemberType] ### [/analysis_store]
+        return modal.Dict.from_name(
+            'analyses', create_if_missing=True
+        )  ### [/analysis_store]

--- a/pydantic_ai_slim/pydantic_ai/sandboxes/_lifecycle.py
+++ b/pydantic_ai_slim/pydantic_ai/sandboxes/_lifecycle.py
@@ -1,0 +1,84 @@
+"""Lifecycle helpers shared by the cloud [sandbox backends][pydantic_ai.sandboxes.SandboxBackend].
+
+Provisioning a cloud environment — or starting a command inside one — is a round trip that can
+be cancelled while it is in flight, at which point the caller is gone but the thing it asked for
+may already exist and be billing. These helpers give the provider backends the guarantees
+[`LocalSandbox`][pydantic_ai.sandboxes.LocalSandbox] has for host subprocesses, without either of
+them growing its own copy: nothing the SDK created is ever abandoned, and teardown never masks
+the exception it runs alongside.
+
+Deliberately SDK-free, so importing it costs nothing and neither backend's optional dependency
+leaks into the other's.
+"""
+
+from __future__ import annotations as _annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Coroutine
+from contextlib import suppress
+from typing import Any, TypeVar
+
+import anyio
+
+__all__ = ('destroy_quietly', 'guarded_create')
+
+_T = TypeVar('_T')
+
+# Bounds every best-effort teardown: an environment that has stopped answering must not hang the
+# block that is trying to let go of it.
+_TEARDOWN_TIMEOUT = 30.0
+
+# A cleanup whose caller has already gone away is referenced by nothing else, and the event loop
+# only holds weak references to running tasks.
+_orphan_cleanups: set[asyncio.Task[None]] = set()
+
+
+async def guarded_create(create: Coroutine[Any, Any, _T], destroy: Callable[[_T], Awaitable[object]]) -> _T:
+    """Await `create`, destroying whatever it produced if the caller is cancelled meanwhile.
+
+    Cancelling the caller of an in-flight `create` would otherwise leave a provisioned — and
+    billed — environment behind with nobody holding a handle to it, because the SDK call
+    completes on the control plane whether or not anyone is left to receive its result.
+    """
+
+    async def attempt() -> _T | Exception:
+        try:
+            return await create
+        except Exception as error:
+            # Returned rather than raised: on Python 3.14, `shield` reports an abandoned
+            # future's exception to the event loop's exception handler.
+            return error
+
+    spawn = asyncio.ensure_future(attempt())
+    try:
+        outcome = await asyncio.shield(spawn)
+    except asyncio.CancelledError:
+        spawn.add_done_callback(lambda done: _destroy_orphan(done, destroy))
+        raise
+    if isinstance(outcome, Exception):
+        raise outcome
+    return outcome
+
+
+def _destroy_orphan(spawn: asyncio.Future[Any], destroy: Callable[[Any], Awaitable[object]]) -> None:
+    if spawn.cancelled():  # pragma: no cover
+        return
+    outcome = spawn.result()
+    if isinstance(outcome, Exception):
+        # Nobody is left to receive the failure, and a create that failed left nothing behind.
+        return
+    cleanup = asyncio.ensure_future(destroy_quietly(destroy(outcome)))
+    _orphan_cleanups.add(cleanup)
+    cleanup.add_done_callback(_orphan_cleanups.discard)
+
+
+async def destroy_quietly(destroy: Awaitable[object]) -> None:
+    """Run a teardown so that neither cancellation nor its own failure can escape it.
+
+    Shielded because teardown routinely runs inside an already-cancelled scope, where every
+    unshielded await re-raises; bounded so an unreachable environment can't hang the block that
+    is letting go of it; and silent because a teardown failure must never mask the exception it
+    runs alongside — nor invent one for a block that succeeded.
+    """
+    with anyio.CancelScope(shield=True), anyio.move_on_after(_TEARDOWN_TIMEOUT), suppress(Exception):
+        await destroy

--- a/pydantic_ai_slim/pydantic_ai/sandboxes/e2b.py
+++ b/pydantic_ai_slim/pydantic_ai/sandboxes/e2b.py
@@ -8,15 +8,19 @@ pulls in the E2B SDK.
 
 from __future__ import annotations as _annotations
 
+import asyncio
+import math
+import posixpath
 import shlex
 from collections.abc import AsyncGenerator, Mapping, Sequence
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import anyio
 from typing_extensions import Self, Unpack
 
+from ._lifecycle import destroy_quietly, guarded_create
 from .protocol import FileEntry, SandboxCommand
 
 try:
@@ -25,6 +29,7 @@ try:
         AsyncCommandHandle,
         AsyncSandbox,
         CommandExitException,
+        CommandResult,
         EntryInfo,
         FileType,
         SandboxException,
@@ -39,6 +44,10 @@ if TYPE_CHECKING:
     from .protocol import SandboxBackend, SandboxProcess, SupportsFilesystem, SupportsStart
 
 __all__ = ('E2BSandbox',)
+
+# Bounds the best-effort kill of a command whose wait is over: a sandbox that has stopped
+# answering must not hang the caller that is walking away from it.
+_TEARDOWN_TIMEOUT = 30.0
 
 
 @dataclass(frozen=True)
@@ -56,7 +65,12 @@ class _E2BProcess:
     def __init__(self, handle: AsyncCommandHandle, *, timeout: float | None):
         self._handle = handle
         self._timeout = timeout
+        # Stamped here rather than at the first `wait()`, so `start(timeout=5)` bounds the
+        # command's life and not the length of whichever wait happens to come first.
+        self._deadline = math.inf if timeout is None else anyio.current_time() + timeout
         self._lock = anyio.Lock()
+        self._pump: asyncio.Future[CommandResult] | None = None
+        self._abandoned = False
         self._outcome: _E2BResult | Exception | None = None
 
     @property
@@ -77,21 +91,68 @@ class _E2BProcess:
         return self._outcome
 
     async def _settle(self) -> _E2BResult:
-        try:
-            with anyio.fail_after(self._timeout):
-                result = await self._handle.wait()
-        except CommandExitException as exit_error:
-            # A non-zero exit is a normal result, not an error; the SDK reports it by raising.
-            return _E2BResult(exit_code=exit_error.exit_code, stdout=exit_error.stdout, stderr=exit_error.stderr)
-        except TimeoutError as error:
-            # E2B's own command deadline only tears the event stream down and leaves the command
-            # running in the sandbox, so the kill the timeout contract promises is ours to perform.
-            await self._handle.kill()
-            raise TimeoutError(f'command timed out after {self._timeout} seconds and was killed') from error
-        return _E2BResult(exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+        with anyio.CancelScope(deadline=self._deadline):
+            try:
+                result = await self._await_pump()
+            except CommandExitException as exit_error:
+                # A non-zero exit is a normal result, not an error; the SDK reports it by raising.
+                return _E2BResult(exit_code=exit_error.exit_code, stdout=exit_error.stdout, stderr=exit_error.stderr)
+            return _E2BResult(exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+        # Only the deadline reaches here: a cancel scope absorbs the cancellation it raised
+        # itself and lets an outer one through, which is what keeps a caller's cancellation — or
+        # a transport `TimeoutError` from the SDK — from being mistaken for the deadline.
+        kill_failure = await self.abandon()
+        # E2B's own command deadline only tears the event stream down and leaves the command
+        # running in the sandbox, so the kill the timeout contract promises is ours to perform.
+        # It is reported either way: a kill that failed cannot turn the timeout into a success.
+        raise TimeoutError(f'command timed out after {self._timeout} seconds and was killed') from kill_failure
+
+    async def _await_pump(self) -> CommandResult:
+        """Wait for the SDK's event pump without handing it this caller's cancellation.
+
+        `AsyncCommandHandle.wait()` awaits a shared `asyncio.Task` — the pump collecting the
+        command's output and exit code — and awaiting a task cancels it along with its awaiter.
+        One cancelled `wait()` would therefore kill the pump for good, and every later `wait()`
+        on the same process would raise `CancelledError` instead of the process's result.
+        """
+        if self._pump is None:
+            self._pump = asyncio.ensure_future(self._handle.wait())
+            # A wait this caller walked away from still completes; retrieving its outcome keeps
+            # the loop from reporting it as an exception nobody ever looked at.
+            self._pump.add_done_callback(_retrieve_outcome)
+        return await asyncio.shield(self._pump)
+
+    async def abandon(self) -> Exception | None:
+        """Best-effort teardown of a command whose wait will never finish.
+
+        Returns the kill's failure rather than raising it: the verdict that brought us here —
+        a deadline, a cancelled `run()` — is the one the caller has to see. Called at most once
+        per command, so a `run()` whose own deadline already dealt with it doesn't kill twice.
+        """
+        if self._abandoned:
+            return None
+        self._abandoned = True
+        failure: Exception | None = None
+        # Shielded and bounded, because this runs on cancellation paths, where an unshielded
+        # await re-raises before the command is dealt with.
+        with anyio.CancelScope(shield=True), anyio.move_on_after(_TEARDOWN_TIMEOUT):
+            try:
+                await self._handle.kill()
+            except Exception as error:
+                failure = error
+            # The kill stops the command; this closes the event stream the SDK keeps open for
+            # it, which is the SDK's own teardown surface for a handle nobody will wait on.
+            with suppress(Exception):
+                await self._handle.disconnect()
+        return failure
 
     async def kill(self) -> None:
         await self._handle.kill()
+
+
+def _retrieve_outcome(wait: asyncio.Future[CommandResult]) -> None:
+    if not wait.cancelled():
+        wait.exception()
 
 
 class _E2BFilesystem:
@@ -139,6 +200,11 @@ def _command_text(command: SandboxCommand, shell: bool) -> str:
         return command
     if isinstance(command, str):
         raise TypeError('a string command requires shell=True; pass an argv sequence otherwise')
+    if not command:
+        # An empty argv quotes back into an empty shell string, which bash would run as a
+        # successful command that did nothing; `LocalSandbox` rejects the same thing, because
+        # there is no program in an empty argv to report an exit code for.
+        raise TypeError('a command needs at least the program to run; the argv sequence is empty')
     # E2B only executes shell strings (every command runs as `/bin/bash -l -c <string>`), so argv
     # form is quoted back into one. `shlex.join` makes each element a single literal word, which
     # is what argv execution means: no element can be split, expanded, or read as an operator.
@@ -164,6 +230,16 @@ class E2BSandbox:
     `output_limit=` is not implemented either: E2B always delivers the full output, and dropping
     characters after the fact would misreport what the command produced. Bound it in-command
     instead, e.g. `| tail -c 10000`.
+
+    `timeout=` is enforced here rather than by E2B, whose own command deadline only drops the
+    event stream and leaves the command running. It runs from `start()`, so it bounds the
+    command's life rather than the length of whichever wait happens to come first, and the kill
+    it promises is performed even when the caller is being cancelled at the same moment. A
+    [`run()`][pydantic_ai.sandboxes.SandboxBackend.run] that is cancelled kills the command it
+    started, for the same reason; a cancelled
+    [`wait()`][pydantic_ai.sandboxes.SandboxProcess.wait] on a process from
+    [`start()`][pydantic_ai.sandboxes.SupportsStart.start] does not, because that process is the
+    caller's, and it stays waitable afterwards.
 
     Deliberately no base class: it conforms to the protocol structurally, like any third-party
     backend would.
@@ -221,24 +297,26 @@ class E2BSandbox:
             api_params: E2B connection options such as `api_key` (which defaults to the
                 `E2B_API_KEY` environment variable) and `domain`.
         """
-        sandbox = await AsyncSandbox.create(
-            template=template,
-            timeout=timeout,
-            envs=dict(envs) if envs is not None else None,
-            metadata=dict(metadata) if metadata is not None else None,
-            **api_params,
+        # Guarded because a caller cancelled while the create is in flight would otherwise leave
+        # a running (and billed) sandbox behind that nobody holds a handle to.
+        sandbox = await guarded_create(
+            AsyncSandbox.create(
+                template=template,
+                timeout=timeout,
+                envs=dict(envs) if envs is not None else None,
+                metadata=dict(metadata) if metadata is not None else None,
+                **api_params,
+            ),
+            lambda created: created.kill(),
         )
         try:
             yield cls(sandbox)
         finally:
-            # Shielded because teardown can run inside an already-cancelled scope, where every
-            # await re-raises: an unshielded kill would leak a running (and billed) sandbox.
-            with anyio.CancelScope(shield=True):
-                await sandbox.kill()
+            await destroy_quietly(sandbox.kill())
 
     @classmethod
-    async def connect(cls, sandbox_id: str, **api_params: Unpack[ApiParams]) -> Self:
-        """Attach to an E2B sandbox that already exists, without taking over its lifecycle.
+    async def connect(cls, sandbox_id: str, *, timeout: int | None = None, **api_params: Unpack[ApiParams]) -> Self:
+        """Attach to an E2B sandbox that already exists, without taking over its destruction.
 
         This is the building block for a
         [`SandboxResolver`][pydantic_ai.sandboxes.SandboxResolver] — a capability's
@@ -265,14 +343,20 @@ class E2BSandbox:
         ```
 
         Connecting never creates: `e2b.SandboxNotFoundException` is raised if the environment is
-        gone, rather than an empty replacement being silently swapped in.
+        gone, rather than an empty replacement being silently swapped in. It is not passive
+        either, and there is no way to ask E2B for a look that is: a paused sandbox is resumed,
+        and the sandbox's own keep-alive timeout is set to `timeout` — E2B's own default of 300
+        seconds when it is omitted — for a sandbox whose remaining time is shorter than that.
 
         Args:
             sandbox_id: The `sandbox_id` of the environment to attach to.
+            timeout: How long E2B keeps the sandbox alive from now, in seconds; a running
+                sandbox's timeout is only ever extended, never cut short. E2B applies its own
+                default of 300 seconds when this is omitted.
             api_params: E2B connection options such as `api_key` (which defaults to the
                 `E2B_API_KEY` environment variable) and `domain`.
         """
-        return cls(await AsyncSandbox.connect(sandbox_id, **api_params))
+        return cls(await AsyncSandbox.connect(sandbox_id, timeout=timeout, **api_params))
 
     async def working_dir(self) -> str:
         # E2B exposes no API for the template's default directory, and a command started without
@@ -284,7 +368,17 @@ class E2BSandbox:
                     f'Could not determine the working directory of sandbox {self.sandbox_id!r}: '
                     f'`pwd` exited {result.exit_code}: {result.stderr}'
                 )
-            self._working_dir = result.stdout.strip()
+            # Every command runs under `bash -l`, so a template whose login shell prints a banner
+            # puts it on stdout ahead of the answer: the path is the last line, and only an
+            # absolute one is an answer. Caching whatever else the shell printed would hand every
+            # later `resolve()` a working directory that is not one.
+            working_dir = result.stdout.strip().rpartition('\n')[2].strip()
+            if not posixpath.isabs(working_dir):
+                raise SandboxException(
+                    f'Could not determine the working directory of sandbox {self.sandbox_id!r}: '
+                    f'`pwd` printed {result.stdout!r}'
+                )
+            self._working_dir = working_dir
         return self._working_dir
 
     async def run(
@@ -298,7 +392,14 @@ class E2BSandbox:
         output_limit: int | None = None,
     ) -> _E2BResult:
         process = await self.start(command, shell=shell, cwd=cwd, env=env, timeout=timeout, output_limit=output_limit)
-        return await process.wait()
+        try:
+            return await process.wait()
+        except BaseException:
+            # `run()` owns the command it started, so a caller that walks away from it — a
+            # cancellation, an SDK failure mid-wait — must not leave it running in the sandbox.
+            # (`start()` hands the process to the caller instead, so `wait()` never kills.)
+            await process.abandon()
+            raise
 
     async def start(
         self,
@@ -312,17 +413,23 @@ class E2BSandbox:
     ) -> _E2BProcess:
         if output_limit is not None:
             raise NotImplementedError('E2BSandbox does not bound output; bound it in-command, e.g. `| tail -c`.')
-        handle = await self.sandbox.commands.run(
-            _command_text(command, shell),
-            background=True,
-            # `envs` are applied on top of the sandbox's environment, not in place of it.
-            envs=dict(env) if env is not None else None,
-            # `cwd=None` leaves the command in the sandbox's own default directory.
-            cwd=cwd,
-            # `0` disables E2B's command deadline (which would otherwise default to 60 seconds).
-            # The deadline is the process handle's to own, because E2B's merely drops the event
-            # stream while the command keeps running, which the timeout contract forbids.
-            timeout=0,
+        # Guarded like `create()`: cancelling the caller of an in-flight start would otherwise
+        # leave a command running in the sandbox that nobody holds a handle to.
+        handle = await guarded_create(
+            self.sandbox.commands.run(
+                _command_text(command, shell),
+                background=True,
+                # `envs` are applied on top of the sandbox's environment, not in place of it.
+                envs=dict(env) if env is not None else None,
+                # `cwd=None` leaves the command in the sandbox's own default directory.
+                cwd=cwd,
+                # `0` disables E2B's command deadline (which would otherwise default to 60
+                # seconds). The deadline is the process handle's to own, because E2B's merely
+                # drops the event stream while the command keeps running, which the timeout
+                # contract forbids.
+                timeout=0,
+            ),
+            lambda started: started.kill(),
         )
         return _E2BProcess(handle, timeout=timeout)
 

--- a/pydantic_ai_slim/pydantic_ai/sandboxes/e2b.py
+++ b/pydantic_ai_slim/pydantic_ai/sandboxes/e2b.py
@@ -1,0 +1,339 @@
+"""[E2B](https://e2b.dev) cloud sandboxes as a [sandbox backend][pydantic_ai.sandboxes.SandboxBackend].
+
+Needs the `e2b` optional dependency group (`pip install "pydantic-ai-slim[e2b]"`). Import
+[`E2BSandbox`][pydantic_ai.sandboxes.e2b.E2BSandbox] from this module directly:
+`pydantic_ai.sandboxes` deliberately doesn't re-export it, so importing the package never
+pulls in the E2B SDK.
+"""
+
+from __future__ import annotations as _annotations
+
+import shlex
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import anyio
+from typing_extensions import Self, Unpack
+
+from .protocol import FileEntry, SandboxCommand
+
+try:
+    from e2b import (
+        ApiParams,
+        AsyncCommandHandle,
+        AsyncSandbox,
+        CommandExitException,
+        EntryInfo,
+        FileType,
+        SandboxException,
+    )
+except ImportError as _import_error:
+    raise ImportError(
+        'Please install `e2b` to use the E2B sandbox, '
+        'you can use the `e2b` optional group — `pip install "pydantic-ai-slim[e2b]"`'
+    ) from _import_error
+
+if TYPE_CHECKING:
+    from .protocol import SandboxBackend, SandboxProcess, SupportsFilesystem, SupportsStart
+
+__all__ = ('E2BSandbox',)
+
+
+@dataclass(frozen=True)
+class _E2BResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    stdout_dropped: int = 0
+    stderr_dropped: int = 0
+
+
+class _E2BProcess:
+    """A command running inside an E2B sandbox, as returned by `E2BSandbox.start()`."""
+
+    def __init__(self, handle: AsyncCommandHandle, *, timeout: float | None):
+        self._handle = handle
+        self._timeout = timeout
+        self._lock = anyio.Lock()
+        self._outcome: _E2BResult | Exception | None = None
+
+    @property
+    def pid(self) -> int:
+        return self._handle.pid
+
+    async def wait(self) -> _E2BResult:
+        # The deadline below fires once, so the first call's verdict is the process's verdict:
+        # caching it is what makes repeated and concurrent `wait()`s agree, as the protocol requires.
+        async with self._lock:
+            if self._outcome is None:
+                try:
+                    self._outcome = await self._settle()
+                except Exception as error:
+                    self._outcome = error
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+    async def _settle(self) -> _E2BResult:
+        try:
+            with anyio.fail_after(self._timeout):
+                result = await self._handle.wait()
+        except CommandExitException as exit_error:
+            # A non-zero exit is a normal result, not an error; the SDK reports it by raising.
+            return _E2BResult(exit_code=exit_error.exit_code, stdout=exit_error.stdout, stderr=exit_error.stderr)
+        except TimeoutError as error:
+            # E2B's own command deadline only tears the event stream down and leaves the command
+            # running in the sandbox, so the kill the timeout contract promises is ours to perform.
+            await self._handle.kill()
+            raise TimeoutError(f'command timed out after {self._timeout} seconds and was killed') from error
+        return _E2BResult(exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+
+    async def kill(self) -> None:
+        await self._handle.kill()
+
+
+class _E2BFilesystem:
+    def __init__(self, sandbox: AsyncSandbox):
+        self._sandbox = sandbox
+
+    async def read_bytes(self, path: str) -> bytes:
+        # `format='bytes'` is the byte-exact read; it yields a `bytearray`, the protocol wants `bytes`.
+        return bytes(await self._sandbox.files.read(path, format='bytes'))
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        # E2B's `write` already creates missing parents and replaces existing contents.
+        # The ignore is for an unparameterized `IO` in the SDK's own signature, not for our call.
+        await self._sandbox.files.write(path, data)  # pyright: ignore[reportUnknownMemberType]
+
+    async def stat(self, path: str) -> FileEntry:
+        return _file_entry(await self._sandbox.files.get_info(path))
+
+    async def list_dir(self, path: str) -> Sequence[FileEntry]:
+        return [_file_entry(entry) for entry in await self._sandbox.files.list(path)]
+
+    async def make_dir(self, path: str) -> None:
+        # Creates parents, and returns `False` rather than raising when the directory
+        # already exists: `mkdir -p` semantics, so the return value carries nothing we need.
+        await self._sandbox.files.make_dir(path)
+
+    async def remove(self, path: str) -> None:
+        await self._sandbox.files.remove(path)
+
+    async def exists(self, path: str) -> bool:
+        return await self._sandbox.files.exists(path)
+
+
+def _file_entry(entry: EntryInfo) -> FileEntry:
+    is_dir = entry.type is FileType.DIR
+    # A directory's reported size is an implementation detail of the underlying filesystem
+    # rather than a content length, so report none for it, like the other built-in backends.
+    return FileEntry(name=entry.name, path=entry.path, is_dir=is_dir, size=None if is_dir else entry.size)
+
+
+def _command_text(command: SandboxCommand, shell: bool) -> str:
+    if shell:
+        if not isinstance(command, str):
+            raise TypeError('an argv sequence cannot be combined with shell=True; pass a single command string')
+        return command
+    if isinstance(command, str):
+        raise TypeError('a string command requires shell=True; pass an argv sequence otherwise')
+    # E2B only executes shell strings (every command runs as `/bin/bash -l -c <string>`), so argv
+    # form is quoted back into one. `shlex.join` makes each element a single literal word, which
+    # is what argv execution means: no element can be split, expanded, or read as an operator.
+    return shlex.join(command)
+
+
+class E2BSandbox:
+    """[`SandboxBackend`][pydantic_ai.sandboxes.SandboxBackend] over an [E2B](https://e2b.dev) cloud sandbox.
+
+    Commands and file operations run inside E2B's Firecracker microVM, so — unlike
+    [`LocalSandbox`][pydantic_ai.sandboxes.LocalSandbox] — the host is never exposed. Create one
+    with [`create()`][pydantic_ai.sandboxes.e2b.E2BSandbox.create], or attach to an existing
+    environment with [`connect()`][pydantic_ai.sandboxes.e2b.E2BSandbox.connect].
+
+    Background processes are supported natively
+    ([`SupportsStart`][pydantic_ai.sandboxes.SupportsStart]), but live output
+    ([`SupportsStream`][pydantic_ai.sandboxes.SupportsStream]) is not: the E2B async SDK
+    delivers output through `on_stdout`/`on_stderr` callbacks that its own event pump awaits, so
+    turning them into an async iterator needs a queue that either grows without bound or stalls
+    the pump — and a stalled pump never completes `wait()`. Poll the process with
+    `wait()` instead, or tee the output to a file inside the sandbox and read it.
+
+    `output_limit=` is not implemented either: E2B always delivers the full output, and dropping
+    characters after the fact would misreport what the command produced. Bound it in-command
+    instead, e.g. `| tail -c 10000`.
+
+    Deliberately no base class: it conforms to the protocol structurally, like any third-party
+    backend would.
+
+    Args:
+        sandbox: A live E2B `AsyncSandbox`. Prefer `create()` or `connect()`; pass a sandbox
+            here only when you already hold one, and remember that whoever created it owns
+            killing it.
+    """
+
+    provider = 'e2b'
+
+    def __init__(self, sandbox: AsyncSandbox):
+        self.sandbox = sandbox
+        """The underlying E2B `AsyncSandbox`, for provider-specific functionality."""
+        self.fs = _E2BFilesystem(sandbox)
+        self._working_dir: str | None = None
+
+    @property
+    def sandbox_id(self) -> str:
+        return self.sandbox.sandbox_id
+
+    @classmethod
+    @asynccontextmanager
+    async def create(
+        cls,
+        template: str | None = None,
+        *,
+        timeout: int | None = None,
+        envs: Mapping[str, str] | None = None,
+        metadata: Mapping[str, str] | None = None,
+        **api_params: Unpack[ApiParams],
+    ) -> AsyncGenerator[Self]:
+        """Provision a fresh E2B sandbox for the duration of the block, then kill it.
+
+        The supplier of a sandbox owns its lifecycle, so this is an async context manager: the
+        environment is killed when the block ends, including on failure and on cancellation.
+        E2B's own `timeout` remains the backstop for the block that never ends.
+
+        ```python {test="skip"}
+        from pydantic_ai.sandboxes.e2b import E2BSandbox
+
+
+        async def main() -> None:
+            async with E2BSandbox.create(timeout=600) as sandbox:
+                result = await sandbox.run(['python', '-c', 'print(1 + 1)'])
+                print(result.stdout)
+        ```
+
+        Args:
+            template: E2B sandbox template name or ID; defaults to E2B's `base` template.
+            timeout: How long E2B keeps the sandbox alive, in seconds (E2B's default is 300).
+            envs: Environment variables set for the whole sandbox.
+            metadata: Custom metadata to tag the sandbox with, e.g. the run it belongs to.
+            api_params: E2B connection options such as `api_key` (which defaults to the
+                `E2B_API_KEY` environment variable) and `domain`.
+        """
+        sandbox = await AsyncSandbox.create(
+            template=template,
+            timeout=timeout,
+            envs=dict(envs) if envs is not None else None,
+            metadata=dict(metadata) if metadata is not None else None,
+            **api_params,
+        )
+        try:
+            yield cls(sandbox)
+        finally:
+            # Shielded because teardown can run inside an already-cancelled scope, where every
+            # await re-raises: an unshielded kill would leak a running (and billed) sandbox.
+            with anyio.CancelScope(shield=True):
+                await sandbox.kill()
+
+    @classmethod
+    async def connect(cls, sandbox_id: str, **api_params: Unpack[ApiParams]) -> Self:
+        """Attach to an E2B sandbox that already exists, without taking over its lifecycle.
+
+        This is the building block for a
+        [`SandboxResolver`][pydantic_ai.sandboxes.SandboxResolver] — a capability's
+        [`get_sandbox`][pydantic_ai.capabilities.AbstractCapability.get_sandbox] hook turning a
+        [`SandboxRef`][pydantic_ai.sandboxes.SandboxRef] back into a live backend, wherever the
+        work actually runs:
+
+        ```python {test="skip"}
+        from typing import Any
+
+        from pydantic_ai import RunContext
+        from pydantic_ai.capabilities import AbstractCapability
+        from pydantic_ai.sandboxes import SandboxBackend, SandboxRef
+        from pydantic_ai.sandboxes.e2b import E2BSandbox
+
+
+        class E2BCapability(AbstractCapability[Any]):
+            async def get_sandbox(
+                self, ctx: RunContext[Any], ref: SandboxRef
+            ) -> SandboxBackend | None:
+                if ref.provider != 'e2b':
+                    return None
+                return await E2BSandbox.connect(ref.sandbox_id)
+        ```
+
+        Connecting never creates: `e2b.SandboxNotFoundException` is raised if the environment is
+        gone, rather than an empty replacement being silently swapped in.
+
+        Args:
+            sandbox_id: The `sandbox_id` of the environment to attach to.
+            api_params: E2B connection options such as `api_key` (which defaults to the
+                `E2B_API_KEY` environment variable) and `domain`.
+        """
+        return cls(await AsyncSandbox.connect(sandbox_id, **api_params))
+
+    async def working_dir(self) -> str:
+        # E2B exposes no API for the template's default directory, and a command started without
+        # `cwd` lands in exactly that directory, so ask the environment itself. It cannot change.
+        if self._working_dir is None:
+            result = await self.run(['pwd'])
+            if result.exit_code != 0:
+                raise SandboxException(
+                    f'Could not determine the working directory of sandbox {self.sandbox_id!r}: '
+                    f'`pwd` exited {result.exit_code}: {result.stderr}'
+                )
+            self._working_dir = result.stdout.strip()
+        return self._working_dir
+
+    async def run(
+        self,
+        command: SandboxCommand,
+        *,
+        shell: bool = False,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        output_limit: int | None = None,
+    ) -> _E2BResult:
+        process = await self.start(command, shell=shell, cwd=cwd, env=env, timeout=timeout, output_limit=output_limit)
+        return await process.wait()
+
+    async def start(
+        self,
+        command: SandboxCommand,
+        *,
+        shell: bool = False,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        output_limit: int | None = None,
+    ) -> _E2BProcess:
+        if output_limit is not None:
+            raise NotImplementedError('E2BSandbox does not bound output; bound it in-command, e.g. `| tail -c`.')
+        handle = await self.sandbox.commands.run(
+            _command_text(command, shell),
+            background=True,
+            # `envs` are applied on top of the sandbox's environment, not in place of it.
+            envs=dict(env) if env is not None else None,
+            # `cwd=None` leaves the command in the sandbox's own default directory.
+            cwd=cwd,
+            # `0` disables E2B's command deadline (which would otherwise default to 60 seconds).
+            # The deadline is the process handle's to own, because E2B's merely drops the event
+            # stream while the command keeps running, which the timeout contract forbids.
+            timeout=0,
+        )
+        return _E2BProcess(handle, timeout=timeout)
+
+
+if TYPE_CHECKING:
+    # Pins full structural conformance — signatures included — which `isinstance` cannot check.
+    # `__new__` rather than a call, because neither SDK object can be constructed without a
+    # live sandbox behind it; this block never runs.
+    _sandbox = AsyncSandbox.__new__(AsyncSandbox)
+    _handle = AsyncCommandHandle.__new__(AsyncCommandHandle)
+    _backend_conforms: SandboxBackend = E2BSandbox(_sandbox)
+    _filesystem_backend_conforms: SupportsFilesystem = E2BSandbox(_sandbox)
+    _start_conforms: SupportsStart = E2BSandbox(_sandbox)
+    _process_conforms: SandboxProcess = _E2BProcess(_handle, timeout=None)

--- a/pydantic_ai_slim/pydantic_ai/sandboxes/modal.py
+++ b/pydantic_ai_slim/pydantic_ai/sandboxes/modal.py
@@ -21,12 +21,18 @@ from typing import TYPE_CHECKING, Literal
 import anyio
 from typing_extensions import Self
 
+from ._lifecycle import destroy_quietly, guarded_create
 from .protocol import FileEntry, SandboxCommand
 
 try:
     from modal import App, Client, Image, Sandbox
     from modal.container_process import ContainerProcess
-    from modal.exception import ExecutionError, SandboxFilesystemNotFoundError
+    from modal.exception import (
+        ExecutionError,
+        SandboxFilesystemNotADirectoryError,
+        SandboxFilesystemNotFoundError,
+    )
+    from modal.io_streams import StreamReader
     from modal.types import FileInfo, FileType
 except ImportError as _import_error:
     raise ImportError(
@@ -66,12 +72,12 @@ class _ModalOutputChunk:
 class _ModalProcess:
     """A command running inside a Modal sandbox, as returned by `ModalSandbox.start()`."""
 
-    def __init__(self, process: ContainerProcess[str], *, timeout: float | None, deadline: int | None):
+    def __init__(self, process: ContainerProcess[str], *, timeout: float | None, deadline: int | None, started: float):
         self._process = process
         self._timeout = timeout
         self._deadline = deadline
-        self._started = time.monotonic()
-        self._output: dict[_Stream, str] = {'stdout': '', 'stderr': ''}
+        self._started = started
+        self._streaming = False
         self._lock = anyio.Lock()
         self._outcome: _ModalResult | Exception | None = None
 
@@ -81,17 +87,28 @@ class _ModalProcess:
         # OS process id, so there is no honest number to give here.
         return None
 
-    async def stream(self) -> AsyncGenerator[_ModalOutputChunk]:
+    def stream(self) -> AsyncGenerator[_ModalOutputChunk]:
         """Iterate over the command's output as Modal produces it.
 
-        Chunks from the two streams are interleaved in arrival order. Everything Modal has
-        already delivered is also kept, so a later
-        [`wait()`][pydantic_ai.sandboxes.SandboxProcess.wait] still reports it — whether this
-        iterator ran to completion or was abandoned part way. A read still in flight when the
-        iterator is abandoned is cancelled, so output produced after that point is not. It is an
-        async generator rather than a bare iterator so that a consumer stopping early can close
-        it — and cancel that read — at a point of its own choosing.
+        Chunks from the two streams are interleaved in arrival order. Modal's readers have a
+        single consumer — each caches the one generator it hands out — so a process can only be
+        streamed once and a second call raises. Nothing here is load-bearing for
+        [`wait()`][pydantic_ai.sandboxes.SandboxProcess.wait], which asks Modal for the command's
+        output in full: a consumer that stops iterating part way costs it nothing, and streaming
+        a command that has already been waited for replays its output from the beginning.
+
+        It is an async generator rather than a bare iterator so that a consumer stopping early
+        can close it — and cancel the reads still in flight — at a point of its own choosing.
         """
+        if self._streaming:
+            raise RuntimeError(
+                "Modal's output streams have a single consumer: `stream()` can only be iterated "
+                'once per started command.'
+            )
+        self._streaming = True
+        return self._stream()
+
+    async def _stream(self) -> AsyncGenerator[_ModalOutputChunk]:
         iterators: dict[_Stream, AsyncIterator[str]] = {
             'stdout': aiter(self._process.stdout),
             'stderr': aiter(self._process.stderr),
@@ -110,14 +127,7 @@ class _ModalProcess:
         try:
             while pending:
                 done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-                arrived = [task.result() for task in sorted(done, key=lambda finished: finished.result()[0])]
-                # Recorded before any of it is handed out, because a delivered chunk has already
-                # moved the SDK's stream position: a consumer that stops iterating half way must
-                # not cost `wait()` output that the sandbox can no longer be asked for again.
-                for _, name, chunk in arrived:
-                    if chunk is not None:
-                        self._output[name] += chunk
-                for _, name, chunk in arrived:
+                for _, name, chunk in sorted(task.result() for task in done):
                     if chunk is None:  # that stream reached EOF and is not re-armed
                         continue
                     # Re-armed before the chunk is handed over, so the next read is already in
@@ -125,8 +135,11 @@ class _ModalProcess:
                     pending.add(asyncio.ensure_future(read_one(name)))
                     yield _ModalOutputChunk(stream=name, data=chunk)
         finally:
+            # Reaped, not just cancelled: an abandoned read would otherwise keep retrying
+            # against the worker long after the consumer walked away.
             for task in pending:
                 task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
 
     async def wait(self) -> _ModalResult:
         # The timeout verdict below can only be reached once, so the first call's verdict is the
@@ -143,27 +156,56 @@ class _ModalProcess:
         return self._outcome
 
     async def _settle(self) -> _ModalResult:
-        # Modal's own SDK reads both streams alongside the wait; a stream already drained by
-        # `stream()` reports itself at EOF and contributes nothing a second time.
-        stdout, stderr, exit_code = await asyncio.gather(
-            self._process.stdout.read.aio(),
-            self._process.stderr.read.aio(),
-            self._process.wait.aio(),
-        )
-        self._output['stdout'] += stdout
-        self._output['stderr'] += stderr
-        if self._timed_out(exit_code):
-            raise TimeoutError(f'command timed out after {self._timeout} seconds and was killed')
-        return _ModalResult(exit_code=exit_code, stdout=self._output['stdout'], stderr=self._output['stderr'])
+        output: dict[_Stream, str] = {}
+        exit_code = 0
+        elapsed = 0.0
 
-    def _timed_out(self, exit_code: int) -> bool:
+        async def read(name: _Stream, reader: StreamReader[str]) -> None:
+            # Every `read()` opens a stream of its own at offset zero and returns the command's
+            # whole output, so what `stream()` consumed changes nothing here: the output is
+            # accumulated exactly once however the two are interleaved.
+            output[name] = await reader.read.aio()
+
+        async def collect_exit_code() -> None:
+            nonlocal exit_code, elapsed
+            exit_code = await self._process.wait.aio()
+            # Stamped where the exit code lands rather than where the last of the output does:
+            # a command that exited long before its output finished streaming must not be read
+            # as one the deadline killed.
+            elapsed = time.monotonic() - self._started
+
+        tasks = [
+            asyncio.ensure_future(read('stdout', self._process.stdout)),
+            asyncio.ensure_future(read('stderr', self._process.stderr)),
+            asyncio.ensure_future(collect_exit_code()),
+        ]
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            # One step failing leaves its siblings retrying network reads long after `run()`
+            # returned, so they are cancelled and reaped rather than orphaned.
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        if self._timed_out(exit_code, elapsed):
+            raise TimeoutError(
+                f'command timed out after {self._deadline} seconds '
+                f'(Modal takes whole seconds; {self._timeout} was requested) and was killed'
+            )
+        return _ModalResult(exit_code=exit_code, stdout=output['stdout'], stderr=output['stderr'])
+
+    def _timed_out(self, exit_code: int, elapsed: float) -> bool:
         if self._deadline is None:
             return False
         if exit_code == _CLIENT_DEADLINE_EXIT:
             return True
         # A command can exit 137 on its own account (an OOM kill, a `kill -9` it asked for), so
-        # that exit only means "the deadline killed it" once the deadline window has elapsed.
-        return exit_code == _SIGKILL_EXIT and time.monotonic() - self._started >= self._deadline
+        # that exit only means "the deadline killed it" once the whole window has elapsed. The
+        # window is measured from before the exec call, which makes it a superset of the one
+        # Modal's own timer runs — the platform starts counting when the command starts, inside
+        # that round trip — so a deadline kill always lands inside it and an earlier exit does not.
+        return exit_code == _SIGKILL_EXIT and elapsed >= self._deadline
 
     async def kill(self) -> None:
         raise NotImplementedError(
@@ -188,8 +230,9 @@ class _ModalFilesystem:
 
     async def list_dir(self, path: str) -> Sequence[FileEntry]:
         entries = await self._sandbox.filesystem.list_files.aio(path)
-        # A listing names its entries relative to the directory that was listed, so the absolute
-        # path the protocol promises is rebuilt from the directory we asked about.
+        # `name` is the entry's base name, so joining it onto the directory we asked about gives
+        # the absolute path the protocol promises. The listing's own `path` is produced by the
+        # sandbox-side fs tools rather than by anything in the SDK, so it is not relied on.
         return [_file_entry(entry, posixpath.join(path, entry.name)) for entry in entries]
 
     async def make_dir(self, path: str) -> None:
@@ -204,10 +247,13 @@ class _ModalFilesystem:
 
     async def exists(self, path: str) -> bool:
         # Modal has no existence check of its own, and `stat` is the cheapest question that
-        # answers one. Only "not found" is an answer: every other failure is still a failure.
+        # answers one. Only "there is nothing at that path" is an answer, and Modal splits it in
+        # two: a missing component, and a non-leaf component that is a file rather than a
+        # directory (`/tmp/notes.txt/deeper`), which the other backends both answer `False` for.
+        # Every other failure is still a failure.
         try:
             await self._sandbox.filesystem.stat.aio(path)
-        except SandboxFilesystemNotFoundError:
+        except (SandboxFilesystemNotFoundError, SandboxFilesystemNotADirectoryError):
             return False
         return True
 
@@ -229,6 +275,10 @@ def _command_argv(command: SandboxCommand, shell: bool) -> Sequence[str]:
         return ['/bin/sh', '-c', command]
     if isinstance(command, str):
         raise TypeError('a string command requires shell=True; pass an argv sequence otherwise')
+    if not command:
+        # Modal would exec zero arguments; `LocalSandbox` rejects the same thing, because there
+        # is no program in an empty argv to report an exit code for.
+        raise TypeError('a command needs at least the program to run; the argv sequence is empty')
     return command
 
 
@@ -245,10 +295,19 @@ class ModalSandbox:
     ([`SupportsStart`][pydantic_ai.sandboxes.SupportsStart]), Modal's SDK exposes a command's
     output as async-iterable streams that it keeps drained on its own, so live output
     ([`SupportsStream`][pydantic_ai.sandboxes.SupportsStream]) needs no bridging and is offered
-    too. What Modal has no API for is killing a single command:
+    too — for one consumer per command, which is all Modal's readers hand out. What Modal has no
+    API for is killing a single command:
     [`kill()`][pydantic_ai.sandboxes.SandboxProcess.kill] raises `NotImplementedError`, and
     `timeout=` — which Modal enforces itself, killing the command at the deadline — is how a
-    command is bounded.
+    command is bounded. Modal takes whole seconds, so a fractional `timeout=` is rounded up to
+    the deadline it actually applies, which is the one a `TimeoutError` reports.
+
+    The deadline kill lands as one of two exits, and both are read as the timeout the protocol
+    promises: the SDK's own `-1`, and the `137` of the platform's `SIGKILL` once the whole
+    deadline window has passed. A `137` from inside that window is a command that killed itself
+    — an OOM kill, a `kill -9` it asked for — and is returned as the honest exit code it is. The
+    residual ambiguity is a self-inflicted `137` that lands exactly as the deadline expires,
+    which is reported as a timeout.
 
     `output_limit=` is not implemented: Modal always delivers the full output, and dropping
     characters after the fact would misreport what the command produced. Bound it in-command
@@ -318,25 +377,31 @@ class ModalSandbox:
             client: Modal client to use; defaults to the ambient Modal credentials.
         """
         resolved_app = app if isinstance(app, App) else await App.lookup.aio(app, create_if_missing=True, client=client)
-        # The ignore is for unparameterized `os.PathLike` mount keys in the SDK's own signature,
-        # not for anything this call passes.
-        sandbox = await Sandbox.create.aio(  # pyright: ignore[reportUnknownMemberType]
-            app=resolved_app,
-            image=image,
-            timeout=timeout,
-            workdir=workdir,
-            env=dict(env) if env is not None else None,
-            cpu=cpu,
-            memory=memory,
-            client=client,
+        # Guarded because a caller cancelled while the create is in flight would otherwise leave
+        # a running (and billed) sandbox behind that nobody holds a handle to.
+        sandbox = await guarded_create(
+            # The ignore is for unparameterized `os.PathLike` mount keys in the SDK's own
+            # signature, not for anything this call passes.
+            Sandbox.create.aio(  # pyright: ignore[reportUnknownMemberType]
+                app=resolved_app,
+                image=image,
+                timeout=timeout,
+                workdir=workdir,
+                env=dict(env) if env is not None else None,
+                cpu=cpu,
+                memory=memory,
+                client=client,
+            ),
+            lambda created: created.terminate.aio(),
         )
+        backend = cls(sandbox)
+        # `create(workdir=...)` already knows the answer `working_dir()` would have to ask the
+        # environment for, and the answer cannot change.
+        backend._working_dir = workdir
         try:
-            yield cls(sandbox)
+            yield backend
         finally:
-            # Shielded because teardown can run inside an already-cancelled scope, where every
-            # await re-raises: an unshielded terminate would leak a running (and billed) sandbox.
-            with anyio.CancelScope(shield=True):
-                await sandbox.terminate.aio()
+            await destroy_quietly(sandbox.terminate.aio())
 
     @classmethod
     async def connect(cls, sandbox_id: str, *, client: Client | None = None) -> Self:
@@ -366,8 +431,11 @@ class ModalSandbox:
                 return await ModalSandbox.connect(ref.sandbox_id)
         ```
 
-        Connecting never creates: `modal.exception.NotFoundError` is raised if the environment is
-        gone, rather than an empty replacement being silently swapped in.
+        Connecting never creates, but it does not prove the environment is alive either: Modal
+        looks the sandbox up and hands back a handle for one it still knows about even after it
+        has terminated, so a dead environment surfaces at the first command as
+        `modal.exception.SandboxTerminatedError` rather than here. An id the workspace does not
+        know raises `modal.exception.NotFoundError`, and a malformed one `modal.exception.InvalidError`.
 
         Args:
             sandbox_id: The `sandbox_id` of the environment to attach to.
@@ -377,8 +445,9 @@ class ModalSandbox:
 
     async def working_dir(self) -> str:
         # Modal exposes no API for a running sandbox's working directory — it is the image's
-        # unless `create(workdir=...)` overrode it — so ask the environment itself. It cannot
-        # change, so one answer serves the sandbox's whole life.
+        # unless `create(workdir=...)` overrode it, in which case `create()` already filled this
+        # in — so ask the environment itself. It cannot change, so one answer serves the
+        # sandbox's whole life.
         if self._working_dir is None:
             result = await self.run(['pwd'])
             if result.exit_code != 0:
@@ -386,7 +455,15 @@ class ModalSandbox:
                     f'Could not determine the working directory of sandbox {self.sandbox_id!r}: '
                     f'`pwd` exited {result.exit_code}: {result.stderr}'
                 )
-            self._working_dir = result.stdout.strip()
+            working_dir = result.stdout.strip()
+            # Only an absolute path is an answer. Caching whatever else the environment printed
+            # would hand every later `resolve()` a working directory that is not one.
+            if not posixpath.isabs(working_dir):
+                raise ExecutionError(
+                    f'Could not determine the working directory of sandbox {self.sandbox_id!r}: '
+                    f'`pwd` printed {result.stdout!r}'
+                )
+            self._working_dir = working_dir
         return self._working_dir
 
     async def run(
@@ -417,6 +494,10 @@ class ModalSandbox:
         # Modal takes whole seconds and reads a missing deadline as "run until the sandbox dies",
         # so a sub-second deadline rounds up rather than silently becoming unbounded.
         deadline = None if timeout is None else max(1, math.ceil(timeout))
+        # Stamped before the call, so the window a `137` is dated against is a superset of the
+        # one Modal's own timer runs: the platform starts counting when the command starts,
+        # which happens inside this round trip.
+        started = time.monotonic()
         process = await self.sandbox.exec.aio(
             *_command_argv(command, shell),
             # Modal's deadline really does kill the command, so — unlike E2B's — the platform
@@ -428,7 +509,7 @@ class ModalSandbox:
             env=dict(env) if env is not None else None,
             text=True,
         )
-        return _ModalProcess(process, timeout=timeout, deadline=deadline)
+        return _ModalProcess(process, timeout=timeout, deadline=deadline, started=started)
 
 
 if TYPE_CHECKING:
@@ -440,5 +521,5 @@ if TYPE_CHECKING:
     _backend_conforms: SandboxBackend = ModalSandbox(_sandbox)
     _filesystem_backend_conforms: SupportsFilesystem = ModalSandbox(_sandbox)
     _start_conforms: SupportsStart = ModalSandbox(_sandbox)
-    _process_conforms: SandboxProcess = _ModalProcess(_process, timeout=None, deadline=None)
-    _stream_conforms: SupportsStream = _ModalProcess(_process, timeout=None, deadline=None)
+    _process_conforms: SandboxProcess = _ModalProcess(_process, timeout=None, deadline=None, started=0.0)
+    _stream_conforms: SupportsStream = _ModalProcess(_process, timeout=None, deadline=None, started=0.0)

--- a/pydantic_ai_slim/pydantic_ai/sandboxes/modal.py
+++ b/pydantic_ai_slim/pydantic_ai/sandboxes/modal.py
@@ -1,0 +1,444 @@
+"""[Modal](https://modal.com) cloud sandboxes as a [sandbox backend][pydantic_ai.sandboxes.SandboxBackend].
+
+Needs the `modal` optional dependency group (`pip install "pydantic-ai-slim[modal]"`). Import
+[`ModalSandbox`][pydantic_ai.sandboxes.modal.ModalSandbox] from this module directly:
+`pydantic_ai.sandboxes` deliberately doesn't re-export it, so importing the package never
+pulls in the Modal SDK.
+"""
+
+from __future__ import annotations as _annotations
+
+import asyncio
+import itertools
+import math
+import posixpath
+import time
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+import anyio
+from typing_extensions import Self
+
+from .protocol import FileEntry, SandboxCommand
+
+try:
+    from modal import App, Client, Image, Sandbox
+    from modal.container_process import ContainerProcess
+    from modal.exception import ExecutionError, SandboxFilesystemNotFoundError
+    from modal.types import FileInfo, FileType
+except ImportError as _import_error:
+    raise ImportError(
+        'Please install `modal` to use the Modal sandbox, '
+        'you can use the `modal` optional group — `pip install "pydantic-ai-slim[modal]"`'
+    ) from _import_error
+
+if TYPE_CHECKING:
+    from .protocol import SandboxBackend, SandboxProcess, SupportsFilesystem, SupportsStart, SupportsStream
+
+__all__ = ('ModalSandbox',)
+
+_Stream = Literal['stdout', 'stderr']
+
+# What Modal's client reports when its own copy of a command's deadline ends the wait.
+_CLIENT_DEADLINE_EXIT = -1
+# The exit status of a process killed by SIGKILL (128 + 9): what the *server* side of the same
+# deadline looks like when its kill lands before the client's deadline fires.
+_SIGKILL_EXIT = 137
+
+
+@dataclass(frozen=True)
+class _ModalResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    stdout_dropped: int = 0
+    stderr_dropped: int = 0
+
+
+@dataclass(frozen=True)
+class _ModalOutputChunk:
+    stream: _Stream
+    data: str
+
+
+class _ModalProcess:
+    """A command running inside a Modal sandbox, as returned by `ModalSandbox.start()`."""
+
+    def __init__(self, process: ContainerProcess[str], *, timeout: float | None, deadline: int | None):
+        self._process = process
+        self._timeout = timeout
+        self._deadline = deadline
+        self._started = time.monotonic()
+        self._output: dict[_Stream, str] = {'stdout': '', 'stderr': ''}
+        self._lock = anyio.Lock()
+        self._outcome: _ModalResult | Exception | None = None
+
+    @property
+    def pid(self) -> int | None:
+        # Modal identifies a command by an exec id of its own and never reports the container's
+        # OS process id, so there is no honest number to give here.
+        return None
+
+    async def stream(self) -> AsyncGenerator[_ModalOutputChunk]:
+        """Iterate over the command's output as Modal produces it.
+
+        Chunks from the two streams are interleaved in arrival order. Everything Modal has
+        already delivered is also kept, so a later
+        [`wait()`][pydantic_ai.sandboxes.SandboxProcess.wait] still reports it — whether this
+        iterator ran to completion or was abandoned part way. A read still in flight when the
+        iterator is abandoned is cancelled, so output produced after that point is not. It is an
+        async generator rather than a bare iterator so that a consumer stopping early can close
+        it — and cancel that read — at a point of its own choosing.
+        """
+        iterators: dict[_Stream, AsyncIterator[str]] = {
+            'stdout': aiter(self._process.stdout),
+            'stderr': aiter(self._process.stderr),
+        }
+        arrival = itertools.count()
+
+        async def read_one(name: _Stream) -> tuple[int, _Stream, str | None]:
+            chunk = await anext(iterators[name], None)
+            # Stamped where the chunk lands rather than where it is collected: a wake-up that
+            # finds both streams ready hands them back as an unordered set, and this is what
+            # keeps the merge in the order Modal produced the output.
+            return next(arrival), name, chunk
+
+        # One read in flight per stream, re-armed as each is consumed.
+        pending = {asyncio.ensure_future(read_one(name)) for name in iterators}
+        try:
+            while pending:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                arrived = [task.result() for task in sorted(done, key=lambda finished: finished.result()[0])]
+                # Recorded before any of it is handed out, because a delivered chunk has already
+                # moved the SDK's stream position: a consumer that stops iterating half way must
+                # not cost `wait()` output that the sandbox can no longer be asked for again.
+                for _, name, chunk in arrived:
+                    if chunk is not None:
+                        self._output[name] += chunk
+                for _, name, chunk in arrived:
+                    if chunk is None:  # that stream reached EOF and is not re-armed
+                        continue
+                    # Re-armed before the chunk is handed over, so the next read is already in
+                    # flight while the consumer works through this one.
+                    pending.add(asyncio.ensure_future(read_one(name)))
+                    yield _ModalOutputChunk(stream=name, data=chunk)
+        finally:
+            for task in pending:
+                task.cancel()
+
+    async def wait(self) -> _ModalResult:
+        # The timeout verdict below can only be reached once, so the first call's verdict is the
+        # process's verdict: caching it is what makes repeated and concurrent `wait()`s agree,
+        # as the protocol requires.
+        async with self._lock:
+            if self._outcome is None:
+                try:
+                    self._outcome = await self._settle()
+                except Exception as error:
+                    self._outcome = error
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+    async def _settle(self) -> _ModalResult:
+        # Modal's own SDK reads both streams alongside the wait; a stream already drained by
+        # `stream()` reports itself at EOF and contributes nothing a second time.
+        stdout, stderr, exit_code = await asyncio.gather(
+            self._process.stdout.read.aio(),
+            self._process.stderr.read.aio(),
+            self._process.wait.aio(),
+        )
+        self._output['stdout'] += stdout
+        self._output['stderr'] += stderr
+        if self._timed_out(exit_code):
+            raise TimeoutError(f'command timed out after {self._timeout} seconds and was killed')
+        return _ModalResult(exit_code=exit_code, stdout=self._output['stdout'], stderr=self._output['stderr'])
+
+    def _timed_out(self, exit_code: int) -> bool:
+        if self._deadline is None:
+            return False
+        if exit_code == _CLIENT_DEADLINE_EXIT:
+            return True
+        # A command can exit 137 on its own account (an OOM kill, a `kill -9` it asked for), so
+        # that exit only means "the deadline killed it" once the deadline window has elapsed.
+        return exit_code == _SIGKILL_EXIT and time.monotonic() - self._started >= self._deadline
+
+    async def kill(self) -> None:
+        raise NotImplementedError(
+            'Modal exposes no way to kill an individual command; start it with `timeout=` so the '
+            'platform kills it at the deadline, or terminate the whole sandbox.'
+        )
+
+
+class _ModalFilesystem:
+    def __init__(self, sandbox: Sandbox):
+        self._sandbox = sandbox
+
+    async def read_bytes(self, path: str) -> bytes:
+        return await self._sandbox.filesystem.read_bytes.aio(path)
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        # Modal takes the data first, creates missing parents, and replaces existing contents.
+        await self._sandbox.filesystem.write_bytes.aio(data, path)
+
+    async def stat(self, path: str) -> FileEntry:
+        return _file_entry(await self._sandbox.filesystem.stat.aio(path), path)
+
+    async def list_dir(self, path: str) -> Sequence[FileEntry]:
+        entries = await self._sandbox.filesystem.list_files.aio(path)
+        # A listing names its entries relative to the directory that was listed, so the absolute
+        # path the protocol promises is rebuilt from the directory we asked about.
+        return [_file_entry(entry, posixpath.join(path, entry.name)) for entry in entries]
+
+    async def make_dir(self, path: str) -> None:
+        # Modal's default `create_parents=True` is `mkdir -p`: missing parents are created and an
+        # existing directory is not an error.
+        await self._sandbox.filesystem.make_directory.aio(path)
+
+    async def remove(self, path: str) -> None:
+        # `recursive=True` is what lets this remove a non-empty directory; on a file it changes
+        # nothing, so one call covers both halves of the protocol's `remove`.
+        await self._sandbox.filesystem.remove.aio(path, recursive=True)
+
+    async def exists(self, path: str) -> bool:
+        # Modal has no existence check of its own, and `stat` is the cheapest question that
+        # answers one. Only "not found" is an answer: every other failure is still a failure.
+        try:
+            await self._sandbox.filesystem.stat.aio(path)
+        except SandboxFilesystemNotFoundError:
+            return False
+        return True
+
+
+def _file_entry(entry: FileInfo, path: str) -> FileEntry:
+    is_dir = entry.type is FileType.DIRECTORY
+    # A directory's reported size is an implementation detail of the underlying filesystem
+    # rather than a content length, so report none for it, like the other built-in backends.
+    return FileEntry(name=entry.name, path=path, is_dir=is_dir, size=None if is_dir else entry.size)
+
+
+def _command_argv(command: SandboxCommand, shell: bool) -> Sequence[str]:
+    if shell:
+        if not isinstance(command, str):
+            raise TypeError('an argv sequence cannot be combined with shell=True; pass a single command string')
+        # Modal executes argv and never a shell string, so shell interpretation is requested
+        # explicitly — the mirror image of `E2BSandbox`, which has to quote argv back into a
+        # string. `/bin/sh` rather than bash: it is the one shell every sandbox image carries.
+        return ['/bin/sh', '-c', command]
+    if isinstance(command, str):
+        raise TypeError('a string command requires shell=True; pass an argv sequence otherwise')
+    return command
+
+
+class ModalSandbox:
+    """[`SandboxBackend`][pydantic_ai.sandboxes.SandboxBackend] over a [Modal](https://modal.com) sandbox.
+
+    Commands and file operations run inside a Modal container, so — unlike
+    [`LocalSandbox`][pydantic_ai.sandboxes.LocalSandbox] — the host is never exposed. Create one
+    with [`create()`][pydantic_ai.sandboxes.modal.ModalSandbox.create], or attach to an existing
+    environment with [`connect()`][pydantic_ai.sandboxes.modal.ModalSandbox.connect].
+
+    Both process opt-ins are implemented, which is where this backend differs from
+    [`E2BSandbox`][pydantic_ai.sandboxes.e2b.E2BSandbox]: alongside background processes
+    ([`SupportsStart`][pydantic_ai.sandboxes.SupportsStart]), Modal's SDK exposes a command's
+    output as async-iterable streams that it keeps drained on its own, so live output
+    ([`SupportsStream`][pydantic_ai.sandboxes.SupportsStream]) needs no bridging and is offered
+    too. What Modal has no API for is killing a single command:
+    [`kill()`][pydantic_ai.sandboxes.SandboxProcess.kill] raises `NotImplementedError`, and
+    `timeout=` — which Modal enforces itself, killing the command at the deadline — is how a
+    command is bounded.
+
+    `output_limit=` is not implemented: Modal always delivers the full output, and dropping
+    characters after the fact would misreport what the command produced. Bound it in-command
+    instead, e.g. `| tail -c 10000`.
+
+    Deliberately no base class: it conforms to the protocol structurally, like any third-party
+    backend would.
+
+    Args:
+        sandbox: A live `modal.Sandbox`. Prefer `create()` or `connect()`; pass a sandbox here
+            when you need a Modal option those two don't expose, and remember that whoever
+            created it owns terminating it.
+    """
+
+    provider = 'modal'
+
+    def __init__(self, sandbox: Sandbox):
+        self.sandbox = sandbox
+        """The underlying `modal.Sandbox`, for provider-specific functionality."""
+        self.fs = _ModalFilesystem(sandbox)
+        self._working_dir: str | None = None
+
+    @property
+    def sandbox_id(self) -> str:
+        return self.sandbox.object_id
+
+    @classmethod
+    @asynccontextmanager
+    async def create(
+        cls,
+        *,
+        app: App | str = 'pydantic-ai-sandbox',
+        image: Image | None = None,
+        timeout: int = 300,
+        workdir: str | None = None,
+        env: Mapping[str, str] | None = None,
+        cpu: float | tuple[float, float] | None = None,
+        memory: int | tuple[int, int] | None = None,
+        client: Client | None = None,
+    ) -> AsyncGenerator[Self]:
+        """Provision a fresh Modal sandbox for the duration of the block, then terminate it.
+
+        The supplier of a sandbox owns its lifecycle, so this is an async context manager: the
+        environment is terminated when the block ends, including on failure and on cancellation.
+        Modal's own `timeout` remains the backstop for the block that never ends.
+
+        ```python {test="skip"}
+        from pydantic_ai.sandboxes.modal import ModalSandbox
+
+
+        async def main() -> None:
+            async with ModalSandbox.create(timeout=600) as sandbox:
+                result = await sandbox.run(['python', '-c', 'print(1 + 1)'])
+                print(result.stdout)
+        ```
+
+        Args:
+            app: The Modal app the sandbox belongs to — every sandbox needs one. A name (the
+                default) is looked up and created if it doesn't exist yet; pass a `modal.App`
+                to reuse one you already hold.
+            image: The image the sandbox runs; defaults to Modal's own default image.
+            timeout: How long Modal keeps the sandbox alive, in seconds (Modal's own default).
+            workdir: Absolute directory commands start in; defaults to the image's.
+            env: Environment variables set for the whole sandbox.
+            cpu: Reserved cores, or a `(request, limit)` pair.
+            memory: Reserved MiB, or a `(request, limit)` pair.
+            client: Modal client to use; defaults to the ambient Modal credentials.
+        """
+        resolved_app = app if isinstance(app, App) else await App.lookup.aio(app, create_if_missing=True, client=client)
+        # The ignore is for unparameterized `os.PathLike` mount keys in the SDK's own signature,
+        # not for anything this call passes.
+        sandbox = await Sandbox.create.aio(  # pyright: ignore[reportUnknownMemberType]
+            app=resolved_app,
+            image=image,
+            timeout=timeout,
+            workdir=workdir,
+            env=dict(env) if env is not None else None,
+            cpu=cpu,
+            memory=memory,
+            client=client,
+        )
+        try:
+            yield cls(sandbox)
+        finally:
+            # Shielded because teardown can run inside an already-cancelled scope, where every
+            # await re-raises: an unshielded terminate would leak a running (and billed) sandbox.
+            with anyio.CancelScope(shield=True):
+                await sandbox.terminate.aio()
+
+    @classmethod
+    async def connect(cls, sandbox_id: str, *, client: Client | None = None) -> Self:
+        """Attach to a Modal sandbox that already exists, without taking over its lifecycle.
+
+        This is the building block for a
+        [`SandboxResolver`][pydantic_ai.sandboxes.SandboxResolver] — a capability's
+        [`get_sandbox`][pydantic_ai.capabilities.AbstractCapability.get_sandbox] hook turning a
+        [`SandboxRef`][pydantic_ai.sandboxes.SandboxRef] back into a live backend, wherever the
+        work actually runs:
+
+        ```python {test="skip"}
+        from typing import Any
+
+        from pydantic_ai import RunContext
+        from pydantic_ai.capabilities import AbstractCapability
+        from pydantic_ai.sandboxes import SandboxBackend, SandboxRef
+        from pydantic_ai.sandboxes.modal import ModalSandbox
+
+
+        class ModalCapability(AbstractCapability[Any]):
+            async def get_sandbox(
+                self, ctx: RunContext[Any], ref: SandboxRef
+            ) -> SandboxBackend | None:
+                if ref.provider != 'modal':
+                    return None
+                return await ModalSandbox.connect(ref.sandbox_id)
+        ```
+
+        Connecting never creates: `modal.exception.NotFoundError` is raised if the environment is
+        gone, rather than an empty replacement being silently swapped in.
+
+        Args:
+            sandbox_id: The `sandbox_id` of the environment to attach to.
+            client: Modal client to use; defaults to the ambient Modal credentials.
+        """
+        return cls(await Sandbox.from_id.aio(sandbox_id, client=client))
+
+    async def working_dir(self) -> str:
+        # Modal exposes no API for a running sandbox's working directory — it is the image's
+        # unless `create(workdir=...)` overrode it — so ask the environment itself. It cannot
+        # change, so one answer serves the sandbox's whole life.
+        if self._working_dir is None:
+            result = await self.run(['pwd'])
+            if result.exit_code != 0:
+                raise ExecutionError(
+                    f'Could not determine the working directory of sandbox {self.sandbox_id!r}: '
+                    f'`pwd` exited {result.exit_code}: {result.stderr}'
+                )
+            self._working_dir = result.stdout.strip()
+        return self._working_dir
+
+    async def run(
+        self,
+        command: SandboxCommand,
+        *,
+        shell: bool = False,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        output_limit: int | None = None,
+    ) -> _ModalResult:
+        process = await self.start(command, shell=shell, cwd=cwd, env=env, timeout=timeout, output_limit=output_limit)
+        return await process.wait()
+
+    async def start(
+        self,
+        command: SandboxCommand,
+        *,
+        shell: bool = False,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        output_limit: int | None = None,
+    ) -> _ModalProcess:
+        if output_limit is not None:
+            raise NotImplementedError('ModalSandbox does not bound output; bound it in-command, e.g. `| tail -c`.')
+        # Modal takes whole seconds and reads a missing deadline as "run until the sandbox dies",
+        # so a sub-second deadline rounds up rather than silently becoming unbounded.
+        deadline = None if timeout is None else max(1, math.ceil(timeout))
+        process = await self.sandbox.exec.aio(
+            *_command_argv(command, shell),
+            # Modal's deadline really does kill the command, so — unlike E2B's — the platform
+            # owns it, and the process handle only has to recognize the kill it performed.
+            timeout=deadline,
+            # `workdir=None` leaves the command in the sandbox's own default directory.
+            workdir=cwd,
+            # `env` is applied on top of the sandbox's environment, not in place of it.
+            env=dict(env) if env is not None else None,
+            text=True,
+        )
+        return _ModalProcess(process, timeout=timeout, deadline=deadline)
+
+
+if TYPE_CHECKING:
+    # Pins full structural conformance — signatures included — which `isinstance` cannot check.
+    # `__new__` rather than a call, because neither SDK object can be constructed without a
+    # live sandbox behind it; this block never runs.
+    _sandbox = Sandbox.__new__(Sandbox)
+    _process = ContainerProcess[str].__new__(ContainerProcess[str])
+    _backend_conforms: SandboxBackend = ModalSandbox(_sandbox)
+    _filesystem_backend_conforms: SupportsFilesystem = ModalSandbox(_sandbox)
+    _start_conforms: SupportsStart = ModalSandbox(_sandbox)
+    _process_conforms: SandboxProcess = _ModalProcess(_process, timeout=None, deadline=None)
+    _stream_conforms: SupportsStream = _ModalProcess(_process, timeout=None, deadline=None)

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -134,6 +134,8 @@ dbos = ["dbos>=2.10.0"]
 prefect = ["prefect>=3.7.5"]
 # Spec (YAML agent specs)
 spec = ["pyyaml>=6.0.2", "pydantic-handlebars>=0.1.0"]
+# Sandboxes
+e2b = ["e2b>=2.34.0"]
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -136,6 +136,7 @@ prefect = ["prefect>=3.7.5"]
 spec = ["pyyaml>=6.0.2", "pydantic-handlebars>=0.1.0"]
 # Sandboxes
 e2b = ["e2b>=2.34.0"]
+modal = ["modal>=1.5.2"]
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ web-fetch = ["pydantic-ai-slim[web-fetch]=={{ version }}"]
 temporal = ["pydantic-ai-slim[temporal]=={{ version }}"]
 spec = ["pydantic-ai-slim[spec]=={{ version }}"]
 e2b = ["pydantic-ai-slim[e2b]=={{ version }}"]
+modal = ["pydantic-ai-slim[modal]=={{ version }}"]
 
 [project.urls]
 Homepage = "https://ai.pydantic.dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ exa = ["pydantic-ai-slim[exa]=={{ version }}"]
 web-fetch = ["pydantic-ai-slim[web-fetch]=={{ version }}"]
 temporal = ["pydantic-ai-slim[temporal]=={{ version }}"]
 spec = ["pydantic-ai-slim[spec]=={{ version }}"]
+e2b = ["pydantic-ai-slim[e2b]=={{ version }}"]
 
 [project.urls]
 Homepage = "https://ai.pydantic.dev"

--- a/tests/test_sandbox_e2b.py
+++ b/tests/test_sandbox_e2b.py
@@ -9,8 +9,10 @@ those shapes fails here instead of in production.
 
 from __future__ import annotations
 
+import asyncio
 import posixpath
 import re
+import shlex
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -128,30 +130,51 @@ class FakeFiles:
 
 
 class FakeCommandHandle:
-    """Stand-in for `AsyncCommandHandle`; reports non-zero exits the way the SDK does."""
+    """Stand-in for `AsyncCommandHandle`; reports non-zero exits the way the SDK does.
+
+    The SDK collects a command's output and exit code in an `asyncio.Task` created in the
+    handle's constructor — its event pump — and `wait()` is `await self._wait` on that shared
+    task, so awaiting it hands the awaiter's cancellation straight to the pump. That structure
+    is reproduced here, because it is what a cancelled `wait()` has to survive.
+    """
 
     def __init__(self, result: CommandResult | None = None, *, error: Exception | None = None) -> None:
         self.pid = 4242
         self.kills = 0
+        self.disconnects = 0
         self._result = result
         self._error = error
+        self._pump = asyncio.ensure_future(self._run())
 
-    async def wait(self) -> CommandResult:
+    async def _run(self) -> CommandResult:
         if self._error is not None:
             raise self._error
         assert self._result is not None
-        if self._result.exit_code != 0:
-            raise CommandExitException(
-                stderr=self._result.stderr,
-                stdout=self._result.stdout,
-                exit_code=self._result.exit_code,
-                error=self._result.error,
-            )
         return self._result
 
+    async def wait(self) -> CommandResult:
+        result = await self._pump
+        if result.exit_code != 0:
+            raise CommandExitException(
+                stderr=result.stderr,
+                stdout=result.stdout,
+                exit_code=result.exit_code,
+                error=result.error,
+            )
+        return result
+
     async def kill(self) -> bool:
+        # Suspends at least once, like the RPC it stands in for, so a kill that runs on a
+        # cancellation path fails visibly unless it is shielded.
+        await anyio.sleep(0)
         self.kills += 1
         return True
+
+    async def disconnect(self) -> None:
+        # The SDK's own teardown surface: it cancels the pump and closes the event stream.
+        self.disconnects += 1
+        self._pump.cancel()
+        await asyncio.wait([self._pump])
 
 
 class HangingCommandHandle(FakeCommandHandle):
@@ -160,9 +183,29 @@ class HangingCommandHandle(FakeCommandHandle):
     def __init__(self) -> None:
         super().__init__(CommandResult(stderr='', stdout='', exit_code=0, error=None))
 
-    async def wait(self) -> CommandResult:
+    async def _run(self) -> CommandResult:
         await anyio.sleep_forever()
-        assert False
+        raise AssertionError('unreachable')  # pragma: no cover
+
+
+class DeferredCommandHandle(FakeCommandHandle):
+    """A command that finishes only when the test says so, so a wait can be cancelled mid-flight."""
+
+    def __init__(self, result: CommandResult) -> None:
+        self.finished = anyio.Event()
+        super().__init__(result)
+
+    async def _run(self) -> CommandResult:
+        await self.finished.wait()
+        return await super()._run()
+
+
+class UnkillableCommandHandle(HangingCommandHandle):
+    """A command the sandbox refuses to kill, so a timeout's teardown fails under it."""
+
+    async def kill(self) -> bool:
+        await anyio.sleep(0)
+        raise SandboxException('503 while killing the command')
 
 
 @dataclass(frozen=True)
@@ -203,9 +246,13 @@ class FakeCommands:
 
 
 class FakeAsyncSandbox:
-    def __init__(self, sandbox_id: str = 'sbx-1', responder: Responder = default_responder) -> None:
+    def __init__(
+        self, sandbox_id: str = 'sbx-1', responder: Responder = default_responder, *, files: FakeFiles | None = None
+    ) -> None:
         self.sandbox_id = sandbox_id
-        self.files = FakeFiles()
+        # Taking one lets a responder serve commands out of the same files `fs` exposes, which
+        # is the protocol's one-environment contract.
+        self.files = files if files is not None else FakeFiles()
         self.commands = FakeCommands(responder)
         self.kills = 0
 
@@ -221,6 +268,9 @@ class FakeSandboxApi:
         self.created: list[dict[str, Any]] = []
         self.connected: list[dict[str, Any]] = []
         self.sandboxes: list[FakeAsyncSandbox] = []
+        self.create_delay = 0.0
+        """Holds the create in flight, so a caller can be cancelled part way through one."""
+        self.create_error: Exception | None = None
         self._responder = responder
 
     def _new(self, sandbox_id: str) -> FakeAsyncSandbox:
@@ -229,6 +279,9 @@ class FakeSandboxApi:
         return sandbox
 
     async def create(self, **kwargs: Any) -> FakeAsyncSandbox:
+        await anyio.sleep(self.create_delay)
+        if self.create_error is not None:
+            raise self.create_error
         self.created.append(kwargs)
         return self._new(f'sbx-{len(self.sandboxes) + 1}')
 
@@ -291,15 +344,82 @@ async def test_create_kills_the_sandbox_when_the_block_raises(sandbox_api: FakeS
     assert sandbox_api.sandboxes[0].kills == 1
 
 
+def _break_kill(backend: E2BSandbox) -> None:
+    async def kill() -> bool:
+        raise SandboxException('the control plane is unreachable')
+
+    cast(Any, backend.sandbox).kill = kill
+
+
+async def test_a_failing_teardown_is_not_raised_at_a_block_that_succeeded(sandbox_api: FakeSandboxApi):
+    """Teardown is best effort: E2B's `kill` raises for any failing status, and that must not
+    invent an exception for a block that ran to completion.
+    """
+    async with E2BSandbox.create() as backend:
+        _break_kill(backend)
+
+
+async def test_a_failing_teardown_does_not_mask_the_block_exception(sandbox_api: FakeSandboxApi):
+    with pytest.raises(RuntimeError, match='boom'):
+        async with E2BSandbox.create() as backend:
+            _break_kill(backend)
+            raise RuntimeError('boom')
+
+
+async def test_cancelling_a_create_in_flight_kills_the_orphan(sandbox_api: FakeSandboxApi):
+    """E2B provisions the sandbox whether or not anyone is left to receive the handle, so a
+    caller cancelled part way through must not leave a running (and billed) environment behind.
+    """
+    sandbox_api.create_delay = 0.05
+    with anyio.move_on_after(0.01):
+        async with E2BSandbox.create():
+            raise AssertionError('the create never completed for this block')  # pragma: no cover
+
+    # The cleanup is scheduled by the create finishing, which is after the caller gave up.
+    await _eventually(lambda: bool(sandbox_api.sandboxes) and sandbox_api.sandboxes[0].kills == 1)
+
+
+async def test_a_create_that_fails_reports_the_failure(sandbox_api: FakeSandboxApi):
+    """Guarding the create against cancellation must not swallow what it went wrong with."""
+    sandbox_api.create_error = SandboxException('no capacity for a new sandbox')
+    with pytest.raises(SandboxException, match='no capacity'):
+        async with E2BSandbox.create():
+            raise AssertionError('the create never produced a sandbox')  # pragma: no cover
+
+
+async def test_cancelling_a_create_that_then_fails_leaves_nothing_to_clean_up(sandbox_api: FakeSandboxApi):
+    """A create that failed provisioned nothing, so the cancelled caller's cleanup has nothing
+    to kill — and nobody is left to be told about the failure either.
+    """
+    sandbox_api.create_delay = 0.05
+    sandbox_api.create_error = SandboxException('no capacity for a new sandbox')
+    with anyio.move_on_after(0.01):
+        async with E2BSandbox.create():
+            raise AssertionError('the create never produced a sandbox')  # pragma: no cover
+
+    await anyio.sleep(0.06)  # long enough for the create to fail behind the caller's back
+    assert sandbox_api.sandboxes == []
+
+
+async def _eventually(condition: Callable[[], bool]) -> None:
+    for _ in range(1000):
+        if condition():
+            return
+        await anyio.sleep(0.001)
+    raise AssertionError('the condition was never met')
+
+
 async def test_connect_attaches_to_an_existing_sandbox_without_owning_it(sandbox_api: FakeSandboxApi):
     """`connect` is the resolver building block: a ref round-trips into a live backend, and the
-    caller that provisioned the environment keeps the right to destroy it.
+    caller that provisioned the environment keeps the right to destroy it. E2B's connect is not
+    a passive look, so the keep-alive `timeout` it applies is exposed and passed through — the
+    SDK's own default when it is omitted.
     """
     ref = SandboxRef(provider='e2b', sandbox_id='sbx-existing')
-    backend = await E2BSandbox.connect(ref.sandbox_id, api_key='e2b_key')
+    backend = await E2BSandbox.connect(ref.sandbox_id, timeout=900, api_key='e2b_key')
 
     assert SandboxRef(provider=backend.provider, sandbox_id=backend.sandbox_id) == ref
-    assert sandbox_api.connected == [{'sandbox_id': 'sbx-existing', 'api_key': 'e2b_key'}]
+    assert sandbox_api.connected == [{'sandbox_id': 'sbx-existing', 'timeout': 900, 'api_key': 'e2b_key'}]
     assert sandbox_api.sandboxes[0].kills == 0
 
 
@@ -334,6 +454,15 @@ async def test_run_rejects_a_command_shape_that_contradicts_shell(
         await backend_for(FakeAsyncSandbox()).run(command, shell=shell)
 
 
+async def test_run_rejects_an_empty_command():
+    """An empty argv quotes back into an empty shell string, which bash would run as a command
+    that succeeded at doing nothing. There is no program to report an exit code for, so it is
+    rejected, exactly as `LocalSandbox` has it.
+    """
+    with pytest.raises(TypeError, match='the argv sequence is empty'):
+        await backend_for(FakeAsyncSandbox()).run([])
+
+
 async def test_run_forwards_cwd_and_env_and_owns_the_deadline():
     sandbox = FakeAsyncSandbox()
     await backend_for(sandbox).run(['true'], cwd='/tmp', env={'TOKEN': 'secret'}, timeout=30)
@@ -363,6 +492,55 @@ async def test_timeout_kills_the_command_before_raising():
     with pytest.raises(TimeoutError, match=re.escape('command timed out after 0.01 seconds and was killed')):
         await backend_for(sandbox).run(['sleep', '600'], timeout=0.01)
     assert sandbox.commands.handles[0].kills == 1
+
+
+async def test_a_failing_kill_still_reports_the_timeout():
+    """A kill that fails cannot turn a timeout into a success — the command is no less over
+    the deadline for it — so the failure is chained onto the verdict rather than replacing it.
+    """
+    sandbox = FakeAsyncSandbox(responder=lambda command: UnkillableCommandHandle())
+    with pytest.raises(TimeoutError) as exc_info:
+        await backend_for(sandbox).run(['sleep', '600'], timeout=0.01)
+    assert isinstance(exc_info.value.__cause__, SandboxException)
+
+
+async def test_a_transport_timeout_is_not_read_as_the_command_deadline():
+    """E2B's transport reports a request that never got through as the builtin `TimeoutError`.
+    That is an infrastructure failure, not a command that outlived its deadline, and a command
+    started without one has no deadline to blame in the first place.
+    """
+    stalled = TimeoutError('the request to the sandbox timed out')
+    sandbox = FakeAsyncSandbox(responder=lambda command: FakeCommandHandle(error=stalled))
+    with pytest.raises(TimeoutError) as exc_info:
+        await backend_for(sandbox).run(['true'])
+    assert exc_info.value is stalled
+
+
+async def test_the_deadline_runs_from_the_start_not_from_the_first_wait():
+    """`start(timeout=)` bounds the command's life, so time that passes before anyone waits
+    comes out of the same budget rather than buying a fresh one.
+    """
+    sandbox = FakeAsyncSandbox(responder=lambda command: HangingCommandHandle())
+    process = await backend_for(sandbox).start(['sleep', '600'], timeout=0.05)
+    await anyio.sleep(0.06)  # the whole budget goes by before the first wait
+
+    started = anyio.current_time()
+    with pytest.raises(TimeoutError):
+        await process.wait()
+    assert anyio.current_time() - started < 0.05
+    assert sandbox.commands.handles[0].kills == 1
+
+
+async def test_a_cancelled_run_kills_the_command_it_started():
+    """`run()` owns the command it started, so a caller that gives up must not leave it running
+    in the sandbox — and the kill has to survive the very cancellation that called for it.
+    """
+    sandbox = FakeAsyncSandbox(responder=lambda command: HangingCommandHandle())
+    with anyio.move_on_after(0.01):
+        await backend_for(sandbox).run(['sleep', '600'], timeout=60)
+
+    handle = sandbox.commands.handles[0]
+    assert (handle.kills, handle.disconnects) == (1, 1)
 
 
 async def test_output_limit_is_not_supported():
@@ -404,6 +582,30 @@ async def test_waiting_twice_reports_the_same_outcome():
     assert await finished.wait() == await finished.wait()
 
 
+async def test_concurrent_waits_report_the_same_outcome():
+    """The protocol requires concurrent waits to agree, so only one of them reaches the SDK."""
+    process = await backend_for(FakeAsyncSandbox()).start(['true'])
+    first, second = await asyncio.gather(process.wait(), process.wait())
+    assert first is second
+
+
+async def test_a_cancelled_wait_leaves_the_process_usable():
+    """The SDK's `wait()` awaits a shared `asyncio.Task` — its event pump — and awaiting a task
+    hands it the awaiter's cancellation. A caller that gives up on one wait must not kill the
+    pump for every later one, and must not kill a process it does not own either.
+    """
+    handle = DeferredCommandHandle(CommandResult(stderr='', stdout='done', exit_code=0, error=None))
+    sandbox = FakeAsyncSandbox(responder=lambda command: handle)
+    process = await backend_for(sandbox).start(['slow'])
+
+    with anyio.move_on_after(0.01):
+        await process.wait()
+    assert handle.kills == 0  # `start()` hands the caller the process; giving up on a wait is not a kill
+
+    handle.finished.set()
+    assert (await process.wait()).stdout == 'done'
+
+
 async def test_working_dir_asks_the_environment_once():
     """E2B exposes no API for the template's default directory, so the sandbox is asked, and the
     answer — which cannot change — is kept.
@@ -423,6 +625,27 @@ async def test_working_dir_reports_an_environment_that_cannot_answer():
     )
     with pytest.raises(SandboxException, match=r"working directory of sandbox 'sbx-1'.+`pwd` exited 127"):
         await backend_for(sandbox).working_dir()
+
+
+def _printing_sandbox(stdout: str) -> FakeAsyncSandbox:
+    return FakeAsyncSandbox(
+        responder=lambda command: FakeCommandHandle(CommandResult(stderr='', stdout=stdout, exit_code=0, error=None))
+    )
+
+
+async def test_working_dir_looks_past_a_login_shell_banner():
+    """Every E2B command runs as `bash -l -c`, so a template whose login shell greets you puts
+    that greeting on stdout ahead of the answer.
+    """
+    assert await backend_for(_printing_sandbox(f'Welcome!\n{WORKING_DIR}\n')).working_dir() == WORKING_DIR
+
+
+async def test_working_dir_rejects_an_answer_that_is_not_a_path():
+    """Caching whatever else the shell printed would hand every later `resolve()` a working
+    directory that is not one.
+    """
+    with pytest.raises(SandboxException, match=r"working directory of sandbox 'sbx-1'.+`pwd` printed"):
+        await backend_for(_printing_sandbox('Welcome!\n')).working_dir()
 
 
 @pytest.mark.parametrize(
@@ -484,6 +707,12 @@ async def test_remove_deletes_files_and_directories():
     assert await backend.fs.exists(f'{WORKING_DIR}/tree/leaf.txt') is False
 
 
+async def test_exists_answers_for_a_file_that_is_there():
+    backend = backend_for(FakeAsyncSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/here.txt', b'x')
+    assert await backend.fs.exists(f'{WORKING_DIR}/here.txt') is True
+
+
 @pytest.mark.parametrize('operation', ['read_bytes', 'stat', 'list_dir', 'remove'])
 async def test_a_missing_path_raises_the_sdk_error_unchanged(operation: str):
     """File errors are E2B's to describe: they pass through rather than being renamed."""
@@ -511,6 +740,56 @@ async def test_the_sandbox_serves_an_agent_run():
 
     assert seen == ['from the model']
     assert sandbox.files.files == {f'{WORKING_DIR}/note.txt': b'from the model'}
+
+
+def _sed_responder(files: FakeFiles) -> Responder:
+    """Serves `pwd` and the `sed` line-window form the `Sandbox` facade emits out of the same
+    files `fs` exposes, which is the protocol's one-environment contract. The shell string is
+    split back into words the way `bash -l -c` would, so the argv quoting is under test too.
+    """
+
+    def respond(command: str) -> FakeCommandHandle:
+        argv = shlex.split(command)
+        if argv == ['pwd']:
+            return FakeCommandHandle(CommandResult(stderr='', stdout=f'{WORKING_DIR}\n', exit_code=0, error=None))
+        assert argv[:2] == ['sed', '-n'], argv
+        expression, path = argv[2], argv[3]
+        if path not in files.files:
+            error = f'sed: {path}: No such file or directory'
+            return FakeCommandHandle(CommandResult(stderr=error, stdout='', exit_code=2, error='exit status 2'))
+        first, _, last = expression.removesuffix('p').partition(',')
+        lines = files.files[path].decode().split('\n')
+        if lines[-1] == '':
+            lines.pop()
+        window = ''.join(f'{line}\n' for line in lines[int(first) - 1 : int(last)])
+        return FakeCommandHandle(CommandResult(stderr='', stdout=window, exit_code=0, error=None))
+
+    return respond
+
+
+async def test_the_facade_slices_a_file_window_inside_the_sandbox():
+    """`Sandbox.read_file` slices the window with `sed` in the sandbox rather than pulling the
+    whole file across, and reads it back from the same environment the command ran in. E2B
+    quotes argv into a single shell string on the way, so this covers that round trip.
+    """
+    files = FakeFiles()
+    sandbox = FakeAsyncSandbox(responder=_sed_responder(files), files=files)
+    facade = Sandbox(backend_for(sandbox))
+    await facade.write_text('notes.txt', 'one\ntwo\nthree\n')
+
+    window = await facade.read_file('notes.txt', offset=2, limit=1)
+    assert (window.lines, window.start_line, window.has_more) == (('two',), 2, True)
+
+
+async def test_the_facade_falls_back_to_a_full_read_when_the_slice_fails():
+    """A `sed` that cannot find the file falls back to the filesystem, which stays the
+    authoritative source of the error.
+    """
+    files = FakeFiles()
+    sandbox = FakeAsyncSandbox(responder=_sed_responder(files), files=files)
+
+    with pytest.raises(FileNotFoundException):
+        await Sandbox(backend_for(sandbox)).read_file('missing.txt', limit=3)
 
 
 async def test_the_facade_exposes_the_backend_for_provider_specific_work():

--- a/tests/test_sandbox_e2b.py
+++ b/tests/test_sandbox_e2b.py
@@ -1,0 +1,520 @@
+"""Tests for the E2B sandbox backend.
+
+The E2B SDK talks to a remote control plane over its own RPC transport, so there is no HTTP
+boundary a cassette could record. The tests therefore stand a fake in for `AsyncSandbox` — the
+one object `E2BSandbox` holds — while every type that crosses the boundary between the SDK and
+our code (`EntryInfo`, `CommandResult`, and the exceptions) is the real one, so a change in
+those shapes fails here instead of in production.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal, cast
+
+import anyio
+import pytest
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.sandboxes import (
+    Sandbox,
+    SandboxBackend,
+    SandboxRef,
+    SupportsFilesystem,
+    SupportsStart,
+    SupportsStream,
+)
+
+from .conftest import try_import
+
+with try_import() as imports_successful:
+    from e2b import (
+        AsyncSandbox,
+        CommandExitException,
+        CommandResult,
+        EntryInfo,
+        FileNotFoundException,
+        FileType,
+        SandboxException,
+        WriteInfo,
+    )
+
+    from pydantic_ai.sandboxes.e2b import E2BSandbox
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(not imports_successful(), reason='e2b not installed'),
+]
+
+WORKING_DIR = '/home/user'
+
+
+def _entry(path: str, *, is_dir: bool, size: int) -> EntryInfo:
+    return EntryInfo(
+        name=posixpath.basename(path),
+        type=FileType.DIR if is_dir else FileType.FILE,
+        path=path,
+        size=size,
+        mode=0o755 if is_dir else 0o644,
+        permissions='drwxr-xr-x' if is_dir else '-rw-r--r--',
+        owner='user',
+        group='user',
+        modified_time=datetime(2026, 8, 17, tzinfo=timezone.utc),
+    )
+
+
+class FakeFiles:
+    """Dictionary-backed stand-in for `AsyncSandbox.files`, matching the SDK's semantics."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+        self.dirs: set[str] = {WORKING_DIR}
+        self.made_dirs: list[str] = []
+        self.removed: list[str] = []
+
+    def _exists(self, path: str) -> bool:
+        return path in self.files or path in self.dirs
+
+    async def read(self, path: str, format: Literal['bytes'] = 'bytes') -> bytearray:
+        if path not in self.files:
+            raise FileNotFoundException(path)
+        # The SDK's byte read hands back a `bytearray`, not `bytes`.
+        return bytearray(self.files[path])
+
+    async def write(self, path: str, data: bytes) -> WriteInfo:
+        parent = posixpath.dirname(path)
+        while parent and parent != '/':  # the SDK's `write` creates missing parents
+            self.dirs.add(parent)
+            parent = posixpath.dirname(parent)
+        self.files[path] = data
+        return WriteInfo(name=posixpath.basename(path), type=FileType.FILE, path=path)
+
+    async def get_info(self, path: str) -> EntryInfo:
+        if not self._exists(path):
+            raise FileNotFoundException(path)
+        is_dir = path in self.dirs
+        return _entry(path, is_dir=is_dir, size=4096 if is_dir else len(self.files[path]))
+
+    async def list(self, path: str) -> list[EntryInfo]:
+        if path not in self.dirs:
+            raise FileNotFoundException(path)
+        children = [child for child in [*self.files, *self.dirs] if posixpath.dirname(child) == path]
+        return [
+            _entry(child, is_dir=child in self.dirs, size=4096 if child in self.dirs else len(self.files[child]))
+            for child in sorted(children)
+        ]
+
+    async def make_dir(self, path: str) -> bool:
+        self.made_dirs.append(path)
+        created = path not in self.dirs
+        self.dirs.add(path)
+        return created  # the SDK reports `False` for an existing directory rather than raising
+
+    async def remove(self, path: str) -> None:
+        self.removed.append(path)
+        if not self._exists(path):
+            raise FileNotFoundException(path)
+        self.dirs.discard(path)
+        for target in [target for target in self.files if target == path or target.startswith(f'{path}/')]:
+            del self.files[target]
+
+    async def exists(self, path: str) -> bool:
+        return self._exists(path)
+
+
+class FakeCommandHandle:
+    """Stand-in for `AsyncCommandHandle`; reports non-zero exits the way the SDK does."""
+
+    def __init__(self, result: CommandResult | None = None, *, error: Exception | None = None) -> None:
+        self.pid = 4242
+        self.kills = 0
+        self._result = result
+        self._error = error
+
+    async def wait(self) -> CommandResult:
+        if self._error is not None:
+            raise self._error
+        assert self._result is not None
+        if self._result.exit_code != 0:
+            raise CommandExitException(
+                stderr=self._result.stderr,
+                stdout=self._result.stdout,
+                exit_code=self._result.exit_code,
+                error=self._result.error,
+            )
+        return self._result
+
+    async def kill(self) -> bool:
+        self.kills += 1
+        return True
+
+
+class HangingCommandHandle(FakeCommandHandle):
+    """A command that never finishes, so a caller's deadline is the only thing that can end it."""
+
+    def __init__(self) -> None:
+        super().__init__(CommandResult(stderr='', stdout='', exit_code=0, error=None))
+
+    async def wait(self) -> CommandResult:
+        await anyio.sleep_forever()
+        assert False
+
+
+@dataclass(frozen=True)
+class RunCall:
+    command: str
+    cwd: str | None
+    envs: dict[str, str] | None
+    timeout: float | None
+
+
+Responder = Callable[[str], FakeCommandHandle]
+
+
+def default_responder(command: str) -> FakeCommandHandle:
+    stdout = f'{WORKING_DIR}\n' if command == 'pwd' else f'ran:{command}'
+    return FakeCommandHandle(CommandResult(stderr='', stdout=stdout, exit_code=0, error=None))
+
+
+class FakeCommands:
+    def __init__(self, responder: Responder) -> None:
+        self.calls: list[RunCall] = []
+        self.handles: list[FakeCommandHandle] = []
+        self._responder = responder
+
+    async def run(
+        self,
+        cmd: str,
+        *,
+        background: Literal[True],
+        envs: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout: float | None = 60,
+    ) -> FakeCommandHandle:
+        self.calls.append(RunCall(command=cmd, cwd=cwd, envs=envs, timeout=timeout))
+        handle = self._responder(cmd)
+        self.handles.append(handle)
+        return handle
+
+
+class FakeAsyncSandbox:
+    def __init__(self, sandbox_id: str = 'sbx-1', responder: Responder = default_responder) -> None:
+        self.sandbox_id = sandbox_id
+        self.files = FakeFiles()
+        self.commands = FakeCommands(responder)
+        self.kills = 0
+
+    async def kill(self) -> bool:
+        self.kills += 1
+        return True
+
+
+class FakeSandboxApi:
+    """Stand-in for the `AsyncSandbox` class itself, recording how it was asked for a sandbox."""
+
+    def __init__(self, responder: Responder = default_responder) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.connected: list[dict[str, Any]] = []
+        self.sandboxes: list[FakeAsyncSandbox] = []
+        self._responder = responder
+
+    def _new(self, sandbox_id: str) -> FakeAsyncSandbox:
+        sandbox = FakeAsyncSandbox(sandbox_id, self._responder)
+        self.sandboxes.append(sandbox)
+        return sandbox
+
+    async def create(self, **kwargs: Any) -> FakeAsyncSandbox:
+        self.created.append(kwargs)
+        return self._new(f'sbx-{len(self.sandboxes) + 1}')
+
+    async def connect(self, sandbox_id: str, **kwargs: Any) -> FakeAsyncSandbox:
+        self.connected.append({'sandbox_id': sandbox_id, **kwargs})
+        return self._new(sandbox_id)
+
+
+@pytest.fixture
+def sandbox_api(monkeypatch: pytest.MonkeyPatch) -> FakeSandboxApi:
+    """Replace the SDK entry point `E2BSandbox.create`/`connect` reach for."""
+    api = FakeSandboxApi()
+    monkeypatch.setattr('pydantic_ai.sandboxes.e2b.AsyncSandbox', api)
+    return api
+
+
+def backend_for(sandbox: FakeAsyncSandbox) -> E2BSandbox:
+    # The fake implements the `AsyncSandbox` members `E2BSandbox` uses; the cast is what lets a
+    # test hold one without a live E2B account behind it.
+    return E2BSandbox(cast(AsyncSandbox, sandbox))
+
+
+async def test_backend_conforms_to_the_protocols_it_implements():
+    backend = backend_for(FakeAsyncSandbox())
+    assert isinstance(backend, SandboxBackend)
+    assert isinstance(backend, SupportsFilesystem)
+    assert isinstance(backend, SupportsStart)
+    # E2B's async SDK reports live output through callbacks, so processes are not streamable.
+    assert not isinstance(await backend.start(['true']), SupportsStream)
+
+
+async def test_create_provisions_a_sandbox_and_kills_it_on_exit(sandbox_api: FakeSandboxApi):
+    async with E2BSandbox.create(
+        'python-3.13', timeout=600, envs={'STAGE': 'test'}, metadata={'run': 'r1'}, api_key='e2b_key'
+    ) as backend:
+        assert (backend.provider, backend.sandbox_id) == ('e2b', 'sbx-1')
+        assert sandbox_api.sandboxes[0].kills == 0
+    assert sandbox_api.created == [
+        {
+            'template': 'python-3.13',
+            'timeout': 600,
+            'envs': {'STAGE': 'test'},
+            'metadata': {'run': 'r1'},
+            'api_key': 'e2b_key',
+        }
+    ]
+    assert sandbox_api.sandboxes[0].kills == 1
+
+
+async def test_create_defaults_leave_every_choice_to_e2b(sandbox_api: FakeSandboxApi):
+    async with E2BSandbox.create():
+        pass
+    assert sandbox_api.created == [{'template': None, 'timeout': None, 'envs': None, 'metadata': None}]
+
+
+async def test_create_kills_the_sandbox_when_the_block_raises(sandbox_api: FakeSandboxApi):
+    with pytest.raises(RuntimeError, match='boom'):
+        async with E2BSandbox.create():
+            raise RuntimeError('boom')
+    assert sandbox_api.sandboxes[0].kills == 1
+
+
+async def test_connect_attaches_to_an_existing_sandbox_without_owning_it(sandbox_api: FakeSandboxApi):
+    """`connect` is the resolver building block: a ref round-trips into a live backend, and the
+    caller that provisioned the environment keeps the right to destroy it.
+    """
+    ref = SandboxRef(provider='e2b', sandbox_id='sbx-existing')
+    backend = await E2BSandbox.connect(ref.sandbox_id, api_key='e2b_key')
+
+    assert SandboxRef(provider=backend.provider, sandbox_id=backend.sandbox_id) == ref
+    assert sandbox_api.connected == [{'sandbox_id': 'sbx-existing', 'api_key': 'e2b_key'}]
+    assert sandbox_api.sandboxes[0].kills == 0
+
+
+@pytest.mark.parametrize(
+    ('command', 'shell', 'expected'),
+    [
+        (['echo', 'hello world'], False, "echo 'hello world'"),
+        (['sh', '-c', 'rm -rf /'], False, "sh -c 'rm -rf /'"),
+        ('echo $HOME | wc -c', True, 'echo $HOME | wc -c'),
+    ],
+    ids=['argv-quoted', 'argv-stays-one-word', 'shell-verbatim'],
+)
+async def test_command_reaches_e2b_as_a_shell_string(command: str | Sequence[str], shell: bool, expected: str):
+    """E2B only executes shell strings, so argv is quoted back into one word per element."""
+    sandbox = FakeAsyncSandbox()
+    await backend_for(sandbox).run(command, shell=shell)
+    assert [call.command for call in sandbox.commands.calls] == [expected]
+
+
+@pytest.mark.parametrize(
+    ('command', 'shell', 'message'),
+    [
+        ('echo hello', False, 'a string command requires shell=True'),
+        (['echo', 'hello'], True, 'an argv sequence cannot be combined with shell=True'),
+    ],
+    ids=['string-without-shell', 'argv-with-shell'],
+)
+async def test_run_rejects_a_command_shape_that_contradicts_shell(
+    command: str | Sequence[str], shell: bool, message: str
+):
+    with pytest.raises(TypeError, match=message):
+        await backend_for(FakeAsyncSandbox()).run(command, shell=shell)
+
+
+async def test_run_forwards_cwd_and_env_and_owns_the_deadline():
+    sandbox = FakeAsyncSandbox()
+    await backend_for(sandbox).run(['true'], cwd='/tmp', env={'TOKEN': 'secret'}, timeout=30)
+    assert sandbox.commands.calls == [
+        # `timeout=0` disables E2B's own deadline: it would only drop the event stream, leaving
+        # the command running, so `E2BSandbox` applies the caller's 30 seconds itself.
+        RunCall(command='true', cwd='/tmp', envs={'TOKEN': 'secret'}, timeout=0)
+    ]
+
+
+async def test_a_non_zero_exit_is_a_result_not_an_exception():
+    """The SDK raises `CommandExitException` for a failed command; the protocol calls that a
+    normal result, so the exception is unpacked rather than propagated.
+    """
+    sandbox = FakeAsyncSandbox(
+        responder=lambda command: FakeCommandHandle(
+            CommandResult(stderr='not found', stdout='partial', exit_code=127, error='exit status 127')
+        )
+    )
+    result = await backend_for(sandbox).run(['missing-binary'])
+    assert (result.exit_code, result.stdout, result.stderr) == (127, 'partial', 'not found')
+    assert (result.stdout_dropped, result.stderr_dropped) == (0, 0)
+
+
+async def test_timeout_kills_the_command_before_raising():
+    sandbox = FakeAsyncSandbox(responder=lambda command: HangingCommandHandle())
+    with pytest.raises(TimeoutError, match=re.escape('command timed out after 0.01 seconds and was killed')):
+        await backend_for(sandbox).run(['sleep', '600'], timeout=0.01)
+    assert sandbox.commands.handles[0].kills == 1
+
+
+async def test_output_limit_is_not_supported():
+    with pytest.raises(NotImplementedError, match='does not bound output'):
+        await backend_for(FakeAsyncSandbox()).run(['true'], output_limit=100)
+
+
+async def test_an_sdk_failure_surfaces_instead_of_becoming_a_fake_exit_code():
+    """An environment that is gone is an infrastructure failure, never `exit_code=1`."""
+    gone = SandboxException('sandbox sbx-1 is no longer running')
+    sandbox = FakeAsyncSandbox(responder=lambda command: FakeCommandHandle(error=gone))
+    with pytest.raises(SandboxException) as exc_info:
+        await backend_for(sandbox).run(['true'])
+    assert exc_info.value is gone
+
+
+async def test_start_hands_back_a_live_process():
+    sandbox = FakeAsyncSandbox()
+    process = await backend_for(sandbox).start(['sleep', '600'])
+    assert process.pid == 4242
+    await process.kill()
+    assert sandbox.commands.handles[0].kills == 1
+
+
+async def test_waiting_twice_reports_the_same_outcome():
+    """The protocol requires repeated waits to agree, and after a timeout the command is gone,
+    so only the first wait can reach it.
+    """
+    sandbox = FakeAsyncSandbox(responder=lambda command: HangingCommandHandle())
+    process = await backend_for(sandbox).start(['sleep', '600'], timeout=0.01)
+    with pytest.raises(TimeoutError) as first:
+        await process.wait()
+    with pytest.raises(TimeoutError) as second:
+        await process.wait()
+    assert second.value is first.value
+    assert sandbox.commands.handles[0].kills == 1
+
+    finished = await backend_for(FakeAsyncSandbox()).start(['true'])
+    assert await finished.wait() == await finished.wait()
+
+
+async def test_working_dir_asks_the_environment_once():
+    """E2B exposes no API for the template's default directory, so the sandbox is asked, and the
+    answer — which cannot change — is kept.
+    """
+    sandbox = FakeAsyncSandbox()
+    backend = backend_for(sandbox)
+    assert await backend.working_dir() == WORKING_DIR
+    assert await backend.working_dir() == WORKING_DIR
+    assert [call.command for call in sandbox.commands.calls] == ['pwd']
+
+
+async def test_working_dir_reports_an_environment_that_cannot_answer():
+    sandbox = FakeAsyncSandbox(
+        responder=lambda command: FakeCommandHandle(
+            CommandResult(stderr='pwd: not found', stdout='', exit_code=127, error='exit status 127')
+        )
+    )
+    with pytest.raises(SandboxException, match=r"working directory of sandbox 'sbx-1'.+`pwd` exited 127"):
+        await backend_for(sandbox).working_dir()
+
+
+@pytest.mark.parametrize(
+    'data',
+    [b'', b'plain text\n', b'\x00\x01\xff\xfe binary \x80', bytes(range(256))],
+    ids=['empty', 'text', 'invalid-utf8', 'every-byte'],
+)
+async def test_bytes_round_trip_unchanged(data: bytes):
+    backend = backend_for(FakeAsyncSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/blob.bin', data)
+    assert await backend.fs.read_bytes(f'{WORKING_DIR}/blob.bin') == data
+
+
+async def test_write_creates_missing_parent_directories():
+    sandbox = FakeAsyncSandbox()
+    await backend_for(sandbox).fs.write_bytes(f'{WORKING_DIR}/deep/nested/file.txt', b'hi')
+    assert f'{WORKING_DIR}/deep/nested' in sandbox.files.dirs
+
+
+async def test_stat_reports_a_file_and_a_directory():
+    """A directory's reported size is filesystem bookkeeping, not content, so it is dropped."""
+    backend = backend_for(FakeAsyncSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/notes.txt', b'hello')
+
+    file_entry = await backend.fs.stat(f'{WORKING_DIR}/notes.txt')
+    assert (file_entry.name, file_entry.path, file_entry.is_dir, file_entry.size) == (
+        'notes.txt',
+        f'{WORKING_DIR}/notes.txt',
+        False,
+        5,
+    )
+    directory = await backend.fs.stat(WORKING_DIR)
+    assert (directory.name, directory.is_dir, directory.size) == ('user', True, None)
+
+
+async def test_list_dir_reports_children_only():
+    backend = backend_for(FakeAsyncSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/a.txt', b'a')
+    await backend.fs.write_bytes(f'{WORKING_DIR}/sub/b.txt', b'bb')
+
+    entries = await backend.fs.list_dir(WORKING_DIR)
+    assert [(entry.name, entry.is_dir, entry.size) for entry in entries] == [('a.txt', False, 1), ('sub', True, None)]
+
+
+async def test_make_dir_is_mkdir_p():
+    sandbox = FakeAsyncSandbox()
+    backend = backend_for(sandbox)
+    await backend.fs.make_dir(f'{WORKING_DIR}/work')
+    await backend.fs.make_dir(f'{WORKING_DIR}/work')  # an existing directory is not an error
+    assert sandbox.files.made_dirs == [f'{WORKING_DIR}/work', f'{WORKING_DIR}/work']
+
+
+async def test_remove_deletes_files_and_directories():
+    backend = backend_for(FakeAsyncSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/tree/leaf.txt', b'x')
+
+    await backend.fs.remove(f'{WORKING_DIR}/tree')
+    assert await backend.fs.exists(f'{WORKING_DIR}/tree') is False
+    assert await backend.fs.exists(f'{WORKING_DIR}/tree/leaf.txt') is False
+
+
+@pytest.mark.parametrize('operation', ['read_bytes', 'stat', 'list_dir', 'remove'])
+async def test_a_missing_path_raises_the_sdk_error_unchanged(operation: str):
+    """File errors are E2B's to describe: they pass through rather than being renamed."""
+    filesystem = backend_for(FakeAsyncSandbox()).fs
+    with pytest.raises(FileNotFoundException):
+        await getattr(filesystem, operation)(f'{WORKING_DIR}/nope')
+
+
+async def test_the_sandbox_serves_an_agent_run():
+    """The end a user sees: commands and files reach the same environment through
+    [`RunContext.sandbox`][pydantic_ai.tools.RunContext.sandbox], with relative paths resolved
+    against the sandbox's own working directory.
+    """
+    sandbox = FakeAsyncSandbox()
+    seen: list[str] = []
+    agent: Agent = Agent(TestModel())  # TestModel calls every registered tool, then returns text
+
+    @agent.tool
+    async def note(ctx: RunContext[Any]) -> str:
+        await ctx.sandbox.write_text('note.txt', 'from the model')
+        seen.append(await ctx.sandbox.read_text('note.txt'))
+        return 'ok'
+
+    await agent.run('go', sandbox=backend_for(sandbox))
+
+    assert seen == ['from the model']
+    assert sandbox.files.files == {f'{WORKING_DIR}/note.txt': b'from the model'}
+
+
+async def test_the_facade_exposes_the_backend_for_provider_specific_work():
+    sandbox = FakeAsyncSandbox()
+    backend = backend_for(sandbox)
+    assert Sandbox(backend).backend is backend
+    assert backend.sandbox is cast(AsyncSandbox, sandbox)

--- a/tests/test_sandbox_modal.py
+++ b/tests/test_sandbox_modal.py
@@ -1,0 +1,673 @@
+"""Tests for the Modal sandbox backend.
+
+The Modal SDK talks to a remote control plane over gRPC and its own worker command router, so
+there is no HTTP boundary a cassette could record. The tests therefore stand fakes in for the two
+SDK entry points `ModalSandbox` reaches for — `Sandbox` and `App` — while every type that crosses
+the boundary between the SDK and our code (`FileInfo`, `FileType`, and the exceptions) is the real
+one, so a change in those shapes fails here instead of in production. `modal.App` is the one
+exception: it cannot be constructed without a live workspace behind it, and nothing about its
+shape is load-bearing here — the backend only recognizes one and passes it through.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import posixpath
+import re
+from collections.abc import Awaitable, Callable, Sequence
+from contextlib import aclosing
+from dataclasses import dataclass
+from typing import Any, ClassVar, Literal, cast
+
+import pytest
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.sandboxes import (
+    Sandbox as SandboxFacade,
+    SandboxBackend,
+    SandboxRef,
+    SupportsFilesystem,
+    SupportsStart,
+    SupportsStream,
+)
+
+from .conftest import try_import
+
+with try_import() as imports_successful:
+    from modal import Sandbox
+    from modal.exception import ExecutionError, SandboxFilesystemNotFoundError, SandboxTerminatedError
+    from modal.types import FileInfo, FileType
+
+    from pydantic_ai.sandboxes.modal import ModalSandbox
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(not imports_successful(), reason='modal not installed'),
+]
+
+WORKING_DIR = '/root'
+
+Stream = Literal['stdout', 'stderr']
+
+
+@dataclass(frozen=True)
+class Aio:
+    """Stand-in for a synchronicity dual sync/async callable; our code only ever uses `.aio`."""
+
+    aio: Callable[..., Awaitable[Any]]
+
+
+def _file_info(path: str, *, is_dir: bool, size: int, name: str | None = None) -> FileInfo:
+    return FileInfo(
+        name=name if name is not None else posixpath.basename(path),
+        path=path,
+        type=FileType.DIRECTORY if is_dir else FileType.FILE,
+        size=size,
+        mode=0o755 if is_dir else 0o644,
+        permissions='drwxr-xr-x' if is_dir else '-rw-r--r--',
+        owner='root',
+        group='root',
+        modified_time=1786000000.0,
+        symlink_target=None,
+    )
+
+
+class FakeFilesystem:
+    """Dictionary-backed stand-in for `Sandbox.filesystem`, matching the SDK's semantics."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+        self.dirs: set[str] = {WORKING_DIR}
+        self.made_dirs: list[tuple[str, bool]] = []
+        self.removals: list[tuple[str, bool]] = []
+        self.read_bytes = Aio(self._read_bytes)
+        self.write_bytes = Aio(self._write_bytes)
+        self.stat = Aio(self._stat)
+        self.list_files = Aio(self._list_files)
+        self.make_directory = Aio(self._make_directory)
+        self.remove = Aio(self._remove)
+
+    def _exists(self, path: str) -> bool:
+        return path in self.files or path in self.dirs
+
+    async def _read_bytes(self, remote_path: str) -> bytes:
+        if remote_path not in self.files:
+            raise SandboxFilesystemNotFoundError(remote_path)
+        return self.files[remote_path]
+
+    async def _write_bytes(self, data: bytes, remote_path: str) -> None:
+        parent = posixpath.dirname(remote_path)
+        while parent and parent != '/':  # the SDK's `write_bytes` creates missing parents
+            self.dirs.add(parent)
+            parent = posixpath.dirname(parent)
+        self.files[remote_path] = data
+
+    async def _stat(self, remote_path: str) -> FileInfo:
+        if not self._exists(remote_path):
+            raise SandboxFilesystemNotFoundError(remote_path)
+        is_dir = remote_path in self.dirs
+        return _file_info(remote_path, is_dir=is_dir, size=4096 if is_dir else len(self.files[remote_path]))
+
+    async def _list_files(self, remote_path: str) -> list[FileInfo]:
+        if remote_path not in self.dirs:
+            raise SandboxFilesystemNotFoundError(remote_path)
+        children = [child for child in [*self.files, *self.dirs] if posixpath.dirname(child) == remote_path]
+        return [
+            # A bare name, not the absolute path: the backend rebuilds the absolute path the
+            # protocol promises from the directory it listed, and this keeps that load-bearing.
+            _file_info(
+                posixpath.basename(child),
+                is_dir=child in self.dirs,
+                size=4096 if child in self.dirs else len(self.files[child]),
+            )
+            for child in sorted(children)
+        ]
+
+    async def _make_directory(self, remote_path: str, *, create_parents: bool = True) -> None:
+        self.made_dirs.append((remote_path, create_parents))
+        self.dirs.add(remote_path)
+
+    async def _remove(self, remote_path: str, *, recursive: bool = False) -> None:
+        self.removals.append((remote_path, recursive))
+        if not self._exists(remote_path):
+            raise SandboxFilesystemNotFoundError(remote_path)
+        self.dirs.discard(remote_path)
+        for target in [
+            target for target in self.files if target == remote_path or target.startswith(f'{remote_path}/')
+        ]:
+            del self.files[target]
+
+
+class FakeStreamReader:
+    """Stand-in for `modal.io_streams.StreamReader`.
+
+    Async-iterable like the SDK's, and `read()` picks up wherever iteration stopped — that
+    resumption is what lets `wait()` collect the output an abandoned `stream()` left behind.
+    Sharing an `order` list between the two readers makes their chunks arrive in one
+    deterministic sequence instead of whichever the event loop happens to pick.
+    """
+
+    def __init__(self, chunks: Sequence[str] = (), *, name: Stream = 'stdout', order: list[Stream] | None = None):
+        self._chunks = list(chunks)
+        self._name = name
+        self._order = order
+        self.read = Aio(self._read)
+
+    def __aiter__(self) -> FakeStreamReader:
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._chunks:
+            raise StopAsyncIteration
+        while self._order and self._order[0] != self._name:
+            await asyncio.sleep(0)  # not this stream's turn yet; let the other reader go first
+        if self._order:
+            self._order.pop(0)
+        return self._chunks.pop(0)
+
+    async def _read(self) -> str:
+        rest, self._chunks = ''.join(self._chunks), []
+        return rest
+
+
+class FakeContainerProcess:
+    """Stand-in for `ContainerProcess`; reports a non-zero exit as a return value, as the SDK does."""
+
+    def __init__(
+        self,
+        *,
+        stdout: FakeStreamReader | str = '',
+        stderr: FakeStreamReader | str = '',
+        exit_code: int = 0,
+        error: Exception | None = None,
+    ) -> None:
+        self.stdout = FakeStreamReader([stdout] if stdout else []) if isinstance(stdout, str) else stdout
+        self.stderr = FakeStreamReader([stderr] if stderr else [], name='stderr') if isinstance(stderr, str) else stderr
+        self._exit_code = exit_code
+        self._error = error
+        self.wait = Aio(self._wait)
+
+    async def _wait(self) -> int:
+        if self._error is not None:
+            raise self._error
+        return self._exit_code
+
+
+@dataclass(frozen=True)
+class ExecCall:
+    argv: tuple[str, ...]
+    workdir: str | None
+    env: dict[str, str] | None
+    timeout: int | None
+
+
+Responder = Callable[[tuple[str, ...]], FakeContainerProcess]
+
+
+def default_responder(argv: tuple[str, ...]) -> FakeContainerProcess:
+    stdout = f'{WORKING_DIR}\n' if argv == ('pwd',) else f'ran:{" ".join(argv)}'
+    return FakeContainerProcess(stdout=stdout)
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_id: str = 'sb-1', responder: Responder = default_responder) -> None:
+        self.object_id = sandbox_id
+        self.filesystem = FakeFilesystem()
+        self.calls: list[ExecCall] = []
+        self.processes: list[FakeContainerProcess] = []
+        self.terminations = 0
+        self._responder = responder
+        self.exec = Aio(self._exec)
+        self.terminate = Aio(self._terminate)
+
+    async def _exec(
+        self,
+        *argv: str,
+        timeout: int | None = None,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        text: bool = True,
+    ) -> FakeContainerProcess:
+        self.calls.append(ExecCall(argv=argv, workdir=workdir, env=env, timeout=timeout))
+        process = self._responder(argv)
+        self.processes.append(process)
+        return process
+
+    async def _terminate(self) -> None:
+        self.terminations += 1
+
+
+class FakeSandboxApi:
+    """Stand-in for the `Sandbox` class itself, recording how it was asked for a sandbox."""
+
+    def __init__(self, responder: Responder = default_responder) -> None:
+        self.created: list[dict[str, Any]] = []
+        self.connected: list[dict[str, Any]] = []
+        self.sandboxes: list[FakeSandbox] = []
+        self._responder = responder
+        self.create = Aio(self._create)
+        self.from_id = Aio(self._from_id)
+
+    def _new(self, sandbox_id: str) -> FakeSandbox:
+        sandbox = FakeSandbox(sandbox_id, self._responder)
+        self.sandboxes.append(sandbox)
+        return sandbox
+
+    async def _create(self, **kwargs: Any) -> FakeSandbox:
+        self.created.append(kwargs)
+        return self._new(f'sb-{len(self.sandboxes) + 1}')
+
+    async def _from_id(self, sandbox_id: str, **kwargs: Any) -> FakeSandbox:
+        self.connected.append({'sandbox_id': sandbox_id, **kwargs})
+        return self._new(sandbox_id)
+
+
+class FakeApp:
+    """Stand-in for the `App` class: `create()` both recognizes one and looks one up by name."""
+
+    lookups: ClassVar[list[dict[str, Any]]] = []
+    lookup: ClassVar[Aio]
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+async def _lookup_app(name: str, *, create_if_missing: bool = False, client: Any = None) -> FakeApp:
+    FakeApp.lookups.append({'name': name, 'create_if_missing': create_if_missing, 'client': client})
+    return FakeApp(name)
+
+
+FakeApp.lookup = Aio(_lookup_app)
+
+
+class FakeClock:
+    """Replaces the backend's `time`, so a deadline can elapse without the test spending it."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+@pytest.fixture
+def modal_api(monkeypatch: pytest.MonkeyPatch) -> FakeSandboxApi:
+    """Replace the SDK entry points `ModalSandbox.create`/`connect` reach for."""
+    api = FakeSandboxApi()
+    monkeypatch.setattr('pydantic_ai.sandboxes.modal.Sandbox', api)
+    monkeypatch.setattr('pydantic_ai.sandboxes.modal.App', FakeApp)
+    monkeypatch.setattr(FakeApp, 'lookups', [])
+    return api
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> FakeClock:
+    fake = FakeClock()
+    monkeypatch.setattr('pydantic_ai.sandboxes.modal.time', fake)
+    return fake
+
+
+def backend_for(sandbox: FakeSandbox) -> ModalSandbox:
+    # The fake implements the `Sandbox` members `ModalSandbox` uses; the cast is what lets a test
+    # hold one without a live Modal workspace behind it.
+    return ModalSandbox(cast(Sandbox, sandbox))
+
+
+async def test_backend_conforms_to_the_protocols_it_implements():
+    backend = backend_for(FakeSandbox())
+    assert isinstance(backend, SandboxBackend)
+    assert isinstance(backend, SupportsFilesystem)
+    assert isinstance(backend, SupportsStart)
+    # Unlike E2B's, Modal's output streams are async-iterable, so its processes are streamable.
+    assert isinstance(await backend.start(['true']), SupportsStream)
+
+
+async def test_create_provisions_a_sandbox_and_terminates_it_on_exit(modal_api: FakeSandboxApi):
+    app = FakeApp('held-app')
+    async with ModalSandbox.create(
+        app=cast(Any, app), timeout=600, workdir='/work', env={'STAGE': 'test'}, cpu=2.0, memory=4096
+    ) as backend:
+        assert (backend.provider, backend.sandbox_id) == ('modal', 'sb-1')
+        assert modal_api.sandboxes[0].terminations == 0
+    assert modal_api.created == [
+        {
+            'app': app,
+            'image': None,
+            'timeout': 600,
+            'workdir': '/work',
+            'env': {'STAGE': 'test'},
+            'cpu': 2.0,
+            'memory': 4096,
+            'client': None,
+        }
+    ]
+    assert FakeApp.lookups == []  # an app that is already held is used as-is
+    assert modal_api.sandboxes[0].terminations == 1
+
+
+async def test_create_looks_up_the_default_app_by_name(modal_api: FakeSandboxApi):
+    """Every Modal sandbox needs an app, so a name is resolved into one — creating it if needed."""
+    async with ModalSandbox.create():
+        pass
+    assert FakeApp.lookups == [{'name': 'pydantic-ai-sandbox', 'create_if_missing': True, 'client': None}]
+    assert modal_api.created[0]['app'].name == 'pydantic-ai-sandbox'
+
+
+async def test_create_terminates_the_sandbox_when_the_block_raises(modal_api: FakeSandboxApi):
+    with pytest.raises(RuntimeError, match='boom'):
+        async with ModalSandbox.create():
+            raise RuntimeError('boom')
+    assert modal_api.sandboxes[0].terminations == 1
+
+
+async def test_connect_attaches_to_an_existing_sandbox_without_owning_it(modal_api: FakeSandboxApi):
+    """`connect` is the resolver building block: a ref round-trips into a live backend, and the
+    caller that provisioned the environment keeps the right to destroy it.
+    """
+    ref = SandboxRef(provider='modal', sandbox_id='sb-existing')
+    backend = await ModalSandbox.connect(ref.sandbox_id)
+
+    assert SandboxRef(provider=backend.provider, sandbox_id=backend.sandbox_id) == ref
+    assert modal_api.connected == [{'sandbox_id': 'sb-existing', 'client': None}]
+    assert modal_api.sandboxes[0].terminations == 0
+
+
+@pytest.mark.parametrize(
+    ('command', 'shell', 'expected'),
+    [
+        (['echo', 'hello world'], False, ('echo', 'hello world')),
+        (['sh', '-c', 'rm -rf /'], False, ('sh', '-c', 'rm -rf /')),
+        ('echo $HOME | wc -c', True, ('/bin/sh', '-c', 'echo $HOME | wc -c')),
+    ],
+    ids=['argv-verbatim', 'argv-stays-separate-words', 'shell-gets-a-shell'],
+)
+async def test_command_reaches_modal_as_argv(command: str | Sequence[str], shell: bool, expected: tuple[str, ...]):
+    """Modal only executes argv, so argv goes straight through and a shell string is handed to a shell."""
+    sandbox = FakeSandbox()
+    await backend_for(sandbox).run(command, shell=shell)
+    assert [call.argv for call in sandbox.calls] == [expected]
+
+
+@pytest.mark.parametrize(
+    ('command', 'shell', 'message'),
+    [
+        ('echo hello', False, 'a string command requires shell=True'),
+        (['echo', 'hello'], True, 'an argv sequence cannot be combined with shell=True'),
+    ],
+    ids=['string-without-shell', 'argv-with-shell'],
+)
+async def test_run_rejects_a_command_shape_that_contradicts_shell(
+    command: str | Sequence[str], shell: bool, message: str
+):
+    with pytest.raises(TypeError, match=message):
+        await backend_for(FakeSandbox()).run(command, shell=shell)
+
+
+async def test_run_forwards_cwd_and_env():
+    sandbox = FakeSandbox()
+    await backend_for(sandbox).run(['true'], cwd='/tmp', env={'TOKEN': 'secret'})
+    assert sandbox.calls == [ExecCall(argv=('true',), workdir='/tmp', env={'TOKEN': 'secret'}, timeout=None)]
+
+
+@pytest.mark.parametrize(
+    ('timeout', 'expected'),
+    [(None, None), (0.01, 1), (1.5, 2), (30.0, 30)],
+    ids=['unbounded', 'sub-second', 'fractional', 'whole'],
+)
+async def test_the_deadline_reaches_modal_as_whole_seconds(timeout: float | None, expected: int | None):
+    """Modal takes whole seconds and reads a missing deadline as unbounded, so a sub-second
+    deadline has to round up rather than round away to nothing.
+    """
+    sandbox = FakeSandbox()
+    await backend_for(sandbox).run(['true'], timeout=timeout)
+    assert [call.timeout for call in sandbox.calls] == [expected]
+
+
+async def test_a_non_zero_exit_is_a_result_not_an_exception():
+    sandbox = FakeSandbox(
+        responder=lambda argv: FakeContainerProcess(stdout='partial', stderr='not found', exit_code=127)
+    )
+    result = await backend_for(sandbox).run(['missing-binary'])
+    assert (result.exit_code, result.stdout, result.stderr) == (127, 'partial', 'not found')
+    assert (result.stdout_dropped, result.stderr_dropped) == (0, 0)
+
+
+@pytest.mark.parametrize('exit_code', [-1, 137], ids=['client-deadline', 'server-sigkill'])
+async def test_a_deadline_kill_raises_a_builtin_timeout_error(clock: FakeClock, exit_code: int):
+    """Modal's deadline kills the command itself, reporting `-1` when its client-side copy of the
+    deadline won the race and the plain SIGKILL exit when the server's kill did.
+    """
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(exit_code=exit_code))
+    process = await backend_for(sandbox).start(['sleep', '600'], timeout=0.01)
+    clock.now = 60.0  # the deadline window has passed
+    with pytest.raises(TimeoutError, match=re.escape('command timed out after 0.01 seconds and was killed')):
+        await process.wait()
+
+
+async def test_a_sigkill_the_deadline_cannot_explain_is_still_a_result(clock: FakeClock):
+    """A command can exit 137 on its own account — an OOM kill, a `kill -9` it asked for — so
+    that exit is only read as a timeout once the deadline window has actually elapsed.
+    """
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(exit_code=137))
+    result = await backend_for(sandbox).run(['self-destruct'], timeout=30)
+    assert result.exit_code == 137
+
+
+async def test_a_deadline_kill_is_not_read_into_a_command_that_had_none():
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(exit_code=137))
+    result = await backend_for(sandbox).run(['self-destruct'])
+    assert result.exit_code == 137
+
+
+async def test_output_limit_is_not_supported():
+    with pytest.raises(NotImplementedError, match='does not bound output'):
+        await backend_for(FakeSandbox()).run(['true'], output_limit=100)
+
+
+async def test_an_sdk_failure_surfaces_instead_of_becoming_a_fake_exit_code():
+    """An environment that is gone is an infrastructure failure, never `exit_code=1`."""
+    gone = SandboxTerminatedError('sandbox sb-1 is no longer running')
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(error=gone))
+    with pytest.raises(SandboxTerminatedError) as exc_info:
+        await backend_for(sandbox).run(['true'])
+    assert exc_info.value is gone
+
+
+async def test_a_started_process_reports_no_pid_and_cannot_be_killed():
+    """Modal names a command by an exec id of its own and offers no way to kill one, so the
+    protocol's escape hatch applies: say so, and name the deadline as the way to bound a command.
+    """
+    process = await backend_for(FakeSandbox()).start(['sleep', '600'])
+    assert process.pid is None
+    with pytest.raises(NotImplementedError, match='start it with `timeout=`'):
+        await process.kill()
+
+
+async def test_waiting_twice_reports_the_same_outcome(clock: FakeClock):
+    """The protocol requires repeated waits to agree, and after a timeout the command is gone,
+    so only the first wait can reach it.
+    """
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(exit_code=-1))
+    process = await backend_for(sandbox).start(['sleep', '600'], timeout=0.01)
+    with pytest.raises(TimeoutError) as first:
+        await process.wait()
+    with pytest.raises(TimeoutError) as second:
+        await process.wait()
+    assert second.value is first.value
+
+    finished = await backend_for(FakeSandbox()).start(['true'])
+    assert await finished.wait() == await finished.wait()
+
+
+async def test_stream_yields_both_streams_in_arrival_order():
+    order: list[Stream] = ['stdout', 'stderr', 'stdout']
+    process = FakeContainerProcess(
+        stdout=FakeStreamReader(['one\n', 'three\n'], name='stdout', order=order),
+        stderr=FakeStreamReader(['two\n'], name='stderr', order=order),
+    )
+    started = await backend_for(FakeSandbox(responder=lambda argv: process)).start(['noisy'])
+    assert isinstance(started, SupportsStream)
+
+    chunks = [(chunk.stream, chunk.data) async for chunk in started.stream()]
+    assert chunks == [('stdout', 'one\n'), ('stderr', 'two\n'), ('stdout', 'three\n')]
+
+
+async def test_wait_after_streaming_reports_what_was_streamed():
+    """`stream()` consumes the output, so `wait()` has to remember it rather than re-read it."""
+    order: list[Stream] = ['stdout', 'stderr']
+    process = FakeContainerProcess(
+        stdout=FakeStreamReader(['done\n'], name='stdout', order=order),
+        stderr=FakeStreamReader(['warned\n'], name='stderr', order=order),
+        exit_code=3,
+    )
+    started = await backend_for(FakeSandbox(responder=lambda argv: process)).start(['noisy'])
+
+    async for _ in started.stream():
+        pass
+    result = await started.wait()
+    assert (result.exit_code, result.stdout, result.stderr) == (3, 'done\n', 'warned\n')
+
+
+async def test_output_delivered_to_an_abandoned_stream_still_reaches_wait():
+    """A consumer that stops iterating leaves an already-delivered chunk behind. Modal cannot be
+    asked for it again, so it is part of the command's output and `wait()` still reports it.
+    """
+    process = FakeContainerProcess(stdout='out', stderr='err')
+    started = await backend_for(FakeSandbox(responder=lambda argv: process)).start(['noisy'])
+
+    # Both streams delivered in the same wake-up; only one of the two is consumed here. Closing
+    # the iterator explicitly is what a `break` leaves to the garbage collector to do later.
+    async with aclosing(started.stream()) as chunks:
+        async for _ in chunks:
+            break
+
+    result = await started.wait()
+    assert (result.stdout, result.stderr) == ('out', 'err')
+
+
+async def test_working_dir_asks_the_environment_once():
+    """Modal exposes no API for a running sandbox's working directory, so the sandbox is asked,
+    and the answer — which cannot change — is kept.
+    """
+    sandbox = FakeSandbox()
+    backend = backend_for(sandbox)
+    assert await backend.working_dir() == WORKING_DIR
+    assert await backend.working_dir() == WORKING_DIR
+    assert [call.argv for call in sandbox.calls] == [('pwd',)]
+
+
+async def test_working_dir_reports_an_environment_that_cannot_answer():
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(stderr='pwd: not found', exit_code=127))
+    with pytest.raises(ExecutionError, match=r"working directory of sandbox 'sb-1'.+`pwd` exited 127"):
+        await backend_for(sandbox).working_dir()
+
+
+@pytest.mark.parametrize(
+    'data',
+    [b'', b'plain text\n', b'\x00\x01\xff\xfe binary \x80', bytes(range(256))],
+    ids=['empty', 'text', 'invalid-utf8', 'every-byte'],
+)
+async def test_bytes_round_trip_unchanged(data: bytes):
+    backend = backend_for(FakeSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/blob.bin', data)
+    assert await backend.fs.read_bytes(f'{WORKING_DIR}/blob.bin') == data
+
+
+async def test_write_creates_missing_parent_directories():
+    sandbox = FakeSandbox()
+    await backend_for(sandbox).fs.write_bytes(f'{WORKING_DIR}/deep/nested/file.txt', b'hi')
+    assert f'{WORKING_DIR}/deep/nested' in sandbox.filesystem.dirs
+
+
+async def test_stat_reports_a_file_and_a_directory():
+    """A directory's reported size is filesystem bookkeeping, not content, so it is dropped."""
+    backend = backend_for(FakeSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/notes.txt', b'hello')
+
+    file_entry = await backend.fs.stat(f'{WORKING_DIR}/notes.txt')
+    assert (file_entry.name, file_entry.path, file_entry.is_dir, file_entry.size) == (
+        'notes.txt',
+        f'{WORKING_DIR}/notes.txt',
+        False,
+        5,
+    )
+    directory = await backend.fs.stat(WORKING_DIR)
+    assert (directory.name, directory.is_dir, directory.size) == ('root', True, None)
+
+
+async def test_list_dir_reports_children_at_absolute_paths():
+    """Modal names a listed entry relative to the directory it listed; the protocol promises an
+    absolute path, so the backend rebuilds one.
+    """
+    backend = backend_for(FakeSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/a.txt', b'a')
+    await backend.fs.write_bytes(f'{WORKING_DIR}/sub/b.txt', b'bb')
+
+    entries = await backend.fs.list_dir(WORKING_DIR)
+    assert [(entry.path, entry.is_dir, entry.size) for entry in entries] == [
+        (f'{WORKING_DIR}/a.txt', False, 1),
+        (f'{WORKING_DIR}/sub', True, None),
+    ]
+
+
+async def test_make_dir_is_mkdir_p():
+    sandbox = FakeSandbox()
+    backend = backend_for(sandbox)
+    await backend.fs.make_dir(f'{WORKING_DIR}/work')
+    await backend.fs.make_dir(f'{WORKING_DIR}/work')  # an existing directory is not an error
+    assert sandbox.filesystem.made_dirs == [(f'{WORKING_DIR}/work', True), (f'{WORKING_DIR}/work', True)]
+
+
+async def test_remove_deletes_files_and_directories():
+    sandbox = FakeSandbox()
+    backend = backend_for(sandbox)
+    await backend.fs.write_bytes(f'{WORKING_DIR}/tree/leaf.txt', b'x')
+
+    await backend.fs.remove(f'{WORKING_DIR}/tree')
+    assert await backend.fs.exists(f'{WORKING_DIR}/tree') is False
+    assert await backend.fs.exists(f'{WORKING_DIR}/tree/leaf.txt') is False
+    # Recursive, because a directory with contents is a directory the protocol must remove.
+    assert sandbox.filesystem.removals == [(f'{WORKING_DIR}/tree', True)]
+
+
+async def test_exists_answers_for_a_file_that_is_there():
+    backend = backend_for(FakeSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/here.txt', b'x')
+    assert await backend.fs.exists(f'{WORKING_DIR}/here.txt') is True
+
+
+@pytest.mark.parametrize('operation', ['read_bytes', 'stat', 'list_dir', 'remove'])
+async def test_a_missing_path_raises_the_sdk_error_unchanged(operation: str):
+    """File errors are Modal's to describe: they pass through rather than being renamed."""
+    filesystem = backend_for(FakeSandbox()).fs
+    with pytest.raises(SandboxFilesystemNotFoundError):
+        await getattr(filesystem, operation)(f'{WORKING_DIR}/nope')
+
+
+async def test_the_sandbox_serves_an_agent_run():
+    """The end a user sees: commands and files reach the same environment through
+    [`RunContext.sandbox`][pydantic_ai.tools.RunContext.sandbox], with relative paths resolved
+    against the sandbox's own working directory.
+    """
+    sandbox = FakeSandbox()
+    seen: list[str] = []
+    agent: Agent = Agent(TestModel())  # TestModel calls every registered tool, then returns text
+
+    @agent.tool
+    async def note(ctx: RunContext[Any]) -> str:
+        await ctx.sandbox.write_text('note.txt', 'from the model')
+        seen.append(await ctx.sandbox.read_text('note.txt'))
+        return 'ok'
+
+    await agent.run('go', sandbox=backend_for(sandbox))
+
+    assert seen == ['from the model']
+    assert sandbox.filesystem.files == {f'{WORKING_DIR}/note.txt': b'from the model'}
+
+
+async def test_the_facade_exposes_the_backend_for_provider_specific_work():
+    sandbox = FakeSandbox()
+    backend = backend_for(sandbox)
+    assert SandboxFacade(backend).backend is backend
+    assert backend.sandbox is cast(Sandbox, sandbox)

--- a/tests/test_sandbox_modal.py
+++ b/tests/test_sandbox_modal.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 import asyncio
 import posixpath
 import re
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
 from contextlib import aclosing
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, cast
 
+import anyio
 import pytest
 
 from pydantic_ai import Agent, RunContext
@@ -36,7 +37,12 @@ from .conftest import try_import
 
 with try_import() as imports_successful:
     from modal import Sandbox
-    from modal.exception import ExecutionError, SandboxFilesystemNotFoundError, SandboxTerminatedError
+    from modal.exception import (
+        ExecutionError,
+        SandboxFilesystemNotADirectoryError,
+        SandboxFilesystemNotFoundError,
+        SandboxTerminatedError,
+    )
     from modal.types import FileInfo, FileType
 
     from pydantic_ai.sandboxes.modal import ModalSandbox
@@ -105,6 +111,13 @@ class FakeFilesystem:
 
     async def _stat(self, remote_path: str) -> FileInfo:
         if not self._exists(remote_path):
+            # Modal separates "nothing at that path" from "a component of the path is a file
+            # rather than a directory", which is what a path below a file reports.
+            parent = posixpath.dirname(remote_path)
+            while parent and parent != '/':
+                if parent in self.files:
+                    raise SandboxFilesystemNotADirectoryError(remote_path)
+                parent = posixpath.dirname(parent)
             raise SandboxFilesystemNotFoundError(remote_path)
         is_dir = remote_path in self.dirs
         return _file_info(remote_path, is_dir=is_dir, size=4096 if is_dir else len(self.files[remote_path]))
@@ -114,13 +127,11 @@ class FakeFilesystem:
             raise SandboxFilesystemNotFoundError(remote_path)
         children = [child for child in [*self.files, *self.dirs] if posixpath.dirname(child) == remote_path]
         return [
-            # A bare name, not the absolute path: the backend rebuilds the absolute path the
-            # protocol promises from the directory it listed, and this keeps that load-bearing.
-            _file_info(
-                posixpath.basename(child),
-                is_dir=child in self.dirs,
-                size=4096 if child in self.dirs else len(self.files[child]),
-            )
+            # `name` is the base name and `path` the whole path, as in the `stat` these entries
+            # are decoded from the same way. The backend joins the base name onto the directory
+            # it listed rather than trusting `path`, which is produced by the sandbox-side fs
+            # tools rather than by anything in the SDK.
+            _file_info(child, is_dir=child in self.dirs, size=4096 if child in self.dirs else len(self.files[child]))
             for child in sorted(children)
         ]
 
@@ -142,33 +153,68 @@ class FakeFilesystem:
 class FakeStreamReader:
     """Stand-in for `modal.io_streams.StreamReader`.
 
-    Async-iterable like the SDK's, and `read()` picks up wherever iteration stopped — that
-    resumption is what lets `wait()` collect the output an abandoned `stream()` left behind.
+    Faithful to the two semantics the backend leans on. `read()` opens a stream of its own at
+    offset zero and hands back everything the command produced: the SDK builds a brand-new
+    stream per call and never consults the iterator, so a drained stream is *not* at EOF for
+    the next `read()`. `__aiter__` caches one generator, so a reader has a single consumer.
     Sharing an `order` list between the two readers makes their chunks arrive in one
     deterministic sequence instead of whichever the event loop happens to pick.
     """
 
     def __init__(self, chunks: Sequence[str] = (), *, name: Stream = 'stdout', order: list[Stream] | None = None):
-        self._chunks = list(chunks)
+        self._chunks = tuple(chunks)
         self._name = name
         self._order = order
+        self._iterator: AsyncGenerator[str] | None = None
         self.read = Aio(self._read)
 
-    def __aiter__(self) -> FakeStreamReader:
-        return self
+    def __aiter__(self) -> AsyncGenerator[str]:
+        if self._iterator is None:
+            self._iterator = self._iterate()
+        return self._iterator
 
-    async def __anext__(self) -> str:
-        if not self._chunks:
-            raise StopAsyncIteration
-        while self._order and self._order[0] != self._name:
-            await asyncio.sleep(0)  # not this stream's turn yet; let the other reader go first
-        if self._order:
-            self._order.pop(0)
-        return self._chunks.pop(0)
+    async def _iterate(self) -> AsyncGenerator[str]:
+        for chunk in self._chunks:
+            while self._order and self._order[0] != self._name:
+                await asyncio.sleep(0)  # not this stream's turn yet; let the other reader go first
+            if self._order:
+                self._order.pop(0)
+            yield chunk
 
     async def _read(self) -> str:
-        rest, self._chunks = ''.join(self._chunks), []
-        return rest
+        return ''.join(self._chunks)
+
+
+class HangingStreamReader(FakeStreamReader):
+    """A read that never finishes on its own, so only a cancellation can end it."""
+
+    def __init__(self, *, name: Stream = 'stdout') -> None:
+        super().__init__(name=name)
+        self.cancelled = False
+
+    async def _read(self) -> str:
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        raise AssertionError('unreachable')  # pragma: no cover
+
+
+class LaggingStreamReader(FakeStreamReader):
+    """Output that finishes arriving only after the command exited, with the deadline window
+    gone by the time it does: a command whose reads outlive it by more than it ran for."""
+
+    def __init__(self, chunks: Sequence[str], *, exited: asyncio.Event, clock: FakeClock, at: float) -> None:
+        super().__init__(chunks)
+        self._exited = exited
+        self._clock = clock
+        self._at = at
+
+    async def _read(self) -> str:
+        await self._exited.wait()
+        self._clock.now = self._at
+        return await super()._read()
 
 
 class FakeContainerProcess:
@@ -181,16 +227,20 @@ class FakeContainerProcess:
         stderr: FakeStreamReader | str = '',
         exit_code: int = 0,
         error: Exception | None = None,
+        exited: asyncio.Event | None = None,
     ) -> None:
         self.stdout = FakeStreamReader([stdout] if stdout else []) if isinstance(stdout, str) else stdout
         self.stderr = FakeStreamReader([stderr] if stderr else [], name='stderr') if isinstance(stderr, str) else stderr
         self._exit_code = exit_code
         self._error = error
+        self._exited = exited
         self.wait = Aio(self._wait)
 
     async def _wait(self) -> int:
         if self._error is not None:
             raise self._error
+        if self._exited is not None:
+            self._exited.set()
         return self._exit_code
 
 
@@ -211,9 +261,17 @@ def default_responder(argv: tuple[str, ...]) -> FakeContainerProcess:
 
 
 class FakeSandbox:
-    def __init__(self, sandbox_id: str = 'sb-1', responder: Responder = default_responder) -> None:
+    def __init__(
+        self,
+        sandbox_id: str = 'sb-1',
+        responder: Responder = default_responder,
+        *,
+        filesystem: FakeFilesystem | None = None,
+    ) -> None:
         self.object_id = sandbox_id
-        self.filesystem = FakeFilesystem()
+        # Taking one lets a responder serve commands out of the same files `fs` exposes, which
+        # is the protocol's one-environment contract.
+        self.filesystem = filesystem if filesystem is not None else FakeFilesystem()
         self.calls: list[ExecCall] = []
         self.processes: list[FakeContainerProcess] = []
         self.terminations = 0
@@ -245,6 +303,8 @@ class FakeSandboxApi:
         self.created: list[dict[str, Any]] = []
         self.connected: list[dict[str, Any]] = []
         self.sandboxes: list[FakeSandbox] = []
+        self.create_delay = 0.0
+        """Holds the create in flight, so a caller can be cancelled part way through one."""
         self._responder = responder
         self.create = Aio(self._create)
         self.from_id = Aio(self._from_id)
@@ -255,6 +315,7 @@ class FakeSandboxApi:
         return sandbox
 
     async def _create(self, **kwargs: Any) -> FakeSandbox:
+        await asyncio.sleep(self.create_delay)
         self.created.append(kwargs)
         return self._new(f'sb-{len(self.sandboxes) + 1}')
 
@@ -361,6 +422,49 @@ async def test_create_terminates_the_sandbox_when_the_block_raises(modal_api: Fa
     assert modal_api.sandboxes[0].terminations == 1
 
 
+def _break_terminate(backend: ModalSandbox) -> None:
+    async def terminate() -> None:
+        raise ExecutionError('the control plane is unreachable')
+
+    cast(Any, backend.sandbox).terminate = Aio(terminate)
+
+
+async def test_a_failing_teardown_is_not_raised_at_a_block_that_succeeded(modal_api: FakeSandboxApi):
+    """Teardown is best effort: a `terminate` that fails must not invent an exception for a
+    block that ran to completion.
+    """
+    async with ModalSandbox.create() as backend:
+        _break_terminate(backend)
+
+
+async def test_a_failing_teardown_does_not_mask_the_block_exception(modal_api: FakeSandboxApi):
+    with pytest.raises(ExecutionError, match='boom'):
+        async with ModalSandbox.create() as backend:
+            _break_terminate(backend)
+            raise ExecutionError('boom')
+
+
+async def test_cancelling_a_create_in_flight_terminates_the_orphan(modal_api: FakeSandboxApi):
+    """Modal provisions the sandbox whether or not anyone is left to receive the handle, so a
+    caller cancelled part way through must not leave a running (and billed) environment behind.
+    """
+    modal_api.create_delay = 0.05
+    with anyio.move_on_after(0.01):
+        async with ModalSandbox.create():
+            raise AssertionError('the create never completed for this block')  # pragma: no cover
+
+    # The cleanup is scheduled by the create finishing, which is after the caller gave up.
+    await _eventually(lambda: bool(modal_api.sandboxes) and modal_api.sandboxes[0].terminations == 1)
+
+
+async def _eventually(condition: Callable[[], bool]) -> None:
+    for _ in range(1000):
+        if condition():
+            return
+        await asyncio.sleep(0.001)
+    raise AssertionError('the condition was never met')
+
+
 async def test_connect_attaches_to_an_existing_sandbox_without_owning_it(modal_api: FakeSandboxApi):
     """`connect` is the resolver building block: a ref round-trips into a live backend, and the
     caller that provisioned the environment keeps the right to destroy it.
@@ -404,6 +508,14 @@ async def test_run_rejects_a_command_shape_that_contradicts_shell(
         await backend_for(FakeSandbox()).run(command, shell=shell)
 
 
+async def test_run_rejects_an_empty_command():
+    """Modal would exec zero arguments; there is no program in an empty argv to report an exit
+    code for, so it is not a command, exactly as `LocalSandbox` has it.
+    """
+    with pytest.raises(TypeError, match='the argv sequence is empty'):
+        await backend_for(FakeSandbox()).run([])
+
+
 async def test_run_forwards_cwd_and_env():
     sandbox = FakeSandbox()
     await backend_for(sandbox).run(['true'], cwd='/tmp', env={'TOKEN': 'secret'})
@@ -436,12 +548,14 @@ async def test_a_non_zero_exit_is_a_result_not_an_exception():
 @pytest.mark.parametrize('exit_code', [-1, 137], ids=['client-deadline', 'server-sigkill'])
 async def test_a_deadline_kill_raises_a_builtin_timeout_error(clock: FakeClock, exit_code: int):
     """Modal's deadline kills the command itself, reporting `-1` when its client-side copy of the
-    deadline won the race and the plain SIGKILL exit when the server's kill did.
+    deadline won the race and the plain SIGKILL exit when the server's kill did. The deadline the
+    error names is the one Modal applied, not the fraction of a second that was asked for.
     """
     sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(exit_code=exit_code))
     process = await backend_for(sandbox).start(['sleep', '600'], timeout=0.01)
     clock.now = 60.0  # the deadline window has passed
-    with pytest.raises(TimeoutError, match=re.escape('command timed out after 0.01 seconds and was killed')):
+    message = 'command timed out after 1 seconds (Modal takes whole seconds; 0.01 was requested) and was killed'
+    with pytest.raises(TimeoutError, match=re.escape(message)):
         await process.wait()
 
 
@@ -452,6 +566,35 @@ async def test_a_sigkill_the_deadline_cannot_explain_is_still_a_result(clock: Fa
     sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(exit_code=137))
     result = await backend_for(sandbox).run(['self-destruct'], timeout=30)
     assert result.exit_code == 137
+
+
+async def test_a_sigkill_is_dated_by_the_exit_code_not_by_the_last_of_the_output(clock: FakeClock):
+    """What dates a `137` is when the command exited, not when its output finished arriving:
+    a command OOM-killed seconds in, whose output only drains after the deadline window has
+    passed, still reports the honest exit code it had.
+    """
+    exited = asyncio.Event()
+    process = FakeContainerProcess(
+        stdout=LaggingStreamReader(['partial'], exited=exited, clock=clock, at=60.0),
+        exit_code=137,
+        exited=exited,
+    )
+    result = await backend_for(FakeSandbox(responder=lambda argv: process)).run(['hungry'], timeout=30)
+    assert (result.exit_code, result.stdout) == (137, 'partial')
+
+
+async def test_a_failing_step_does_not_leave_the_output_reads_running():
+    """`wait()` collects the exit code and both streams together, so one of them failing has to
+    end the others: an abandoned read would keep retrying against the worker long after `run()`
+    returned.
+    """
+    stdout, stderr = HangingStreamReader(), HangingStreamReader(name='stderr')
+    gone = SandboxTerminatedError('sandbox sb-1 is no longer running')
+    process = FakeContainerProcess(stdout=stdout, stderr=stderr, error=gone)
+
+    with pytest.raises(SandboxTerminatedError):
+        await backend_for(FakeSandbox(responder=lambda argv: process)).run(['true'])
+    assert (stdout.cancelled, stderr.cancelled) == (True, True)
 
 
 async def test_a_deadline_kill_is_not_read_into_a_command_that_had_none():
@@ -513,8 +656,10 @@ async def test_stream_yields_both_streams_in_arrival_order():
     assert chunks == [('stdout', 'one\n'), ('stderr', 'two\n'), ('stdout', 'three\n')]
 
 
-async def test_wait_after_streaming_reports_what_was_streamed():
-    """`stream()` consumes the output, so `wait()` has to remember it rather than re-read it."""
+async def test_wait_after_streaming_counts_the_output_once():
+    """Modal's `read()` opens a stream of its own at offset zero, so a drained stream is not at
+    EOF for it: `wait()` reports the command's output exactly once, not twice.
+    """
     order: list[Stream] = ['stdout', 'stderr']
     process = FakeContainerProcess(
         stdout=FakeStreamReader(['done\n'], name='stdout', order=order),
@@ -530,8 +675,8 @@ async def test_wait_after_streaming_reports_what_was_streamed():
 
 
 async def test_output_delivered_to_an_abandoned_stream_still_reaches_wait():
-    """A consumer that stops iterating leaves an already-delivered chunk behind. Modal cannot be
-    asked for it again, so it is part of the command's output and `wait()` still reports it.
+    """A consumer that stops iterating half way costs `wait()` nothing: it asks Modal for the
+    command's output in full rather than for whatever the iterator left behind.
     """
     process = FakeContainerProcess(stdout='out', stderr='err')
     started = await backend_for(FakeSandbox(responder=lambda argv: process)).start(['noisy'])
@@ -544,6 +689,38 @@ async def test_output_delivered_to_an_abandoned_stream_still_reaches_wait():
 
     result = await started.wait()
     assert (result.stdout, result.stderr) == ('out', 'err')
+
+
+async def test_streaming_after_a_wait_replays_the_output():
+    """`wait()` reads the streams rather than consuming them, so streaming a command that has
+    already been waited for replays its output from the beginning.
+    """
+    process = FakeContainerProcess(stdout='out')
+    started = await backend_for(FakeSandbox(responder=lambda argv: process)).start(['noisy'])
+
+    assert (await started.wait()).stdout == 'out'
+    assert [chunk.data async for chunk in started.stream()] == ['out']
+
+
+async def test_a_process_can_only_be_streamed_once():
+    """Modal's readers each cache the one generator they hand out, so a second consumer would
+    collide with the first inside the SDK. The backend refuses it instead.
+    """
+    started = await backend_for(FakeSandbox()).start(['noisy'])
+    async with aclosing(started.stream()) as chunks:
+        async for _ in chunks:
+            pass
+
+    with pytest.raises(RuntimeError, match='single consumer'):
+        started.stream()
+
+
+async def test_concurrent_waits_report_the_same_outcome():
+    """The protocol requires concurrent waits to agree, so only one of them reaches the SDK."""
+    sandbox = FakeSandbox()
+    process = await backend_for(sandbox).start(['true'])
+    first, second = await asyncio.gather(process.wait(), process.wait())
+    assert first is second
 
 
 async def test_working_dir_asks_the_environment_once():
@@ -561,6 +738,22 @@ async def test_working_dir_reports_an_environment_that_cannot_answer():
     sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(stderr='pwd: not found', exit_code=127))
     with pytest.raises(ExecutionError, match=r"working directory of sandbox 'sb-1'.+`pwd` exited 127"):
         await backend_for(sandbox).working_dir()
+
+
+async def test_working_dir_rejects_an_answer_that_is_not_a_path():
+    """Caching whatever else the environment printed would hand every later `resolve()` a
+    working directory that is not one.
+    """
+    sandbox = FakeSandbox(responder=lambda argv: FakeContainerProcess(stdout='not a path\n'))
+    with pytest.raises(ExecutionError, match=r"working directory of sandbox 'sb-1'.+`pwd` printed"):
+        await backend_for(sandbox).working_dir()
+
+
+async def test_create_already_knows_the_working_directory_it_asked_for(modal_api: FakeSandboxApi):
+    """`create(workdir=...)` decided the answer, so the environment is never asked for it."""
+    async with ModalSandbox.create(workdir='/work') as backend:
+        assert await backend.working_dir() == '/work'
+    assert modal_api.sandboxes[0].calls == []
 
 
 @pytest.mark.parametrize(
@@ -637,6 +830,15 @@ async def test_exists_answers_for_a_file_that_is_there():
     assert await backend.fs.exists(f'{WORKING_DIR}/here.txt') is True
 
 
+async def test_exists_answers_false_for_a_path_below_a_file():
+    """Modal reports a path whose parent component is a file as "not a directory" rather than
+    "not found". Nothing is there either way, which is what the other backends answer.
+    """
+    backend = backend_for(FakeSandbox())
+    await backend.fs.write_bytes(f'{WORKING_DIR}/notes.txt', b'x')
+    assert await backend.fs.exists(f'{WORKING_DIR}/notes.txt/deeper') is False
+
+
 @pytest.mark.parametrize('operation', ['read_bytes', 'stat', 'list_dir', 'remove'])
 async def test_a_missing_path_raises_the_sdk_error_unchanged(operation: str):
     """File errors are Modal's to describe: they pass through rather than being renamed."""
@@ -664,6 +866,51 @@ async def test_the_sandbox_serves_an_agent_run():
 
     assert seen == ['from the model']
     assert sandbox.filesystem.files == {f'{WORKING_DIR}/note.txt': b'from the model'}
+
+
+def _sed_responder(filesystem: FakeFilesystem) -> Responder:
+    """Serves `pwd` and the `sed` line-window form the `Sandbox` facade emits out of the same
+    files `fs` exposes, which is the protocol's one-environment contract.
+    """
+
+    def respond(argv: tuple[str, ...]) -> FakeContainerProcess:
+        if argv == ('pwd',):
+            return FakeContainerProcess(stdout=f'{WORKING_DIR}\n')
+        assert argv[:2] == ('sed', '-n'), argv
+        expression, path = argv[2], argv[3]
+        if path not in filesystem.files:
+            return FakeContainerProcess(stderr=f'sed: {path}: No such file or directory', exit_code=2)
+        first, _, last = expression.removesuffix('p').partition(',')
+        lines = filesystem.files[path].decode().split('\n')
+        if lines[-1] == '':
+            lines.pop()
+        return FakeContainerProcess(stdout=''.join(f'{line}\n' for line in lines[int(first) - 1 : int(last)]))
+
+    return respond
+
+
+async def test_the_facade_slices_a_file_window_inside_the_sandbox():
+    """`Sandbox.read_file` slices the window with `sed` in the sandbox rather than pulling the
+    whole file across, and reads it back from the same environment the command ran in.
+    """
+    filesystem = FakeFilesystem()
+    sandbox = FakeSandbox(responder=_sed_responder(filesystem), filesystem=filesystem)
+    facade = SandboxFacade(backend_for(sandbox))
+    await facade.write_text('notes.txt', 'one\ntwo\nthree\n')
+
+    window = await facade.read_file('notes.txt', offset=2, limit=1)
+    assert (window.lines, window.start_line, window.has_more) == (('two',), 2, True)
+
+
+async def test_the_facade_falls_back_to_a_full_read_when_the_slice_fails():
+    """A `sed` that cannot find the file falls back to the filesystem, which stays the
+    authoritative source of the error.
+    """
+    filesystem = FakeFilesystem()
+    sandbox = FakeSandbox(responder=_sed_responder(filesystem), filesystem=filesystem)
+
+    with pytest.raises(SandboxFilesystemNotFoundError):
+        await SandboxFacade(backend_for(sandbox)).read_file('missing.txt', limit=3)
 
 
 async def test_the_facade_exposes_the_backend_for_provider_specific_work():

--- a/uv.lock
+++ b/uv.lock
@@ -766,6 +766,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,6 +1185,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b5/63e14ab9d4d4cc58818562db4120a35fa7454e3035633da41bdc6b712abd/connectrpc-0.11.1.tar.gz", hash = "sha256:18277f7838847b4271ca38d40c7d2387b5a2ea6a29f240689c19e1ec84aaff66", size = 46222, upload-time = "2026-07-15T06:33:31.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/ac/aa647675812cd075f2cb9acb00d62f4f2cbcbc6736049a62342b7371ce5b/connectrpc-0.11.1-py3-none-any.whl", hash = "sha256:8a52e2e92a485fa9681c1101a79a5ebeb31807e3ea3d5aabd41f484a6398bc7b", size = 64991, upload-time = "2026-07-15T06:33:29.396Z" },
 ]
 
 [[package]]
@@ -1629,6 +1651,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1700,6 +1731,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "connectrpc" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/24/9c1949aec729e62ccb02cb52c24561583e441dcbddaa3fab1dcfe19ecd92/e2b-2.37.1.tar.gz", hash = "sha256:d228d688b71e19d374992a30e8dfc2ae82f0a902c197281c02d0d5a5a76a509c", size = 200625, upload-time = "2026-08-07T14:15:24.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/9f/0cc812b2b5ec53cfa83bb3aa1a972c45c0bd36b7e849898d75c9e3a5a441/e2b-2.37.1-py3-none-any.whl", hash = "sha256:2f1c5e00feb315d1cf38f94e7cdd63ea51127877a18f009d00a2258f09650e61", size = 359484, upload-time = "2026-08-07T14:15:22.536Z" },
 ]
 
 [[package]]
@@ -5120,6 +5174,53 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf-py"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py-ext", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ed/02fd902d9c51b7ff53dfc9a745eb11490722edfd30073af889e171f07b8e/protobuf_py-0.1.1.tar.gz", hash = "sha256:6bd08ac4d8f1661965bbe2685429d79043704cdd1ee720a7a89617331742240b", size = 133525, upload-time = "2026-06-24T19:02:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/00/1b3775aca1c70e3007e06ef5996f6bb9b3a32341eb0cce3ffb6effad8dec/protobuf_py-0.1.1-py3-none-any.whl", hash = "sha256:efc4f50f275ed6dae10a1f30bb81ad1a75368557b3ff22a532b7a472050368f1", size = 181656, upload-time = "2026-06-24T19:01:29.556Z" },
+]
+
+[[package]]
+name = "protobuf-py-ext"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/6dc9ccff1e8159eb9a144e6d3c4acfd2211cd4fcd20c34fe9155d17d6a7f/protobuf_py_ext-0.1.1.tar.gz", hash = "sha256:e85bfdfdb3ed50634db8ccc7429dd9286520109489c735463971a418707b4fef", size = 31912, upload-time = "2026-06-24T19:02:16.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/2b5d62a60a2e0d88ecde1ae98db3132bcd2672fb39c8d581b82b34ac0bd8/protobuf_py_ext-0.1.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:310039e03cb15181781a0b78017419f6d4ee302e988c3c70b87f1facdf05532d", size = 306008, upload-time = "2026-06-24T19:01:31.399Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d6/73c06bb4cac2e04c0adc154965fe8b6520224bd737fd7e73bba405056321/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ec8348d1ba045f79b2fedd14e40cca36f2a41b52f2c4fdf55a60c58add2353", size = 314769, upload-time = "2026-06-24T19:01:32.89Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c5/e4e6bc6096b66d1c82639a1b501147f16ee65d32567304b987d002e2c666/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:182798e4861aba72d05855bd06febe4926aa7265e6f444a1b8af5252beee4f7e", size = 328122, upload-time = "2026-06-24T19:01:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/1d792a40d0f0a0f914f1dfa8bb5e9573ca0ecd5fe5cecf80d77193212abd/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9eb25c3a329c0551cc86b209a5e5d8ecb8d834b9924a3aa019377853a703b6d3", size = 492338, upload-time = "2026-06-24T19:01:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/5ad329223c905e5c530cae38ae24cde3584d8ab7e09457f2a01afce80e60/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aaecbde82bef10c7c40578cbb61b7a19896bf7fa450972050a3bb302acb7d5d6", size = 541578, upload-time = "2026-06-24T19:01:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c7/01bd8a8bfe2df4b07aafac12ccfb7b7ebe2303f65296a9e02fcafa28ff3e/protobuf_py_ext-0.1.1-cp310-abi3-win_amd64.whl", hash = "sha256:6b0c615c48e95acc53cf33e9310eeaff8b30d2d7555bf93e7bca8fb4f40e9a5c", size = 251319, upload-time = "2026-06-24T19:01:38.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/914065538b5db54b6a920b5af38c1ef142252ea1eea711820435fa259fac/protobuf_py_ext-0.1.1-cp310-abi3-win_arm64.whl", hash = "sha256:72956cd0af5dee24b41c6f5ba5e42622d17e6d555002b5efc1634e27a1446de2", size = 241635, upload-time = "2026-06-24T19:01:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/0b5d73cab815fd50615cb87a02e04e8332f9e27380c890aba1459cf7e919/protobuf_py_ext-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6f0cd58620f415a3534d195358338f4999a774e12510f91c592b38d13d37388", size = 304903, upload-time = "2026-06-24T19:01:41.796Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/14c120b9ac36a0e11bb05e482fa6ae322de583a8e1068e4859035c289947/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21572764f625d829604fc4d83635f533f35775f11c6da142345b3f3c8d64bd09", size = 316148, upload-time = "2026-06-24T19:01:43.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7c00a1a9783c3ba74f6b2f5d2f049f09037bbd489c465c09a34f32fb611b/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f14f00c2678bfbe7ad46f057b9f9938c1677bcf39e405e163e272c6f9814b8", size = 326458, upload-time = "2026-06-24T19:01:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/81fa50c0d6c4d664e5be6d0a3c4f2c7edfef87ab12d0bac764abca1f2955/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1610865622e2e27568277ca63d8d2d23dcc55eaa767398865c21539ddf4ce24d", size = 493596, upload-time = "2026-06-24T19:01:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/3183cf6e4de62846c20549654a1d573dae51ca06aaf7fed06accdfab74f6/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8995efba9476e1ea18ef9873306871dba697308994bc2766558fec3387acc3de", size = 539656, upload-time = "2026-06-24T19:01:48.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/6c/09841f3dbe7c3d4b3f2779f8f2832ac23fb96ac8ab71674e91af732cf9ff/protobuf_py_ext-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba61d49dace8f874361583030a7c48139b42eb37c9ffbb1e7e8a227a51576f44", size = 305017, upload-time = "2026-06-24T19:01:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/52/43/e450b5e202f6715274acc9acd9f9769908cbdeab861a53c798fcbd467d35/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a9c2f026096ca4c595c89a297067ef371e241d3ff8e1f6d7c779aa8419cdca7", size = 316215, upload-time = "2026-06-24T19:01:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5c/23e79b35f1b5755b9bdc0c0c9b8cd8abababaef1a1639608d8a96bb61a9d/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf78707a040b9294e5e1ec4a1875f0046acfe52e92150cea27de4e9fc9db39bb", size = 326419, upload-time = "2026-06-24T19:01:52.93Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/de/5493de0ec12920a3b1dd72608ce0c1e8cdb7e0eb9e87accaecc5216df29e/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae4373845cbb85bdade3ef5368cc2f4b5f80bf173383afc1ab063f95644e5599", size = 493734, upload-time = "2026-06-24T19:01:54.301Z" },
+    { url = "https://files.pythonhosted.org/packages/98/89/31da55b414e6332aad11d858e9a86bd36fbb324f52fa3fc6d8f1c57840a9/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2a4cc478eef7a2acc1daaebcde479a3ac2396d47e6bdc7e776ca4c4147ba8b4c", size = 539703, upload-time = "2026-06-24T19:01:55.707Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/71/39f231838ef06476d46ac40dd814894277a732a3688c0a0c994850b3b62f/protobuf_py_ext-0.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:359dccdc1c3eafed2a913c570bb082b8df848a1d27d548ce8385f246a7d68be2", size = 302145, upload-time = "2026-06-24T19:01:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f1/01c81ff5f420600366a0e6a613ce2af20834534d2b3d7523f4f3b4ddb54f/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91c38b4a10a306366443273ee03ca554537a0965bf05b7ada8e7dbdee04cc93e", size = 314541, upload-time = "2026-06-24T19:01:58.745Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d8/1cbf5a0298ceddc0cdbb28bf1ecaf8bd3cff54ed4ced6a1392d5226172fc/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79eee3bcbb289d6ea114eb8fe3a1469c5b59bf53e207238469f567d9c53ba56f", size = 325092, upload-time = "2026-06-24T19:02:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/af/23/8b1694616044cbfec2d18d4c6fffb03e05089c8bdb5970c6bafd60cc7fd5/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:10992141a8282a71ac3e3530d1a489efb27618d84000b9a47918cf70e5816d9b", size = 491684, upload-time = "2026-06-24T19:02:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/99997a7a6cf6989c944d9183c5deb6a045c27460add0316c7b34763891b3/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4411ffe0e06a774b83c5c71c546ce097640a25f596c45f95f53d3e3148e3f22d", size = 538048, upload-time = "2026-06-24T19:02:03.362Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/9e99ecbb68e1d5b46016d821eb1cbba9a91e6b50e71e75faf0c1e6189f0d/protobuf_py_ext-0.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55a17d80ea419501ff221a6627523f38a431bb33e6aa3de81ae3a7f271c49c75", size = 296337, upload-time = "2026-06-24T19:02:04.787Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f2/305338a28225fb54b28d6c3f5948109b9088b329a2b6f77ca610c2bdcd34/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbb518b5638403ceaa08ac4fc7dac626f45ed9b856b3517de3906cf3de4d632", size = 308961, upload-time = "2026-06-24T19:02:06.185Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f9/416103c93677ff2ea407704ea64fa6de9e700dc030c48360a182d91ce373/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a4adc65ab6a5e4885c67fc808bcacb83d755d05b566d312a0e10c2a873f2ad4", size = 321895, upload-time = "2026-06-24T19:02:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/83/eb3e81bb2f83834b7deff4cee2d56eeb1adcbc847492a56b7f910ab257db/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e97f45c49676efacfb8e95bfcb1a002bc337e618a6780be1e55df2ba5ebd2f1e", size = 486091, upload-time = "2026-06-24T19:02:09.243Z" },
+    { url = "https://files.pythonhosted.org/packages/99/96/bd88fca38556b3105e4dd41d6a176e31dcc583fe979e830aeedd2f8c20ee/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:53a6b3590f6aa7f97b8ed60f62fef9b096babfeae82f7283fd3a4c405827d4f8", size = 534582, upload-time = "2026-06-24T19:02:11.227Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5360,6 +5461,9 @@ dbos = [
 duckduckgo = [
     { name = "pydantic-ai-slim", extra = ["duckduckgo"] },
 ]
+e2b = [
+    { name = "pydantic-ai-slim", extra = ["e2b"] },
+]
 exa = [
     { name = "pydantic-ai-slim", extra = ["exa"] },
 ]
@@ -5464,6 +5568,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["cohere"], marker = "extra == 'cohere'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'duckduckgo'", editable = "pydantic_ai_slim" },
+    { name = "pydantic-ai-slim", extras = ["e2b"], marker = "extra == 'e2b'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["exa"], marker = "extra == 'exa'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["groq"], marker = "extra == 'groq'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["huggingface"], marker = "extra == 'huggingface'", editable = "pydantic_ai_slim" },
@@ -5479,7 +5584,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["web-fetch"], marker = "extra == 'web-fetch'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["xai"], marker = "extra == 'xai'", editable = "pydantic_ai_slim" },
 ]
-provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "exa", "examples", "groq", "huggingface", "mistral", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
+provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "e2b", "exa", "examples", "groq", "huggingface", "mistral", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5619,6 +5724,9 @@ dbos = [
 duckduckgo = [
     { name = "ddgs" },
 ]
+e2b = [
+    { name = "e2b" },
+]
 evals = [
     { name = "pydantic-evals" },
 ]
@@ -5707,6 +5815,7 @@ requires-dist = [
     { name = "cohere", marker = "sys_platform != 'emscripten' and extra == 'cohere'", specifier = ">=5.20.6" },
     { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0" },
     { name = "ddgs", marker = "extra == 'duckduckgo'", specifier = ">=9.0.0" },
+    { name = "e2b", marker = "extra == 'e2b'", specifier = ">=2.34.0" },
     { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.0.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },
     { name = "fastmcp-slim", extras = ["client"], marker = "extra == 'mcp'", specifier = ">=3.3.0,<4" },
@@ -5750,7 +5859,7 @@ requires-dist = [
     { name = "voyageai", marker = "python_full_version < '3.14' and extra == 'voyageai'", specifier = ">=0.3.7" },
     { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.14.0" },
 ]
-provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
+provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "e2b", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
 
 [[package]]
 name = "pydantic-core"
@@ -6051,6 +6160,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/8576f0eeb44d3fe14c70e2bafa77ae6930c5e6f42b93c568719ea4456715/pyqwest-0.7.0.tar.gz", hash = "sha256:ac65f2243f3e814e7f4aad3f2fcfe78f89aad2de2a825eaaabf4c102f1937843", size = 457991, upload-time = "2026-07-19T05:20:06.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/49/7f26a2c2a3e8bbab4862bcbf4f54b706d9524fa9705cc0127553b81ed161/pyqwest-0.7.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7b2339f3b55ae179e0cb55bbd5792ae1c954d31f80de7b4dde0e95b03576b6be", size = 5159904, upload-time = "2026-07-19T05:18:57.757Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f1/4aba1976566936ca873e1a726a0d9bdf8195a0dc4e4f78122f6050328566/pyqwest-0.7.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2159c7e2eaf2563cdadfda17314e2b1747c30603979bf73db8daef311247db82", size = 5044476, upload-time = "2026-07-19T05:18:59.473Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/06/45908e5cda7fa28ba60df5ed2091056893c394c3217a796bc6577c4bd294/pyqwest-0.7.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a826f1b492a7497f469c8467bd51faf582733654bb2bc9fcdd4fa502f3e6ca1", size = 5560021, upload-time = "2026-07-19T05:19:01.097Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/3d/603f5c9446e8c13a4970b816246d7928e895408a7ed1778d98de3e25ea43/pyqwest-0.7.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da43c7e86bee9e74ff474d4829cd398fb9220ff0d84d633094ea6797fdfe03a1", size = 5506130, upload-time = "2026-07-19T05:19:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/2984aa02f4d0296dddb5df159e1af6c6e0ddc0b507d592f13d6ccd0b3162/pyqwest-0.7.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d1c71327c323a19dc90a0dafb1d68fb13f4f775a2498a26bf95f17165e64da9f", size = 5719961, upload-time = "2026-07-19T05:19:04.213Z" },
+    { url = "https://files.pythonhosted.org/packages/19/06/e30c0d31eea17cabf99ef90c7c02e14cc94ca7d59793d397de9359148693/pyqwest-0.7.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c002e0fc31a96f1c47986299710f49ed4551e4a912a7cdb69aba6fd94db6d544", size = 5908279, upload-time = "2026-07-19T05:19:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/db/a1368faae1cbd094a0d179b76de69b8d1908bd45898d3bcd29ac98622072/pyqwest-0.7.0-cp310-abi3-win_amd64.whl", hash = "sha256:847e4468b5379a219b91a13dd3c92dd3b7b3d9f59af23e4c6776e663594cb241", size = 4755104, upload-time = "2026-07-19T05:19:07.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/38/c493e85ebd17d3a5c56eb53fbea36a1a6f396b999b38173ffde513576eb1/pyqwest-0.7.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4988fa1c368072886dce48f52fcbabe9f25784c6e189a9a6f2b42f6e9f383973", size = 5172962, upload-time = "2026-07-19T05:19:09.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/68/1b340fdc7735b5682d308cabc2d65ea76c03a6cc2c30072a0c14c24f716c/pyqwest-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dfb61138c802c7317d840a274fa24f9d878301f693268e9186a9896452017a71", size = 5032604, upload-time = "2026-07-19T05:19:10.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/52/eecd858568ef6586cbdc3c419a9a0b1e8f891e2968f0f6b2a9fa9bdaac19/pyqwest-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6fdc0601590bdc547007828627082f0dc0e445e92d900dccb227e51898d7243", size = 5558302, upload-time = "2026-07-19T05:19:12.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8f/b67d0056b18a9f99a1c9253cb983d5c4361e3e102d729df6623b71d6d939/pyqwest-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f82c971810695f5fd7962859a2469616c83b7aca6664d8f147287ee5ff430cd", size = 5501483, upload-time = "2026-07-19T05:19:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a6/69b87c4c80ced01645a143679458895dcb5c0e5ca0b3d4a43d979939cce6/pyqwest-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9dc2f405803b94525ab030c01cdac7093bcc1a5da6802de3345a868a0f51b3da", size = 5717334, upload-time = "2026-07-19T05:19:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/5891b72b9193b692b50ecdc4e26e7e3687f9763f5f263646bc8f997f5b62/pyqwest-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:537f71f97a533fa355d02c15ed9f0cc05fb8915996cb921caa87fe7310b457ee", size = 5902447, upload-time = "2026-07-19T05:19:17.273Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/1b280618af3f9d36081449d153efc5620f0eea93ac169574fc69208d2b91/pyqwest-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:196aa73fb7eee4b6c052d6f4172a4321904a7208331f4322ccee3ee7d0adbc78", size = 4750469, upload-time = "2026-07-19T05:19:18.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/9c/64c8df83a152804ac3074fb879c1229c3aca55a12dc33dc73c72e93405e6/pyqwest-0.7.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:72d001892ed570df1dcc489ef8b0a03bc7abd4fbdca10625c358a87e66b226ad", size = 5171308, upload-time = "2026-07-19T05:19:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d1/46e629541a3f7231dd978fa9939e6ddcd075238880395bcfb16544769165/pyqwest-0.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:03da0797bac5c2eb1a40f02afccd4b5aad5ad0d375bb993df2f5e0c692fc0c6c", size = 5032449, upload-time = "2026-07-19T05:19:21.967Z" },
+    { url = "https://files.pythonhosted.org/packages/44/3c/132194c747696e41ad5745c51587bd20057d800b6a64fb901ce2ac990149/pyqwest-0.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:837e18aef4490eed25b4194d49f16732ccf1abf2cdd0845e75d75d2a4428b98c", size = 5556847, upload-time = "2026-07-19T05:19:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5d/6726a70e89c60bf3cd30d5d918eff68dc1d1ceb9c911331d7fb57977bfc3/pyqwest-0.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:418e8c3a67ca6226bfb6147b8668203c74d9c872657117086f4c264a674d7980", size = 5500333, upload-time = "2026-07-19T05:19:25.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3f/329df64d3e8778bc311a22e432280cd317619c3f9b7e414f375127bb90b0/pyqwest-0.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31176abbbcbe6d03740967b5c0241deaa60b328792644cb2e317a34d6b076433", size = 5717248, upload-time = "2026-07-19T05:19:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/93/6670afb97c6ce7b5ba27981e023d9edc7413e509bbe18afebb729834d9e6/pyqwest-0.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e21102f9c13234a0066d42bb5429dc5c311d7fd99401878837d9675a7f6e03b9", size = 5902814, upload-time = "2026-07-19T05:19:28.637Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d3/bf9440a03c97f408743313215d8c7e9875b0b2b0d2ef97f5fbb5066cd57d/pyqwest-0.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:ca19e96b5e902a6d35e18cee7f5e90612fca6ab169378d42242cdcb638578cee", size = 4750510, upload-time = "2026-07-19T05:19:30.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/25/8b0919bf504309982857e564e3035ffd799d7aaa23457eb351485573e5ee/pyqwest-0.7.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4e4e79187c3e4ebd07d663d8dc7a7cba865c72020332e41807426a7e3526fda0", size = 5177972, upload-time = "2026-07-19T05:19:32.051Z" },
+    { url = "https://files.pythonhosted.org/packages/52/12/d652213fe336c52b75fb4df710f5cff08f8a1dcc9e385c9120f18476f5c9/pyqwest-0.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1bc2c569481ade1bc0b89b07daf1b49b20a1337a53207ffe0ef325260f509404", size = 5032608, upload-time = "2026-07-19T05:19:33.772Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b0/406c91563140b87ade5c5935410997b26449b8eb2f91511bc52741ae38fb/pyqwest-0.7.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ef1bfbdca9ec9c8a7b223268f5ef8d45694da7226929454b0cb40f2e3d1ddd5", size = 5558937, upload-time = "2026-07-19T05:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/17/a0a09936b5dd5d9d7517289aee3683bbf6554b0853bce5280ead9da27336/pyqwest-0.7.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c2f6a6830becfa1c5bb94aa169ad854da5749a95a440aee759932d5965c213", size = 5500603, upload-time = "2026-07-19T05:19:37.023Z" },
+    { url = "https://files.pythonhosted.org/packages/00/34/ccec52ca9f14fbe11292fadbe89c771353e0f46d58aa88d8e93d6e018117/pyqwest-0.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0d11128ccc382f64fcdf92d3bce6be7191489c1b3a9a3f0dbdf89e55451638de", size = 5719784, upload-time = "2026-07-19T05:19:38.649Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/58dca466c236e497cbb2e75b97a2489225d21f5063d932ab7d1723294112/pyqwest-0.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5832373c7bcccfbc3bb79c44b592e0871631139a2ef5aef771b8fe2b7bd4301d", size = 5901396, upload-time = "2026-07-19T05:19:40.402Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a0/983ea3b859828bef8372896e9c407f62bf426b84526d0b0cf9fd9abce411/pyqwest-0.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:7330070c4497e564007985716ac347cb9a7500eba5c9610500653a2ce4cfe86e", size = 4751036, upload-time = "2026-07-19T05:19:42.159Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1d/e2fe3dfe6d87989017412f394abc45435a3af2526e998c83cf836937b23c/pyqwest-0.7.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:02fd606a35be7803a770071f642a375e55df4c2025e49b10b859430f424c4492", size = 5165801, upload-time = "2026-07-19T05:19:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/fe/90126ac71fe09c729f36c166cb71b5148dd8a80e47f6f232bf71494604a2/pyqwest-0.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a807835c6a0777f0cc57c321c78c7bf162f6354698844d78db6e03ba9edd83dc", size = 5025128, upload-time = "2026-07-19T05:19:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/15/ee84ce834705d613c0b113fb4cf9d274011cfcc6c6ededb52d92a38a2367/pyqwest-0.7.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86d84871cb0a572700dece3a6c45c294721f655f3d0b85477333209b487ecef1", size = 5551017, upload-time = "2026-07-19T05:19:47.046Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/18b4540fb276f9b540018efe024aca0801acfe4209417d4faed85bccdb04/pyqwest-0.7.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:005ddd2a777d30ca7ce4de12df1336760e14d46394ab56299a9e81626d78b991", size = 5493032, upload-time = "2026-07-19T05:19:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/91/f25477eb80c375378a876cf2bac80c55ec9ea36b94bd7d4b2b2931860c85/pyqwest-0.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ca02089249c292ab9c148fa86c06927701897090226a13e392a6ec53312380ea", size = 5712503, upload-time = "2026-07-19T05:19:50.542Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/63/c5be988c55c69c87de950e3dabab322f82a78dc7c2ebdf89af32626bd473/pyqwest-0.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:da3bc117c1380e9577994da15b8236f7c3bb400111d6be4b57a9b2e4f30c9a79", size = 5893782, upload-time = "2026-07-19T05:19:52.286Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a7/96144e6db9a49eb5e42734562ac5d387c2b78fe1142674d3a284ce188ef7/pyqwest-0.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a599ddac7ded32ed62d15ca90bc9c77652ba34b225cf17a404821cec92a189fa", size = 4744187, upload-time = "2026-07-19T05:19:53.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/42/26cf547b2e43078b4663e717715a289f31fc873d65d45cf354f364faa744/pyqwest-0.7.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bebc51e3c9c6339d81964c6e60516a5f5c9fe793c82da57ef7c2d87a55741829", size = 5170766, upload-time = "2026-07-19T05:19:55.472Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/bc/1aac42f34bd3e5ac4c13a2c267dba6bda4bdea594ff96c7851dff930c8f1/pyqwest-0.7.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:37623b492aea7ccd3b6cfe3179110643d28c2cdc83c765aac3d207b4321995d2", size = 5053361, upload-time = "2026-07-19T05:19:56.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/e3d8cfd2c7be0e12773ee4f767efc03be50ccdd28c6155d0b176bf1d8a9a/pyqwest-0.7.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02ff96a7746de208a4b8c78abe780c413d66576146a4ec64efd348b0c8a8328c", size = 5573900, upload-time = "2026-07-19T05:19:58.536Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a4/7dd4d548be6d54b195d737164dc67c39d9c5df40aa76a873fe1d2d9b4426/pyqwest-0.7.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd2e9bfa81198db7023202962a94920986a9a3dd12fe2f9d310f0cfcdddc092c", size = 5510692, upload-time = "2026-07-19T05:20:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/13/c070baf81da8653803328b632baddb5647b66cc7c6353c58f024ca82277c/pyqwest-0.7.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:e1548708dbeb29a60db199c70b9e93733d6b334e7efa1dfa5e3846a4f890db6d", size = 5735516, upload-time = "2026-07-19T05:20:01.487Z" },
+    { url = "https://files.pythonhosted.org/packages/84/46/e0f2a02ebf504db6bdf4bf343f0d3362eccf8dd5a325382fab1305fa7022/pyqwest-0.7.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:4bb3cf0975ee829b6c76e1c42f01863122ce71b1a952e507e260a9d29eb9b183", size = 5916743, upload-time = "2026-07-19T05:20:03.132Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7c/4a35df79a142e5fcb5f46fce2d1d70dd72325a65db4139bbba4fbed0d9b9/pyqwest-0.7.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2ea1ce4d630c92cb2cc6b3bf91ada0053b051dfd5c0662d89957ebd829cfdcce", size = 4759967, upload-time = "2026-07-19T05:20:04.837Z" },
 ]
 
 [[package]]
@@ -8113,6 +8275,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -940,6 +940,62 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/14/b02446bacfe44351b1689c04937ade007588f44570431880a6937e525e6c/cbor2-6.1.4.tar.gz", hash = "sha256:01ecc79a28f33d17331943ce508fc1e21f4b06553c73f874f4c77120d72b2ef9", size = 90840, upload-time = "2026-08-01T20:41:39.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/7d/91e6b680e8ae313e53ae8da1d0b578c668d240c9f294be06d729fc014854/cbor2-6.1.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3cfb7eec57406b86aab47183f6dc90ece888e03721d37a4d33315e79e486898d", size = 415427, upload-time = "2026-08-01T20:40:24.371Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/43/3d8d53f22be9566cbb011bdaaf799a77f52e447b60a54efc9537f271f177/cbor2-6.1.4-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:ae14eb3f2f251102d72625ab02a28c83a8d11adf3d0383bd6d7bd9d672e18119", size = 458280, upload-time = "2026-08-01T20:40:26.362Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/d8/0b2fb7e936b63395ab1acf91074dc0788c575a57e8d808d9e8489de631f4/cbor2-6.1.4-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7b697c2a18eab9a3326447fe0f1c927db065a096febc57f064f0f5ed67fe96fc", size = 464737, upload-time = "2026-08-01T20:40:27.897Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f794155ec864c0e85a2df293adc589e7e45133ab15c0d21ac5ae3a51f804/cbor2-6.1.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:032ce71cbdc9267e9cec42132f6ac6c40f441ec27ebc87ca9dd209dcab6804ee", size = 524277, upload-time = "2026-08-01T20:40:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/7b/819912a5192ffdb0261b9c73e57b2ee77b4141132ffac77bf374c738e310/cbor2-6.1.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e8097e8259b78c8feb5dd5b833b23f83ed588e821ef44cf1455082cfc9434440", size = 533360, upload-time = "2026-08-01T20:40:30.922Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f4/73aaf73837bae5c47f01e1a602214a9b9ece6c0687b7b1d6e4ecafe55b74/cbor2-6.1.4-cp310-cp310-win32.whl", hash = "sha256:41aae72e8863ac0d50705ea8290b72c49db90a6d953110feaa91360ae526fa8d", size = 282266, upload-time = "2026-08-01T20:40:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a9/a1a88346b44a7fbcd4b4aa4f527fbc5f46649bf0706e994d8e59aada4641/cbor2-6.1.4-cp310-cp310-win_amd64.whl", hash = "sha256:deff027a56e04caebfee649029bfd1836f4fb468d2cf66d2a396ae1018f655db", size = 303781, upload-time = "2026-08-01T20:40:34.198Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/fb/969a945d3f3c0bd619d73e7eb375ef1800af33451d7ece2d56d881ef1732/cbor2-6.1.4-cp310-cp310-win_arm64.whl", hash = "sha256:c435720a25c1de9b241df883b5890b35aff3bf64365efc8037d4d26df085724e", size = 296316, upload-time = "2026-08-01T20:40:35.885Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/84/1e363301c06f509963d134f5479e82b3ade87fb1495ddacf9bf7ff24ac42/cbor2-6.1.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8156fdeb73c3ff6c8cf67ad414fb5c887cd708ff0af6d61f62629f41cb4c17b2", size = 414947, upload-time = "2026-08-01T20:40:37.405Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/d8e1ed3e79ea20a3423a96b5c89ce794fa02cb428e4429e601f8ebcbac7c/cbor2-6.1.4-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:e1fe2d62c50df290576280b18247ec63486f78be73e285bae269c2456c6ddff0", size = 457343, upload-time = "2026-08-01T20:40:38.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0c/5796c2ed2dcd0696fc4abedf0ea0dfd5361b3f022a311481f977fa51b2b8/cbor2-6.1.4-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c204a75f91f8cd9ed0881f6b88ec395c59aeac9fcf4d08155e7f899db2a1c46e", size = 464314, upload-time = "2026-08-01T20:40:40.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/88/de524c6c2c91b740e5df6e6955a113fb616e979b26fd2e6a0693082d36e0/cbor2-6.1.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:28fa5db05a7eae8fd80709959988d8a7f12838c6d4e5c58ec951414058641195", size = 523053, upload-time = "2026-08-01T20:40:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/84/07/cb5fd92834633508d680a5b5695aeaf99d33ca0bdc5b844550d538f335b0/cbor2-6.1.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316e217a496640418d3137483279d0e70053b000cdd4b52a4dbf20ea478bc40a", size = 532177, upload-time = "2026-08-01T20:40:44.058Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/19/be98721365edfe6fc23e6bcd1385afa0e960b247c5f0b50bb67f5d05e2d9/cbor2-6.1.4-cp311-cp311-win32.whl", hash = "sha256:4903f24e0f9087275a0b6606c8b0aa586277001d51e4844fcdbc5b7211330aa8", size = 281660, upload-time = "2026-08-01T20:40:45.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/23/d54f679d4b155918f5a0879dab78203ce4fd514d311b7cfeba27dafe480b/cbor2-6.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:5b99305d4013867e059f147752b95f728680682ab03d75a3f4dcfbb270d8dfe9", size = 303207, upload-time = "2026-08-01T20:40:47.293Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3c/b3839d6213c88b249ba860525df05ff18b27bdc28ebc09cb1547790f001a/cbor2-6.1.4-cp311-cp311-win_arm64.whl", hash = "sha256:bd20ecc5c8ece24db952e48a91c8c47319eaa6358af707c85ac2bb388a79abc8", size = 296123, upload-time = "2026-08-01T20:40:48.808Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/fb64293c19cafb860060310c57b768fd9cfb7cf592449660b756538cc116/cbor2-6.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1fc15061553e4494dc10883237501e3402c645fe509248dd698e1faf2460d68b", size = 404608, upload-time = "2026-08-01T20:40:50.219Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ac/f58b3bafce7c86ada2ad8eaf189453136d2cf5bae526ea0540e1b9bc9d06/cbor2-6.1.4-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d9ada5a6ccfbb8ea7a3aa2aeb028421b52d8e0cd9323f0a2aeaa9c09d25fbce2", size = 449851, upload-time = "2026-08-01T20:40:51.725Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a5/10c6c126d59b07f2bd005094dd12a20afa46146f7e2673ed6f61a57641a7/cbor2-6.1.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:310f3dfb296ba48fe9b63c5cf26e691e3548a1eae6901d2f0c18e941d151f220", size = 461193, upload-time = "2026-08-01T20:40:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e4/4445e6237088d1cca3b8536daeb90d6b4e23776de5609c9fa46773874757/cbor2-6.1.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e6c76004d674ad1c620660cb0bc5a8a0b72a5d8c7b70926d8e09e6d7e87332f", size = 516937, upload-time = "2026-08-01T20:40:54.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/87/9c0959510f7a402e5995c81ccfd82cb9f314140dc0cce88c12836e5b93f1/cbor2-6.1.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32a4663425fbca4a4a7aa918eb5789d844c406439e58424cf34511f79f559242", size = 529229, upload-time = "2026-08-01T20:40:56.365Z" },
+    { url = "https://files.pythonhosted.org/packages/91/8e/6811e4ee84203ac657f6f461a37c7c9ba0287bde80eb83c7971e9b3fe156/cbor2-6.1.4-cp312-cp312-win32.whl", hash = "sha256:2310f07db3f9ba26f2a623774ff9f3dc7185af54f732ea119785a6b1bf7e1e7e", size = 278810, upload-time = "2026-08-01T20:40:57.76Z" },
+    { url = "https://files.pythonhosted.org/packages/da/27/87440788fc0d9513534c3c699238e2a9ca6010f8cb72e9c203b7af20a9f6/cbor2-6.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:cc8cd300e236e9797b2e1ce306109dc481fcccf78bfa2682bf36d99e6eab1ec6", size = 299971, upload-time = "2026-08-01T20:40:59.256Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f9/77981e6e63092de19d7306a09a12b0eb3fd2907dc22c10dd5d389eb27faf/cbor2-6.1.4-cp312-cp312-win_arm64.whl", hash = "sha256:553a46bda7d09552631a714e22b91e6ff2c867ecd91511596ce290d8879b8d5b", size = 290662, upload-time = "2026-08-01T20:41:00.89Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/0b20c88e76942ede86c98cdce138681690f95908c540c264fff847729cd4/cbor2-6.1.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c48a7c938fc5fa5300ff82b5df09068dcb4838685ae8556b5ee8279d74f97ab4", size = 403677, upload-time = "2026-08-01T20:41:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3d/93eed770864540c5c9ea0841008208e9db686b7335f42520705b7d6dc6b2/cbor2-6.1.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4bd29f21529e279d50fc14f1a811f7b05b4d8e66a7969163cce98983b6817245", size = 449762, upload-time = "2026-08-01T20:41:04.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/21/69e4d37f00319b3d37322355aedc83154b4d8b75dc9e9789c06e1fbd8a92/cbor2-6.1.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36ae16d64b1f7b620c1af748e7b6947e20069ef80eee56871c5fbb84cc635905", size = 460420, upload-time = "2026-08-01T20:41:05.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/26/2cfdd5ee826205a88a826bb38b7a572c676ec3efa29574be5cdbd04b4859/cbor2-6.1.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:69978901302ecbc8cda57b520487c5c5240ed217de783eb7728fceb258311d76", size = 516490, upload-time = "2026-08-01T20:41:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d687cd1c2c9f9a986e8552ad1fdbd22411cc86389b5705dba6ec6f7e3226/cbor2-6.1.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad4efa23fee6447e56a269191044e06eb39e809458bcd674e164fe9445feafd0", size = 528810, upload-time = "2026-08-01T20:41:09.144Z" },
+    { url = "https://files.pythonhosted.org/packages/40/08/88cecf20b8825bdd991c47b317415c08ef9e7d5f05a1def9acd346edabde/cbor2-6.1.4-cp313-cp313-win32.whl", hash = "sha256:d2560c2ba6a95904ba2a0ca257af878c4344409d9b46d8e646d8ebb617b1e0dd", size = 278058, upload-time = "2026-08-01T20:41:10.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/67/ba140234a6415c16dcfbe0585ce12f905157b70e9cb1bb63a2b6d5721e70/cbor2-6.1.4-cp313-cp313-win_amd64.whl", hash = "sha256:c08b9c7d2ea013e24a0cb819b872b0119dde404f64a1182c0b24095b7bba781f", size = 299315, upload-time = "2026-08-01T20:41:12.067Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/35d53ff4252a5a85656480d3a81d5a5af823979ccd0c5cac95196a7548a6/cbor2-6.1.4-cp313-cp313-win_arm64.whl", hash = "sha256:598710183daae69cbdeb177a870ec64aa601de8138a61491fd256826d15a860f", size = 289976, upload-time = "2026-08-01T20:41:13.63Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5d/c5374c76471ab41dff4420a276569a56352e83166374fba6f40fd0bde7ad/cbor2-6.1.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24da0a481294ac416e1e369e2d204b2b1d993cbd082d0d99fa3d6f5f27ae5e69", size = 407497, upload-time = "2026-08-01T20:41:15.189Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f9/b9f12a5e24d5ae355e4c0f6d37330a2bbedad3331247a223a51c4cd39d5e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0859a0837e6e2d4fe5f5b849f6475797e4db545da98c19db4b1d3487bd47aa22", size = 452191, upload-time = "2026-08-01T20:41:16.705Z" },
+    { url = "https://files.pythonhosted.org/packages/67/22/8224b01f95a6fe07b1a64082aea34d9f49068392b3de93f5f3a10c73c62e/cbor2-6.1.4-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c0f5f2d6d3b58e44146860c049f3c082207a4005588b8926d51bf937ab66773c", size = 462383, upload-time = "2026-08-01T20:41:18.17Z" },
+    { url = "https://files.pythonhosted.org/packages/92/52/437e4aa4f5df1fb41020d64b3d99a8239f0f99a3a75eb6ffa5cb66004b7f/cbor2-6.1.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:239db0f92d537fd29eaec4e40195fc3b2b48bc34a5887059658162489a9eb6ae", size = 518700, upload-time = "2026-08-01T20:41:19.592Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/2f5ea5bfe0fd800b3739c7df8679bdffa9f7def6b2f2fee064ada1c63e85/cbor2-6.1.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3f4a434c36bb0d33aeb48ddae8e8b673ca7e1f14545ee7cf4a4c7c39380ea9a2", size = 531243, upload-time = "2026-08-01T20:41:21.21Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c6/0beac64cb74cd3217f295f9bb0d64675e1809c683a31ea2a49ac9d4d1504/cbor2-6.1.4-cp314-cp314-win32.whl", hash = "sha256:6abcf072b8c0fdc8ad7902ee26a906cafbf3427d026b662ff21166a253f85e18", size = 285248, upload-time = "2026-08-01T20:41:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7d/4afa096ddc94049f5a514690891b02a18319e146ceb14465ce30c8340a8b/cbor2-6.1.4-cp314-cp314-win_amd64.whl", hash = "sha256:855764e02dc60ab9413acd044e997c3170000fdea6155d6c43a923a1d966dbe6", size = 313044, upload-time = "2026-08-01T20:41:24.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b5/e614cee861772f6b5c4d926b066d2e7dbc11e220b50ba716ba91e430fb0f/cbor2-6.1.4-cp314-cp314-win_arm64.whl", hash = "sha256:c6b28b928c5f2dbf47dffa12dce9c8e36fe6ac1c1358bc326499c0736263b66f", size = 304088, upload-time = "2026-08-01T20:41:25.431Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/41/3b28184154f6cbf7e47c1b7fb4a7a291c54f27a6f3a0a2f64b078c6a13e1/cbor2-6.1.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7336ff4cb7d161ec43b65eef43bf3e9bcab44bd152efb54dd637b7afe711254f", size = 401042, upload-time = "2026-08-01T20:41:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/a8624023b84b41c43a150a89517c104aed0e467bd258866f13be4c3ac0c6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8f1019494b0ec81a3df3ebb01b6acb446d5b946fe35845b1726379abd66a71da", size = 445301, upload-time = "2026-08-01T20:41:28.35Z" },
+    { url = "https://files.pythonhosted.org/packages/60/39/07dd0ea957c1f48673d3947f97ee36826efd4a824053dd0ec4df2f0c89d6/cbor2-6.1.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:179a794bf4be1d46ff190695929f65f0b42019c156919846ae539d2a7ec42e54", size = 459816, upload-time = "2026-08-01T20:41:29.839Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8e/2015175132a27c1daed434f671ac6d9c1311461995df47f201307700e0da/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9b904b8d0f4ddac9259197d21d121fae4cb8b555700d65bc12c5d46a2e6c2025", size = 511565, upload-time = "2026-08-01T20:41:31.939Z" },
+    { url = "https://files.pythonhosted.org/packages/82/66/420991095d9473614b205d4c4e40b5d3b9f1ee4410eb3c48c1e902947837/cbor2-6.1.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:71fcf4f237d68bf4445bf45070f36f82b333f2e6a62612aa2c256683b51378a9", size = 527709, upload-time = "2026-08-01T20:41:33.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/7c/73057e7a38488a816a0d40ff9e7cd9f418800894582e2e48fb2f47ce66a2/cbor2-6.1.4-cp314-cp314t-win32.whl", hash = "sha256:7deccc50fd0b55c4c7dd265b144c5358a645121e457c0ae3722b5ad59832b257", size = 281462, upload-time = "2026-08-01T20:41:35.127Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/d5db22837cb566de733b9d1c418cdf1912ccb1efc7b179e295430b1d81a2/cbor2-6.1.4-cp314-cp314t-win_amd64.whl", hash = "sha256:f3fc7d15cba4174373df2496070faa4a927fe3ed772130d281808120aec7b61c", size = 309165, upload-time = "2026-08-01T20:41:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5f/ff2c6da83553a692219a0a62a21b57a27ded4405200e50db758a17fbaf15/cbor2-6.1.4-cp314-cp314t-win_arm64.whl", hash = "sha256:164ca22b509408435b2d8236c80c964e4fc77c085ab034569cd04c40d5cc8883", size = 298386, upload-time = "2026-08-01T20:41:38.392Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2449,11 +2505,34 @@ wheels = [
 name = "grpclib"
 version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "h2" },
     { name = "multidict" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/b9/55936e462a5925190d7427e880b3033601d1effd13809b483d13a926061a/grpclib-0.4.7.tar.gz", hash = "sha256:2988ef57c02b22b7a2e8e961792c41ccf97efc2ace91ae7a5b0de03c363823c3", size = 61254, upload-time = "2023-12-24T17:47:41.572Z" }
+
+[[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
+]
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
 
 [[package]]
 name = "h11"
@@ -3716,27 +3795,27 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.0.4"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "cbor2" },
     { name = "certifi" },
     { name = "click" },
-    { name = "grpclib" },
+    { name = "grpclib", version = "0.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpclib", version = "0.4.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "protobuf" },
     { name = "rich" },
     { name = "synchronicity" },
     { name = "toml" },
-    { name = "typer", version = "0.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "typer", version = "0.26.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "types-certifi" },
     { name = "types-toml" },
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/66/4967c5de24416e758302c540d54d3e23d9d43ddc1ca5aa93303fb631ad43/modal-1.0.4.tar.gz", hash = "sha256:09a575ff5fcae1e690b10187bea6da7ff01430c38ec1785090bf7a7ccee7f408", size = 511755, upload-time = "2025-06-13T14:47:00.749Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/13/c54908743129b75f9761ebcc767f8de5e5b16e2a0303e171f7ae38d90d4d/modal-1.5.3.tar.gz", hash = "sha256:0551c6fa2386ce78619f1a058eb4dd3ca527a54048952ea870e26704557c76c4", size = 844542, upload-time = "2026-07-23T21:06:49.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c3/4d9fbb14285698b7ae9f64423048ca9d28f5eb08b99f768b978f9118f780/modal-1.0.4-py3-none-any.whl", hash = "sha256:6c0d96bb49b09fa47e407a13e49545e32fe0803803b4330fbeb38de5e71209cc", size = 579637, upload-time = "2025-06-13T14:46:58.712Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5d/834ba7387383077538f28a1d17d2df95d596e225a44a1ea1207ad90977f3/modal-1.5.3-py3-none-any.whl", hash = "sha256:d3fbe1d95321d1e4bdb08140bf42711084d705e7e3de644f7ae55c9b96b6c51d", size = 961068, upload-time = "2026-07-23T21:06:46.866Z" },
 ]
 
 [[package]]
@@ -5479,6 +5558,9 @@ huggingface = [
 mistral = [
     { name = "pydantic-ai-slim", extra = ["mistral"] },
 ]
+modal = [
+    { name = "pydantic-ai-slim", extra = ["modal"] },
+]
 openrouter = [
     { name = "pydantic-ai-slim", extra = ["openrouter"] },
 ]
@@ -5573,6 +5655,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["groq"], marker = "extra == 'groq'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["huggingface"], marker = "extra == 'huggingface'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["mistral"], marker = "extra == 'mistral'", editable = "pydantic_ai_slim" },
+    { name = "pydantic-ai-slim", extras = ["modal"], marker = "extra == 'modal'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["openrouter"], marker = "extra == 'openrouter'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["prefect"], marker = "extra == 'prefect'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["sentence-transformers"], marker = "extra == 'sentence-transformers'", editable = "pydantic_ai_slim" },
@@ -5584,7 +5667,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["web-fetch"], marker = "extra == 'web-fetch'", editable = "pydantic_ai_slim" },
     { name = "pydantic-ai-slim", extras = ["xai"], marker = "extra == 'xai'", editable = "pydantic_ai_slim" },
 ]
-provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "e2b", "exa", "examples", "groq", "huggingface", "mistral", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
+provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "e2b", "exa", "examples", "groq", "huggingface", "mistral", "modal", "openrouter", "prefect", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5754,6 +5837,9 @@ mcp = [
 mistral = [
     { name = "mistralai" },
 ]
+modal = [
+    { name = "modal" },
+]
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
@@ -5830,6 +5916,7 @@ requires-dist = [
     { name = "logfire", extras = ["httpx"], marker = "extra == 'logfire'", specifier = ">=4.16.0" },
     { name = "markdownify", marker = "extra == 'web-fetch'", specifier = ">=1.2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.4.2,!=2.4.6" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.2" },
     { name = "openai", marker = "extra == 'bedrock-mantle'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.45.0" },
     { name = "openai", marker = "extra == 'openrouter'", specifier = ">=2.45.0" },
@@ -5859,7 +5946,7 @@ requires-dist = [
     { name = "voyageai", marker = "python_full_version < '3.14' and extra == 'voyageai'", specifier = ">=0.3.7" },
     { name = "xai-sdk", marker = "extra == 'xai'", specifier = ">=1.14.0" },
 ]
-provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "e2b", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
+provides-extras = ["ag-ui", "anthropic", "bedrock", "bedrock-mantle", "cli", "cohere", "dbos", "duckduckgo", "e2b", "evals", "exa", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "modal", "openai", "openrouter", "prefect", "retries", "sentence-transformers", "snowflake", "spec", "tavily", "temporal", "ui", "voyageai", "web", "web-fetch", "xai", "zai"]
 
 [[package]]
 name = "pydantic-core"
@@ -7372,18 +7459,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sigtools"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/db/669ca14166814da187b3087b908ca924cf83f5b504fe23b3859a3ef67d4f/sigtools-4.0.1.tar.gz", hash = "sha256:4b8e135a9cd4d2ea00da670c093372d74e672ba3abb87f4c98d8e73dea54445c", size = 71910, upload-time = "2022-10-13T07:03:54.149Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/91/853dbf6ec096197dba9cd5fd0c836c5fc19142038b7db60ebe6332b1bab1/sigtools-4.0.1-py2.py3-none-any.whl", hash = "sha256:d216b4cf920bbab0fce636ddc429ed8463a5b533d9e1492acb45a2a1bc36ac6c", size = 76419, upload-time = "2022-10-13T07:03:52.658Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7521,15 +7596,14 @@ wheels = [
 
 [[package]]
 name = "synchronicity"
-version = "0.9.16"
+version = "0.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sigtools" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/75/0987c52929e352f0055705ece16614ce107db26856a4ee7850c6ae39413e/synchronicity-0.9.16.tar.gz", hash = "sha256:bc174b756d12330b1e6027f8293c3b944cf3684dec241af009cb7bb169a0072f", size = 53303, upload-time = "2025-06-16T14:07:14.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/db/772959498f87bc03f4c8ebe8ee0d07dee4cab2a862b66361d1ef3123e0d8/synchronicity-0.9.16-py3-none-any.whl", hash = "sha256:79dd3451c063a06489d466b0585808e1d5d257fc3c2304f5f733a142ef269e97", size = 37595, upload-time = "2025-06-16T14:07:12.261Z" },
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!NOTE]
> **Demonstration draft, stacked on #6492 (`sandbox-concept`).** The goal is to show what integrating multiple real sandbox providers on top of the sandbox abstraction looks like in practice — how much code a provider needs, where the protocol carries its weight, and where providers legitimately diverge. Not necessarily intended to merge as-is.

- Refs #6492

## What this shows

Two provider backends, each a single module conforming structurally to `SandboxBackend` + `SupportsFilesystem` (no base class, like `LocalSandbox`), with lifecycle as `create()` (owning async context manager) / `connect()` (non-owning, the natural `SandboxResolver` building block):

- `pydantic_ai.sandboxes.e2b.E2BSandbox` (new `e2b` extra, `e2b>=2.34.0`)
- `pydantic_ai.sandboxes.modal.ModalSandbox` (new `modal` extra, `modal>=1.5.2`)

The instructive part is where they differ — the optional `Supports*` protocols absorb real platform asymmetry instead of forcing a lowest common denominator:

| | `E2BSandbox` | `ModalSandbox` | `LocalSandbox` |
|---|---|---|---|
| `SupportsFilesystem` | ✅ native files API | ✅ native `filesystem` API | ✅ |
| `SupportsStart` | ✅ (`background=True` handle) | ✅ (`exec` handle) | ❌ |
| `SupportsStream` | ❌ SDK streaming is callback-only | ✅ native async readers | ❌ |
| `SandboxProcess.kill()` | ✅ | ❌ SDK has none → `NotImplementedError` naming `timeout=` | n/a |
| shell mapping | everything is `bash -l -c`; argv via `shlex.join` | argv is native; `shell=True` wraps in `sh -c` | both native |
| `timeout=` ownership | client-owned deadline + kill (E2B's own `timeout=` abandons rather than kills) | platform-owned (`exec(timeout=)` really kills) | client-owned |

Both went through an adversarial review round (protocol contracts, async lifecycle/cancellation, SDK fidelity against the floor versions); the fixes that came out of it — cancellation-safe `wait()`, shielded creates/teardowns, honest timeout attribution, exactly-once output accounting alongside streaming — are in dedicated commits, and the tests pin them (fakes were corrected to real SDK semantics first, so the pinned tests failed red before each fix).

## Flags for maintainers

1. **`working_dir()` costs a command.** Neither SDK reports the default working directory, so both backends run `pwd` once and cache it (Modal skips this when `create(workdir=...)` was given). Consequence: `ReadOnlySandbox`'s "commands are blocked" stance is softened — a relative-path `read_text` through the facade resolves via `working_dir()` and executes `pwd` on the wrapped backend. If that guarantee should stay absolute, the protocol may want a way for backends to declare the workdir statically.
2. **Modal `stream()` + `wait()` fetches output twice over the network.** Modal's exec reader replays from byte zero on every `read()`, so `wait()` re-reads rather than sharing an accumulator with `stream()` — correctness (exactly-once in the result) was chosen over the extra round trip. Alternative designs welcome.
3. **Cancellation asymmetry, on purpose:** a cancelled `run()` kills the remote command (matching `LocalSandbox`'s kill-on-every-path bar); a cancelled `wait()` on a `start()`ed process does not — that process belongs to the caller.
4. **`E2BSandbox.connect()` is not fully lifecycle-neutral** and the docstring says so: the E2B API auto-resumes a paused sandbox and extends its deadline (`timeout=` exposed to control it). Modal's `connect()` is a pure lookup.
5. **`modal` floor raised to `>=1.5.2`** (locked 1.0.4 → 1.5.3) — 1.0.x has no `Sandbox.filesystem` and no `env=` on `exec`. `examples/pyproject.toml` keeps its `modal>=1.0.4` floor (lock-only bump there); two `slack_lead_qualifier` files needed pyright-ignore churn from the new stubs.
6. **New private `sandboxes/_lifecycle.py`** (`guarded_create`/`destroy_quietly`) shared by both backends — the cloud-provider mirror of `local.py`'s guarded-spawn pattern. `local.py` keeps its own copy; folding it onto the helper is possible follow-up.
7. Pre-existing on `sandbox-concept`, untouched here: 4 unformatted files under the current ruff, one unused import in `tests/test_logfire.py`, and a `SANDBOXES.md:103` skill-example lint failure — flagged rather than swept to keep this diff readable.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

