### PR TITLE
fix: don't leak deferred-capability tools in unknown-tool retry prompt

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -501,8 +501,12 @@ class ToolManager(Generic[AgentDepsT]):
         name = call.tool_name
         tool = self.tools.get(name)
         if tool is None:
-            if self.tools:
-                available = sorted(self.tools.keys())
+            available = sorted(
+                name
+                for name, t in self.tools.items()
+                if self._unavailable_reason(t.tool_def) is None
+            )
+            if available:
                 msg = f'Available tools: {", ".join(f"{n!r}" for n in available)}'
             else:
                 msg = 'No tools available.'

--- a/tests/test_tool_availability.py
+++ b/tests/test_tool_availability.py
@@ -560,3 +560,45 @@ async def test_stripped_reveal_marker_survives_a_boundary_the_wire_skipped() -> 
     assert result.output == 'EXECUTED'
     refusals = [str(part.content) for part in iter_message_parts(result.all_messages(), ModelRequest, RetryPromptPart)]
     assert refusals == []
+
+
+async def test_unknown_tool_retry_does_not_leak_deferred_capability_tools() -> None:
+    """An unresolvable tool name must not enumerate unloaded capability tools.
+
+    `_resolve_tool` builds the "Available tools" retry hint from the full tool
+    registry, which includes tools owned by deferred capabilities that have not
+    been loaded. A model that guesses one of those names would otherwise read the
+    real names out of the error and call them directly, skipping
+    `load_capability`. Only tools callable right now may be listed. Regression
+    test for #7552.
+    """
+    retry_contents: list[str] = []
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        retry_contents[:] = [
+            str(part.content)
+            for message in messages
+            for part in message.parts
+            if isinstance(part, RetryPromptPart)
+        ]
+        if not retry_contents:
+            return ModelResponse(parts=[ToolCallPart(tool_name='bogus_tool', args={}, tool_call_id='b1')])
+        return make_text_response('done')
+
+    agent = Agent(
+        FunctionModel(model_fn), capabilities=[TestUnavailableCapabilityToolsAreNotCallable._guarded_capability()]
+    )
+
+    @agent.tool_plain
+    def untouched() -> str:
+        return 'safe'  # pragma: no cover
+
+    result = await agent.run('hello')
+
+    assert result.output == 'done'
+    assert len(retry_contents) == 1
+    retry = retry_contents[0]
+    assert 'bogus_tool' in retry
+    assert 'untouched' in retry
+    assert 'load_capability' in retry
+    assert 'secret_op' not in retry


### PR DESCRIPTION
Fixes #7552

`ToolManager._resolve_tool` builds the "Available tools" retry hint from the entire tool registry, including tools owned by deferred capabilities that have not been loaded. A model that guesses one of those names can read the real names out of the error and call them directly without ever calling `load_capability`, defeating deferred capability loading (confirmed by the pydanty triage on #7552).

Filter the enumerated list through the existing `_unavailable_reason` seam so only tools callable right now are disclosed. Unknown-tool retries still name the visible tools, and the "No tools available." fallback is unchanged.

Adds a regression test asserting the hidden capability tool name is not leaked into the retry prompt while visible tools still are.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

