### PR TITLE
Support deferred capability tools in realtime sessions via mid-session `session.update` tool reveals

### DIFF
--- a/docs/api/realtime.md
+++ b/docs/api/realtime.md
@@ -85,7 +85,8 @@ turn-control verbs ([`CommitAudio`][pydantic_ai.realtime.codec.CommitAudio],
 [`CreateResponse`][pydantic_ai.realtime.codec.CreateResponse],
 [`CancelResponse`][pydantic_ai.realtime.codec.CancelResponse], and
 [`TruncateOutput`][pydantic_ai.realtime.codec.TruncateOutput]) that those session methods emit, plus
-[`ToolResult`][pydantic_ai.realtime.codec.ToolResult] — which the session sends itself as each tool
+[`ToolResult`][pydantic_ai.realtime.codec.ToolResult] and
+[`UpdateTools`][pydantic_ai.realtime.codec.UpdateTools] — which the session sends itself as each tool
 completes.
 
 **Connection events** — [`RealtimeCodecEvent`][pydantic_ai.realtime.codec.RealtimeCodecEvent], the low-level codec

--- a/docs/realtime/azure.md
+++ b/docs/realtime/azure.md
@@ -244,6 +244,7 @@ model = AzureRealtimeModel(
 | Interruption/truncation | Full feature support | [`interrupt(played_ms=...)`](turns.md#barge-in) records the heard cutoff |
 | Input transcription | Limited parameter support | Requires a [compatible transcription deployment](#input-transcription-deployment) in the Azure resource |
 | Native tools | Unsupported | Configure [local fallbacks](tools.md#native-tools) for web capabilities |
+| Mid-session tool updates | Full feature support | Inherited from OpenAI: a [deferred capability](capabilities.md#deferred-capability-loading) can contribute tools |
 | Usage | Full feature support | Token, audio, and cache breakdowns |
 | Reconnection | Full feature support | Pydantic AI [replays completed local history](lifecycle.md#state-restoration); in-flight media is lost |
 

--- a/docs/realtime/capabilities.md
+++ b/docs/realtime/capabilities.md
@@ -68,11 +68,27 @@ session when filtering or redaction is required.
 
 Deferred capabilities load in a session the same way they do in a regular run: the capability
 catalog is part of the session's instructions, and calling the `load_capability` tool returns the
-loaded capability's instructions as its result — which works on every provider. What a session
-cannot do is advertise *new tools* mid-conversation (the connection's tools are fixed when it
-opens; see [#7288](https://github.com/pydantic/pydantic-ai/issues/7288)), so opening a session with
-a `defer_loading=True` capability that contributes tools or native tools raises
-[`UserError`][pydantic_ai.exceptions.UserError] before connecting — accepting it would silently
-provide less than requested. Realtime per-turn/exchange hooks are expected to widen this boundary
-in the future; see [#7190](https://github.com/pydantic/pydantic-ai/issues/7190) and
-[#7191](https://github.com/pydantic/pydantic-ai/issues/7191).
+loaded capability's instructions as its result — which works on every provider.
+
+A capability that also contributes *tools* needs those tools to reach the model after the session is
+already open. That works on providers whose realtime profile sets
+[`supports_tool_updates`][pydantic_ai.realtime.RealtimeModelProfile.supports_tool_updates] — the
+OpenAI-protocol providers ([OpenAI](openai.md), [Azure OpenAI](azure.md)) — where the load
+re-advertises the session's tool list before it answers the tool call, so the tools exist by the time
+the model hears the capability is active. On a provider that fixes its tools when the connection
+opens ([Gemini Live](gemini.md), and [xAI](xai.md) until its behavior is verified), opening a session
+with such a capability raises [`UserError`][pydantic_ai.exceptions.UserError] before connecting,
+because accepting it would silently provide less than requested.
+
+Two related cases are unaffected by the provider:
+
+- A capability that a seeded [`message_history`](history.md#seeding-a-session) still carries the full
+  record of loading — the `load_capability` exchange *and* the
+  [`ToolAvailabilityDeltaPart`][pydantic_ai.messages.ToolAvailabilityDeltaPart] recording its tool
+  reveal — advertises those tools with the rest of the connect-time tool list, so it needs no update
+  and is accepted everywhere.
+- A capability contributing [native tools](../native-tools.md) is still rejected on every provider:
+  no realtime API can turn a server-side tool on mid-conversation.
+
+Realtime per-turn/exchange hooks are expected to widen this boundary further; see
+[#7190](https://github.com/pydantic/pydantic-ai/issues/7190).

--- a/docs/realtime/gemini.md
+++ b/docs/realtime/gemini.md
@@ -112,6 +112,7 @@ facts with [`profile=`](overview.md#provider-support), which resolves like a
 | Explicit interruption/truncation | Unsupported | Gemini [interrupts server-side](turns.md#barge-in) and emits `RealtimeResponseInterruptedEvent` |
 | Input transcription | Full feature support | Native [transcription](audio.md#input-transcription), enabled by default; no separate model ID |
 | Native tools | Limited parameter support | Google Search grounding only; URL context and code execution fall back to a [`local=` tool](tools.md#native-tools) (see above) |
+| Mid-session tool updates | Unsupported | Tools are fixed at `setup`, so a tool-contributing [deferred capability](capabilities.md#deferred-capability-loading) is rejected before connecting |
 | Usage | Full feature support | Token and modality breakdowns; function-call usage may arrive on a later turn |
 | State-restoring reconnect | Full feature support | Requires [session resumption](#session-resumption) plus a reconnect policy |
 

--- a/docs/realtime/openai.md
+++ b/docs/realtime/openai.md
@@ -107,6 +107,7 @@ secure offer-relay flow, and the sideband trust model, and the
 | Interruption/truncation | Full feature support | [`interrupt(played_ms=...)`](turns.md#barge-in) records the heard cutoff |
 | Input transcription | Full feature support | [Dedicated model](audio.md#input-transcription); `'auto'` by default |
 | Native tools | Unsupported | Configure [local fallbacks](tools.md#native-tools) for web capabilities |
+| Mid-session tool updates | Full feature support | `session.update` re-advertises tools, so a [deferred capability](capabilities.md#deferred-capability-loading) can contribute tools |
 | Usage | Full feature support | Token, audio, and cache breakdowns |
 | Reconnection | Full feature support | Pydantic AI [replays completed local history](lifecycle.md#state-restoration); in-flight media is lost |
 

--- a/docs/realtime/overview.md
+++ b/docs/realtime/overview.md
@@ -261,8 +261,8 @@ fit for a product, two alternatives sit outside it:
 | Limitation | Tracking |
 | --- | --- |
 | SIP is not built in; bridge telephony through a provider such as Twilio. | [Connecting a frontend](deployment.md#siptelephony-bridge) |
-| New tools cannot be advertised mid-session, so `defer_loading=True` tools and tool-contributing capabilities are [rejected](capabilities.md#deferred-capability-loading). | [#7288](https://github.com/pydantic/pydantic-ai/issues/7288) |
-| Realtime-specific exchange hooks are not yet available; use supported [tool hooks](capabilities.md) and [session events](events.md). | [#7190](https://github.com/pydantic/pydantic-ai/issues/7190), [#7191](https://github.com/pydantic/pydantic-ai/issues/7191) |
+| Tool-contributing deferred capabilities need a provider that can [re-advertise tools mid-session](capabilities.md#deferred-capability-loading); elsewhere they are rejected, as are `defer_loading=True` tools that no capability owns and deferred capabilities contributing native tools. | [#7288](https://github.com/pydantic/pydantic-ai/issues/7288) |
+| Realtime-specific exchange hooks are not yet available; use supported [tool hooks](capabilities.md) and [session events](events.md). | [#7190](https://github.com/pydantic/pydantic-ai/issues/7190) |
 | Provider resumption handles cannot be persisted and resumed in another process. | [#7302](https://github.com/pydantic/pydantic-ai/issues/7302) |
 | Dynamic instructions are resolved once when the session connects. | [#7303](https://github.com/pydantic/pydantic-ai/issues/7303) |
 | History processors do not transform `message_history` before realtime seeding; [preprocess it](capabilities.md#seeded-history-is-not-processed) before opening the session when filtering or redaction is required. | [#7299](https://github.com/pydantic/pydantic-ai/issues/7299) |

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -150,8 +150,10 @@ consumer can observe what was asked and decided. It is not a hook to respond to 
 event in a standard run, nothing waits for the consumer, and no event is emitted when no handler is
 installed and the call is refused.
 
-Tools registered with `defer_loading=True` are rejected in a realtime session for a related reason;
-see [Deferred capability loading](capabilities.md#deferred-capability-loading).
+Tools registered with `defer_loading=True` that no capability owns are rejected in a realtime
+session: they are revealed by [tool search](../tools-advanced.md#tool-search), which a session has no
+surface for. A deferred *capability*'s tools are revealed by loading it instead; see
+[Deferred capability loading](capabilities.md#deferred-capability-loading).
 
 ## Enqueuing prompts from tools
 

--- a/docs/realtime/xai.md
+++ b/docs/realtime/xai.md
@@ -76,6 +76,7 @@ Other Grok Voice models ignore the setting.
 | Interruption | Limited parameter support | [`interrupt()`](turns.md#barge-in) works; output truncation with `played_ms` does not |
 | Input transcription | Full feature support | [Dedicated provider path](audio.md#input-transcription); `'auto'` by default |
 | Native tools | Unsupported | Configure [local fallbacks](tools.md#native-tools) for web capabilities |
+| Mid-session tool updates | Unsupported | A second tools-bearing `session.update` is unverified, so a tool-contributing [deferred capability](capabilities.md#deferred-capability-loading) is rejected before connecting |
 | Usage | Full feature support | Audio-token buckets and `billable_audio_seconds` in `RunUsage.details` |
 | State-restoring reconnect | Full feature support | Native [resumption](#session-resumption) is automatic with a reconnect policy |
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -280,7 +280,11 @@ Key facts for building realtime agents:
   (OpenAI/Azure/xAI only — Gemini has no manual turn controls and raises).
 - **Tools**: every tool runs in the background, so a slow tool never blocks the session. Whether
   the model keeps speaking meanwhile is provider-specific (OpenAI/Azure do; Gemini needs
-  `google_async_tool_calls=True` on a native-audio model).
+  `google_async_tool_calls=True` on a native-audio model). A `defer_loading=True` capability that
+  contributes tools loads mid-session on providers whose profile sets `supports_tool_updates`
+  (OpenAI, Azure OpenAI — the session re-advertises its tool list when the capability loads); Gemini
+  and xAI reject it before connecting. A capability a seeded `message_history` already shows as
+  loaded advertises its tools at connect and is accepted on every provider.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -6,7 +6,7 @@ import inspect
 import time
 from asyncio import Task
 from collections import deque
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterable, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterable, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from copy import deepcopy
@@ -827,7 +827,7 @@ async def _prepare_request_parameters(
         native_tools=native_tools,
         deferred_capability_ids=deferred_capability_ids,
         # Preserve discovered names that aren't in the current definitions.
-        revealed_tool_names=_revealed_tool_names(
+        revealed_tool_names=resolve_revealed_tool_names(
             run_context.discovered_tool_names,
             function_tools,
             deferred_capability_ids=deferred_capability_ids,
@@ -2383,23 +2383,34 @@ def run_cancelled_snapshot(
     )
 
 
-def _refresh_loaded_capability_ids(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, Any]]) -> None:
-    """Refresh the history-derived loaded capability ids from the current graph state."""
+def refresh_loaded_capability_ids(
+    loaded_capability_ids: set[str],
+    messages: Sequence[_messages.ModelMessage],
+    capabilities: Mapping[str, AbstractCapability[Any]],
+) -> None:
+    """Refresh history-derived loaded capability ids in place.
+
+    Shared with the realtime session, which re-derives the same state per turn from its own history
+    rather than from graph state.
+    """
     # The `load_capability` tool (and therefore any `LoadCapability*` history parts) only exists
     # when a deferred capability is configured — the same condition that injects the loader. Without
     # one, the set can never change during the run, so the seeded value stays in sync without rescanning.
     # (`discovered_tool_names` has no equally-cheap guard: tool search is auto-injected and its trigger
     # is "deferred tools exist", which isn't known without resolving toolsets, so its refresh stays
     # unconditional.)
-    if not any(capability.defer_loading is True for capability in ctx.deps.capabilities.values()):
+    if not any(capability.defer_loading is True for capability in capabilities.values()):
         return
-
-    loaded_capability_ids = parse_loaded_capabilities(ctx.state.message_history)
 
     # Mutate in place (not reassign): this set is shared by reference with the run's `RunContext`
     # copies made via `replace(ctx, ...)`, so clear + update keeps them all in sync.
-    ctx.deps.loaded_capability_ids.clear()
-    ctx.deps.loaded_capability_ids.update(loaded_capability_ids)
+    loaded_capability_ids.clear()
+    loaded_capability_ids.update(parse_loaded_capabilities(messages))
+
+
+def _refresh_loaded_capability_ids(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, Any]]) -> None:
+    """Refresh the history-derived loaded capability ids from the current graph state."""
+    refresh_loaded_capability_ids(ctx.deps.loaded_capability_ids, ctx.state.message_history, ctx.deps.capabilities)
 
 
 def _refresh_discovered_tool_names(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, Any]]) -> None:
@@ -2411,7 +2422,7 @@ def _refresh_discovered_tool_names(ctx: GraphRunContext[GraphAgentState, GraphAg
     ctx.deps.discovered_tool_names.update(discovered_tool_names)
 
 
-def _revealed_tool_names(
+def resolve_revealed_tool_names(
     discovered: Iterable[str],
     function_tools: Iterable[ToolDefinition],
     *,
@@ -2460,7 +2471,7 @@ def _with_outgoing_reveal_state(
     """
     return replace(
         parameters,
-        revealed_tool_names=_revealed_tool_names(
+        revealed_tool_names=resolve_revealed_tool_names(
             parse_discovered_tools(messages),
             parameters.function_tools,
             deferred_capability_ids=parameters.deferred_capability_ids,

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -99,6 +99,7 @@ from ..tools import (
     ToolsPrepareFunc,
 )
 from ..toolsets import AbstractToolset, AgentToolset
+from ..toolsets._capability_owned import is_gated_by_deferred_capability
 from ..toolsets._dynamic import (
     DynamicToolset,
     ToolsetFunc,
@@ -3177,6 +3178,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         and is not itself a run.
         """
         from ..realtime import RealtimeModel, infer_realtime_model
+        from ..realtime._utils import resolve_realtime_request_tools
 
         if not isinstance(model, RealtimeModel):
             model = infer_realtime_model(model)
@@ -3206,6 +3208,12 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             # functions and capability `for_run` hooks see the prior conversation. KEEP IN SYNC with `iter`.
             messages=list(message_history) if message_history else [],
             max_retries=max_tool_retries,
+            # A session resumed from a history in which a deferred capability was already loaded (or a
+            # deferred tool already discovered) starts where that history left off, exactly as `iter`
+            # does — so those tools advertise at connect and `load_capability` refuses a redundant
+            # re-load. KEEP IN SYNC with `iter`.
+            loaded_capability_ids=parse_loaded_capabilities(message_history) if message_history else set[str](),
+            discovered_tool_names=parse_discovered_tools(message_history) if message_history else set[str](),
         )
         # Both need the context that only exists once it's built, so they're assigned rather than passed —
         # the graph does the same via `replace`. Without them a tool validated in a session sees a
@@ -3264,25 +3272,44 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             base_is_override=base_is_override,
         )
         run_capability = resolved_caps.run_capability
-        # Deferred capabilities load in a session the same way they do in a graph run: the catalog
-        # renders into the connect-time instructions and the loaded instructions come back as the
-        # `load_capability` tool's own result, which every provider supports. What no provider
-        # connection can do (yet) is advertise NEW tools mid-session — tools are fixed at connect —
-        # so a deferred capability whose loading would have to reveal tools can't be honored, and
-        # fails up front rather than silently loading less than it promised. The direct hook calls
-        # probe the same contributions extraction reads; their results are discarded.
-        undeliverable_capability_ids = [
+        model_profile = model.profile
+        deferred_capability_ids = {
             capability_id
             for capability_id, capability in run_context.capabilities.items()
             if capability.defer_loading is True
-            and (capability.get_toolset() is not None or (capability.get_native_tools() or ()))
-        ]
-        if undeliverable_capability_ids:
-            formatted_ids = ', '.join(repr(capability_id) for capability_id in undeliverable_capability_ids)
+        }
+        # Deferred capabilities load in a session the same way they do in a graph run: the catalog
+        # renders into the connect-time instructions and the loaded instructions come back as the
+        # `load_capability` tool's own result, which every provider supports. Revealing the *tools* a
+        # load brings with it takes a second tool advertisement mid-session, which only a provider
+        # whose profile sets `supports_tool_updates` accepts — except for a capability the seeded
+        # `message_history` already shows as loaded, whose tools go out at connect like any other. A
+        # native tool can't be revealed on any provider. Whatever is left over fails up front rather
+        # than silently loading less than it promised. The direct hook calls probe the same
+        # contributions extraction reads; their results are discarded.
+        if native_tool_capability_ids := [
+            capability_id
+            for capability_id in deferred_capability_ids
+            if run_context.capabilities[capability_id].get_native_tools()
+        ]:
+            formatted_ids = ', '.join(repr(capability_id) for capability_id in sorted(native_tool_capability_ids))
             raise exceptions.UserError(
-                'Realtime sessions cannot reveal tools mid-session, so deferred capabilities that '
-                'contribute tools or native tools are not supported; remove `defer_loading=True` '
-                f'from: {formatted_ids}.'
+                'Realtime sessions cannot reveal native tools mid-session, so deferred capabilities '
+                f'that contribute native tools are not supported; remove `defer_loading=True` from: {formatted_ids}.'
+            )
+        if not model_profile.get('supports_tool_updates', False) and (
+            unrevealable_capability_ids := [
+                capability_id
+                for capability_id in deferred_capability_ids
+                if capability_id not in run_context.loaded_capability_ids
+                and run_context.capabilities[capability_id].get_toolset() is not None
+            ]
+        ):
+            formatted_ids = ', '.join(repr(capability_id) for capability_id in sorted(unrevealable_capability_ids))
+            raise exceptions.UserError(
+                f'The {model.model_name!r} realtime model does not support updating tools mid-session, so a '
+                'deferred capability that contributes tools cannot be loaded during a session; remove '
+                f'`defer_loading=True` from: {formatted_ids}.'
             )
         # `_resolve_run_capabilities` already registered `run_context.capabilities` for the toolset/connect
         # `for_run` below, exactly as the graph run relies on. The root of that chain has to be published
@@ -3330,7 +3357,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 native_tool = resolved_native
             if not (isinstance(native_tool, ToolSearchTool) and native_tool.optional):
                 native_tools.append(native_tool)
-        model_profile = model.profile
 
         toolset = self._get_toolset(
             output_toolset=None,
@@ -3426,38 +3452,39 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             model_request_parameters = models.ModelRequestParameters(
                 function_tools=tool_defs,
                 native_tools=native_tools,
+                deferred_capability_ids=deferred_capability_ids,
+                # Seeded from `message_history` the way the graph seeds each request: a capability the
+                # prior run loaded advertises its tools from connect, so no mid-session update is
+                # needed for it — on any provider.
+                revealed_tool_names=_agent_graph.resolve_revealed_tool_names(
+                    run_context.discovered_tool_names,
+                    tool_defs,
+                    deferred_capability_ids=deferred_capability_ids,
+                    loaded_capability_ids=run_context.loaded_capability_ids,
+                ),
             )
-            # Resolve `include_return_schema` exactly as `Model.prepare_request` does: return schemas
-            # are cleared on tools that didn't opt in, kept as-is for a model that renders them
-            # natively (Gemini Live's function-declaration `response` schema), and injected into the
-            # tool description elsewhere.
-            model_request_parameters = models.prepare_return_schemas(
-                model_request_parameters,
-                supports_tool_return_schema=model_profile.get('supports_tool_return_schema', False),
-            )
-            # Run the same native ↔ local-tool fallback swap the classic agent-run path applies (via
-            # `Model._resolve_request_tools`): drop an unsupported native tool when a local fallback
-            # (stamped `unless_native=...` by the capability's toolset) is present, drop the redundant
-            # local tool when the native tool IS supported, and raise the shared `UserError` (suggesting
-            # `local=...`) only when unsupported with no local fallback. Realtime models genuinely default
-            # to supporting no native tools, so the default here is `frozenset()`, not `SUPPORTED_NATIVE_TOOLS`.
-            # No `can_withhold_tool_schemas`/`tool_addition_mode`: a realtime connection can neither
-            # withhold a schema nor reveal a tool later, so every deferred unrevealed tool resolves
-            # to `'withheld'` in the visibility table.
-            model_request_parameters = models.resolve_request_tools(
-                model_request_parameters, model_profile.get('supported_native_tools', frozenset())
-            )
-            # A `defer_loading=True` tool is hidden until tool search reveals it, which a session whose
-            # tools are fixed at connect can never do — the model would be handed a `search_tools`
-            # affordance that finds the tool and then can't have it. Rejected up front for the same
-            # reason a deferred *capability* that contributes tools is (see `_resolve_run_capabilities`
-            # above), rather than silently advertising a search that leads nowhere.
-            deferred_tool_names = [tool.name for tool in model_request_parameters.function_tools if tool.defer_loading]
+            model_request_parameters = resolve_realtime_request_tools(model_request_parameters, model_profile)
+            # A `defer_loading=True` tool that no *deferred capability* gates is hidden until tool
+            # search reveals it, and the session drops the optional `ToolSearchTool` — so the model
+            # would be handed a `search_tools` affordance that finds the tool and then can't have it.
+            # Rejected up front, rather than silently advertising a search that leads nowhere. Two
+            # kinds are left alone: one a deferred capability gates, which loading that capability
+            # reveals (the guards above already established this session can honor it), and one the
+            # seeded history has already revealed, which goes out with the connect-time list like any
+            # visible tool and needs nothing further.
+            deferred_tool_names = [
+                tool.name
+                for tool in model_request_parameters.function_tools
+                if tool.defer_loading
+                and tool.name not in model_request_parameters.revealed_tool_names
+                and not is_gated_by_deferred_capability(run_context, tool)
+            ]
             if deferred_tool_names:
                 formatted_names = ', '.join(repr(name) for name in deferred_tool_names)
                 raise exceptions.UserError(
-                    'Realtime sessions cannot reveal tools mid-session, so tools with '
-                    f'`defer_loading=True` are not supported; remove it from: {formatted_names}.'
+                    'Realtime sessions have no tool-search surface, so a tool with `defer_loading=True` '
+                    'that no capability owns can never be revealed; remove it from: '
+                    f'{formatted_names}.'
                 )
             # Realtime codecs read `function_tools` directly, so hidden tools are dropped from the
             # connect-time advertisement entirely — the same physical removal this path applied

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -413,6 +413,9 @@ def openai_realtime_model_profile(model_name: str) -> RealtimeModelProfile:
         # wire flag to set, unlike Gemini. The session already runs tools in the background and
         # defers `response.create` while a response is active, so this is true end to end.
         'supports_async_tool_calls': True,
+        # `session.update` accepts a fresh `tools` array mid-session, so a deferred capability's tools
+        # can be revealed after connect.
+        'supports_tool_updates': True,
         'emits_input_speech_events': True,
         'audio_input_sample_rate': 24000,
         'audio_output_sample_rate': 24000,

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -19,6 +19,7 @@ from opentelemetry.context import Context
 from typing_extensions import TypeAliasType, assert_never
 
 from .. import _agent_graph
+from .._deferred_capabilities import LoadCapabilityCallPart
 from .._enqueue import PendingMessage, PendingMessagePriority
 from .._tool_execution import (
     _reject_unloaded_capability_reveals,  # pyright: ignore[reportPrivateUsage]
@@ -60,11 +61,13 @@ from ..messages import (
     SystemPromptPart,
     TextPart,
     TextPartDelta,
+    ToolAvailabilityDeltaPart,
     ToolCallPart,
     ToolReturnPart,
     UserContent,
     UserPromptPart,
 )
+from ..models import ModelRequestParameters
 from ..native_tools import SUPPORTED_NATIVE_TOOLS
 from ..run import AgentRunResult
 from ..tool_manager import ToolManager
@@ -72,7 +75,7 @@ from ..usage import RequestUsage, RunUsage, UsageLimits
 from ._instrumentation import (
     SessionInstrumentation,
 )
-from ._utils import seed_pcm_audio
+from ._utils import resolve_advertised_tools, resolve_realtime_request_tools, seed_pcm_audio
 from .codec import (
     AudioDelta,
     CancelResponse,
@@ -93,6 +96,7 @@ from .codec import (
     ToolCallCancelled,
     ToolResult,
     TruncateOutput,
+    UpdateTools,
 )
 from .model import RealtimeError
 from .profiles import DEFAULT_AUDIO_SAMPLE_RATE, RealtimeModelProfile
@@ -100,9 +104,8 @@ from .settings import AudioRetention, RealtimeModelSettings
 
 if TYPE_CHECKING:
     from ..messages import AgentStreamEvent
-    from ..models import ModelRequestParameters
     from ..models.instrumented import InstrumentationSettings
-    from ..tools import DeferredToolRequests, DeferredToolResults
+    from ..tools import DeferredToolRequests, DeferredToolResults, ToolDefinition
     from .model import RealtimeModel
 
 # Session-level events (yielded by `RealtimeSession.__aiter__`).
@@ -261,7 +264,8 @@ _TranslatableEvent: TypeAlias = (
     | PartEndEvent
     | RealtimeSessionErrorEvent
 )
-_SettledToolResult: TypeAlias = tuple[ToolReturnPart | RetryPromptPart, str | Sequence[UserContent] | None]
+_SettledToolResult: TypeAlias = tuple[ToolReturnPart | RetryPromptPart, str | Sequence[UserContent] | None, list[str]]
+"""A settled tool call's history part, follow-up user content, and the tool names it newly revealed."""
 
 
 def _as_event(item: object) -> RealtimeEvent:
@@ -343,7 +347,8 @@ def _tool_result_call_id(message: ModelMessage) -> str | None:
         return None
     result = message.parts[0]
     if not isinstance(result, (ToolReturnPart, RetryPromptPart)) or not all(
-        isinstance(part, (ToolReturnPart, RetryPromptPart, UserPromptPart)) for part in message.parts
+        isinstance(part, (ToolReturnPart, RetryPromptPart, ToolAvailabilityDeltaPart, UserPromptPart))
+        for part in message.parts
     ):
         return None
     return result.tool_call_id
@@ -356,8 +361,8 @@ def _is_tool_result_request(message: ModelMessage) -> bool:
 
 def _build_session_tool_return(
     tool_result: Any, call_part: ToolCallPart, tool_manager: ToolManager[Any]
-) -> tuple[ToolReturnPart | RetryPromptPart, str | Sequence[UserContent] | None]:
-    """Translate a settled session tool result into its history part, rejecting mid-session reveals."""
+) -> tuple[ToolReturnPart | RetryPromptPart, str | Sequence[UserContent] | None, Sequence[str]]:
+    """Translate a settled session tool result into its history part and the tools it reveals."""
     tool_def = tool_manager.get_tool_def(call_part.tool_name)
     result_part, user_content, tools_added = build_tool_return_part(
         tool_result,
@@ -365,14 +370,17 @@ def _build_session_tool_return(
         tool_kind=tool_def.tool_kind if tool_def else None,
     )
     if tools_added:
-        # Mirrors the graph (`_tool_execution._call_tool`), which rejects only a name owned by an
-        # unloaded capability and treats every other name — a typo, an already-visible tool — as a
-        # silent no-op. Killing the session over any reveal at all was harsher than the graph *and*
-        # unreachable-by-design harshness: a session refuses `defer_loading=True` tools and
-        # tool-contributing deferred capabilities when it opens, so it holds nothing that a reveal
-        # could have surfaced. Nothing is silently lost by dropping the request here.
-        _reject_unloaded_capability_reveals(tools_added, tool_manager)
-    return result_part, user_content
+        # Mirrors the graph (`_tool_execution._call_tool`), which lets a `load_capability` call reveal
+        # its own capability's tools, rejects a name owned by a capability that isn't loaded, and
+        # treats every other name — a typo, an already-visible tool — as a silent no-op.
+        _reject_unloaded_capability_reveals(
+            tools_added,
+            tool_manager,
+            activating_capability_id=(
+                call_part.capability_id if isinstance(call_part, LoadCapabilityCallPart) else None
+            ),
+        )
+    return result_part, user_content, tools_added or ()
 
 
 def _unsettled_call_return(call: ToolCallPart, error: ApprovalRequired | CallDeferred | RunCancelled) -> ToolReturnPart:
@@ -568,8 +576,17 @@ class RealtimeSession:
         # each model request can vary — a realtime session sends these once at connect, so they belong on
         # the session span (set once), not repeated on every per-turn `chat` span. Carrying
         # `model_request_parameters` is what makes the session's configured native tools inspectable.
+        # These stay the connect-time snapshot: a mid-session reveal (`_build_tool_update`) widens what
+        # the provider advertises without re-stamping the span, so the tool list a trace shows is the one
+        # the session opened with — the reveal itself is visible in history, as a `ToolAvailabilityDeltaPart`.
         self._model_request_parameters = model_request_parameters
         self._model_settings = model_settings
+        # What the connection was opened advertising, and the base every mid-session re-advertisement
+        # is recomputed from. A session constructed without parameters advertised nothing, and only a
+        # `supports_tool_updates` provider can change any of it once the connection is open.
+        self._advertised_parameters = model_request_parameters or ModelRequestParameters()
+        self._revealed_tool_names = set(self._advertised_parameters.revealed_tool_names)
+        self._advertised_tool_names = {tool.name for tool in self._advertise(self._advertised_parameters)}
         self._wrap_event_stream = wrap_event_stream
         self._instructions = instructions
         self._metadata = metadata
@@ -1590,8 +1607,15 @@ class RealtimeSession:
         call_part: ToolCallPart,
         result_part: ToolReturnPart | RetryPromptPart,
         content: str | Sequence[UserContent] | None = None,
+        tools_added: list[str] | None = None,
     ) -> list[RealtimeEvent]:
         request_parts: list[ModelRequestPart] = [result_part]
+        if tools_added:
+            # Recorded exactly where the graph records it, so history handed to `Agent.run` carries
+            # the same reveal state the session is running with.
+            request_parts.append(
+                ToolAvailabilityDeltaPart(tools_added=tools_added, tool_call_id=call_part.tool_call_id)
+            )
         if content:
             request_parts.append(UserPromptPart(content=content))
         self._insert_tool_return(call_part, self._new_request(request_parts))
@@ -2075,6 +2099,58 @@ class RealtimeSession:
                 return text
         return None
 
+    def _advertise(self, parameters: ModelRequestParameters) -> list[ToolDefinition]:
+        """The function tools these parameters put in front of the model.
+
+        The provider applies the same two filters when it builds its connect-time session config —
+        withheld tools never reach the wire, and `tool_choice` can narrow what is left — so a
+        re-advertisement has to reproduce both or it would silently widen the list.
+        """
+        tools, _ = resolve_advertised_tools(
+            parameters.declared_function_tools, (self._model_settings or {}).get('tool_choice')
+        )
+        return tools
+
+    def _record_reveal(
+        self, revealed: Sequence[str], tool_defs: list[ToolDefinition]
+    ) -> tuple[list[str], UpdateTools | None]:
+        """Take up the tools a settled call revealed: the names to record, and the update to send."""
+        # First reveal of a name owns it, as in a graph run (`_prune_duplicate_tool_reveals`): a later
+        # call naming it again neither re-advertises nor re-records it. `dict.fromkeys` collapses a
+        # name the same call repeated, matching the graph's own call-level dedupe.
+        tools_added = [name for name in dict.fromkeys(revealed) if name not in self._revealed_tool_names]
+        self._revealed_tool_names.update(tools_added)
+        # A reveal only reaches the wire on a model that takes a new tool list mid-session; elsewhere
+        # the connect-time guards mean there is nothing revealable to advertise.
+        if tools_added and self._profile.get('supports_tool_updates', False):
+            return tools_added, self._build_tool_update(tool_defs)
+        return tools_added, None
+
+    def _build_tool_update(self, tool_defs: list[ToolDefinition]) -> UpdateTools | None:
+        """The re-advertisement a reveal calls for, or `None` when the advertised list is unchanged.
+
+        Recomputed from the calling step's tool definitions rather than patched: a reveal moves a
+        tool's resolved visibility, and running the whole connect-time resolution again is what keeps
+        the mid-session list identical to the one this session would have opened with.
+        """
+        parameters = resolve_realtime_request_tools(
+            replace(
+                self._advertised_parameters,
+                function_tools=tool_defs,
+                revealed_tool_names=set(self._revealed_tool_names),
+            ),
+            self._profile,
+        )
+        tools = self._advertise(parameters)
+        names = {tool.name for tool in tools}
+        if names == self._advertised_tool_names:
+            # A reveal that adds nothing the model can't already see (a typo, an already-visible tool)
+            # is a no-op, as in a graph run — and sending an identical list would churn the session
+            # for nothing.
+            return None
+        self._advertised_tool_names = names
+        return UpdateTools(tools=tools)
+
     async def _execute_tool(
         self,
         call_part: ToolCallPart,
@@ -2105,6 +2181,8 @@ class RealtimeSession:
             await self._queue.put(DeferredToolRequestsEvent(requests))
             await self._queue.put(DeferredToolResultsEvent(results))
 
+        revealed: Sequence[str] = ()
+        settled_tool_defs: list[ToolDefinition] = []
         try:
             async with self._tool_manager_lock:
                 ctx = self._tool_manager.ctx
@@ -2120,10 +2198,16 @@ class RealtimeSession:
                     # `ModelResponse` is finalized, so this re-prepares the *local* manager once per
                     # turn — refreshing prepare hooks, availability filters, and retry state exactly
                     # as the graph does per model request. It never re-advertises tools mid-call: the
-                    # tool list the provider sees is fixed at connect (`session.update` is sent
-                    # once), so a prepare filter changing here only affects whether a call the model
-                    # makes is accepted or settled as unknown-tool.
+                    # tool list the provider sees only changes when a reveal re-advertises it
+                    # (`_build_tool_update`), so a prepare filter changing here otherwise only
+                    # affects whether a call the model makes is accepted or settled as unknown-tool.
                     if ctx.run_step < run_step:
+                        # Which deferred capabilities are loaded is derived from history, so it has to
+                        # be re-read before the new step's tools are prepared — the graph refreshes
+                        # the same set before each model request.
+                        _agent_graph.refresh_loaded_capability_ids(
+                            ctx.loaded_capability_ids, ctx.messages, ctx.capabilities
+                        )
                         self._tool_manager = await self._tool_manager.for_run_step(replace(ctx, run_step=run_step))
                 # Pin the step-synchronized manager for this call: a concurrent tool task can swap
                 # `self._tool_manager` (its own `for_run_step` advance) between here and the calls below,
@@ -2149,7 +2233,11 @@ class RealtimeSession:
             result_part = _unsettled_call_return(call_part, e)
             user_content = None
         else:
-            result_part, user_content = _build_session_tool_return(tool_result, call_part, tool_manager)
+            result_part, user_content, revealed = _build_session_tool_return(tool_result, call_part, tool_manager)
+            # Snapshotted with the result: the re-advertisement is computed from the definitions this
+            # call ran against, and `self._tool_manager` can be swapped by a concurrent task's own
+            # step advance before the reveal is taken up below.
+            settled_tool_defs = tool_manager.tool_defs if revealed else []
         finally:
             # The call has settled: on success `handle_call` has already recorded it on
             # `usage.tool_calls` in this same event-loop segment (so no limit check can observe the
@@ -2170,19 +2258,29 @@ class RealtimeSession:
             wire_content.extend(user_content)
         if not response_usage_follows:
             await self._drain_pending_messages('asap')
+        # Taken up here, not where the result settled, so that claiming the names, building the
+        # re-advertisement, and queueing for the wire form one uninterrupted synchronous stretch: no
+        # other tool task can slip a claim in between, and `_send_lock` is acquired (or joined as a
+        # FIFO waiter) before this task can yield. Concurrent reveals therefore reach the provider in
+        # the order their lists were computed, and each list is a superset of the ones before it, so
+        # `_advertised_tool_names` keeps describing what the model actually last saw.
+        tools_added, update_tools = self._record_reveal(revealed, settled_tool_defs)
         self._reserve_response_request()
         try:
+            # One group, so the model can never learn a capability loaded before the tools it brought
+            # exist server-side.
             await self._send_frame(
+                *((update_tools,) if update_tools is not None else ()),
                 ToolResult(
                     tool_call_id=call_part.tool_call_id,
                     output=output,
                     content=wire_content or None,
-                )
+                ),
             )
         except BaseException:
             self._pending_response_requests -= 1
             raise
-        return result_part, user_content
+        return result_part, user_content, tools_added
 
     # --- streaming --------------------------------------------------------------------------------
 
@@ -2315,7 +2413,7 @@ class RealtimeSession:
     ) -> None:
         """Run a tool and feed its completion (or failure) back through the queue."""
         try:
-            result_part, content = await self._execute_tool(
+            result_part, content, tools_added = await self._execute_tool(
                 call_part,
                 validation_done=validation_done,
                 execution_prerequisites=execution_prerequisites,
@@ -2337,7 +2435,7 @@ class RealtimeSession:
             self._tool_completion_events.discard(completion)
             # Settled (completed, failed, or cancelled): no longer cancellable by `ToolCallCancelled`.
             self._pending_tool_calls.pop(call_part.tool_call_id, None)
-        events = self._complete_tool_call(call_part, result_part, content)
+        events = self._complete_tool_call(call_part, result_part, content, tools_added)
         if ordered_events:
             # Held until nothing is still running, then released in call order — the graph waits for a
             # whole segment (`ALL_COMPLETED`) and replays it by index for the same reason. The release
@@ -2404,10 +2502,17 @@ class RealtimeSession:
         # its request. Read at execution time instead, a call held behind a `sequential` barrier
         # could observe a later response's advance and land a step ahead of its own batch.
         tool_run_step = self._tool_run_step
-        call_part = ToolCallPart(
-            tool_name=event.tool_name,
-            args=event.args,
-            tool_call_id=event.tool_call_id,
+        # Promoted to the typed subclass its `tool_kind` registers, exactly as the graph promotes the
+        # calls in a non-streaming response (`_narrow_tool_call_parts`). Without it a `load_capability`
+        # call stays a base part and nothing downstream — the session's own per-step refresh, or a
+        # later `Agent.run(message_history=...)` — can pair it with its return.
+        call_part = ToolCallPart.narrow_type(
+            ToolCallPart(
+                tool_name=event.tool_name,
+                args=event.args,
+                tool_call_id=event.tool_call_id,
+            ),
+            tool_kind=tool_def.tool_kind if tool_def else None,
         )
         for out in self._handle_tool_call_part(
             call_part,

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -216,6 +216,7 @@ _FULL_PROFILE = RealtimeModelProfile(
     supports_interruption=True,
     supports_output_truncation=True,
     supports_session_seeding=True,
+    supports_tool_updates=True,
     supported_native_tools=SUPPORTED_NATIVE_TOOLS,
     audio_input_sample_rate=DEFAULT_AUDIO_SAMPLE_RATE,
     audio_output_sample_rate=DEFAULT_AUDIO_SAMPLE_RATE,

--- a/pydantic_ai_slim/pydantic_ai/realtime/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_utils.py
@@ -26,12 +26,41 @@ from ..messages import (
     UserPromptPart,
     VideoUrl,
 )
-from ..models import ModelRequestParameters, download_item
+from ..models import ModelRequestParameters, download_item, prepare_return_schemas, resolve_request_tools
 from ..models._tool_choice import ResolvedToolChoice, resolve_tool_choice
 from ..settings import ToolChoice
 from ..tools import ToolDefinition
 from .codec import RealtimeSessionInput
+from .profiles import RealtimeModelProfile
 from .settings import ReconnectPolicy
+
+
+def resolve_realtime_request_tools(
+    parameters: ModelRequestParameters, profile: RealtimeModelProfile
+) -> ModelRequestParameters:
+    """Resolve the tools a realtime session advertises, at connect and at every mid-session reveal.
+
+    Return schemas resolve exactly as `Model.prepare_request` does: cleared on tools that didn't opt
+    in, kept for a model that renders them natively (Gemini Live's function-declaration `response`
+    schema), injected into the description elsewhere.
+
+    Then the same native ↔ local-tool fallback swap the classic agent-run path applies (via
+    `Model._resolve_request_tools`): drop an unsupported native tool when a local fallback (stamped
+    `unless_native=...` by the capability's toolset) is present, drop the redundant local tool when
+    the native tool IS supported, and raise the shared `UserError` (suggesting `local=...`) only when
+    unsupported with no local fallback. Realtime models genuinely default to supporting no native
+    tools, so the default is `frozenset()`, not `SUPPORTED_NATIVE_TOOLS`. No
+    `can_withhold_tool_schemas`/`tool_addition_mode`: a realtime connection can't withhold a schema,
+    and it reveals a tool by re-advertising the whole list rather than through history, so every
+    unrevealed deferred tool resolves to `'withheld'` in the visibility table and a revealed one to
+    `'visible'`.
+
+    Shared so the connect-time advertisement and a `session.update` that re-advertises it can't drift.
+    """
+    parameters = prepare_return_schemas(
+        parameters, supports_tool_return_schema=profile.get('supports_tool_return_schema', False)
+    )
+    return resolve_request_tools(parameters, profile.get('supported_native_tools', frozenset()))
 
 
 def resolve_advertised_tools(

--- a/pydantic_ai_slim/pydantic_ai/realtime/codec.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/codec.py
@@ -37,6 +37,7 @@ from ..messages import (
     RealtimeSessionReconnectEvent,
     UserContent,
 )
+from ..tools import ToolDefinition
 from ..usage import RequestUsage
 from .profiles import DEFAULT_AUDIO_SAMPLE_RATE, DEFAULT_REALTIME_PROFILE, merge_realtime_profile
 
@@ -107,6 +108,22 @@ class TruncateOutput:
     __repr__ = _utils.dataclasses_no_defaults_repr
 
 
+@dataclass(repr=False)
+class UpdateTools:
+    """Re-advertise the session's tool list mid-conversation.
+
+    Sent by [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] when loading a deferred
+    capability reveals tools the connect-time advertisement withheld. Only providers whose profile
+    sets [`supports_tool_updates`][pydantic_ai.realtime.RealtimeModelProfile.supports_tool_updates]
+    accept it; the rest fix their tool list when the connection opens and reject the input.
+    """
+
+    tools: Sequence[ToolDefinition]
+    """The complete list of tools to advertise from now on, not a delta."""
+
+    __repr__ = _utils.dataclasses_no_defaults_repr
+
+
 RealtimeSessionInput = TypeAliasType('RealtimeSessionInput', 'str | BinaryContent')
 """The content types a caller feeds into [`RealtimeSession.send`][pydantic_ai.realtime.RealtimeSession.send].
 
@@ -117,13 +134,14 @@ raw PCM before it is streamed, matching the history-seeding path), or a raw PCM 
 Turn-control verbs (`CommitAudio`, `ClearAudio`, `CreateResponse`, `CancelResponse`,
 `TruncateOutput`) are connection-level vocabulary driven through the dedicated `RealtimeSession`
 methods (`commit_audio()`, `clear_audio()`, `create_response()`, `interrupt()`), and
-[`ToolResult`][pydantic_ai.realtime.codec.ToolResult] is sent by the session itself when a tool
-completes — neither is accepted by `send()`.
+[`ToolResult`][pydantic_ai.realtime.codec.ToolResult] and
+[`UpdateTools`][pydantic_ai.realtime.codec.UpdateTools] are sent by the session itself when a tool
+completes — none is accepted by `send()`.
 """
 
 RealtimeInput = TypeAliasType(
     'RealtimeInput',
-    'str | BinaryAudio | BinaryImage | CommitAudio | ClearAudio | CreateResponse | CancelResponse | TruncateOutput | ToolResult',
+    'str | BinaryAudio | BinaryImage | CommitAudio | ClearAudio | CreateResponse | CancelResponse | TruncateOutput | UpdateTools | ToolResult',
 )
 """Union of content types accepted by [`RealtimeConnection.send`][pydantic_ai.realtime.codec.RealtimeConnection.send].
 
@@ -132,8 +150,9 @@ already normalized: a `str` is a complete text turn, a
 [`BinaryAudio`][pydantic_ai.messages.BinaryAudio] carries a raw mono PCM16 chunk at the model's
 [`audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]
 (`media_type='audio/pcm'`), and a [`BinaryImage`][pydantic_ai.messages.BinaryImage] an image frame.
-The connection additionally accepts the turn-control verbs and
-[`ToolResult`][pydantic_ai.realtime.codec.ToolResult], which
+The connection additionally accepts the turn-control verbs,
+[`ToolResult`][pydantic_ai.realtime.codec.ToolResult], and
+[`UpdateTools`][pydantic_ai.realtime.codec.UpdateTools], which
 [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] sends on the caller's behalf.
 """
 
@@ -476,6 +495,7 @@ __all__ = (
     'CreateResponse',
     'CancelResponse',
     'TruncateOutput',
+    'UpdateTools',
     # Model-profile helpers for provider implementations.
     'merge_realtime_profile',
     'DEFAULT_AUDIO_SAMPLE_RATE',

--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -115,6 +115,7 @@ from .codec import (
     SessionUsage,
     ToolResult,
     TruncateOutput,
+    UpdateTools,
 )
 from .model import RealtimeClientSecret, RealtimeModel, RealtimeProviderSession, WebRTCAnswer
 from .profiles import RealtimeModelProfileSpec
@@ -361,8 +362,14 @@ class OpenAIRealtimeConnection(RealtimeConnection):
         model_name: str | None = None,
         model_name_getter: Callable[[], str | None] | None = None,
         observes_output_audio: bool = True,
+        session_config: dict[str, Any] | None = None,
     ) -> None:
         self._ws = ws
+        # The `session.update` payload the handshake configured this session with, and the one a
+        # re-dial replays. `UpdateTools` rewrites its `tools` in place so a reconnect re-advertises
+        # whatever the session has revealed since. Empty when a connection is built without one, in
+        # which case a tool update only reaches the live socket.
+        self._session_config = session_config if session_config is not None else {}
         self._model_name = model_name
         self._model_name_getter = model_name_getter
         # `dial` re-establishes a fully configured connection; with a `reconnect` policy it is used to
@@ -431,12 +438,54 @@ class OpenAIRealtimeConnection(RealtimeConnection):
     def input_transcription_enabled(self) -> bool:
         return self._input_transcription_enabled
 
+    def _apply_tool_update(self, tools: Sequence[ToolDefinition]) -> dict[str, Any]:
+        """Adopt `tools` as the session's advertised list, returning the frame that re-advertises it."""
+        payload = [tool_def_to_openai(tool) for tool in tools]
+        # Written back into the captured config so a re-dial's `session.update` advertises the
+        # revealed tools too, instead of resuming the call with the connect-time list.
+        self._session_config['tools'] = payload
+        session: dict[str, Any] = {'tools': payload}
+        # Only the tools are re-sent: OpenAI rejects an update that repeats settled audio
+        # configuration (e.g. `audio.output.voice`) once the model has produced audio. The GA shape
+        # still requires its `type` discriminator; Azure Voice Live's beta config has none.
+        if (session_type := self._session_config.get('type')) is not None:
+            session['type'] = session_type
+        return {'type': SESSION_UPDATE_EVENT, 'session': session}
+
+    async def _send_tool_result(self, content: ToolResult) -> None:
+        """Send a settled tool call's result, plus any follow-up content, and ask for the answer."""
+        # Normalize any follow-up content (downloading and re-encoding media) before the first
+        # frame goes out, so content this provider can't carry fails with nothing sent rather than
+        # leaving the result on the wire without the material that explains it.
+        item = (
+            await user_message_item(
+                content.content,
+                provider_name=self._provider_name,
+                supports_images=self._supports_tool_result_images,
+            )
+            if content.content
+            else None
+        )
+        await self._send_event(
+            {
+                'type': CONVERSATION_ITEM_CREATE_EVENT,
+                'item': {
+                    'type': 'function_call_output',
+                    'call_id': content.tool_call_id,
+                    'output': content.output,
+                },
+            }
+        )
+        if item:
+            await self._send_event({'type': CONVERSATION_ITEM_CREATE_EVENT, 'item': item})
+        await self._request_response()
+
     async def send(self, content: RealtimeInput) -> None:
         """Send content to the OpenAI Realtime API.
 
         Accepts `BinaryAudio` (raw PCM16, 24kHz, mono), a `str` text turn, `BinaryImage`,
-        `ToolResult`, and the control verbs `CommitAudio`, `ClearAudio`, `CreateResponse`,
-        `CancelResponse`, and `TruncateOutput`.
+        `ToolResult`, `UpdateTools`, and the control verbs `CommitAudio`, `ClearAudio`,
+        `CreateResponse`, `CancelResponse`, and `TruncateOutput`.
         """
         if isinstance(content, BinaryAudio):
             require_pcm_audio(content, provider_name=self._provider_label)
@@ -459,31 +508,7 @@ class OpenAIRealtimeConnection(RealtimeConnection):
             )
             await self._request_response()
         elif isinstance(content, ToolResult):
-            # Normalize any follow-up content (downloading and re-encoding media) before the first
-            # frame goes out, so content this provider can't carry fails with nothing sent rather than
-            # leaving the result on the wire without the material that explains it.
-            item = (
-                await user_message_item(
-                    content.content,
-                    provider_name=self._provider_name,
-                    supports_images=self._supports_tool_result_images,
-                )
-                if content.content
-                else None
-            )
-            await self._send_event(
-                {
-                    'type': CONVERSATION_ITEM_CREATE_EVENT,
-                    'item': {
-                        'type': 'function_call_output',
-                        'call_id': content.tool_call_id,
-                        'output': content.output,
-                    },
-                }
-            )
-            if item:
-                await self._send_event({'type': CONVERSATION_ITEM_CREATE_EVENT, 'item': item})
-            await self._request_response()
+            await self._send_tool_result(content)
         elif isinstance(content, BinaryImage):
             # An image is added as conversation context (like a video frame), not a turn of its own,
             # so it doesn't trigger a response — drive that with audio (VAD) or `CreateResponse`.
@@ -498,6 +523,10 @@ class OpenAIRealtimeConnection(RealtimeConnection):
                     },
                 }
             )
+        elif isinstance(content, UpdateTools):
+            # No wait for the `session.updated` ack: the pump owns the socket reads mid-session, and
+            # WebSocket ordering already guarantees the server applies this before any later frame.
+            await self._send_event(self._apply_tool_update(content.tools))
         elif isinstance(content, CommitAudio):
             await self._send_event({'type': INPUT_AUDIO_BUFFER_COMMIT_EVENT})
         elif isinstance(content, ClearAudio):
@@ -1166,6 +1195,7 @@ class OpenAIRealtimeModel(RealtimeModel):
                 model_name=server_model,
                 model_name_getter=lambda: server_model,
                 observes_output_audio=False,
+                session_config=session_config,
             )
         finally:
             if cm is not None:  # pragma: no branch
@@ -1249,6 +1279,7 @@ class OpenAIRealtimeModel(RealtimeModel):
                 input_transcription_enabled=transcription_enabled,
                 model_name=server_model,
                 model_name_getter=model_name_getter,
+                session_config=session_config,
             )
 
         async with connect_openai_protocol(

--- a/pydantic_ai_slim/pydantic_ai/realtime/profiles.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/profiles.py
@@ -84,6 +84,16 @@ class RealtimeModelProfile(TypedDict, total=False):
     (Gemini Live's function-declaration `response` schema). Where it can't, a tool that opted in via
     `include_return_schema` gets the schema injected into its description instead, exactly as on a
     standard [`Model`][pydantic_ai.models.Model]."""
+    supports_tool_updates: bool
+    """Whether the model accepts a new tool list mid-session, so tools can be revealed after connect.
+
+    The OpenAI-protocol GA providers (OpenAI, Azure OpenAI) take a `session.update` carrying a fresh
+    `tools` array; Gemini Live fixes its tools at `setup`, and xAI Grok Voice is unverified. When
+    `False` (the default), a session's advertised tools are whatever it connected with, so
+    [`Agent.realtime`][pydantic_ai.agent.AbstractAgent.realtime] rejects a `defer_loading=True`
+    capability that contributes tools before connecting rather than letting a load deliver less than
+    it promised. A capability already loaded in a seeded `message_history` needs no update and is
+    accepted either way."""
     supported_native_tools: frozenset[type[AbstractNativeTool]]
     """The [native tools][pydantic_ai.native_tools.AbstractNativeTool] the model runs server-side, e.g.
     [`WebSearchTool`][pydantic_ai.native_tools.WebSearchTool].
@@ -130,6 +140,7 @@ DEFAULT_REALTIME_PROFILE: RealtimeModelProfile = {
     'supports_seeding_audio': False,
     'supports_async_tool_calls': False,
     'supports_tool_return_schema': False,
+    'supports_tool_updates': False,
     'supported_native_tools': frozenset(),
     'emits_input_speech_events': False,
     'audio_input_sample_rate': DEFAULT_AUDIO_SAMPLE_RATE,

--- a/pydantic_ai_slim/pydantic_ai/realtime/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/xai.py
@@ -259,6 +259,7 @@ class XaiRealtimeConnection(OpenAIRealtimeConnection):
         model_name_getter: Callable[[], str | None] | None = None,
         conversation_id: str | None = None,
         replayed_items: list[ConversationItemCreated] | None = None,
+        session_config: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
             ws,
@@ -267,6 +268,7 @@ class XaiRealtimeConnection(OpenAIRealtimeConnection):
             input_transcription_enabled=input_transcription_enabled,
             model_name=model_name,
             model_name_getter=model_name_getter,
+            session_config=session_config,
         )
         self._restores_state_on_reconnect = True
         self._conversation_id = conversation_id
@@ -531,6 +533,7 @@ class XaiRealtimeModel(RealtimeModel):
                 model_name_getter=model_name_getter,
                 conversation_id=conversation_id,
                 replayed_items=replayed_items,
+                session_config=session_config,
             )
             return connection
 

--- a/tests/realtime/test_azure.py
+++ b/tests/realtime/test_azure.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations as _annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import pytest
+from inline_snapshot import snapshot
 
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.tools import ToolDefinition
 
 from ..conftest import try_import
 
 with try_import() as imports_successful:
+    import websockets
     from openai.types.realtime.realtime_audio_config_output import VoiceID
 
     from pydantic_ai.providers.azure import AzureProvider
@@ -28,7 +32,7 @@ with try_import() as imports_successful:
         _default_azure_realtime_apis,  # pyright: ignore[reportPrivateUsage]
         _map_voice_live_event,  # pyright: ignore[reportPrivateUsage]
     )
-    from pydantic_ai.realtime.codec import OutputTranscript
+    from pydantic_ai.realtime.codec import OutputTranscript, UpdateTools
 
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='openai / websockets not installed')
 
@@ -133,6 +137,36 @@ def test_azure_realtime_api_routing(model_name: str, azure_voice_live: bool | No
     else:
         url = model._realtime_url(settings)  # pyright: ignore[reportPrivateUsage]
         assert ('/voice-live/realtime' in url) == (expected == 'voice_live')
+
+
+@pytest.mark.anyio
+async def test_voice_live_update_tools_omits_the_ga_type_discriminator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-session tool update matches the session config the connection was opened with.
+
+    Azure inherits `supports_tool_updates` from the OpenAI realtime profile, but Voice Live's beta
+    session object has no `type` discriminator — sending the GA one would make the update reject.
+    """
+    from .test_openai import FakeConnect, FakeWebSocket
+
+    ws = FakeWebSocket(
+        [json.dumps({'type': 'session.created', 'session': {}}), json.dumps({'type': 'session.updated'})]
+    )
+    monkeypatch.setattr(websockets, 'connect', FakeConnect(ws))
+    settings = AzureRealtimeModelSettings(azure_voice_live=True)
+    model = AzureRealtimeModel('gpt-realtime', provider=_azure_provider(), settings=settings)
+    assert model.profile.get('supports_tool_updates') is True
+
+    async with model.connect(
+        messages=[], model_settings=None, model_request_parameters=ModelRequestParameters()
+    ) as conn:
+        await conn.send(UpdateTools(tools=[ToolDefinition(name='forecast', parameters_json_schema={'type': 'object'})]))
+
+    assert json.loads(ws.sent[-1]) == snapshot(
+        {
+            'type': 'session.update',
+            'session': {'tools': [{'type': 'function', 'name': 'forecast', 'parameters': {'type': 'object'}}]},
+        }
+    )
 
 
 def test_azure_realtime_profile_override_routes_unconventional_deployment() -> None:

--- a/tests/realtime/test_azure_voice_live_ws.py
+++ b/tests/realtime/test_azure_voice_live_ws.py
@@ -189,6 +189,7 @@ async def test_audio_in_server_vad_turn(
         # Voice Live's session config takes `modalities: ['text']`, so text output is supported.
         supports_text_output=True,
         supports_tool_return_schema=False,  # no native surface; opted-in schemas go into descriptions
+        supports_tool_updates=True,  # inherited from the OpenAI realtime profile
         emits_input_speech_events=True,
         audio_input_sample_rate=24000,
         audio_output_sample_rate=24000,

--- a/tests/realtime/test_capabilities.py
+++ b/tests/realtime/test_capabilities.py
@@ -17,8 +17,14 @@ from contextlib import asynccontextmanager
 from dataclasses import replace
 
 import pytest
+from inline_snapshot import snapshot
 
 from pydantic_ai import Agent
+from pydantic_ai._deferred_capabilities import (
+    LoadCapabilityCallPart,
+    LoadCapabilityReturnPart,
+    parse_loaded_capabilities,
+)
 from pydantic_ai._instrumentation import get_instructions
 from pydantic_ai.capabilities import Hooks, NativeTool, ProcessEventStream, WebSearch
 from pydantic_ai.capabilities.abstract import AbstractCapability, WrapRunHandler
@@ -27,14 +33,18 @@ from pydantic_ai.messages import (
     AgentStreamEvent,
     FunctionToolResultEvent,
     ModelMessage,
+    ModelRequest,
     ModelResponse,
     PartDeltaEvent,
     PartStartEvent,
+    RetryPromptPart,
     SpeechPart,
     SpeechPartDelta,
+    ToolAvailabilityDeltaPart,
     ToolCallPart,
     ToolReturn,
     ToolReturnPart,
+    UserPromptPart,
 )
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.test import TestModel
@@ -54,11 +64,15 @@ from pydantic_ai.realtime.codec import (
     RealtimeInput,
     ResponseDone,
     ToolCall,
+    ToolResult,
+    UpdateTools,
 )
 from pydantic_ai.run import AgentRunResult
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.toolsets import FunctionToolset
+
+from ..conftest import IsDatetime
 
 pytestmark = pytest.mark.anyio
 
@@ -86,11 +100,15 @@ class _RecordingModel(RealtimeModel):
         *,
         settings: RealtimeModelSettings | None = None,
         supported_native_tools: frozenset[type[AbstractNativeTool]] = frozenset(),
+        supports_tool_updates: bool = False,
         connection_events: Sequence[RealtimeCodecEvent] = (ResponseDone(),),
+        connection: RealtimeConnection | None = None,
     ) -> None:
         self.settings = settings
         self._supported = supported_native_tools
+        self._supports_tool_updates = supports_tool_updates
         self._connection_events = connection_events
+        self.connection = connection
         self.instructions: str | None = None
         self.tools: list[ToolDefinition] | None = None
         self.native_tools: list[AbstractNativeTool] | None = None
@@ -112,6 +130,7 @@ class _RecordingModel(RealtimeModel):
             supports_interruption=True,
             supports_output_truncation=True,
             supports_session_seeding=True,
+            supports_tool_updates=self._supports_tool_updates,
             supported_native_tools=self._supported,
         )
 
@@ -127,7 +146,9 @@ class _RecordingModel(RealtimeModel):
         self.tools = model_request_parameters.function_tools
         self.native_tools = model_request_parameters.native_tools
         self.model_settings = model_settings
-        yield _Connection(self._connection_events)
+        if self.connection is None:
+            self.connection = _Connection(self._connection_events)
+        yield self.connection
 
 
 async def _drain(agent: Agent[None, str], model: _RecordingModel, **kwargs: object) -> list[RealtimeEvent]:
@@ -232,39 +253,241 @@ async def test_capability_toolset_reaches_session() -> None:
     assert any(t.name == 'greet' for t in model.tools)
 
 
-@pytest.mark.parametrize('contribution', ['tools', 'native_tools'])
-async def test_deferred_capability_with_tools_raises_before_connect(contribution: str) -> None:
-    """A deferred capability whose loading would have to reveal tools fails at session open.
-
-    A session's tools are fixed when the connection opens, so a mid-session load could never make
-    them available — silently loading less than promised is worse than the up-front error.
-    """
+def _weather_toolset() -> FunctionToolset[None]:
     toolset = FunctionToolset[None]()
 
     @toolset.tool_plain
-    def greet() -> str:  # pragma: no cover — the session raises before any tool can run
-        return 'Hello!'
+    def forecast(city: str) -> str:
+        return f'Sunny in {city}.'
+
+    return toolset
+
+
+class _Weather(AbstractCapability[None]):
+    """A deferred capability that contributes one tool, revealed when it loads."""
+
+    id = 'weather'
+    defer_loading = True
+
+    def get_description(self) -> str:
+        return 'Look up the weather.'
+
+    def get_instructions(self) -> str | None:
+        return 'Answer weather questions from the forecast tool.'
+
+    def get_toolset(self) -> FunctionToolset[None]:
+        return _weather_toolset()
+
+
+class _ScriptedConnection(RealtimeConnection):
+    """Replays turns, holding each one back until the session has answered the previous tool call.
+
+    A real provider only speaks again once it has the tool result, and the reveal under test depends
+    on that ordering: the follow-up call must be dispatched against the tool list the load produced.
+    """
+
+    def __init__(self, turns: Sequence[Sequence[RealtimeCodecEvent]]) -> None:
+        self._turns = turns
+        self.sent: list[RealtimeInput] = []
+        self._answered = asyncio.Event()
+
+    async def send(self, content: RealtimeInput) -> None:
+        self.sent.append(content)
+        if isinstance(content, ToolResult):
+            self._answered.set()
+
+    async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+        for index, turn in enumerate(self._turns):
+            if index:
+                await self._answered.wait()
+                self._answered.clear()
+            for event in turn:
+                yield event
+
+
+@pytest.mark.parametrize('supports_tool_updates', [False, True])
+async def test_deferred_capability_with_native_tools_raises_before_connect(supports_tool_updates: bool) -> None:
+    """A deferred capability contributing *native* tools fails at session open on every provider.
+
+    Re-advertising function tools is what `supports_tool_updates` buys; no realtime provider can turn
+    on a server-side native tool mid-conversation, so the flag makes no difference here.
+    """
 
     class DeferredCap(AbstractCapability[None]):
         id = 'deferred'
         defer_loading = True
 
-        def get_toolset(self) -> FunctionToolset[None] | None:
-            return toolset if contribution == 'tools' else None
-
         def get_native_tools(self) -> Sequence[AbstractNativeTool]:
-            return [WebSearchTool()] if contribution == 'native_tools' else []
+            return [WebSearchTool()]
 
     agent = Agent()
-    model = _RecordingModel(supported_native_tools=frozenset({WebSearchTool}))
+    model = _RecordingModel(
+        supported_native_tools=frozenset({WebSearchTool}), supports_tool_updates=supports_tool_updates
+    )
 
     with pytest.raises(
         UserError,
-        match=r"Realtime sessions cannot reveal tools mid-session.*'deferred'",
+        match=r"Realtime sessions cannot reveal native tools mid-session.*'deferred'",
     ):
         await _drain(agent, model, capabilities=[DeferredCap()])
 
     assert model.tools is None
+
+
+async def test_deferred_capability_with_tools_raises_when_the_model_cannot_update_tools() -> None:
+    """A tool-contributing deferred capability fails at open on a model that fixes tools at connect.
+
+    Loading it would advertise nothing new, so the model would be told a capability is active while
+    the tools it promised stay invisible — worse than the up-front error.
+    """
+    agent = Agent()
+    model = _RecordingModel()
+
+    with pytest.raises(
+        UserError,
+        match=r"does not support updating tools mid-session.*'weather'",
+    ):
+        await _drain(agent, model, capabilities=[_Weather()])
+
+    assert model.tools is None
+
+
+async def test_deferred_capability_tools_are_revealed_by_a_mid_session_update() -> None:
+    """On a `supports_tool_updates` model, loading a deferred capability advertises its tools.
+
+    The connect-time list holds `load_capability` and not the capability's own tools; the load sends
+    a re-advertisement carrying them, ahead of the tool result that announces the load, so the model
+    can never learn of the capability before its tools exist. The revealed tool is then callable, and
+    the reveal is recorded in history the way a graph run records it.
+    """
+    connection = _ScriptedConnection(
+        [
+            [ToolCall(tool_call_id='tc_1', tool_name='load_capability', args='{"id": "weather"}')],
+            [ToolCall(tool_call_id='tc_2', tool_name='forecast', args='{"city": "Lisbon"}'), ResponseDone()],
+        ]
+    )
+    agent = Agent()
+    model = _RecordingModel(supports_tool_updates=True, connection=connection)
+
+    events: list[RealtimeEvent] = []
+    async with agent.realtime(model, capabilities=[_Weather()]).session() as session:  # type: ignore[arg-type]
+        async for event in session:  # pragma: no branch
+            events.append(event)
+
+    assert model.tools is not None
+    assert [tool.name for tool in model.tools] == ['load_capability']
+
+    update, load_result, forecast_result = connection.sent
+    assert isinstance(update, UpdateTools)
+    assert [tool.name for tool in update.tools] == ['load_capability', 'forecast']
+    assert isinstance(load_result, ToolResult) and load_result.tool_call_id == 'tc_1'
+    assert isinstance(forecast_result, ToolResult) and forecast_result.output == 'Sunny in Lisbon.'
+
+    results = [e.part for e in events if isinstance(e, FunctionToolResultEvent)]
+    assert [(part.tool_name, part.content) for part in results] == snapshot(
+        [
+            ('load_capability', {'instructions': 'Answer weather questions from the forecast tool.'}),
+            ('forecast', 'Sunny in Lisbon.'),
+        ]
+    )
+
+    history = session.all_messages()
+    assert parse_loaded_capabilities(history) == {'weather'}
+    assert [
+        part
+        for message in history
+        for part in message.parts
+        if isinstance(part, (LoadCapabilityCallPart, LoadCapabilityReturnPart, ToolAvailabilityDeltaPart))
+    ] == snapshot(
+        [
+            LoadCapabilityCallPart(args='{"id": "weather"}', tool_call_id='tc_1'),
+            LoadCapabilityReturnPart(
+                content={'instructions': 'Answer weather questions from the forecast tool.'},
+                tool_call_id='tc_1',
+                timestamp=IsDatetime(),
+            ),
+            ToolAvailabilityDeltaPart(tools_added=['forecast'], tool_call_id='tc_1'),
+        ]
+    )
+
+
+async def test_seeded_history_advertises_a_loaded_capabilitys_tools_at_connect() -> None:
+    """A capability the seeded history already loaded needs no mid-session update, on any provider.
+
+    Its tools go out with the connect-time list, so this works on a model that fixes its tools at
+    connect (`supports_tool_updates` off) — the guard that rejects a tool-contributing deferred
+    capability exempts an already-loaded one. Loading it again is refused as already available.
+    """
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="What's the weather?")]),
+        ModelResponse(parts=[LoadCapabilityCallPart(args={'id': 'weather'}, tool_call_id='tc_0')]),
+        ModelRequest(
+            parts=[
+                LoadCapabilityReturnPart(content={'instructions': 'Use it.'}, tool_call_id='tc_0'),
+                ToolAvailabilityDeltaPart(tools_added=['forecast'], tool_call_id='tc_0'),
+            ]
+        ),
+    ]
+    agent = Agent()
+    model = _RecordingModel(
+        connection_events=[
+            ToolCall(tool_call_id='tc_1', tool_name='load_capability', args='{"id": "weather"}'),
+            ResponseDone(),
+        ],
+    )
+    events = await _drain(agent, model, capabilities=[_Weather()], message_history=history)
+
+    assert model.tools is not None
+    assert [tool.name for tool in model.tools] == ['load_capability', 'forecast']
+    assert model.connection is not None
+    assert not any(isinstance(frame, UpdateTools) for frame in model.connection.sent)  # type: ignore[attr-defined]
+
+    retry = next(e.part for e in events if isinstance(e, FunctionToolResultEvent))
+    assert isinstance(retry, RetryPromptPart)
+    assert retry.content == snapshot(
+        "Capability 'weather' is already available. Use its existing instructions and any tools it "
+        'provides; do not call `load_capability` for it again.'
+    )
+
+
+async def test_seeded_history_advertises_an_already_revealed_deferred_tool_at_connect() -> None:
+    """A plain `defer_loading=True` tool the seeded history already revealed advertises at connect.
+
+    The session has no tool-search surface to reveal one *during* the call, which is why an unrevealed
+    deferred tool is refused — but a history that already carries its
+    `ToolAvailabilityDeltaPart` resolves it to visible, so there is nothing left to reveal and nothing
+    to refuse. Works on a model that fixes its tools at connect (`supports_tool_updates` off).
+
+    The local `search_tools` fallback rides along, because a deferred tool exists to build a corpus
+    from. It is inert here rather than a dead end: this state is only reachable when *every* deferred
+    tool is already revealed (an unrevealed one still fails the guard), so a search can only ever name
+    tools the model can already see, which the session recognizes as a no-op reveal.
+    """
+    agent: Agent[None, str] = Agent()
+
+    @agent.tool_plain
+    def unlock() -> ToolReturn[str]:  # pragma: no cover — only its recorded history is replayed here
+        return ToolReturn(return_value='unlocked', tools=['withheld_tool'])
+
+    @agent.tool_plain(defer_loading=True)
+    def withheld_tool() -> str:  # pragma: no cover — the model never calls it in this test
+        return 'withheld'
+
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='unlock the extras')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='unlock', args='{}', tool_call_id='tc_0')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='unlock', content='unlocked', tool_call_id='tc_0'),
+                ToolAvailabilityDeltaPart(tools_added=['withheld_tool'], tool_call_id='tc_0'),
+            ]
+        ),
+    ]
+    model = _RecordingModel()
+    await _drain(agent, model, message_history=history)
+
+    assert model.tools is not None
+    assert sorted(tool.name for tool in model.tools) == snapshot(['search_tools', 'unlock', 'withheld_tool'])
 
 
 async def test_deferred_instruction_capability_loads_through_the_tool() -> None:
@@ -913,12 +1136,13 @@ async def test_external_cancellation_keeps_its_type_and_settles_history() -> Non
     assert any(isinstance(part, SpeechPart) and part.transcript == 'cut off mid-' for part in response.parts)
 
 
-async def test_agent_realtime_session_rejects_a_deferred_tool() -> None:
-    # A `defer_loading=True` tool is hidden until tool search reveals it, which a session whose tools
-    # are fixed at connect can never do. Advertising it silently would hand the model a `search_tools`
-    # affordance that finds the tool and then can't have it — a dead end — so the session refuses to
-    # open, exactly as it does for a deferred *capability* that contributes tools. The guard fires
-    # before any dial, so no provider is involved.
+@pytest.mark.parametrize('supports_tool_updates', [False, True])
+async def test_agent_realtime_session_rejects_a_deferred_tool(supports_tool_updates: bool) -> None:
+    # A `defer_loading=True` tool that no capability owns is hidden until tool *search* reveals it,
+    # and a session drops the optional `ToolSearchTool`. Advertising it silently would hand the model
+    # a `search_tools` affordance that finds the tool and then can't have it — a dead end. Being able
+    # to re-advertise tools mid-session doesn't help: nothing in a session would ever trigger the
+    # reveal. The guard fires before any dial, so no provider is involved.
     agent: Agent[None, str] = Agent()
 
     @agent.tool_plain(defer_loading=True)
@@ -927,42 +1151,119 @@ async def test_agent_realtime_session_rejects_a_deferred_tool() -> None:
 
     with pytest.raises(
         UserError,
-        match=r'cannot reveal tools mid-session.*`defer_loading=True`.*"?\'withheld_tool\'"?',
+        match=r'no tool-search surface.*`defer_loading=True`.*"?\'withheld_tool\'"?',
     ):
-        async with agent.realtime(_RecordingModel()).session():
+        async with agent.realtime(_RecordingModel(supports_tool_updates=supports_tool_updates)).session():
             pass  # pragma: no cover
 
 
-async def test_session_tool_reveal_is_a_no_op_like_a_standard_run() -> None:
+async def test_session_reveal_of_an_unloaded_capabilitys_tool_ends_the_session() -> None:
+    """An ordinary tool revealing a still-unloaded capability's tool ends the session, as it ends a run.
+
+    `ToolReturn.tools` may not smuggle a capability's tool past `load_capability` — the load is what
+    activates the bundle's instructions and hooks. The graph raises the same `UserError` out of the
+    run; here it surfaces through the session's event stream and the conversation stops.
+
+    Reachable only now that a session can hold a tool-contributing deferred capability at all, and
+    pinned rather than endorsed: whether a developer-error reveal should be allowed to end a live
+    voice call is a maintainer question, flagged on the PR.
+    """
+    agent: Agent[None, str] = Agent()
+
+    @agent.tool_plain
+    def sneaky() -> ToolReturn[str]:
+        return ToolReturn(return_value='done', tools=['forecast'])
+
+    model = _RecordingModel(
+        supports_tool_updates=True,
+        connection_events=[
+            ToolCall(tool_call_id='tc_1', tool_name='sneaky', args='{}'),
+            ResponseDone(),
+        ],
+    )
+
+    with pytest.raises(
+        UserError,
+        match=r"`ToolReturn.tools` cannot reveal 'forecast'.*belongs to capability 'weather'",
+    ):
+        await _drain(agent, model, capabilities=[_Weather()])
+
+    assert model.connection is not None
+    # The refusal happens before anything is sent, so the model never hears about the reveal.
+    assert not any(isinstance(frame, UpdateTools) for frame in model.connection.sent)  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize('supports_tool_updates', [False, True])
+async def test_agent_realtime_session_rejects_an_always_on_capabilitys_deferred_tool(
+    supports_tool_updates: bool,
+) -> None:
+    # `defer_loading=True` on a tool inside an *always-on* capability is a tool-search gate, not a
+    # capability-load gate — nothing in a session would ever reveal it, so it is refused like any
+    # other search-gated tool. Only a tool a *deferred* capability gates has a reveal path.
+    toolset = FunctionToolset[None]()
+
+    @toolset.tool_plain(defer_loading=True)
+    def searchable() -> str:  # pragma: no cover — the session raises before any tool can run
+        return 'searchable'
+
+    class AlwaysOn(AbstractCapability[None]):
+        id = 'always_on'
+
+        def get_toolset(self) -> FunctionToolset[None]:
+            return toolset
+
+    agent = Agent()
+    model = _RecordingModel(supports_tool_updates=supports_tool_updates)
+
+    with pytest.raises(UserError, match=r"no tool-search surface.*'searchable'"):
+        await _drain(agent, model, capabilities=[AlwaysOn()])
+
+    assert model.tools is None
+
+
+@pytest.mark.parametrize('supports_tool_updates', [False, True])
+async def test_session_tool_reveal_is_a_no_op_like_a_standard_run(supports_tool_updates: bool) -> None:
     """`ToolReturn.tools` naming nothing revealable is a silent no-op, exactly as in a graph run.
 
     The graph rejects only a name owned by an unloaded capability and treats every other name — a
     typo, an already-visible tool — as a no-op (see `_reject_unloaded_capability_reveals`, and
-    `ToolAvailabilityDeltaPart`'s "silent no-op by design"). A session used to raise on *any* reveal,
-    which was both harsher than the graph and harsher than it needed to be: a session refuses
-    `defer_loading=True` tools and tool-contributing deferred capabilities when it opens, so it holds
-    nothing a reveal could have surfaced and nothing is lost by dropping the request.
+    `ToolAvailabilityDeltaPart`'s "silent no-op by design"). The session records the reveal in history
+    the same way, and nothing goes out on the wire either way: a model that can't re-advertise tools
+    never tries, and one that can finds the advertised list unchanged and sends nothing.
 
-    That also makes the unloaded-capability branch unreachable from a session — the capabilities that
-    own hidden tools are exactly the ones a session refuses at connect — so it is covered on the graph
-    side rather than here.
+    The repeated name pins the graph's call-level dedupe (`list(dict.fromkeys(tools))`): one name
+    reveals once, however many times a single result asks for it.
     """
     agent = Agent()
 
     @agent.tool_plain
     def revealer() -> ToolReturn[str]:
-        return ToolReturn(return_value='done', tools=['hidden_tool'])
+        return ToolReturn(return_value='done', tools=['hidden_tool', 'hidden_tool'])
 
     model = _RecordingModel(
+        supports_tool_updates=supports_tool_updates,
         connection_events=[
             ToolCall(tool_call_id='tc_1', tool_name='revealer', args='{}'),
             ResponseDone(),
         ],
     )
-    events = await _drain(agent, model)
+    events: list[RealtimeEvent] = []
+    async with agent.realtime(model).session() as session:
+        async for event in session:  # pragma: no branch
+            events.append(event)
+
+    assert model.connection is not None
+    assert not any(isinstance(frame, UpdateTools) for frame in model.connection.sent)  # type: ignore[attr-defined]
 
     # Reaching here at all is the point: the reveal no longer raises out of the session.
     result = next(e for e in events if isinstance(e, FunctionToolResultEvent))
     assert isinstance(result.part, ToolReturnPart)
     assert result.part.content == 'done'
     assert result.part.outcome == 'success'
+
+    assert [
+        part
+        for message in session.all_messages()
+        for part in message.parts
+        if isinstance(part, ToolAvailabilityDeltaPart)
+    ] == snapshot([ToolAvailabilityDeltaPart(tools_added=['hidden_tool'], tool_call_id='tc_1')])

--- a/tests/realtime/test_google_ws.py
+++ b/tests/realtime/test_google_ws.py
@@ -407,6 +407,7 @@ def test_profile_allow_seeding() -> None:
         supports_async_tool_calls=True,
         # Gemini Live renders an opted-in return schema natively (the declaration's `response`).
         supports_tool_return_schema=True,
+        supports_tool_updates=False,  # Gemini Live fixes the tool list at `setup`
         # Search grounding only: Live models reject or silently ignore code execution and URL context.
         supported_native_tools=frozenset({WebSearchTool}),
         # Gemini Live never reports user speech start/end; a UI must key off interruption events.

--- a/tests/realtime/test_openai.py
+++ b/tests/realtime/test_openai.py
@@ -86,6 +86,7 @@ from pydantic_ai.realtime.codec import (
     ToolCall,
     ToolResult,
     TruncateOutput,
+    UpdateTools,
 )
 from pydantic_ai.realtime.profiles import merge_realtime_profile
 from pydantic_ai.realtime.xai import map_conversation_event as _map_conversation_wire_event
@@ -932,6 +933,46 @@ async def test_connect_handshake_and_session_config(monkeypatch: pytest.MonkeyPa
     assert session['audio']['output']['voice'] == 'alloy'
     assert session['tools'][0]['name'] == 'get_weather'
     assert session['tools'][0]['type'] == 'function'
+
+
+@pytest.mark.anyio
+async def test_update_tools_re_advertises_only_the_tool_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-session `UpdateTools` sends the new `tools` plus the GA `type` discriminator, nothing else.
+
+    Re-sending the whole session config would repeat settled audio configuration, which the API
+    rejects once the model has produced audio. The server's `session.updated` acknowledgement carries
+    nothing a session needs, so it maps to no codec event instead of surfacing as an error — the
+    session never waits for it, and WebSocket ordering already guarantees the update lands first.
+    """
+    ws = FakeWebSocket([_created(), _updated(), _updated()])
+    monkeypatch.setattr(rt_openai.websockets, 'connect', FakeConnect(ws))
+    model = OpenAIRealtimeModel(
+        'gpt-realtime',
+        provider=OpenAIProvider(api_key='k'),
+        settings=rt_openai.OpenAIRealtimeModelSettings(openai_voice='alloy'),
+    )
+    forecast = ToolDefinition(name='forecast', description='Weather', parameters_json_schema={'type': 'object'})
+
+    async with _connect(model, 'Be nice') as conn:
+        await conn.send(UpdateTools(tools=[forecast]))
+        assert await collect_codec_events(conn) == []
+
+    assert json.loads(ws.sent[-1]) == snapshot(
+        {
+            'type': 'session.update',
+            'session': {
+                'tools': [
+                    {
+                        'type': 'function',
+                        'name': 'forecast',
+                        'parameters': {'type': 'object'},
+                        'description': 'Weather',
+                    }
+                ],
+                'type': 'realtime',
+            },
+        }
+    )
 
 
 @pytest.mark.anyio
@@ -2866,6 +2907,30 @@ async def test_connect_reconnect_closes_previous_connection(monkeypatch: pytest.
 
     assert events == [RealtimeSessionReconnectEvent(state_restored=False), OutputTranscript(text='hi', is_final=True)]
     assert connect.closed == [dropped, good]
+
+
+@pytest.mark.anyio
+async def test_update_tools_survives_a_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A re-dial re-advertises the revealed tools, not the list the session originally connected with.
+
+    The update is written back into the captured session config, which is what `dial()` replays — so
+    a dropped socket doesn't quietly take a loaded capability's tools away mid-call.
+    """
+    dropped = _DropAfterHandshake([_created(), _updated()])
+    good = FakeWebSocket([_created(), _updated()])
+    monkeypatch.setattr(rt_openai.websockets, 'connect', _RecordingConnect([dropped, good]))
+    model = OpenAIRealtimeModel('gpt-realtime', settings={'reconnect': {'base_delay': 0.0, 'max_attempts': 1}})
+    forecast = ToolDefinition(name='forecast', parameters_json_schema={'type': 'object'})
+
+    async with _connect(model, 'x') as conn:
+        await conn.send(UpdateTools(tools=[forecast]))
+        events = await collect_codec_events(conn)
+
+    assert events == [RealtimeSessionReconnectEvent(state_restored=False)]
+    # The connect-time config carried no tools at all, so this can only come from the update.
+    redial = json.loads(good.sent[0])
+    assert redial['type'] == 'session.update'
+    assert [tool['name'] for tool in redial['session']['tools']] == ['forecast']
 
 
 @pytest.mark.anyio

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -487,6 +487,7 @@ def test_profile_allow_seeding() -> None:
         supports_thinking=False,  # GA `gpt-realtime` is not a reasoning model
         supports_async_tool_calls=True,  # the realtime models keep talking through a tool call
         supports_tool_return_schema=False,  # no native surface; opted-in schemas go into descriptions
+        supports_tool_updates=True,  # `session.update` takes a fresh `tools` array mid-session
         supported_native_tools=frozenset(),
         emits_input_speech_events=True,
         audio_input_sample_rate=24000,

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -4794,11 +4794,15 @@ async def test_tool_completion_drains_messages_deferred_until_usage_arrives(monk
         response_usage_follows: bool,
         run_step: int,
         reserved_budget: bool,
-    ) -> tuple[ToolReturnPart, None]:
+    ) -> tuple[ToolReturnPart, None, list[str]]:
         del validation_done, execution_prerequisites, response_usage_follows
         del run_step, reserved_budget
         session._tool_calls_awaiting_usage.clear()  # pyright: ignore[reportPrivateUsage]
-        return ToolReturnPart(tool_name=call_part.tool_name, content='done', tool_call_id=call_part.tool_call_id), None
+        return (
+            ToolReturnPart(tool_name=call_part.tool_name, content='done', tool_call_id=call_part.tool_call_id),
+            None,
+            [],
+        )
 
     session._tool_calls_awaiting_usage.add('call')  # pyright: ignore[reportPrivateUsage]
     monkeypatch.setattr(session, '_execute_tool', complete_after_usage)
@@ -4845,11 +4849,15 @@ async def test_deferred_asap_drain_failure_after_tool_is_forwarded(monkeypatch: 
         response_usage_follows: bool,
         run_step: int,
         reserved_budget: bool,
-    ) -> tuple[ToolReturnPart, None]:
+    ) -> tuple[ToolReturnPart, None, list[str]]:
         del validation_done, execution_prerequisites, response_usage_follows
         del run_step, reserved_budget
         session._tool_calls_awaiting_usage.clear()  # pyright: ignore[reportPrivateUsage]
-        return ToolReturnPart(tool_name=call_part.tool_name, content='done', tool_call_id=call_part.tool_call_id), None
+        return (
+            ToolReturnPart(tool_name=call_part.tool_name, content='done', tool_call_id=call_part.tool_call_id),
+            None,
+            [],
+        )
 
     session._tool_calls_awaiting_usage.add('call')  # pyright: ignore[reportPrivateUsage]
     monkeypatch.setattr(session, '_execute_tool', complete_after_usage)

--- a/tests/realtime/test_xai.py
+++ b/tests/realtime/test_xai.py
@@ -279,6 +279,7 @@ def test_profile() -> None:
         supports_thinking=True,
         supports_async_tool_calls=False,
         supports_tool_return_schema=False,
+        supports_tool_updates=False,  # a second tools-bearing `session.update` is unverified on xAI
         emits_input_speech_events=True,
         audio_input_sample_rate=24000,
         audio_output_sample_rate=24000,

--- a/tests/realtime/test_xai_ws.py
+++ b/tests/realtime/test_xai_ws.py
@@ -510,6 +510,7 @@ def test_profile_allow_seeding() -> None:
         supports_thinking=True,
         supports_async_tool_calls=False,
         supports_tool_return_schema=False,
+        supports_tool_updates=False,  # a second tools-bearing `session.update` is unverified on xAI
         supported_native_tools=frozenset(),
         emits_input_speech_events=True,
         audio_input_sample_rate=24000,


### PR DESCRIPTION
- Closes #7191

## What this does

Until now, a realtime session advertised its tools exactly once, when the connection opened. That meant a `defer_loading=True` capability that contributes tools was rejected with a `UserError` before connecting: the model could have loaded the capability mid-call, but there was no way to hand it the tools, so it would have silently gotten less than the catalog promised.

OpenAI's Realtime API can lift that: `session.update` accepts a fresh `tools` array at any time. This PR uses it, gated on a new realtime profile flag:

- **New profile flag `supports_tool_updates`** — set for OpenAI and Azure OpenAI. Gemini Live fixes its tools in the `setup` message, so it keeps the up-front error. xAI reuses the OpenAI protocol but its server's behavior for a second tools-bearing `session.update` is unverified, so it stays off for now.
- **Mid-session reveal** — when the model calls `load_capability` on a supporting provider, the session recomputes the advertised tool list (the same resolution the connect path uses, shared in one helper so they can't drift) and sends it as a new codec input, `UpdateTools`, in the same locked send group as — and ahead of — the tool result. The model never hears "capability active" before the tools exist server-side.
- **Reconnects keep the revealed tools** — the update rewrites the connection's captured session config in place, so a redial re-advertises what the session had revealed, not the connect-time list.
- **Already-loaded capabilities need no update at all** — a session seeded with a `message_history` in which the capability was loaded (the load call/return plus its tool-reveal record) now advertises those tools at connect, on every provider including Gemini. Sessions also seed `loaded_capability_ids`/`discovered_tool_names` from history like a classic run, so `load_capability` now correctly refuses a redundant re-load instead of allowing unbounded ones.
- **History stays interchangeable with a classic run** — the session now promotes `load_capability` calls to `LoadCapabilityCallPart` and records reveals as `ToolAvailabilityDeltaPart`, exactly like the graph, so a session's history keeps working as `Agent.run(message_history=...)` input with the same reveal state, and vice versa.

## Example

```python
from pydantic_ai import Agent
from pydantic_ai.capabilities import Capability
from pydantic_ai.toolsets import FunctionToolset


async def check_availability(date: str) -> str: ...


reservations = Capability(
    id='reservations',
    description='Look up and book restaurant tables.',
    toolset=FunctionToolset(tools=[check_availability]),
    defer_loading=True,  # previously: UserError at session open
)

agent = Agent('openai:gpt-realtime', capabilities=[reservations])

async with agent.realtime().session() as session:
    async for event in session:
        ...
```

The session connects advertising only `load_capability` (plus any always-on tools). When the caller asks about booking a table, the model loads the `reservations` capability; the session sends `session.update` with `check_availability` included, then answers the load call, and the model can book from the next response on.

## Wire flow (OpenAI)

1. Connect: `session.update` advertises always-on tools + `load_capability`; the capability catalog is part of the instructions (unchanged).
2. Model emits a `load_capability` tool call.
3. Session executes it, which reveals the capability's tool names.
4. Session re-resolves the advertised list and sends `session.update` with the revealed tools appended — first frame in the send group.
5. Session sends the tool result (the capability's instructions) and requests a response — same send group, so nothing interleaves.
6. Next model turn can call the revealed tools; the session's per-turn tool refresh has marked the capability loaded from history, so the calls are accepted.
7. If the socket drops, the redial's `session.update` already contains the revealed tools (the captured config was updated in place at step 4).

## Deliberately out of scope / flags for review

- **Native tools stay rejected everywhere**: no realtime API turns a server-side tool on mid-session, so a deferred capability contributing native tools keeps the up-front error (now with its own accurate message).
- **xAI**: needs a live probe of a second tools-bearing `session.update` before flipping its flag; its connection now receives the session config so a user profile override behaves correctly across redials.
- **Plain `defer_loading=True` tools** (no owning capability) are still rejected at open — they're revealed by tool search, which a session has no surface for — unless the seeded history already revealed them, in which case they advertise at connect like everything else.
- **Question for @DouweM**: with capability tools now live in sessions, a *developer-error* reveal (an ordinary tool returning `ToolReturn.tools` naming a still-unloaded capability's tool) raises the same `UserError` as a graph run — but in a session that ends the live conversation. Pinned by a parity test as-is; happy to soften it to a failed tool return in a follow-up if you'd rather not kill a voice call over it.
- **Question for @DouweM (pre-existing, graph parity)**: `resolve_revealed_tool_names` filters history-discovered names but never *adds* a loaded capability's tools, so a history processor that drops the `ToolAvailabilityDeltaPart` while keeping the load leaves the capability loaded-but-toolless on any provider (graph runs behave identically; execution is resilient, advertisement is not). Worth deciding whether loading should imply the tools — separate PR if so.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

