### PR TITLE
Point the xAI voice docs link at the page that exists

### DIFF
--- a/docs/realtime/xai.md
+++ b/docs/realtime/xai.md
@@ -25,7 +25,7 @@ the connection requires the API key.
 Use a Grok Voice ID such as `grok-voice-latest` or a pinned `grok-voice-think-*` model.
 `grok-voice-latest` follows xAI's current flagship and can change underneath an application; pin a
 version when behavior must remain stable. Use the
-[official xAI voice documentation](https://docs.x.ai/docs/guides/voice-agent) for the canonical
+[official xAI voice documentation](https://docs.x.ai/docs/guides/voice) for the canonical
 model list.
 
 ## Settings


### PR DESCRIPTION
The link-checker report in #7502 flags `https://docs.x.ai/docs/guides/voice-agent` in `docs/realtime/xai.md` as a 404. It is the link the page offers as the canonical source for the Grok voice model list, so anyone following it to check whether `grok-voice-latest` has moved lands on nothing.

xAI appears to have dropped the `-agent` suffix. I checked both URLs: the current one returns 404, and `https://docs.x.ai/docs/guides/voice` resolves to "Model Capabilities - Voice Overview", which covers speech-to-speech realtime voice agents over WebSockets, text to speech, speech to text and custom voices. That is the right target for this sentence.

Scoped to that one link. The report's other two entries both point at `https://github.com/pydantic/unified-docs` from `AGENTS.md` and `CLAUDE.md`, and since that 404s anonymously while being your own publishing pipeline, it reads like a private repo rather than a wrong URL. I left those alone rather than guess at what you want them to say.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

quick note: built with Claude Code's help and read the diff myself. I did not add `Fixes #7502` since this only clears one of the three reported links.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

