### PR TITLE
Replace truthiness guards on streamed tool-call `function` deltas with explicit `is not None` checks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -767,8 +767,8 @@ class GroqStreamedResponse(StreamedResponse):
                     for dtc in choice.delta.tool_calls or []:
                         maybe_event = self._parts_manager.handle_tool_call_delta(
                             vendor_part_id=dtc.index,
-                            tool_name=dtc.function and dtc.function.name,
-                            args=dtc.function and dtc.function.arguments,
+                            tool_name=dtc.function.name if dtc.function is not None else None,
+                            args=dtc.function.arguments if dtc.function is not None else None,
                             tool_call_id=dtc.id,
                         )
                         if maybe_event is not None:

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -586,10 +586,11 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                         yield event
 
                 for dtc in choice.delta.tool_calls or []:
+                    # The SDK declares `function` as required, but the API can send chunks without it.
                     maybe_event = self._parts_manager.handle_tool_call_delta(
                         vendor_part_id=dtc.index,
-                        tool_name=dtc.function and dtc.function.name,  # pyright: ignore[reportArgumentType]
-                        args=dtc.function and dtc.function.arguments,
+                        tool_name=dtc.function.name if dtc.function is not None else None,  # pyright: ignore[reportUnnecessaryComparison]
+                        args=dtc.function.arguments if dtc.function is not None else None,  # pyright: ignore[reportUnnecessaryComparison]
                         tool_call_id=dtc.id,
                     )
                     if maybe_event is not None:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3964,8 +3964,8 @@ class OpenAIStreamedResponse(StreamedResponse):
         for dtc in choice.delta.tool_calls or []:
             maybe_event = self._parts_manager.handle_tool_call_delta(
                 vendor_part_id=dtc.index,
-                tool_name=dtc.function and dtc.function.name,
-                args=dtc.function and dtc.function.arguments,
+                tool_name=dtc.function.name if dtc.function is not None else None,
+                args=dtc.function.arguments if dtc.function is not None else None,
                 tool_call_id=dtc.id,
             )
             if maybe_event is not None:

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 import httpx
 import pytest
 from pydantic import BaseModel
-from typing_extensions import TypedDict
 
 from pydantic_ai import (
     Agent,
@@ -61,8 +60,6 @@ with try_import() as imports_successful:
     from groq.types.chat.chat_completion_chunk import (
         Choice as ChunkChoice,
         ChoiceDelta,
-        ChoiceDeltaToolCall,
-        ChoiceDeltaToolCallFunction,
     )
     from groq.types.chat.chat_completion_message import ChatCompletionMessage
     from groq.types.chat.chat_completion_message_tool_call import Function
@@ -508,127 +505,6 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
         assert not result.is_complete
         assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             ['hello ', 'hello world', 'hello world.', 'hello world.']
-        )
-        assert result.is_complete
-
-
-def struc_chunk(
-    tool_name: str | None, tool_arguments: str | None, finish_reason: FinishReason | None = None
-) -> chat.ChatCompletionChunk:
-    return chunk(
-        [
-            ChoiceDelta(
-                tool_calls=[
-                    ChoiceDeltaToolCall(
-                        index=0, function=ChoiceDeltaToolCallFunction(name=tool_name, arguments=tool_arguments)
-                    )
-                ]
-            ),
-        ],
-        finish_reason=finish_reason,
-    )
-
-
-class MyTypedDict(TypedDict, total=False):
-    first: str
-    second: str
-
-
-async def test_stream_structured(allow_model_requests: None):
-    stream = (
-        chunk([ChoiceDelta()]),
-        chunk([ChoiceDelta(tool_calls=[])]),
-        chunk([ChoiceDelta(tool_calls=[ChoiceDeltaToolCall(index=0, function=None)])]),
-        chunk([ChoiceDelta(tool_calls=[ChoiceDeltaToolCall(index=0, function=None)])]),
-        struc_chunk('final_result', None),
-        chunk([ChoiceDelta(tool_calls=[ChoiceDeltaToolCall(index=0, function=None)])]),
-        struc_chunk(None, '{"first": "One'),
-        struc_chunk(None, '", "second": "Two"'),
-        struc_chunk(None, '}'),
-        chunk([]),
-    )
-    mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=mock_client))
-    agent = Agent(m, output_type=MyTypedDict)
-
-    async with agent.run_stream('') as result:
-        assert not result.is_complete
-        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
-            [
-                {},
-                {'first': 'One'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-            ]
-        )
-        assert result.is_complete
-
-    assert result.usage == snapshot(RunUsage(requests=1, cost=Decimal('0.00')))
-    assert result.all_messages() == snapshot(
-        [
-            ModelRequest(
-                parts=[UserPromptPart(content='', timestamp=IsDatetime())],
-                timestamp=IsDatetime(),
-                run_id=IsStr(),
-                conversation_id=IsStr(),
-            ),
-            ModelResponse(
-                parts=[
-                    ToolCallPart(
-                        tool_name='final_result',
-                        args='{"first": "One", "second": "Two"}',
-                        tool_call_id=IsStr(),
-                    )
-                ],
-                usage=RequestUsage(cost=Decimal('0.00')),
-                model_name='llama-3.3-70b-versatile',
-                timestamp=IsDatetime(),
-                provider_name='groq',
-                provider_url='https://api.groq.com',
-                provider_details={'timestamp': datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)},
-                provider_response_id='x',
-                run_id=IsStr(),
-                conversation_id=IsStr(),
-            ),
-            ModelRequest(
-                parts=[
-                    ToolReturnPart(
-                        tool_name='final_result',
-                        content='Final result processed.',
-                        tool_call_id=IsStr(),
-                        timestamp=IsDatetime(),
-                    )
-                ],
-                timestamp=IsDatetime(),
-                run_id=IsStr(),
-                conversation_id=IsStr(),
-            ),
-        ]
-    )
-
-
-async def test_stream_structured_finish_reason(allow_model_requests: None):
-    stream = (
-        struc_chunk('final_result', None),
-        struc_chunk(None, '{"first": "One'),
-        struc_chunk(None, '", "second": "Two"'),
-        struc_chunk(None, '}'),
-        struc_chunk(None, None, finish_reason='stop'),
-    )
-    mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=mock_client))
-    agent = Agent(m, output_type=MyTypedDict)
-
-    async with agent.run_stream('') as result:
-        assert not result.is_complete
-        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
-            [
-                {'first': 'One'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-            ]
         )
         assert result.is_complete
 

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -11,7 +11,6 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
-from typing_extensions import TypedDict
 
 from pydantic_ai import (
     Agent,
@@ -59,8 +58,6 @@ with try_import() as imports_successful:
         ChatCompletionStreamOutput,
         ChatCompletionStreamOutputChoice,
         ChatCompletionStreamOutputDelta,
-        ChatCompletionStreamOutputDeltaToolCall,
-        ChatCompletionStreamOutputFunction,
         ChatCompletionStreamOutputUsage,
     )
     from huggingface_hub.errors import HfHubHTTPError
@@ -558,125 +555,6 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
         assert not result.is_complete
         assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(
             ['hello ', 'hello world', 'hello world.']
-        )
-        assert result.is_complete
-
-
-def struc_chunk(
-    tool_name: str | None, tool_arguments: str | None, finish_reason: FinishReason | None = None
-) -> ChatCompletionStreamOutput:
-    return chunk(
-        [
-            ChatCompletionStreamOutputDelta.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
-                {
-                    'role': 'assistant',
-                    'tool_calls': [
-                        ChatCompletionStreamOutputDeltaToolCall.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
-                            {
-                                'index': 0,
-                                'function': ChatCompletionStreamOutputFunction.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
-                                    {
-                                        'name': tool_name,
-                                        'arguments': tool_arguments,
-                                    }
-                                ),
-                            }
-                        )
-                    ],
-                }
-            ),
-        ],
-        finish_reason=finish_reason,
-    )
-
-
-class MyTypedDict(TypedDict, total=False):
-    first: str
-    second: str
-
-
-async def test_stream_structured(allow_model_requests: None):
-    stream = [
-        chunk([ChatCompletionStreamOutputDelta(role='assistant')]),
-        chunk([ChatCompletionStreamOutputDelta(role='assistant', tool_calls=[])]),
-        chunk(
-            [
-                ChatCompletionStreamOutputDelta(
-                    role='assistant',
-                    tool_calls=[
-                        ChatCompletionStreamOutputDeltaToolCall(id='0', type='function', index=0, function=None)  # pyright: ignore[reportArgumentType]
-                    ],
-                )
-            ]
-        ),
-        chunk(
-            [
-                ChatCompletionStreamOutputDelta(
-                    role='assistant',
-                    tool_calls=[
-                        ChatCompletionStreamOutputDeltaToolCall(id='0', type='function', index=0, function=None)  # pyright: ignore[reportArgumentType]
-                    ],
-                )
-            ]
-        ),
-        struc_chunk('final_result', None),
-        chunk(
-            [
-                ChatCompletionStreamOutputDelta(
-                    role='assistant',
-                    tool_calls=[
-                        ChatCompletionStreamOutputDeltaToolCall(id='0', type='function', index=0, function=None)  # pyright: ignore[reportArgumentType]
-                    ],
-                )
-            ]
-        ),
-        struc_chunk(None, '{"first": "One'),
-        struc_chunk(None, '", "second": "Two"'),
-        struc_chunk(None, '}'),
-        chunk([]),
-    ]
-    mock_client = MockHuggingFace.create_stream_mock(stream)
-    m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
-    agent = Agent(m, output_type=MyTypedDict)
-
-    async with agent.run_stream('') as result:
-        assert not result.is_complete
-        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
-            [
-                {},
-                {'first': 'One'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-            ]
-        )
-        assert result.is_complete
-        assert result.usage == snapshot(RunUsage(requests=1, input_tokens=20, output_tokens=10))
-        # double check usage matches stream count
-        assert result.usage.output_tokens == len(stream)
-
-
-async def test_stream_structured_finish_reason(allow_model_requests: None):
-    stream = [
-        struc_chunk('final_result', None),
-        struc_chunk(None, '{"first": "One'),
-        struc_chunk(None, '", "second": "Two"'),
-        struc_chunk(None, '}'),
-        struc_chunk(None, None, finish_reason='stop'),
-    ]
-    mock_client = MockHuggingFace.create_stream_mock(stream)
-    m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
-    agent = Agent(m, output_type=MyTypedDict)
-
-    async with agent.run_stream('') as result:
-        assert not result.is_complete
-        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
-            [
-                {'first': 'One'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-            ]
         )
         assert result.is_complete
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -806,65 +806,6 @@ class MyTypedDict(TypedDict, total=False):
     second: str
 
 
-async def test_stream_structured(allow_model_requests: None):
-    stream = [
-        chunk([ChoiceDelta()]),
-        chunk([ChoiceDelta(tool_calls=[])]),
-        chunk([ChoiceDelta(tool_calls=[ChoiceDeltaToolCall(index=0, function=None)])]),
-        chunk([ChoiceDelta(tool_calls=[ChoiceDeltaToolCall(index=0, function=None)])]),
-        struc_chunk('final_result', None),
-        chunk([ChoiceDelta(tool_calls=[ChoiceDeltaToolCall(index=0, function=None)])]),
-        struc_chunk(None, '{"first": "One'),
-        struc_chunk(None, '", "second": "Two"'),
-        struc_chunk(None, '}'),
-        chunk([]),
-    ]
-    mock_client = MockOpenAI.create_mock_stream(stream)
-    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
-    agent = Agent(m, output_type=MyTypedDict)
-
-    async with agent.run_stream('') as result:
-        assert not result.is_complete
-        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
-            [
-                {},
-                {'first': 'One'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-            ]
-        )
-        assert result.is_complete
-        assert result.usage == snapshot(RunUsage(requests=1, input_tokens=20, output_tokens=10))
-        # double check usage matches stream count
-        assert result.usage.output_tokens == len(stream)
-
-
-async def test_stream_structured_finish_reason(allow_model_requests: None):
-    stream = [
-        struc_chunk('final_result', None),
-        struc_chunk(None, '{"first": "One'),
-        struc_chunk(None, '", "second": "Two"'),
-        struc_chunk(None, '}'),
-        struc_chunk(None, None, finish_reason='stop'),
-    ]
-    mock_client = MockOpenAI.create_mock_stream(stream)
-    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
-    agent = Agent(m, output_type=MyTypedDict)
-
-    async with agent.run_stream('') as result:
-        assert not result.is_complete
-        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
-            [
-                {'first': 'One'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-                {'first': 'One', 'second': 'Two'},
-            ]
-        )
-        assert result.is_complete
-
-
 async def test_stream_native_output(allow_model_requests: None):
     stream = [
         chunk([]),

--- a/tests/models/test_streamed_tool_call_deltas.py
+++ b/tests/models/test_streamed_tool_call_deltas.py
@@ -1,0 +1,512 @@
+"""Pin how the Chat Completions-shaped providers map streamed tool-call deltas onto parts.
+
+Groq, OpenAI and Hugging Face each stream a tool call as a run of per-chunk entries and read the name
+and the argument fragment off each entry's `function` object. The three loops are line-for-line the
+same, so they are tested together here: one scripted chunk sequence is replayed through each SDK's
+mocked stream and the parts that come out are asserted, which is what keeps the three in step.
+
+The shapes that matter are the ones the SDK types understate. An entry whose `function` is absent
+carries only an index and must contribute nothing, and an empty-string name or argument fragment must
+reach the parts manager as `''` rather than as `None` — the two are not interchangeable there, since
+`''` opens a part where `None` leaves a bare delta.
+
+These are unit tests rather than VCR tests because those shapes are not reachable from a recording.
+Nothing makes a live provider emit a `function`-less entry or an empty-string fragment on demand, and
+a cassette that happened to hold one would keep replaying green after the mapping stopped
+distinguishing `''` from `None`, since a cassette pins the request rather than how the response is
+read. Scripting the chunks is what makes each shape reachable and each assertion meaningful.
+"""
+
+from __future__ import annotations as _annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Literal
+
+import pytest
+from typing_extensions import TypedDict
+
+from pydantic_ai import (
+    Agent,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.direct import model_request_stream
+from pydantic_ai.messages import ModelMessage
+from pydantic_ai.models import Model
+from pydantic_ai.usage import RequestUsage, RunUsage
+
+from .._inline_snapshot import snapshot
+from ..conftest import IsDatetime, IsStr, try_import
+from .mock_openai import MockOpenAI
+
+with try_import() as openai_imports_successful:
+    from openai.types import chat as openai_chat
+    from openai.types.chat.chat_completion_chunk import (
+        Choice as OpenAIChunkChoice,
+        ChoiceDelta as OpenAIChoiceDelta,
+        ChoiceDeltaToolCall as OpenAIChoiceDeltaToolCall,
+        ChoiceDeltaToolCallFunction as OpenAIChoiceDeltaToolCallFunction,
+    )
+    from openai.types.completion_usage import CompletionUsage as OpenAICompletionUsage
+
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+with try_import() as groq_imports_successful:
+    from groq.types import chat as groq_chat
+    from groq.types.chat.chat_completion_chunk import (
+        Choice as GroqChunkChoice,
+        ChoiceDelta as GroqChoiceDelta,
+        ChoiceDeltaToolCall as GroqChoiceDeltaToolCall,
+        ChoiceDeltaToolCallFunction as GroqChoiceDeltaToolCallFunction,
+    )
+    from groq.types.completion_usage import CompletionUsage as GroqCompletionUsage
+
+    from pydantic_ai.models.groq import GroqModel
+    from pydantic_ai.providers.groq import GroqProvider
+
+    from .test_groq import MockGroq
+
+with try_import() as huggingface_imports_successful:
+    from huggingface_hub import (
+        ChatCompletionStreamOutput,
+        ChatCompletionStreamOutputChoice,
+        ChatCompletionStreamOutputDelta,
+        ChatCompletionStreamOutputDeltaToolCall,
+        ChatCompletionStreamOutputFunction,
+        ChatCompletionStreamOutputUsage,
+    )
+
+    from pydantic_ai.models.huggingface import HuggingFaceModel
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    from .test_huggingface import MockHuggingFace
+
+pytestmark = pytest.mark.anyio
+
+FinishReason = Literal['stop', 'length', 'tool_calls', 'content_filter', 'function_call']
+
+
+@dataclass(frozen=True)
+class ToolCallDelta:
+    """One tool-call entry inside a streamed chunk's delta, in the terms the three SDKs share."""
+
+    index: int = 0
+    name: str | None = None
+    arguments: str | None = None
+    function: bool = True
+    """Whether the entry carries a `function` object at all — providers send entries without one."""
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """One streamed chunk, in the terms the three SDKs share."""
+
+    tool_calls: tuple[ToolCallDelta, ...] | None = None
+    """`None` builds a delta carrying no `tool_calls` at all; `()` builds one carrying an empty list."""
+
+    finish_reason: FinishReason | None = None
+
+    has_choice: bool = True
+    """`False` builds a chunk with no choices, which providers send as a usage-only trailer."""
+
+
+NAME_THEN_ARGUMENTS = (
+    Chunk(),
+    Chunk(tool_calls=()),
+    Chunk(tool_calls=(ToolCallDelta(function=False),)),
+    Chunk(tool_calls=(ToolCallDelta(function=False),)),
+    Chunk(tool_calls=(ToolCallDelta(name='final_result'),)),
+    Chunk(tool_calls=(ToolCallDelta(function=False),)),
+    Chunk(tool_calls=(ToolCallDelta(arguments='{"first": "One'),)),
+    Chunk(tool_calls=(ToolCallDelta(arguments='", "second": "Two"'),)),
+    Chunk(tool_calls=(ToolCallDelta(arguments='}'),)),
+    Chunk(has_choice=False),
+)
+"""One tool call spread over a stream that also carries every empty shape a provider interleaves."""
+
+ARGUMENTS_THEN_FINISH_REASON = (
+    Chunk(tool_calls=(ToolCallDelta(name='final_result'),)),
+    Chunk(tool_calls=(ToolCallDelta(arguments='{"first": "One'),)),
+    Chunk(tool_calls=(ToolCallDelta(arguments='", "second": "Two"'),)),
+    Chunk(tool_calls=(ToolCallDelta(arguments='}'),)),
+    Chunk(tool_calls=(ToolCallDelta(),), finish_reason='stop'),
+)
+"""The same call, closed by a `function` object whose name and arguments are both `None`."""
+
+EMPTY_STRING_DELTAS = (
+    Chunk(tool_calls=(ToolCallDelta(index=0, arguments=''),)),
+    Chunk(tool_calls=(ToolCallDelta(index=0, name='my_tool'),)),
+    Chunk(tool_calls=(ToolCallDelta(index=1, name=''),)),
+)
+"""Empty-string fragments, at the two points where `''` and `None` produce different parts."""
+
+
+def _openai_chunk(chunk: Chunk) -> openai_chat.ChatCompletionChunk:
+    choices: list[OpenAIChunkChoice] = []
+    if chunk.has_choice:
+        tool_calls = (
+            None
+            if chunk.tool_calls is None
+            else [
+                OpenAIChoiceDeltaToolCall(
+                    index=delta.index,
+                    function=OpenAIChoiceDeltaToolCallFunction(name=delta.name, arguments=delta.arguments)
+                    if delta.function
+                    else None,
+                )
+                for delta in chunk.tool_calls
+            ]
+        )
+        choices.append(
+            OpenAIChunkChoice(
+                index=0, delta=OpenAIChoiceDelta(tool_calls=tool_calls), finish_reason=chunk.finish_reason
+            )
+        )
+    return openai_chat.ChatCompletionChunk(
+        id='123',
+        choices=choices,
+        created=1704067200,  # 2024-01-01
+        model='gpt-4o-123',
+        object='chat.completion.chunk',
+        usage=OpenAICompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+    )
+
+
+def _openai_model(chunks: Sequence[Chunk]) -> Model:
+    client = MockOpenAI.create_mock_stream([_openai_chunk(chunk) for chunk in chunks])
+    return OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=client))
+
+
+def _groq_chunk(chunk: Chunk) -> groq_chat.ChatCompletionChunk:
+    choices: list[GroqChunkChoice] = []
+    if chunk.has_choice:
+        tool_calls = (
+            None
+            if chunk.tool_calls is None
+            else [
+                GroqChoiceDeltaToolCall(
+                    index=delta.index,
+                    function=GroqChoiceDeltaToolCallFunction(name=delta.name, arguments=delta.arguments)
+                    if delta.function
+                    else None,
+                )
+                for delta in chunk.tool_calls
+            ]
+        )
+        choices.append(
+            GroqChunkChoice(index=0, delta=GroqChoiceDelta(tool_calls=tool_calls), finish_reason=chunk.finish_reason)
+        )
+    return groq_chat.ChatCompletionChunk(
+        id='x',
+        choices=choices,
+        created=1704067200,  # 2024-01-01
+        x_groq=None,
+        model='llama-3.3-70b-versatile',
+        object='chat.completion.chunk',
+        usage=GroqCompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+    )
+
+
+def _groq_model(chunks: Sequence[Chunk]) -> Model:
+    client = MockGroq.create_mock_stream([_groq_chunk(chunk) for chunk in chunks])
+    return GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=client))
+
+
+def _huggingface_tool_call(delta: ToolCallDelta) -> ChatCompletionStreamOutputDeltaToolCall:
+    """Build the entry through `parse_obj_as_instance`, the only way past the SDK's required fields.
+
+    The SDK types both `function` and its `arguments` as required, which is what the streamed shapes
+    contradict, and the dict path applies no such constraint.
+    """
+    entry: dict[str, object] = {'id': str(delta.index), 'type': 'function', 'index': delta.index}
+    if delta.function:
+        entry['function'] = ChatCompletionStreamOutputFunction.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
+            {'name': delta.name, 'arguments': delta.arguments}
+        )
+    return ChatCompletionStreamOutputDeltaToolCall.parse_obj_as_instance(entry)  # pyright: ignore[reportUnknownMemberType]
+
+
+def _huggingface_chunk(chunk: Chunk) -> ChatCompletionStreamOutput:
+    choices: list[ChatCompletionStreamOutputChoice] = []
+    if chunk.has_choice:
+        tool_calls = None if chunk.tool_calls is None else [_huggingface_tool_call(delta) for delta in chunk.tool_calls]
+        choices.append(
+            ChatCompletionStreamOutputChoice(
+                index=0,
+                delta=ChatCompletionStreamOutputDelta(role='assistant', tool_calls=tool_calls),
+                finish_reason=chunk.finish_reason,
+            )
+        )
+    return ChatCompletionStreamOutput.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
+        {
+            'id': 'x',
+            'choices': choices,
+            'created': 1704067200,  # 2024-01-01
+            'model': 'hf-model',
+            'object': 'chat.completion.chunk',
+            'usage': ChatCompletionStreamOutputUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+        }
+    )
+
+
+def _huggingface_model(chunks: Sequence[Chunk]) -> Model:
+    client = MockHuggingFace.create_stream_mock([_huggingface_chunk(chunk) for chunk in chunks])
+    return HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=client, api_key='x'))
+
+
+ModelFactory = Callable[[Sequence[Chunk]], Model]
+"""Builds a model whose SDK client replays the given chunks as one streamed response."""
+
+
+@dataclass(frozen=True)
+class Case:
+    """One provider, and what the shared chunk scripts produce through it."""
+
+    id: str
+    build_model: ModelFactory
+    usage: RunUsage
+    messages: list[ModelMessage]
+    output_tokens_per_chunk: int
+    """Groq counts streamed usage only off its `x_groq` trailer, which the scripted chunks don't carry."""
+
+    marks: tuple[pytest.MarkDecorator, ...] = ()
+
+
+CASES = [
+    Case(
+        id='openai',
+        build_model=_openai_model,
+        usage=snapshot(RunUsage(requests=1, input_tokens=20, output_tokens=10)),
+        messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name='final_result',
+                            args='{"first": "One", "second": "Two"}',
+                            tool_call_id=IsStr(),
+                        )
+                    ],
+                    usage=RequestUsage(output_tokens=10, input_tokens=20),
+                    model_name='gpt-4o-123',
+                    timestamp=IsDatetime(),
+                    provider_name='openai',
+                    provider_url='https://api.openai.com/v1',
+                    provider_details={'timestamp': IsDatetime()},
+                    provider_response_id='123',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name='final_result',
+                            content='Final result processed.',
+                            tool_call_id=IsStr(),
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        output_tokens_per_chunk=1,
+        marks=(pytest.mark.skipif(not openai_imports_successful(), reason='openai not installed'),),
+    ),
+    Case(
+        id='groq',
+        build_model=_groq_model,
+        usage=snapshot(RunUsage(requests=1, cost=Decimal('0.00'))),
+        messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name='final_result',
+                            args='{"first": "One", "second": "Two"}',
+                            tool_call_id=IsStr(),
+                        )
+                    ],
+                    usage=RequestUsage(cost=Decimal('0.00')),
+                    model_name='llama-3.3-70b-versatile',
+                    timestamp=IsDatetime(),
+                    provider_name='groq',
+                    provider_url='https://api.groq.com',
+                    provider_details={'timestamp': datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)},
+                    provider_response_id='x',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name='final_result',
+                            content='Final result processed.',
+                            tool_call_id=IsStr(),
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        output_tokens_per_chunk=0,
+        marks=(pytest.mark.skipif(not groq_imports_successful(), reason='groq not installed'),),
+    ),
+    Case(
+        id='huggingface',
+        build_model=_huggingface_model,
+        usage=snapshot(RunUsage(requests=1, input_tokens=20, output_tokens=10)),
+        messages=snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        # Hugging Face is the one SDK whose entries carry an id, so the part keeps it
+                        # instead of the generated one the other two get.
+                        ToolCallPart(
+                            tool_name='final_result', args='{"first": "One", "second": "Two"}', tool_call_id='0'
+                        )
+                    ],
+                    usage=RequestUsage(output_tokens=10, input_tokens=20),
+                    model_name='hf-model',
+                    timestamp=IsDatetime(),
+                    provider_name='huggingface',
+                    provider_url='https://api-inference.huggingface.co',
+                    provider_details={'timestamp': IsDatetime()},
+                    provider_response_id='x',
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name='final_result',
+                            content='Final result processed.',
+                            tool_call_id='0',
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        ),
+        output_tokens_per_chunk=1,
+        marks=(pytest.mark.skipif(not huggingface_imports_successful(), reason='huggingface_hub not installed'),),
+    ),
+]
+
+CASE_PARAMS = [pytest.param(case, id=case.id, marks=case.marks) for case in CASES]
+
+
+class MyTypedDict(TypedDict, total=False):
+    first: str
+    second: str
+
+
+@pytest.mark.parametrize('case', CASE_PARAMS)
+async def test_tool_call_deltas_accumulate_into_one_part(case: Case, allow_model_requests: None):
+    """A name-only entry opens the call and later argument-only entries fill it in.
+
+    The script interleaves the empty shapes a provider sends around a tool call — a delta with no
+    `tool_calls`, one with an empty list, entries carrying no `function`, and a trailing chunk with no
+    choices at all — none of which may disturb the call being accumulated.
+    """
+    agent = Agent(case.build_model(NAME_THEN_ARGUMENTS), output_type=MyTypedDict)
+
+    async with agent.run_stream('') as result:
+        assert not result.is_complete
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
+            [
+                {},
+                {'first': 'One'},
+                {'first': 'One', 'second': 'Two'},
+                {'first': 'One', 'second': 'Two'},
+                {'first': 'One', 'second': 'Two'},
+            ]
+        )
+        assert result.is_complete
+
+    assert result.usage == case.usage
+    # Every scripted chunk carries the same usage, so the total is what proves each one was consumed.
+    assert result.usage.output_tokens == case.output_tokens_per_chunk * len(NAME_THEN_ARGUMENTS)
+    assert result.all_messages() == case.messages
+
+
+@pytest.mark.parametrize('case', CASE_PARAMS)
+async def test_tool_call_deltas_closed_by_an_empty_function(case: Case, allow_model_requests: None):
+    """A `function` carrying neither a name nor arguments leaves the accumulated call as it stands.
+
+    It rides on the chunk that also carries the finish reason, which is how a provider closes a tool
+    call: the run has to end on the arguments it already has rather than on a further chunk.
+    """
+    agent = Agent(case.build_model(ARGUMENTS_THEN_FINISH_REASON), output_type=MyTypedDict)
+
+    async with agent.run_stream('') as result:
+        assert not result.is_complete
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
+            [
+                {'first': 'One'},
+                {'first': 'One', 'second': 'Two'},
+                {'first': 'One', 'second': 'Two'},
+                {'first': 'One', 'second': 'Two'},
+            ]
+        )
+        assert result.is_complete
+
+
+@pytest.mark.parametrize('case', CASE_PARAMS)
+async def test_empty_string_tool_call_deltas_reach_the_parts_manager(case: Case, allow_model_requests: None):
+    """`''` is forwarded as `''`, which the resulting parts distinguish from `None` in both fields.
+
+    An empty argument fragment arriving before the name has to survive until the name completes the
+    call, and an empty name has to open a part on its own — collapsing either to `None` would leave
+    the first call with `args=None` and the second as a bare delta contributing no part at all.
+
+    The stream is driven through `model_request_stream` rather than an agent because neither call
+    names a tool an agent could route, which is the point: the mapping is what's under test, not what
+    the run does with it.
+    """
+    async with model_request_stream(
+        case.build_model(EMPTY_STRING_DELTAS), [ModelRequest.user_text_prompt('')]
+    ) as stream:
+        async for _ in stream:
+            pass
+        response = stream.get()
+
+    assert response.parts == snapshot(
+        [
+            ToolCallPart(tool_name='my_tool', args='', tool_call_id=IsStr()),
+            ToolCallPart(tool_name='', tool_call_id=IsStr()),
+        ]
+    )


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Three streamed tool-call-delta loops passed `dtc.function and dtc.function.name` (and `... and dtc.function.arguments`) to `ModelResponsePartsManager.handle_tool_call_delta`. Truthiness narrowing types that expression as `Function | str | None` — if a `Function` subclass overrode `__bool__`, the object itself would flow through as `tool_name`. The explicit `dtc.function.name if dtc.function is not None else None` types as exactly `str | None` and states the actual condition (presence of `function`, not its truthiness). A shorter `... or None` rewrite would be wrong: streamed deltas legitimately carry `''`, which `or` would coerce to `None`, and the parts manager distinguishes the two.

Surfaced while running [ty](https://github.com/astral-sh/ty) over the repo (#3970): ty and mypy both reject the truthiness form; only pyright accepts it. The explicit form is the remedy the ty maintainers recommend ([astral-sh/ty#2432 discussion](https://github.com/astral-sh/ty/issues/2432#issuecomment-5318948053)).

Notes:

- `huggingface.py`: the SDK declares `ChatCompletionStreamOutputDeltaToolCall.function` as required, but the API sends chunks without it — `test_stream_structured` constructs `function=None` chunks and fails on direct attribute access. The guard therefore stays, now with `# pyright: ignore[reportUnnecessaryComparison]` documenting the wrong SDK declaration (replacing the previous `reportArgumentType` ignore on the truthiness form).
- `cohere.py`'s `if c.function and c.function.name and c.function.arguments:` is left as-is deliberately — it's a boolean condition, not a value being passed, so truthiness is semantically fine there.
- Tests: the mock-stream tool-call-delta tests are extracted from the three provider files into `tests/models/test_streamed_tool_call_deltas.py`, parametrized over the three providers with per-SDK chunk builders (3 scenarios × 3 providers), and extended with the edge shapes this diff touches — `function` present, `function=None`, and empty-string `name`/`arguments` deltas, pinning that `''` reaches the parts manager as `''` and never becomes `None`. Net −124/−59/−122 lines from `test_groq.py`/`test_openai.py`/`test_huggingface.py`; missing-line coverage of the three modules is byte-identical before and after the move.

## Why this cannot change any payload

- **No `None` check is being added.** All three sites already guarded with `dtc.function and ...`; this diff only changes the spelling of the existing guard.
- **The two forms can only diverge on a falsy-but-not-`None` `function`.** OpenAI's and Groq's `ChoiceDeltaToolCallFunction` are pydantic `BaseModel`s that define neither `__bool__` nor `__len__`, and Hugging Face's is a plain dataclass — instances of all three are unconditionally truthy, so the diverging input cannot be constructed from these SDKs. For every constructible input the two forms produce identical values: `None → None`, instance → `.name` / `.arguments`.
- **The `None` arm is real and already pinned per provider**: `tests/models/test_openai.py`, `tests/models/test_groq.py`, and `tests/models/test_huggingface.py` all stream `function=None` chunks and snapshot the resulting parts. All of them pass unchanged on this diff.
