### PR TITLE
Sort tool results ahead of tool availability announcements so Bedrock accepts turns revealing multiple tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2929,10 +2929,7 @@ def _merge_consecutive_messages(messages: list[_messages.ModelMessage]) -> list[
                 # turn -- a real regression -- just to preserve fields the model request node never reads.
             ):
                 parts = [*last_message.parts, *message.parts]
-                parts.sort(
-                    # Tool return parts always need to be at the start
-                    key=lambda x: 0 if isinstance(x, _messages.ToolReturnPart | _messages.RetryPromptPart) else 1
-                )
+                parts.sort(key=_messages._tool_results_first_sort_key)  # pyright: ignore[reportPrivateUsage]
                 merged_message = _messages.ModelRequest(
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2474,6 +2474,15 @@ ModelRequestPart = Annotated[
 """A message part sent by Pydantic AI to a model."""
 
 
+def _tool_results_first_sort_key(part: ModelRequestPart) -> int:  # pyright: ignore[reportUnusedFunction]
+    """Stable-sort key placing the parts that answer tool calls ahead of a request's other parts.
+
+    Providers such as Anthropic require every tool result answering an assistant turn to lead the
+    next message, ahead of any other content.
+    """
+    return 0 if isinstance(part, ToolReturnPart | RetryPromptPart) else 1
+
+
 def _model_response_part_discriminator(v: Any) -> str | None:
     """Callable discriminator for [`ModelResponsePart`][pydantic_ai.messages.ModelResponsePart].
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1982,7 +1982,7 @@ def _convert_speech_parts(messages: list[ModelMessage], *, include_audio: bool) 
     return new_messages
 
 
-def _standing_system_prompt_count(request: ModelRequest) -> int:
+def _standing_system_prompt_count(parts: Sequence[ModelRequestPart]) -> int:
     """How many of a request's opening parts belong to the run's standing system prompt.
 
     The standing prompt is authored before the run starts, so it is whatever `SystemPromptPart`s the
@@ -1995,7 +1995,7 @@ def _standing_system_prompt_count(request: ModelRequest) -> int:
     exists to avoid.
     """
     count = 0
-    for part in request.parts:
+    for part in parts:
         if not isinstance(part, SystemPromptPart):
             break
         count += 1
@@ -2079,7 +2079,7 @@ def _standing_prompt_request(prefix: list[ModelMessage], *, include_system_parts
     """
     first_request = next((m for m in prefix if isinstance(m, ModelRequest)), None)
     opening: Sequence[ModelRequestPart] = (
-        first_request.parts[: _standing_system_prompt_count(first_request)]
+        first_request.parts[: _standing_system_prompt_count(first_request.parts)]
         if first_request and include_system_parts
         else []
     )
@@ -2112,7 +2112,7 @@ def _wrap_non_leading_system_prompts(messages: list[ModelMessage]) -> list[Model
     new_messages: list[ModelMessage] = list(messages[:first_request_idx])
     changed = False
     for offset, msg in enumerate(messages[first_request_idx:]):
-        start = _standing_system_prompt_count(msg) if offset == 0 and isinstance(msg, ModelRequest) else 0
+        start = _standing_system_prompt_count(msg.parts) if offset == 0 and isinstance(msg, ModelRequest) else 0
         if isinstance(msg, ModelRequest) and any(isinstance(p, SystemPromptPart) for p in msg.parts[start:]):
             new_parts = [
                 UserPromptPart(content=f'<system>{part.content}</system>', timestamp=part.timestamp)
@@ -2333,13 +2333,14 @@ def _announce_tool_availability_delta_messages(
     # rendering is deterministic; no finer positional fidelity is required within one request.
     transformed: list[ModelMessage] = []
     changed = False
-    leading_request_pending = True
+    is_first_kept_request = True
     for message in messages:
-        if not isinstance(message, ModelRequest) or not any(
-            isinstance(part, ToolAvailabilityDeltaPart) for part in message.parts
-        ):
+        if not isinstance(message, ModelRequest):
             transformed.append(message)
-            leading_request_pending = leading_request_pending and not isinstance(message, ModelRequest)
+            continue
+        if not any(isinstance(part, ToolAvailabilityDeltaPart) for part in message.parts):
+            transformed.append(message)
+            is_first_kept_request = False
             continue
 
         changed = True
@@ -2359,16 +2360,16 @@ def _announce_tool_availability_delta_messages(
         # A request whose only part was an empty delta would otherwise reach the adapter with no
         # parts at all, which providers reject.
         if replacement_parts:
-            request = replace(message, parts=replacement_parts)
-            # The leading kept request's opening system run is the standing prompt the adapters
-            # hoist out of the message; it must keep its position rather than sort behind the tool
-            # results. Position in the output decides: a dropped empty-delta request ahead of this
-            # one passes the leading role along.
-            start = _standing_system_prompt_count(request) if leading_request_pending else 0
-            tail = sorted(replacement_parts[start:], key=_tool_results_first_sort_key)
-            replacement_parts[start:] = tail
-            transformed.append(request)
-            leading_request_pending = False
+            # Anthropic requires the tool results answering the previous turn to open the message,
+            # so the announcements sort to the back. One exception: system prompts opening the
+            # history's first request are the agent's standing prompt, which the adapters lift into
+            # the provider's dedicated system field based on exactly this position, so they stay at
+            # the front.
+            keep = _standing_system_prompt_count(replacement_parts) if is_first_kept_request else 0
+            head, tail = replacement_parts[:keep], replacement_parts[keep:]
+            tail.sort(key=_tool_results_first_sort_key)
+            transformed.append(replace(message, parts=[*head, *tail]))
+            is_first_kept_request = False
 
     return transformed if changed else messages
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -2317,10 +2317,10 @@ def _announce_tool_availability_delta_messages(
     * It had to fabricate a `tool_call_id`, and two deltas over the same tool names produced the same
       one — duplicate ids in a history that providers requiring uniqueness reject.
 
-    A `SystemPromptPart` also replaces the delta *in place*, where the pair had to be spliced across
-    two messages: the fabricated `ModelResponse` went in ahead of the rebuilt `ModelRequest`, so a
-    delta sharing a request with a user prompt put the assistant's turn before it and reordered the
-    conversation.
+    A `SystemPromptPart` also stays inside the delta's own message, where the pair had to be spliced
+    across two messages: the fabricated `ModelResponse` went in ahead of the rebuilt `ModelRequest`,
+    so a delta sharing a request with a user prompt put the assistant's turn before it and reordered
+    the conversation. Within that message the announcements render after the request's tool results.
 
     On a model that takes a mid-conversation system message this lands as a real one, carrying the
     operator authority the statement deserves; elsewhere `_wrap_non_leading_system_prompts` — which
@@ -2332,6 +2332,7 @@ def _announce_tool_availability_delta_messages(
     # rendering is deterministic; no finer positional fidelity is required within one request.
     transformed: list[ModelMessage] = []
     changed = False
+    first_request = next((message for message in messages if isinstance(message, ModelRequest)), None)
     for message in messages:
         if not isinstance(message, ModelRequest) or not any(
             isinstance(part, ToolAvailabilityDeltaPart) for part in message.parts
@@ -2356,7 +2357,16 @@ def _announce_tool_availability_delta_messages(
         # A request whose only part was an empty delta would otherwise reach the adapter with no
         # parts at all, which providers reject.
         if replacement_parts:
-            transformed.append(replace(message, parts=replacement_parts))
+            request = replace(message, parts=replacement_parts)
+            # The first request's opening system run is the standing prompt the adapters hoist out
+            # of the message; it must keep its position rather than sort behind the tool results.
+            start = _standing_system_prompt_count(request) if message is first_request else 0
+            tail = replacement_parts[start:]
+            tail.sort(
+                # Anthropic requires tool results to lead the message that answers a tool call
+                key=lambda p: 0 if isinstance(p, ToolReturnPart | RetryPromptPart) else 1
+            )
+            transformed.append(replace(request, parts=[*replacement_parts[:start], *tail]))
 
     return transformed if changed else messages
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -66,6 +66,7 @@ from ..messages import (
     UserPromptPart,
     VideoUrl,
     _compaction_part_is_wire_boundary,  # pyright: ignore[reportPrivateUsage]
+    _tool_results_first_sort_key,  # pyright: ignore[reportPrivateUsage]
 )
 from ..native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from ..native_tools._tool_search import TOOL_SEARCH_FUNCTION_TOOL_NAME, ToolSearchTool
@@ -2364,12 +2365,9 @@ def _announce_tool_availability_delta_messages(
             # results. Position in the output decides: a dropped empty-delta request ahead of this
             # one passes the leading role along.
             start = _standing_system_prompt_count(request) if leading_request_pending else 0
-            tail = replacement_parts[start:]
-            tail.sort(
-                # Anthropic requires tool results to lead the message that answers a tool call
-                key=lambda p: 0 if isinstance(p, ToolReturnPart | RetryPromptPart) else 1
-            )
-            transformed.append(replace(request, parts=[*replacement_parts[:start], *tail]))
+            tail = sorted(replacement_parts[start:], key=_tool_results_first_sort_key)
+            replacement_parts[start:] = tail
+            transformed.append(request)
             leading_request_pending = False
 
     return transformed if changed else messages

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -2332,12 +2332,13 @@ def _announce_tool_availability_delta_messages(
     # rendering is deterministic; no finer positional fidelity is required within one request.
     transformed: list[ModelMessage] = []
     changed = False
-    first_request = next((message for message in messages if isinstance(message, ModelRequest)), None)
+    leading_request_pending = True
     for message in messages:
         if not isinstance(message, ModelRequest) or not any(
             isinstance(part, ToolAvailabilityDeltaPart) for part in message.parts
         ):
             transformed.append(message)
+            leading_request_pending = leading_request_pending and not isinstance(message, ModelRequest)
             continue
 
         changed = True
@@ -2358,15 +2359,18 @@ def _announce_tool_availability_delta_messages(
         # parts at all, which providers reject.
         if replacement_parts:
             request = replace(message, parts=replacement_parts)
-            # The first request's opening system run is the standing prompt the adapters hoist out
-            # of the message; it must keep its position rather than sort behind the tool results.
-            start = _standing_system_prompt_count(request) if message is first_request else 0
+            # The leading kept request's opening system run is the standing prompt the adapters
+            # hoist out of the message; it must keep its position rather than sort behind the tool
+            # results. Position in the output decides: a dropped empty-delta request ahead of this
+            # one passes the leading role along.
+            start = _standing_system_prompt_count(request) if leading_request_pending else 0
             tail = replacement_parts[start:]
             tail.sort(
                 # Anthropic requires tool results to lead the message that answers a tool call
                 key=lambda p: 0 if isinstance(p, ToolReturnPart | RetryPromptPart) else 1
             )
             transformed.append(replace(request, parts=[*replacement_parts[:start], *tail]))
+            leading_request_pending = False
 
     return transformed if changed else messages
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1982,7 +1982,7 @@ def _convert_speech_parts(messages: list[ModelMessage], *, include_audio: bool) 
     return new_messages
 
 
-def _standing_system_prompt_count(parts: Sequence[ModelRequestPart]) -> int:
+def _standing_system_prompt_count(request: ModelRequest) -> int:
     """How many of a request's opening parts belong to the run's standing system prompt.
 
     The standing prompt is authored before the run starts, so it is whatever `SystemPromptPart`s the
@@ -1995,7 +1995,7 @@ def _standing_system_prompt_count(parts: Sequence[ModelRequestPart]) -> int:
     exists to avoid.
     """
     count = 0
-    for part in parts:
+    for part in request.parts:
         if not isinstance(part, SystemPromptPart):
             break
         count += 1
@@ -2079,7 +2079,7 @@ def _standing_prompt_request(prefix: list[ModelMessage], *, include_system_parts
     """
     first_request = next((m for m in prefix if isinstance(m, ModelRequest)), None)
     opening: Sequence[ModelRequestPart] = (
-        first_request.parts[: _standing_system_prompt_count(first_request.parts)]
+        first_request.parts[: _standing_system_prompt_count(first_request)]
         if first_request and include_system_parts
         else []
     )
@@ -2112,7 +2112,7 @@ def _wrap_non_leading_system_prompts(messages: list[ModelMessage]) -> list[Model
     new_messages: list[ModelMessage] = list(messages[:first_request_idx])
     changed = False
     for offset, msg in enumerate(messages[first_request_idx:]):
-        start = _standing_system_prompt_count(msg.parts) if offset == 0 and isinstance(msg, ModelRequest) else 0
+        start = _standing_system_prompt_count(msg) if offset == 0 and isinstance(msg, ModelRequest) else 0
         if isinstance(msg, ModelRequest) and any(isinstance(p, SystemPromptPart) for p in msg.parts[start:]):
             new_parts = [
                 UserPromptPart(content=f'<system>{part.content}</system>', timestamp=part.timestamp)
@@ -2365,10 +2365,11 @@ def _announce_tool_availability_delta_messages(
             # history's first request are the agent's standing prompt, which the adapters lift into
             # the provider's dedicated system field based on exactly this position, so they stay at
             # the front.
-            keep = _standing_system_prompt_count(replacement_parts) if is_first_kept_request else 0
+            request = replace(message, parts=replacement_parts)
+            keep = _standing_system_prompt_count(request) if is_first_kept_request else 0
             head, tail = replacement_parts[:keep], replacement_parts[keep:]
             tail.sort(key=_tool_results_first_sort_key)
-            transformed.append(replace(message, parts=[*head, *tail]))
+            transformed.append(replace(request, parts=[*head, *tail]))
             is_first_kept_request = False
 
     return transformed if changed else messages

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1698,7 +1698,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         tool_defs_by_name = {tool.name: tool for tool in model_request_parameters.function_tools}
         for m in messages:
             if isinstance(m, ModelRequest):
-                standing_prompt_count = _standing_system_prompt_count(m.parts) if m is leading_request else 0
+                standing_prompt_count = _standing_system_prompt_count(m) if m is leading_request else 0
                 user_content_params: list[BetaContentBlockParam] = []
                 mid_conversation_system_prompts: list[str] = []
                 tool_availability_blocks: list[dict[str, Any]] = []

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1698,7 +1698,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         tool_defs_by_name = {tool.name: tool for tool in model_request_parameters.function_tools}
         for m in messages:
             if isinstance(m, ModelRequest):
-                standing_prompt_count = _standing_system_prompt_count(m) if m is leading_request else 0
+                standing_prompt_count = _standing_system_prompt_count(m.parts) if m is leading_request else 0
                 user_content_params: list[BetaContentBlockParam] = []
                 mid_conversation_system_prompts: list[str] = []
                 tool_availability_blocks: list[dict[str, Any]] = []

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -3415,6 +3415,49 @@ async def test_bedrock_delta_renders_announcement_and_plain_tool_spec(
     assert 'defer_loading' not in json.dumps(request['toolConfig'])
 
 
+async def test_bedrock_tool_results_lead_multi_reveal_turn(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """Two tools revealed in one turn keep every `toolResult` block ahead of the announcement text."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    tools = [
+        ToolDefinition(name='first_tool', defer_loading=True),
+        ToolDefinition(name='second_tool', defer_loading=True),
+    ]
+    parameters = ModelRequestParameters(function_tools=tools, revealed_tool_names={tool.name for tool in tools})
+    settings, parameters = model.prepare_request(None, parameters)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='start')]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='load_capability', args={'id': 'first'}, tool_call_id='tooluse_1'),
+                ToolCallPart(tool_name='load_capability', args={'id': 'second'}, tool_call_id='tooluse_2'),
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='load_capability', content='loaded', tool_call_id='tooluse_1'),
+                ToolAvailabilityDeltaPart(tools_added=['first_tool']),
+                ToolReturnPart(tool_name='load_capability', content='loaded', tool_call_id='tooluse_2'),
+                ToolAvailabilityDeltaPart(tools_added=['second_tool']),
+            ]
+        ),
+    ]
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'ok'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await model.request(model.prepare_messages(history, parameters), settings, parameters)
+
+    *_, last_message = mock_converse.call_args.kwargs['messages']
+    assert [next(iter(block)) for block in last_message['content']] == ['toolResult', 'toolResult', 'text', 'text']
+    assert [block['toolResult']['toolUseId'] for block in last_message['content'][:2]] == ['tooluse_1', 'tooluse_2']
+
+
 async def test_bedrock_sanitize_tool_name_in_history(bedrock_provider: BedrockProvider):
     """Hallucinated tool names with invalid chars (e.g. dots) are sanitized when replayed to Bedrock."""
     model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)

--- a/tests/test_tool_availability_portability.py
+++ b/tests/test_tool_availability_portability.py
@@ -1711,6 +1711,9 @@ def test_standing_system_prompt_stays_ahead_of_sorted_tool_returns() -> None:
     tool = ToolDefinition(name='first_tool', defer_loading=True)
     prepared = model.prepare_messages(
         [
+            # Drops out entirely (its only delta names a tool that is no longer served), passing
+            # the leading role to the next request.
+            ModelRequest(parts=[ToolAvailabilityDeltaPart(tools_added=['withdrawn_tool'])]),
             ModelRequest(
                 parts=[
                     SystemPromptPart(content='standing'),

--- a/tests/test_tool_availability_portability.py
+++ b/tests/test_tool_availability_portability.py
@@ -1668,6 +1668,68 @@ def test_announcement_part_respects_inline_system_prompt_support(supports_inline
         assert part.content == f'<system>{expected}</system>'
 
 
+def test_announcements_render_after_sibling_tool_returns() -> None:
+    """Announcements for a turn that reveals several tools land after the request's tool returns."""
+    model = FunctionModel(
+        lambda _messages, _info: ModelResponse(parts=[TextPart(content='unused')]),
+        profile=ModelProfile(supports_inline_system_prompts=True),
+    )
+    tools = [
+        ToolDefinition(name='first_tool', defer_loading=True),
+        ToolDefinition(name='second_tool', defer_loading=True),
+    ]
+    prepared = model.prepare_messages(
+        [
+            ModelRequest(parts=[UserPromptPart(content='start')]),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(tool_name='load_capability', content='loaded', tool_call_id='call_1'),
+                    ToolAvailabilityDeltaPart(tools_added=['first_tool']),
+                    ToolReturnPart(tool_name='load_capability', content='loaded', tool_call_id='call_2'),
+                    ToolAvailabilityDeltaPart(tools_added=['second_tool']),
+                ]
+            ),
+        ],
+        ModelRequestParameters(function_tools=tools, revealed_tool_names={tool.name for tool in tools}),
+    )
+
+    parts = prepared[1].parts
+    assert [type(part) for part in parts] == [ToolReturnPart, ToolReturnPart, SystemPromptPart, SystemPromptPart]
+    assert [part.tool_call_id for part in parts if isinstance(part, ToolReturnPart)] == ['call_1', 'call_2']
+    assert [part.content for part in parts if isinstance(part, SystemPromptPart)] == [
+        TOOL_AVAILABILITY_ANNOUNCEMENT.format(names='`first_tool`'),
+        TOOL_AVAILABILITY_ANNOUNCEMENT.format(names='`second_tool`'),
+    ]
+
+
+def test_standing_system_prompt_stays_ahead_of_sorted_tool_returns() -> None:
+    """The first request's opening system prompt keeps its place when tool returns sort forward."""
+    model = FunctionModel(
+        lambda _messages, _info: ModelResponse(parts=[TextPart(content='unused')]),
+        profile=ModelProfile(supports_inline_system_prompts=True),
+    )
+    tool = ToolDefinition(name='first_tool', defer_loading=True)
+    prepared = model.prepare_messages(
+        [
+            ModelRequest(
+                parts=[
+                    SystemPromptPart(content='standing'),
+                    ToolReturnPart(tool_name='load_capability', content='loaded', tool_call_id='call_1'),
+                    ToolAvailabilityDeltaPart(tools_added=['first_tool']),
+                ]
+            ),
+        ],
+        ModelRequestParameters(function_tools=[tool], revealed_tool_names={tool.name}),
+    )
+
+    parts = prepared[0].parts
+    assert [type(part) for part in parts] == [SystemPromptPart, ToolReturnPart, SystemPromptPart]
+    assert [part.content for part in parts if isinstance(part, SystemPromptPart)] == [
+        'standing',
+        TOOL_AVAILABILITY_ANNOUNCEMENT.format(names='`first_tool`'),
+    ]
+
+
 async def test_responses_output_tool_stays_forceable_alongside_reveal(allow_model_requests: None) -> None:
     """Output-tool forcing remains independent from a revealed function in `additional_tools`."""
     client = MockOpenAIResponses.create_mock(_empty_responses_message())


### PR DESCRIPTION
- Closes #7564

When one turn revealed tools through multiple calls (e.g. batched `load_capability`), each announcement rendered at its delta's position, between the request's tool returns. Providers without a native reveal channel then received `[toolResult, text, toolResult, text, ...]`, and Anthropic requires every `tool_result` to sit at the start of the message, so Bedrock rejected the request with `ValidationException: tool_use ids were found without tool_result blocks`.

`_announce_tool_availability_delta_messages` now stable-sorts the delta-carrying request so tool returns lead and announcements follow, reusing the graph layer's tool-results-first key via a shared helper. The opening system prompts of the history's first request keep their position, since adapters lift the standing prompt into the provider's system field by exactly that position. Requests without deltas are untouched and the rendering is deterministic, so cached prefixes stay stable.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
