### PR TITLE
Record `RunContext.cancel()` from setup-phase `for_run` hooks instead of raising `UserError`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1308,6 +1308,12 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         # run would otherwise consume it and attach the outer handle to the wrong run.
         binding = take_run_binding()
 
+        # The controller likewise exists before any user-supplied setup code, so `RunContext.cancel()`
+        # from a capability/toolset `for_run()` hook records the request instead of raising. Delivery
+        # still waits for `bind()` below: setup hooks are never interrupted, and a request recorded
+        # here ends the run at the first await after binding, before any model request (#7386).
+        cancellation = binding.cancellation if binding is not None else RunCancellation()
+
         # A bare `int` overrides both budgets; a partial `retries={'tools': ...}` / `{'output': ...}`
         # dict overrides only the named budget for this run (riding `ToolManager.default_max_retries`).
         retry_overrides = _normalize_agent_retry_overrides(retries)
@@ -1548,6 +1554,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             pending_messages=state.pending_messages,
             run_id=state.run_id,
             conversation_id=state.conversation_id,
+            _cancellation=cancellation,
         )
 
         # Resolve run metadata up front so capability and toolset `for_run` hooks
@@ -1738,7 +1745,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             tracer=tracer,
             get_instructions=get_instructions,
             instrumentation_settings=instrumentation_settings,
-            cancellation=binding.cancellation if binding is not None else RunCancellation(),
+            cancellation=cancellation,
         )
 
         user_prompt_node = _agent_graph.UserPromptNode[AgentDepsT](

--- a/tests/test_run_cancellation.py
+++ b/tests/test_run_cancellation.py
@@ -60,6 +60,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.run import AgentRun, AgentRunResult
 from pydantic_ai.tools import RunContext
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, WrapperToolset
 from pydantic_ai.usage import RequestUsage, RunUsage
 
 from .conftest import IsNow, IsStr
@@ -1556,6 +1557,57 @@ async def test_nested_run_in_for_run_hook_does_not_steal_binding():
 
     assert inner_outputs == ['inner done']
     assert exc_info.value.all_messages()
+
+
+async def test_capability_for_run_cancel_ends_run_before_model_request():
+    """`RunContext.cancel()` from a capability `for_run()` hook records the request — the run's
+    controller exists before any setup hook runs — and the run ends with `RunCancelled` before
+    the first model request. Recording is not interruption: the hook itself and the remaining
+    setup hooks (here the toolset's `for_run()`) still run to completion."""
+    hooks_ran: list[str] = []
+
+    class CancelsInForRun(AbstractCapability):
+        async def for_run(self, ctx: RunContext) -> CancelsInForRun:
+            ctx.cancel()
+            hooks_ran.append('capability')
+            return self
+
+    class RecordsForRun(WrapperToolset[Any]):
+        async def for_run(self, ctx: RunContext[Any]) -> AbstractToolset[Any]:
+            hooks_ran.append('toolset')
+            return await super().for_run(ctx)
+
+    async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
+        raise AssertionError('the model must not be called after a setup-phase cancellation')
+
+    agent = Agent(
+        FunctionModel(model_function),
+        capabilities=[CancelsInForRun()],
+        toolsets=[RecordsForRun(FunctionToolset())],
+    )
+    with pytest.raises(RunCancelled) as exc_info:
+        await agent.run('hello')
+
+    assert exc_info.value.all_messages() == []  # cancelled before any model request
+    assert hooks_ran == ['capability', 'toolset']
+
+
+async def test_toolset_for_run_cancel_ends_run_before_model_request():
+    """`RunContext.cancel()` from a toolset `for_run()` hook is likewise recorded, not a `UserError`."""
+
+    class CancelsInForRun(WrapperToolset[Any]):
+        async def for_run(self, ctx: RunContext[Any]) -> AbstractToolset[Any]:
+            ctx.cancel()
+            return await super().for_run(ctx)
+
+    async def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
+        raise AssertionError('the model must not be called after a setup-phase cancellation')
+
+    agent = Agent(FunctionModel(model_function), toolsets=[CancelsInForRun(FunctionToolset())])
+    with pytest.raises(RunCancelled) as exc_info:
+        await agent.run('hello')
+
+    assert exc_info.value.all_messages() == []
 
 
 async def test_cancel_during_blocked_before_run_is_delivered():


### PR DESCRIPTION
- Addresses the `ctx.cancel()` half of #7386 — deliberately does **not** close it; see scope below.

## Problem

The `RunContext` handed to capability and toolset `for_run()` hooks has `_cancellation=None`, because the run's `RunCancellation` controller was only constructed on `GraphAgentDeps` *after* capability and toolset resolution. So `ctx.cancel()` during run setup raised `UserError` ("no run to cancel") — while the `RunContext.cancel()` docstring already promises it is "safe to call from anywhere a `RunContext` is available — tools, `event_stream_handler`s, and capability hooks". This makes the code match the documented contract.

## Fix

Create the controller (or adopt the `AgentRunEvents` binding's) alongside the binding consumption at the top of `Agent.iter()`, wire it into the initial `RunContext`, and share the one instance with `GraphAgentDeps`. Three small hunks; no new public API.

The behavior is **recording, not interruption**: a `for_run` hook that calls `ctx.cancel()` returns normally, the remaining setup hooks still run to completion, and `RunCancellation.bind()` delivers the recorded request at the run's first await after binding — so the run ends with `RunCancelled` (empty message history) before any model request. `attach_token` deliberately stays where it is: `CancellationToken._register` already fires immediately for a token cancelled before or during setup, right after `bind()`, so those cases were already honored.

## Scope, re #7386's "resolve inside #7053"

#7386 suggests resolving this inside the setup-phase hook-contract rework (#7053) to avoid pre-empting contract decisions. This PR takes only the slice that pre-empts nothing: it changes no hook lifecycle (no hook is interrupted, none are skipped, no unwind semantics are introduced) — it only makes the controller exist early enough that the documented `cancel()` contract holds. The genuinely contract-shaped half of #7386 — interrupting a `for_run` hook that is *blocked* mid-await, and what happens to already-entered hooks — stays with #7053, which is why this doesn't close the issue.

Two tests pin the semantics: capability-side and toolset-side `for_run` cancellation, including "remaining hooks still run, the model is never called".

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

