### PR TITLE
Only list available tools in the unknown-tool retry message

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -501,9 +501,17 @@ class ToolManager(Generic[AgentDepsT]):
         name = call.tool_name
         tool = self.tools.get(name)
         if tool is None:
-            if self.tools:
-                available = sorted(self.tools.keys())
+            # Name only what the model can call this turn, the same `is_tool_available` gate the unavailable-tool
+            # check applies, so a name that tool search or `load_capability` has yet to reveal stays out of
+            # this message.
+            available = sorted(n for n, t in self.tools.items() if self.ctx.is_tool_available(t.tool_def))
+            if available:
                 msg = f'Available tools: {", ".join(f"{n!r}" for n in available)}'
+            elif self.tools:
+                msg = (
+                    'No tools are available yet: search for the tool you need, '
+                    "then call it once you've seen its schema."
+                )
             else:
                 msg = 'No tools available.'
             raise ModelRetry(f'Unknown tool name: {name!r}. {msg}')

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -508,10 +508,7 @@ class ToolManager(Generic[AgentDepsT]):
             if available:
                 msg = f'Available tools: {", ".join(f"{n!r}" for n in available)}'
             elif self.tools:
-                msg = (
-                    'No tools are available yet: search for the tool you need, '
-                    "then call it once you've seen its schema."
-                )
+                msg = 'No tools are available yet: search for the tools you need.'
             else:
                 msg = 'No tools available.'
             raise ModelRetry(f'Unknown tool name: {name!r}. {msg}')

--- a/tests/test_tool_availability.py
+++ b/tests/test_tool_availability.py
@@ -479,7 +479,7 @@ async def test_unknown_tool_retry_steers_to_search_when_nothing_is_callable_yet(
     result = await agent.run('hello')
 
     assert result.output == snapshot(
-        "Unknown tool name: 'bogus_op'. No tools are available yet: search for the tool you need, then call it once you've seen its schema."
+        "Unknown tool name: 'bogus_op'. No tools are available yet: search for the tools you need."
     )
 
 

--- a/tests/test_tool_availability.py
+++ b/tests/test_tool_availability.py
@@ -17,6 +17,7 @@ from pydantic_ai.agent import Agent
 from pydantic_ai.capabilities import (
     Capability,
     ProcessHistory,
+    ToolSearch,
 )
 from pydantic_ai.exceptions import (
     ModelRetry,
@@ -241,6 +242,13 @@ def _call_secret_op(messages: list[ModelMessage], info: AgentInfo) -> ModelRespo
     )
 
 
+def _call_bogus_tool(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Call a tool that does not exist, then echo the retry that refuses it."""
+    for part in iter_message_parts(messages, ModelRequest, RetryPromptPart):
+        return make_text_response(str(part.content))
+    return ModelResponse(parts=[ToolCallPart(tool_name='bogus_op', args={}, tool_call_id='b1')])
+
+
 def _load_compact_then_call_secret_op(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """Load `guarded`, emit a `CompactionPart` to reset that state, then direct-call its tool."""
     if (report := _report_secret_op_outcome(messages)) is not None:
@@ -431,6 +439,48 @@ class TestUnavailableCapabilityToolsAreNotCallable:
         await agent.run('hello')
 
         assert advertised == snapshot([['load_capability', 'untouched']])
+
+    async def test_unknown_tool_retry_lists_only_available_tools(self):
+        """The unknown-tool retry names the callable tools only — a withheld one stays undisclosed."""
+        agent = Agent(FunctionModel(_call_bogus_tool), capabilities=[self._guarded_capability()])
+
+        @agent.tool_plain
+        def untouched() -> str:
+            return 'safe'  # pragma: no cover
+
+        result = await agent.run('hello')
+
+        assert result.output == snapshot(
+            "Unknown tool name: 'bogus_op'. Available tools: 'load_capability', 'untouched'"
+        )
+
+
+async def test_unknown_tool_retry_omits_undiscovered_search_gated_tools():
+    """A deferred tool no search has revealed yet is not disclosed by the unknown-tool retry."""
+    toolset = FunctionToolset[Any]()
+    toolset.add_function(lambda: 'ran', name='hidden', defer_loading=True)
+    agent = Agent(FunctionModel(_call_bogus_tool), toolsets=[toolset])
+
+    result = await agent.run('hello')
+
+    assert result.output == snapshot("Unknown tool name: 'bogus_op'. Available tools: 'search_tools'")
+
+
+async def test_unknown_tool_retry_steers_to_search_when_nothing_is_callable_yet():
+    """A native-only strategy emits no `search_tools`, so an undiscovered corpus leaves nothing callable.
+
+    A bare 'No tools available.' would be false here — the corpus exists, it just has not been
+    searched — so the retry names the step that makes a tool callable instead.
+    """
+    toolset = FunctionToolset[Any]()
+    toolset.add_function(lambda: 'ran', name='hidden', defer_loading=True)
+    agent = Agent(FunctionModel(_call_bogus_tool), toolsets=[toolset], capabilities=[ToolSearch(strategy='bm25')])
+
+    result = await agent.run('hello')
+
+    assert result.output == snapshot(
+        "Unknown tool name: 'bogus_op'. No tools are available yet: search for the tool you need, then call it once you've seen its schema."
+    )
 
 
 async def test_reveal_of_another_capabilitys_tool_is_rejected_even_while_loaded():


### PR DESCRIPTION
- Closes #7552

When the model called a tool name that did not exist, the retry message listed every name in the internal tool dict, including tools withheld by deferred capability loading (`defer_loading=True`) and tool search. One bad guess disclosed the full hidden catalog, so `load_capability` became optional in practice.

The unknown-tool retry now lists only tools the model can call this turn, using the same `is_tool_available` gate as the existing unavailable-tool check. Calling a withheld tool by exact name still gets the existing load/search steering. When tools exist but none are callable yet (a named-native search strategy such as `bm25` with an undiscovered corpus), the retry steers the model to search instead of claiming no tools exist, since a bare "No tools available." would be false there.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

