### PR TITLE
Fix `WrapperModel.__aexit__` and `XaiModel.supported_native_tools` override signatures

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -4,6 +4,7 @@ import warnings
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Any
 
 from typing_extensions import Self
@@ -45,8 +46,13 @@ class WrapperModel(Model):
         await self.wrapped.__aenter__()
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
-        return await self.wrapped.__aexit__(*args)
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        return await self.wrapped.__aexit__(exc_type, exc_val, exc_tb)
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -55,7 +55,14 @@ from ..models import (
     check_allow_model_requests,
     download_item,
 )
-from ..native_tools import CodeExecutionTool, FileSearchTool, MCPServerTool, WebSearchTool, XSearchTool
+from ..native_tools import (
+    AbstractNativeTool,
+    CodeExecutionTool,
+    FileSearchTool,
+    MCPServerTool,
+    WebSearchTool,
+    XSearchTool,
+)
 from ..output import OutputObjectDefinition
 from ..profiles import DEFAULT_THINKING_TAGS, ModelProfileSpec
 from ..profiles.grok import GrokModelProfile, GrokReasoningEffort
@@ -324,7 +331,7 @@ class XaiModel(Model[AsyncClient]):
         return cast(GrokModelProfile, super().profile)
 
     @classmethod
-    def supported_native_tools(cls) -> frozenset[type]:
+    def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
         """Return the set of builtin tool types this model can handle."""
         return frozenset({WebSearchTool, CodeExecutionTool, MCPServerTool, XSearchTool, FileSearchTool})
 


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Two `Model` override signatures violate the Liskov substitution principle against their base class. Both were caught by running [ty](https://github.com/astral-sh/ty) 0.0.72 over the repo (tracked in #3970); pyright flags neither.

- `WrapperModel.__aexit__` declared `*args: Any`, so calling it with `Model.__aexit__`'s parameters by keyword (`exc_type=...`) raised `TypeError` at runtime. It now mirrors the base signature exactly.
- `XaiModel.supported_native_tools` returned `frozenset[type]`, widening the base's `frozenset[type[AbstractNativeTool]]`. It now matches the base.

No new tests: the change is type-level, and the touched lines are already exercised (e.g. the `FallbackModel` `__aenter__`/`__aexit__` propagation test in `tests/models/test_fallback.py`). The other `__aexit__(self, *args)` implementations in the codebase were checked and left alone deliberately — their own base classes also declare `*args`, so there is no substitutability issue there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

