### PR TITLE
fix: accrue subagent tool usage into the outer run's RunUsage

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/common_tools/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/image_generation.py
@@ -102,7 +102,7 @@ class ImageGenerationSubagentTool:
             instructions=self.instructions,
         )
         try:
-            result = await agent.run(prompt)
+            result = await agent.run(prompt, usage=ctx.usage)
         except UnexpectedModelBehavior as e:
             raise ModelRetry(str(e)) from e
         return result.output

--- a/pydantic_ai_slim/pydantic_ai/common_tools/x_search.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/x_search.py
@@ -72,7 +72,7 @@ class XSearchSubagentTool:
             instructions=self.instructions,
         )
         try:
-            result = await agent.run(query)
+            result = await agent.run(query, usage=ctx.usage)
         except UnexpectedModelBehavior as e:
             raise ModelRetry(str(e)) from e
         return result.output

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -73,6 +73,7 @@ from pydantic_ai.exceptions import (
     SkipToolValidation,
     ToolFailed,
     UnexpectedModelBehavior,
+    UsageLimitExceeded,
     UserError,
 )
 from pydantic_ai.messages import (
@@ -139,7 +140,7 @@ from pydantic_ai.toolsets._deferred_capability_loader import (
     LOAD_CAPABILITY_ALREADY_AVAILABLE_MESSAGE_TEMPLATE,
     LOAD_CAPABILITY_TOOL_NAME,
 )
-from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 from pydantic_graph import End
 
 from ._inline_snapshot import snapshot
@@ -8042,6 +8043,105 @@ class TestXSearchCapability:
         subagent = XSearchSubagentTool(model='xai:grok-4-1-fast-non-reasoning', native_tool=XSearchTool())
         with pytest.raises(AttributeError, match='no_such_field'):
             subagent.no_such_field  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+
+    async def test_x_search_subagent_usage_accrues_into_run_usage(self):
+        """The subagent's spend reaches `RunUsage`, not just the outer requests.
+
+        See https://github.com/pydantic/pydantic-ai/issues/7147 - the nested run's
+        tokens used to be dropped entirely, so `AgentRunResult.usage` under-reported.
+        """
+        from pydantic_ai.common_tools.x_search import x_search_tool
+
+        def inner_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            return ModelResponse(
+                parts=[TextPart(content='search results')],
+                usage=RequestUsage(input_tokens=1000, output_tokens=500),
+            )
+
+        def outer_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            if len(messages) == 1:
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name='x_search', args='{"query": "test"}')],
+                    usage=RequestUsage(input_tokens=5, output_tokens=1),
+                )
+            return ModelResponse(
+                parts=[TextPart(content='done')],
+                usage=RequestUsage(input_tokens=5, output_tokens=1),
+            )
+
+        tool = x_search_tool(FunctionModel(inner_model_fn), XSearchTool())
+        agent = Agent(FunctionModel(outer_model_fn), tools=[tool])
+        result = await agent.run('search X')
+
+        usage = result.usage
+        # 2 outer requests at 5/1, plus the subagent's single 1000/500 request
+        assert usage.input_tokens == 1010
+        assert usage.output_tokens == 502
+        assert usage.requests == 3
+
+    async def test_x_search_subagent_usage_counts_against_usage_limits(self):
+        """The subagent's spend is charged against `UsageLimits`.
+
+        Accruing into `RunUsage` without this would still let a run quietly blow
+        through its budget inside the tool. See issue #7147.
+        """
+        from pydantic_ai.common_tools.x_search import x_search_tool
+
+        def inner_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            return ModelResponse(
+                parts=[TextPart(content='search results')],
+                usage=RequestUsage(input_tokens=1000, output_tokens=500),
+            )
+
+        def outer_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            if len(messages) == 1:
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name='x_search', args='{"query": "test"}')],
+                    usage=RequestUsage(input_tokens=5, output_tokens=1),
+                )
+            return ModelResponse(
+                parts=[TextPart(content='done')],
+                usage=RequestUsage(input_tokens=5, output_tokens=1),
+            )
+
+        tool = x_search_tool(FunctionModel(inner_model_fn), XSearchTool())
+        agent = Agent(FunctionModel(outer_model_fn), tools=[tool])
+
+        with pytest.raises(UsageLimitExceeded):
+            await agent.run('search X', usage_limits=UsageLimits(total_tokens_limit=100))
+
+    async def test_image_generation_subagent_usage_accrues_into_run_usage(self):
+        """Same accrual for the image-generation subagent tool. See issue #7147."""
+        from pydantic_ai.common_tools.image_generation import image_generation_tool
+
+        image = BinaryImage(data=b'fake-image-bytes', media_type='image/png')
+
+        def inner_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            return ModelResponse(
+                parts=[FilePart(content=image)],
+                usage=RequestUsage(input_tokens=1000, output_tokens=500),
+            )
+
+        def outer_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            if len(messages) == 1:
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name='generate_image', args='{"prompt": "a cat"}')],
+                    usage=RequestUsage(input_tokens=5, output_tokens=1),
+                )
+            return ModelResponse(
+                parts=[TextPart(content='done')],
+                usage=RequestUsage(input_tokens=5, output_tokens=1),
+            )
+
+        inner_model = FunctionModel(inner_model_fn, profile=ModelProfile(supports_image_output=True))
+        tool = image_generation_tool(inner_model, ImageGenerationTool())
+        agent = Agent(FunctionModel(outer_model_fn), tools=[tool])
+        result = await agent.run('draw a cat')
+
+        usage = result.usage
+        assert usage.input_tokens == 1010
+        assert usage.output_tokens == 502
+        assert usage.requests == 3
 
 
 class TestWebFetchCapability:


### PR DESCRIPTION
Closes #7147

## The problem

Both subagent-backed local tools run a whole nested `Agent.run` and return only `result.output`, so the nested run's spend is dropped. Reproduced on `main` (`fa9561e`) with `FunctionModel`s billing 5/1 on the outer agent and 1000/500 on the subagent:

```
outer run usage      : RunUsage(input_tokens=10, output_tokens=2, requests=2, tool_calls=1)

subagent really spent: input_tokens=1000 output_tokens=500 requests=1
accrued into RunUsage: 0 extra input tokens

with total_tokens_limit=100: NO UsageLimitExceeded
  (~1512 tokens genuinely spent)
```

The limit consequence is the sharp end: a run can burn 1500 tokens inside a tool under a 100-token budget and finish successfully.

## The fix

Pass the outer run's usage into the nested run, in `XSearchSubagentTool.__call__` and `ImageGenerationSubagentTool.__call__`:

```python
result = await agent.run(query, usage=ctx.usage)
```

After:

```
outer run usage      : RunUsage(input_tokens=1010, output_tokens=502, requests=3, tool_calls=1)
accrued into RunUsage: 1000 extra input tokens

with total_tokens_limit=100 -> UsageLimitExceeded The next request would exceed the
total_tokens_limit of 100 (total_tokens=1506).
```

## Three corrections to the issue

I checked each of the issue's implementation claims against `main` rather than following them, and all three have moved:

**1. The third path no longer exists.** `_DirectImageGenerationTool` in `capabilities/image_generation.py` is gone — that file now only defines the `ImageGeneration` capability. So this is two call sites, not three, and no signature change is needed. The issue's warning that the third one "does not take a `RunContext` at all" is moot.

**2. The recommended two-statement increment would double-count `requests`.** The issue says `RunUsage.incr` doesn't bump `requests` for a `RunUsage` argument, so you must also write `ctx.usage.requests += 1`. On current `main` that branch does run (`usage.py:377-379`):

```python
if isinstance(incr_usage, RunUsage):
    self.requests += incr_usage.requests
    self.tool_calls += incr_usage.tool_calls
```

So the prescribed fix would have counted the subagent's request twice. Verified: with `usage=`, `requests` goes 2 → 3, which is exactly the one extra request the subagent made.

**3. `usage=` is the documented mechanism, so no manual accrual is needed.** `Agent.run(usage=...)` is described as *"useful for resuming a conversation or agents used in tools"*, and it is the same thing `docs/multi-agent-applications.md` already tells users to do by hand. I verified the object is shared rather than copied — a tool mutating `ctx.usage` is mutating the run's live `RunUsage` (same `id()`), and the mutation lands in `result.usage`. Using `usage=` therefore makes these library tools do what the docs already ask user code to do, instead of introducing a second accrual convention.

## On the #6886 gating concern

The issue says this is *"likely gated on #6886"* because a fix that only works in-process would silently do nothing under Temporal. That concern is real and I'm not claiming to resolve it. Two things worth separating:

- **In-process, DBOS and Prefect**: the live `RunContext` is passed through, so this works today.
- **Temporal**: `TemporalRunContext` rehydrates `usage` into a new object, so the accrual is discarded — the same limitation that already applies to the documented `usage=ctx.usage` delegation pattern user code is told to write.

So this doesn't make Temporal worse, and it doesn't fix it either: it makes the library's own tools behave exactly like the delegation pattern the docs prescribe, on every engine. When #6886's return channel lands, these two call sites benefit from it automatically, with no change here. If you'd rather hold this until #6886 is decided, that's a reasonable call — but the in-process bug is real today and the fix is two characters shy of a one-liner.

## Tests

Three tests in `tests/test_capabilities.py`:

| Test | Asserts |
|---|---|
| `..._x_search_subagent_usage_accrues_into_run_usage` | `input_tokens == 1010`, `output_tokens == 502`, `requests == 3` |
| `..._x_search_subagent_usage_counts_against_usage_limits` | `UsageLimitExceeded` raised under `total_tokens_limit=100` |
| `..._image_generation_subagent_usage_accrues_into_run_usage` | same accrual for the image tool |

The exact token counts matter here rather than a "greater than" assertion: they're what distinguishes a correct accrual from one that double-counts `requests`, which is the specific way the issue's suggested fix would have gone wrong.

**Mutation-checked.** With both call sites reverted and the tests unchanged, all three fail (`assert 10 == 1010`, `DID NOT RAISE UsageLimitExceeded`); restored, all three pass.

**Baseline.** `tests/test_capabilities.py` 898 passed, `tests/models/xai/test_search_tools.py` + `tests/test_usage_limits.py` 58 passed. `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

