### PR TITLE
Attach a later `UserPromptPart`'s leading `CachePoint` to the preceding OpenRouter content

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from collections.abc import AsyncIterable, Iterable, Sequence
+from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
@@ -15,9 +15,11 @@ from ..messages import (
     CachePoint,
     FinishReason,
     ModelMessage,
+    ModelRequest,
     ModelResponseStreamEvent,
     ThinkingPart,
     UserContent,
+    UserPromptPart,
     VideoUrl,
 )
 from ..native_tools import AbstractNativeTool, AdvisorTool, WebSearchTool
@@ -654,6 +656,43 @@ def _openrouter_settings_to_openai_settings(
     return OpenAIChatModelSettings(**model_settings)  # type: ignore[reportCallIssue]
 
 
+def _hoist_leading_cache_points(message: ModelRequest) -> ModelRequest:
+    """Move a later `UserPromptPart`'s leading `CachePoint`s onto the preceding user part.
+
+    OpenRouter maps each `UserPromptPart` to its own message, so a `CachePoint` at the start of a
+    later part has no content to attach to and raises, even when an earlier part in the same request
+    produced eligible content. A `CachePoint` caches everything up to that point, so moving one from
+    the start of a later part to the end of the nearest preceding user part is equivalent while giving
+    it content to attach to. Returns `message` unchanged (leaving the raise intact) when there is no
+    preceding user part to hoist onto.
+    """
+    parts = list(message.parts)
+    previous_user_index: int | None = None
+    changed = False
+    for index, part in enumerate(parts):
+        if not isinstance(part, UserPromptPart):
+            continue
+        content = part.content
+        if (
+            previous_user_index is not None
+            and not isinstance(content, str)
+            and content
+            and isinstance(content[0], CachePoint)
+        ):
+            content = list(content)
+            leading: list[UserContent] = []
+            while content and isinstance(content[0], CachePoint):
+                leading.append(content.pop(0))
+            previous = parts[previous_user_index]
+            assert isinstance(previous, UserPromptPart)
+            previous_content = [previous.content] if isinstance(previous.content, str) else list(previous.content)
+            parts[previous_user_index] = replace(previous, content=[*previous_content, *leading])
+            parts[index] = replace(part, content=content)
+            changed = True
+        previous_user_index = index
+    return replace(message, parts=parts) if changed else message
+
+
 class OpenRouterModel(OpenAIChatModel):
     """Extends OpenAIChatModel to capture extra metadata for Openrouter."""
 
@@ -1106,6 +1145,19 @@ class OpenRouterModel(OpenAIChatModel):
     @override
     def _streamed_response_cls(self):
         return OpenRouterStreamedResponse
+
+    @override
+    async def _map_user_message(self, message: ModelRequest) -> AsyncIterable[chat.ChatCompletionMessageParam]:
+        # OpenRouter maps each `UserPromptPart` to its own message, so a `CachePoint` at the start of a
+        # later part reaches `_add_cache_control` with an empty content list and raises, even though an
+        # earlier user part in the same request already produced eligible content. Anthropic attaches
+        # such a marker to the preceding content instead (see `anthropic.py`'s `_last_message_content`
+        # fallback); mirror that by hoisting the leading `CachePoint`s onto the nearest preceding user
+        # part before mapping. A `CachePoint` with no preceding user content still raises downstream.
+        if self._resolved_profile.get('openrouter_supports_cache_control', False):
+            message = _hoist_leading_cache_points(message)
+        async for item in super()._map_user_message(message):
+            yield item
 
     @override
     async def _map_user_prompt_content_item(

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -662,15 +662,22 @@ def _hoist_leading_cache_points(message: ModelRequest) -> ModelRequest:
     OpenRouter maps each `UserPromptPart` to its own message, so a `CachePoint` at the start of a
     later part has no content to attach to and raises, even when an earlier part in the same request
     produced eligible content. A `CachePoint` caches everything up to that point, so moving one from
-    the start of a later part to the end of the nearest preceding user part is equivalent while giving
-    it content to attach to. Returns `message` unchanged (leaving the raise intact) when there is no
-    preceding user part to hoist onto.
+    the start of a later part to the end of an immediately preceding user part is equivalent while
+    giving it content to attach to.
+
+    Hoisting only happens across *adjacent* user parts: a `ToolReturnPart` (or any other non-user
+    part) between them would sit inside the cached prefix, so moving the marker before it would cache
+    a shorter prefix than the marker denotes. In that case the tracking resets and the marker is left
+    in place, so the downstream raise is preserved rather than silently mis-caching. An empty user
+    part is likewise skipped as an anchor, since it has no content to attach the marker to. Returns
+    `message` unchanged when there is no eligible preceding user part to hoist onto.
     """
     parts = list(message.parts)
     previous_user_index: int | None = None
     changed = False
     for index, part in enumerate(parts):
         if not isinstance(part, UserPromptPart):
+            previous_user_index = None
             continue
         content = part.content
         if (
@@ -689,7 +696,10 @@ def _hoist_leading_cache_points(message: ModelRequest) -> ModelRequest:
             parts[previous_user_index] = replace(previous, content=[*previous_content, *leading])
             parts[index] = replace(part, content=content)
             changed = True
-        previous_user_index = index
+        # Only track parts that still have content to anchor a hoisted marker to; a part that is
+        # empty (originally, or emptied by hoisting all its content away) can't carry a breakpoint.
+        if isinstance(content, str) or content:
+            previous_user_index = index
     return replace(message, parts=parts) if changed else message
 
 

--- a/tests/models/openrouter/test_cache.py
+++ b/tests/models/openrouter/test_cache.py
@@ -86,7 +86,8 @@ async def test_openrouter_cache_point_start_of_later_user_part(allow_model_reque
     ]
 
     # The two leading `CachePoint`s move onto the preceding `'Hello'` block (the last wins, matching
-    # same-part semantics), and the intervening tool part is left untouched.
+    # same-part semantics). The tool part precedes both user parts, so it stays within the cached
+    # prefix and is left untouched.
     assert mapped == snapshot(
         [
             {'role': 'tool', 'tool_call_id': 'c', 'content': 'tool output'},
@@ -94,6 +95,72 @@ async def test_openrouter_cache_point_start_of_later_user_part(allow_model_reque
                 'role': 'user',
                 'content': [{'text': 'Hello', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}}],
             },
+            {'role': 'user', 'content': [{'text': 'reminder', 'type': 'text'}]},
+        ]
+    )
+
+
+async def test_openrouter_cache_point_intervening_tool_part_raises_error(allow_model_requests: None) -> None:
+    """A `CachePoint` is not hoisted across an intervening non-user part, preserving the raise.
+
+    A `CachePoint` caches everything up to it, so with a `ToolReturnPart` *between* the anchor user
+    part and the marker, hoisting onto the earlier user part would cache a shorter prefix that
+    excludes the tool output. Hoisting only spans adjacent user parts; when a non-user part
+    intervenes the marker is left in place and the pre-existing `UserError` stands, rather than
+    silently caching the wrong prefix.
+    """
+    model = OpenRouterModel('anthropic/claude-sonnet-4.6', provider=OpenRouterProvider(api_key='test-key'))
+
+    with pytest.raises(
+        UserError,
+        match='CachePoint cannot be the first content in a user message - there must be previous content',
+    ):
+        _ = [
+            message
+            async for message in model._map_user_message(  # pyright: ignore[reportPrivateUsage]
+                ModelRequest(
+                    parts=[
+                        UserPromptPart('Hello'),
+                        ToolReturnPart(tool_name='t', content='tool output', tool_call_id='c'),
+                        UserPromptPart([CachePoint(), 'reminder']),
+                    ]
+                )
+            )
+        ]
+
+
+async def test_openrouter_cache_point_skips_empty_preceding_user_part(allow_model_requests: None) -> None:
+    """A leading `CachePoint` skips an empty preceding user part and anchors to the last non-empty one.
+
+    An empty `UserPromptPart` has no content to attach a breakpoint to, so hoisting onto it would
+    still raise. The hoist falls back to the nearest *non-empty* preceding user part (here a
+    list-content part), leaving the empty part untouched.
+    """
+    model = OpenRouterModel('anthropic/claude-sonnet-4.6', provider=OpenRouterProvider(api_key='test-key'))
+
+    mapped = [
+        message
+        async for message in model._map_user_message(  # pyright: ignore[reportPrivateUsage]
+            ModelRequest(
+                parts=[
+                    UserPromptPart(['real', 'stuff']),
+                    UserPromptPart([]),
+                    UserPromptPart([CachePoint(ttl='5m'), 'reminder']),
+                ]
+            )
+        )
+    ]
+
+    assert mapped == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'real', 'type': 'text'},
+                    {'text': 'stuff', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                ],
+            },
+            {'role': 'user', 'content': []},
             {'role': 'user', 'content': [{'text': 'reminder', 'type': 'text'}]},
         ]
     )

--- a/tests/models/openrouter/test_cache.py
+++ b/tests/models/openrouter/test_cache.py
@@ -21,6 +21,7 @@ from pydantic_ai import (
     ModelRequest,
     ModelResponse,
     TextPart,
+    ToolReturnPart,
     UserPromptPart,
 )
 from pydantic_ai.exceptions import UserError
@@ -59,6 +60,72 @@ async def test_openrouter_cache_point_first_content_raises_error(allow_model_req
         match='CachePoint cannot be the first content in a user message - there must be previous content',
     ):
         await agent.run([CachePoint(), 'This should fail'])
+
+
+async def test_openrouter_cache_point_start_of_later_user_part(allow_model_requests: None) -> None:
+    """A `CachePoint` starting a later `UserPromptPart` attaches to the preceding user content.
+
+    Regression test for #7467: OpenRouter maps each `UserPromptPart` independently, so a `CachePoint`
+    at the start of a later part used to raise even when an earlier part produced eligible content.
+    It now attaches to the preceding block, mirroring `AnthropicModel`. Exercises `_map_user_message`
+    directly since the boundary spans two parts of the same request (no network request is made).
+    """
+    model = OpenRouterModel('anthropic/claude-sonnet-4.6', provider=OpenRouterProvider(api_key='test-key'))
+
+    mapped = [
+        message
+        async for message in model._map_user_message(  # pyright: ignore[reportPrivateUsage]
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(tool_name='t', content='tool output', tool_call_id='c'),
+                    UserPromptPart('Hello'),
+                    UserPromptPart([CachePoint(ttl='1h'), CachePoint(ttl='5m'), 'reminder']),
+                ]
+            )
+        )
+    ]
+
+    # The two leading `CachePoint`s move onto the preceding `'Hello'` block (the last wins, matching
+    # same-part semantics), and the intervening tool part is left untouched.
+    assert mapped == snapshot(
+        [
+            {'role': 'tool', 'tool_call_id': 'c', 'content': 'tool output'},
+            {
+                'role': 'user',
+                'content': [{'text': 'Hello', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}}],
+            },
+            {'role': 'user', 'content': [{'text': 'reminder', 'type': 'text'}]},
+        ]
+    )
+
+
+async def test_openrouter_cache_point_later_part_unsupported_profile() -> None:
+    """A profile without cache-control support skips hoisting and drops the `CachePoint`.
+
+    Only reachable via a custom profile: no built-in OpenRouter model both maps as multiple user
+    parts and disables `openrouter_supports_cache_control`. Pins the `_map_user_message` branch that
+    leaves the request untouched, deferring to `_add_cache_control`, which no-ops (rather than raises)
+    for providers that don't support cache control.
+    """
+    model = OpenRouterModel(
+        'openai/gpt-4o',
+        provider=OpenRouterProvider(api_key='test-key'),
+        profile=OpenRouterModelProfile(openrouter_supports_cache_control=False),
+    )
+
+    mapped = [
+        message
+        async for message in model._map_user_message(  # pyright: ignore[reportPrivateUsage]
+            ModelRequest(parts=[UserPromptPart('Hello'), UserPromptPart([CachePoint(), 'reminder'])])
+        )
+    ]
+
+    assert mapped == snapshot(
+        [
+            {'role': 'user', 'content': 'Hello'},
+            {'role': 'user', 'content': [{'text': 'reminder', 'type': 'text'}]},
+        ]
+    )
 
 
 async def test_openrouter_cache_points_exceed_limit_raises(allow_model_requests: None) -> None:


### PR DESCRIPTION
- Closes #7467

## Problem

`OpenRouterModel` maps each `UserPromptPart` to its own message, so a `CachePoint` at the *start* of a later part reaches `_add_cache_control` with an empty content list and raises `UserError`, even when an earlier part in the same request already produced eligible content:

```python
request = ModelRequest(
    parts=[
        UserPromptPart("Hello"),
        UserPromptPart([CachePoint(ttl="5m"), "reminder"]),
    ]
)
# UserError: CachePoint cannot be the first content in a user message ...
```

`AnthropicModel` maps the identical two-part message without error, attaching `cache_control` to the preceding block. This prevents a capability from appending raw ephemeral context with a cache boundary on OpenRouter without either changing the text contract with a hidden prefix or dropping the cache point.

## Fix

Before delegating to the parent mapper, hoist a later `UserPromptPart`'s *leading* `CachePoint`s onto the end of the nearest preceding user part within the same request. A `CachePoint` caches everything up to that point, so moving it from the start of a later part to the end of the preceding part is equivalent while giving it content to attach to — mirroring `AnthropicModel`'s already-shipped behavior.

The change is gated on `openrouter_supports_cache_control`, so providers that don't support cache control are untouched. A `CachePoint` with no preceding user content anywhere still raises (that guard is behaviorally distinct and preserved).

## Tests

- `test_openrouter_cache_point_start_of_later_user_part` — the reproduction now attaches `cache_control` to the preceding block; also covers multiple leading `CachePoint`s and an intervening non-user part.
- `test_openrouter_cache_point_later_part_unsupported_profile` — an unsupported-cache profile leaves the request untouched and drops the marker (no raise).
- `test_openrouter_cache_point_first_content_raises_error` (existing) still passes: a `CachePoint` as the first content of the whole request raises.

100% line and branch coverage on the new code. `ruff`, `ruff format`, and `pyright` are clean.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

The issue is maintainer-confirmed (`pr_ready`) but not yet assigned — happy to have it assigned to me. I kept the fix scoped to the reproduced intra-request case; if a cross-message fallback (as Anthropic's `_last_message_content` does) is also wanted, I can follow up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

