### PR TITLE
Run synchronous `Hooks` in an executor

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -137,18 +137,25 @@ def using_thread_executor(executor: Executor) -> Generator[None]:
 
 
 async def run_in_executor(func: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
-    if _disable_threads.get():
-        return func(*args, **kwargs)
+    return await _run_in_executor(partial(func, *args, **kwargs))
 
-    wrapped_func = partial(func, *args, **kwargs)
+
+async def run_in_executor_abandon_on_cancel(func: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    """Run a sync function in an executor without shielding cancellation while it runs."""
+    return await _run_in_executor(partial(func, *args, **kwargs), abandon_on_cancel=True)
+
+
+async def _run_in_executor(func: Callable[[], _R], *, abandon_on_cancel: bool = False) -> _R:
+    if _disable_threads.get():
+        return func()
 
     executor = _thread_executor.get()
     if executor is not None:
         loop = asyncio.get_running_loop()
         ctx = copy_context()
-        return await loop.run_in_executor(executor, ctx.run, wrapped_func)
+        return await loop.run_in_executor(executor, ctx.run, func)
 
-    return await run_sync(wrapped_func)
+    return await run_sync(func, abandon_on_cancel=abandon_on_cancel)
 
 
 def is_async_generator_already_running(exc: RuntimeError) -> bool:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -20,7 +20,6 @@ agent = Agent('openai:gpt-5', capabilities=[hooks])
 
 from __future__ import annotations
 
-import inspect
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from functools import cached_property
@@ -243,7 +242,7 @@ async def _call_entry(entry: _HookEntry[Any], hook_name: str, *args: Any, **kwar
     if entry.timeout is not None:
         try:
             with anyio.fail_after(entry.timeout):
-                return await _call_func(func, *args, **kwargs)
+                return await _call_func(func, *args, abandon_on_cancel=True, **kwargs)
         except TimeoutError:
             raise HookTimeoutError(
                 hook_name=hook_name,
@@ -253,12 +252,16 @@ async def _call_entry(entry: _HookEntry[Any], hook_name: str, *args: Any, **kwar
     return await _call_func(func, *args, **kwargs)
 
 
-async def _call_func(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+async def _call_func(func: Callable[..., Any], *args: Any, abandon_on_cancel: bool = False, **kwargs: Any) -> Any:
     """Call a function, auto-wrapping sync functions."""
-    result = func(*args, **kwargs)
-    if inspect.isawaitable(result):
-        return await result
-    return result
+    if _utils.is_async_callable(func):
+        return await func(*args, **kwargs)
+
+    if abandon_on_cancel:
+        result = await _utils.run_in_executor_abandon_on_cancel(func, *args, **kwargs)
+    else:
+        result = await _utils.run_in_executor(func, *args, **kwargs)
+    return await _utils.await_maybe(result)
 
 
 def _filter_tool_entries(entries: list[_HookEntry[Any]], *, call: ToolCallPart) -> list[_HookEntry[Any]]:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -5,6 +5,7 @@ import contextvars
 import inspect
 import re
 import threading
+import time
 import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -18,6 +19,7 @@ from uuid import UUID
 
 import anyio
 import pytest
+from anyio.to_thread import run_sync
 from opentelemetry.trace import NoOpTracer
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
@@ -12302,15 +12304,57 @@ class TestHooksCapability:
     async def test_sync_function_auto_wrapping(self):
         hooks = Hooks()
         call_log: list[str] = []
+        hook_thread_id: int | None = None
 
         @hooks.on.before_model_request
         def sync_hook(ctx: RunContext[Any], request_context: ModelRequestContext) -> ModelRequestContext:
+            nonlocal hook_thread_id
             call_log.append('sync_hook')
+            hook_thread_id = threading.get_ident()
             return request_context
 
         agent = Agent(FunctionModel(simple_model_function), capabilities=[hooks])
         await agent.run('hello')
         assert call_log == ['sync_hook']
+        assert hook_thread_id != threading.get_ident()
+
+    async def test_sync_function_returning_awaitable(self):
+        hooks = Hooks()
+        call_log: list[str] = []
+
+        @hooks.on.before_model_request
+        def sync_hook(ctx: RunContext[Any], request_context: ModelRequestContext) -> Awaitable[ModelRequestContext]:
+            call_log.append('sync_hook')
+
+            async def return_request_context() -> ModelRequestContext:
+                call_log.append('awaitable')
+                return request_context
+
+            return return_request_context()
+
+        agent = Agent(FunctionModel(simple_model_function), capabilities=[hooks])
+        await agent.run('hello')
+        assert call_log == ['sync_hook', 'awaitable']
+
+    async def test_sync_function_uses_configured_thread_executor(self):
+        hooks = Hooks()
+        hook_thread_name: str | None = None
+
+        @hooks.on.before_model_request
+        def sync_hook(ctx: RunContext[Any], request_context: ModelRequestContext) -> ModelRequestContext:
+            nonlocal hook_thread_name
+            hook_thread_name = threading.current_thread().name
+            return request_context
+
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix='hooks-pool')
+        try:
+            agent = Agent(FunctionModel(simple_model_function), capabilities=[UseThreadExecutor(executor), hooks])
+            await agent.run('hello')
+        finally:
+            executor.shutdown(wait=True)
+
+        assert hook_thread_name is not None
+        assert hook_thread_name.startswith('hooks-pool')
 
     async def test_timeout(self):
         hooks = Hooks()
@@ -12328,6 +12372,39 @@ class TestHooksCapability:
         assert exc_info.value.timeout == 0.01
         assert isinstance(exc_info.value, AgentRunError)
         assert isinstance(exc_info.value, TimeoutError)
+
+    async def test_sync_timeout(self):
+        hooks = Hooks()
+        loop = asyncio.get_running_loop()
+        callback_done = asyncio.Event()
+        callback_delay = 0.0
+        hook_finished = threading.Event()
+
+        @hooks.on.before_model_request(timeout=0.01)
+        def slow_hook(ctx: RunContext[Any], request_context: ModelRequestContext) -> ModelRequestContext:
+            hook_started = time.perf_counter()
+
+            def callback() -> None:
+                nonlocal callback_delay
+                callback_delay = time.perf_counter() - hook_started
+                callback_done.set()
+
+            try:
+                loop.call_soon_threadsafe(callback)
+                time.sleep(0.15)
+                return request_context
+            finally:
+                hook_finished.set()
+
+        agent = Agent(FunctionModel(simple_model_function), capabilities=[hooks])
+        with pytest.raises(HookTimeoutError) as exc_info:
+            await agent.run('hello')
+        assert exc_info.value.hook_name == 'before_model_request'
+        assert exc_info.value.func_name == 'slow_hook'
+        assert exc_info.value.timeout == 0.01
+        await callback_done.wait()
+        assert callback_delay < 0.1
+        assert await run_sync(hook_finished.wait, 1)
 
     async def test_has_wrap_node_run(self):
         hooks = Hooks()


### PR DESCRIPTION
- Closes #7553

### Summary

Run synchronous hooks through the shared executor so they do not block the event loop. Timed synchronous hooks abandon the worker result when cancelled, allowing `HookTimeoutError` to be raised at the configured deadline.

### Tests

- `uv run pytest tests/test_utils.py -q`
- `uv run pytest tests/test_capabilities.py -q`
- `uv run pytest tests/test_capabilities.py::TestHooksCapability -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_utils.py pydantic_ai_slim/pydantic_ai/capabilities/hooks.py tests/test_capabilities.py`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

