### PR TITLE
Fix CachePoint after replayed MCP tool result

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3362,9 +3362,10 @@ def _add_cache_control_param(
             'To cache system instructions or tool definitions, use the `anthropic_cache_instructions` or `anthropic_cache_tool_definitions` settings instead.'
         )
 
-    # Cast needed because BetaContentBlockParam is a union including response Block types (Pydantic models)
-    # that don't support dict operations, even though at runtime we only have request Param types (TypedDicts).
-    last_param = cast(dict[str, Any], params[-1])
+    last_param = params[-1]
+    if not is_str_dict(last_param):
+        param_type = getattr(last_param, 'type', type(last_param).__name__)
+        raise UserError(f'Cache control not supported for param type: {param_type}')
     if last_param['type'] not in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
         raise UserError(f'Cache control not supported for param type: {last_param["type"]}')
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -635,6 +635,20 @@ def test_cache_control_unsupported_param_type():
         m._add_cache_control_to_last_param(params)  # type: ignore[arg-type]  # Testing internal method
 
 
+def test_cache_control_rejects_response_model_param():
+    """Response-model blocks must produce UserError instead of a subscripting TypeError."""
+    from types import SimpleNamespace
+
+    from pydantic_ai.exceptions import UserError
+    from pydantic_ai.models.anthropic import _add_cache_control_param
+
+    with pytest.raises(UserError, match='Cache control not supported for param type: mcp_tool_result'):
+        _add_cache_control_param(  # type: ignore[arg-type]  # Testing an SDK response block shape
+            [SimpleNamespace(type='mcp_tool_result')],
+            {'type': 'ephemeral'},
+        )
+
+
 def test_cache_control_last_cacheable_param_allows_empty_params():
     """Empty-params guard for the cache-control walk — a defensive branch no real API response reaches, so it's a unit test, not VCR."""
     m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(api_key='test-key'))


### PR DESCRIPTION
Fixes #7546.\n\n_add_cache_control_param now checks that its last block is a request parameter mapping before indexing it. A replayed BetaMCPToolResultBlock is instead rejected with the existing UserError contract, rather than raising TypeError while building the request.\n\nThe regression test covers a response-model-shaped block and asserts that the raised error identifies the unsupported parameter type.\n\nValidation:\n- python -m py_compile anthropic.py test_anthropic.py\n- git diff --check\n\nFull project tests, formatting, linting, and type checking were not runnable locally because the GitHub clone/fetch repeatedly timed out in this environment; the PR's CI should provide repository-native validation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

