### PR TITLE
Add a daily attention coverage heartbeat to the triage channel

### DIFF
--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -1180,6 +1180,51 @@ def _write_notices(repo: str, notices: Sequence[Notice]) -> None:
             output.write(f'slack_payload={json.dumps(payload, separators=(",", ":"))}\n')
 
 
+def _search_count(client: GitHubClient, query: str) -> int:
+    """Return how many items match, without fetching any of them."""
+    # `total_count` is the full match count even though a search page stops at
+    # 1000 results, so one per_page=1 request answers a repository-wide count.
+    result = cast(dict[str, Any], client.get(f'/search/issues?q={urllib.parse.quote_plus(query)}&per_page=1'))
+    return int(result.get('total_count') or 0)
+
+
+def _stalest_unattended(client: GitHubClient, repo: str, *, now: dt.datetime) -> tuple[int, int] | None:
+    query = f'repo:{repo} is:open no:assignee -label:"{_ACTION_LABEL}" -label:"{_ESCALATED_LABEL}"'
+    result = cast(
+        dict[str, Any],
+        client.get(f'/search/issues?q={urllib.parse.quote_plus(query)}&sort=updated&order=asc&per_page=1'),
+    )
+    items = cast(list[dict[str, Any]], result.get('items') or [])
+    if not items:
+        return None
+    idle = max(0, (now - _parse_time(str(items[0]['updated_at']))).days)
+    return int(items[0]['number']), idle
+
+
+def census(client: GitHubClient, repo: str, *, now: dt.datetime) -> str:
+    """Build the unconditional daily coverage line, so silence becomes visible."""
+    issues = _search_count(client, f'repo:{repo} is:issue is:open')
+    pulls = _search_count(client, f'repo:{repo} is:pr is:open')
+    active = _search_count(client, f'repo:{repo} is:open label:"{_ACTION_LABEL}"')
+    cooling = _search_count(client, f'repo:{repo} is:open label:"{_ESCALATED_LABEL}"')
+    unassigned = _search_count(client, f'repo:{repo} is:open no:assignee')
+    stalest = _stalest_unattended(client, repo, now=now)
+    # Counts and item numbers only: the heartbeat must stay free of issue and PR
+    # prose, which is attacker-controlled text.
+    tail = f'most stale unattended: #{stalest[0]} (idle {stalest[1]}d).' if stalest else 'no unattended items.'
+    return (
+        f':telescope: Attention coverage for {_slack_escape(repo)} — '
+        f'{issues} issues + {pulls} PRs open; queue: {active} active, {cooling} cooling; '
+        f'{unassigned} unassigned; {tail}'
+    )
+
+
+def _write_coverage(text: str) -> None:
+    if output_path := os.environ.get('GITHUB_OUTPUT'):
+        with Path(output_path).open('a', encoding='utf-8') as output:
+            output.write(f'slack_payload={json.dumps({"text": text}, separators=(",", ":"))}\n')
+
+
 _LOGIN_PATTERN = re.compile(r'(?=.{1,39}\Z)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?')
 
 
@@ -1352,7 +1397,7 @@ def _write_summary(lines: Sequence[str]) -> None:
 def main() -> int:
     """Build a snapshot, apply decisions, or reconcile reminders."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('mode', choices=['snapshot', 'apply', 'reconcile', 'prepare', 'finalize'])
+    parser.add_argument('mode', choices=['snapshot', 'apply', 'reconcile', 'prepare', 'finalize', 'census'])
     parser.add_argument('--snapshot-path', default='attention-candidates.json')
     parser.add_argument('--agent-output', default=os.environ.get('GH_AW_AGENT_OUTPUT'))
     args = parser.parse_args()
@@ -1381,6 +1426,10 @@ def main() -> int:
         notices = prepare_notices(client, repo, _notice_refs(json.loads(source)), now=now)
         _write_notices(repo, notices)
         lines = [f'prepared {len(notices)} current attention notice(s)']
+    elif args.mode == 'census':
+        coverage = census(client, repo, now=now)
+        _write_coverage(coverage)
+        lines = [coverage]
     else:
         source = os.environ.get('ATTENTION_NOTICES')
         if source is None:

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -1081,6 +1081,89 @@ def test_notice_output_is_actionable_and_escapes_untrusted_titles(tmp_path: Path
     assert 'Do not remove the attention labels' in text
 
 
+class CensusClient(FakeClient):
+    """Search counts only: the whole surface the coverage heartbeat touches."""
+
+    def __init__(self, counts: dict[str, int], *, stalest: dict[str, Any] | None = None) -> None:
+        super().__init__()
+        self.counts = counts
+        self.stalest = stalest
+
+    def get(self, path: str) -> Any:
+        self.calls.append(('GET', path, None))
+        assert path.startswith('/search/issues?')
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
+        terms = query['q'][0]
+        if '-label:' in terms:
+            # The probe must exclude both queue labels *and* assigned items, or
+            # it reports something a maintainer already owns as unattended.
+            assert terms == (
+                'repo:pydantic/pydantic-ai is:open no:assignee '
+                f'-label:"{monitor._ACTION_LABEL}" -label:"{monitor._ESCALATED_LABEL}"'
+            )
+            assert query['sort'] == ['updated'] and query['order'] == ['asc']
+            return {'total_count': 1 if self.stalest else 0, 'items': [self.stalest] if self.stalest else []}
+        return {'total_count': self.counts[terms], 'items': []}
+
+
+CENSUS_COUNTS = {
+    'repo:pydantic/pydantic-ai is:issue is:open': 361,
+    'repo:pydantic/pydantic-ai is:pr is:open': 141,
+    f'repo:pydantic/pydantic-ai is:open label:"{monitor._ACTION_LABEL}"': 14,
+    f'repo:pydantic/pydantic-ai is:open label:"{monitor._ESCALATED_LABEL}"': 9,
+    'repo:pydantic/pydantic-ai is:open no:assignee': 274,
+}
+
+
+def test_census_counts_coverage_without_fetching_or_writing_anything():
+    client = CensusClient(CENSUS_COUNTS, stalest={'number': 4812, 'updated_at': '2025-06-03T00:00:00Z'})
+
+    assert monitor.census(client, 'pydantic/pydantic-ai', now=NOW) == (
+        ':telescope: Attention coverage for pydantic/pydantic-ai — 361 issues + 141 PRs open; '
+        'queue: 14 active, 9 cooling; 274 unassigned; most stale unattended: #4812 (idle 412d).'
+    )
+    # Count-only by construction: no writes, no pagination, no per-item reads.
+    assert {method for method, _, _ in client.calls} == {'GET'}
+    assert all(
+        urllib.parse.parse_qs(urllib.parse.urlparse(path).query)['per_page'] == ['1'] for _, path, _ in client.calls
+    )
+
+
+def test_census_reports_an_empty_unattended_backlog():
+    client = CensusClient(CENSUS_COUNTS)
+
+    assert monitor.census(client, 'pydantic/pydantic-ai', now=NOW).endswith('274 unassigned; no unattended items.')
+
+
+def test_coverage_output_is_one_plain_text_slack_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    output = tmp_path / 'github-output'
+    monkeypatch.setenv('GITHUB_OUTPUT', str(output))
+    text = ':telescope: Attention coverage for pydantic/pydantic-ai — no unattended items.'
+
+    monitor._write_coverage(text)
+
+    values = dict(line.split('=', 1) for line in output.read_text(encoding='utf-8').splitlines())
+    assert json.loads(values['slack_payload']) == {'text': text}
+
+
+def test_census_mode_writes_the_heartbeat_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    output = tmp_path / 'github-output'
+    monkeypatch.setattr(monitor, 'GitHubClient', lambda token: CensusClient(CENSUS_COUNTS))
+    monkeypatch.setattr(sys, 'argv', ['issue_pr_attention_monitor.py', 'census'])
+    monkeypatch.setenv('GITHUB_TOKEN', 'token')
+    monkeypatch.setenv('GITHUB_REPOSITORY', 'pydantic/pydantic-ai')
+    monkeypatch.setenv('GITHUB_OUTPUT', str(output))
+    monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
+
+    assert monitor.main() == 0
+
+    values = dict(line.split('=', 1) for line in output.read_text(encoding='utf-8').splitlines())
+    assert json.loads(values['slack_payload']) == {
+        'text': ':telescope: Attention coverage for pydantic/pydantic-ai — 361 issues + 141 PRs open; '
+        'queue: 14 active, 9 cooling; 274 unassigned; no unattended items.'
+    }
+
+
 def test_reconcile_rejects_a_foreign_stage_label():
     client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._ESCALATED_LABEL])})
     client.timelines[7] = [
@@ -1685,12 +1768,34 @@ def test_operations_workflow_routes_all_notices_to_the_triage_channel():
     assert jobs['reconcile']['permissions']['pull-requests'] == 'write'
     assert jobs['notify']['permissions']['pull-requests'] == 'read'
     assert jobs['finalize']['permissions']['pull-requests'] == 'write'
-    for job_name in ('reconcile', 'notify', 'finalize'):
+    for job_name in ('reconcile', 'notify', 'finalize', 'coverage'):
         checkout = next(
             step for step in jobs[job_name]['steps'] if step.get('uses', '').startswith('actions/checkout@')
         )
         assert checkout['with']['repository'] == '${{ job.workflow_repository }}'
         assert checkout['with']['ref'] == '${{ job.workflow_sha }}'
+        assert checkout['with']['persist-credentials'] is False
+
+
+def test_operations_workflow_sends_an_unconditional_daily_coverage_heartbeat():
+    workflow = Path(__file__).parent.parent / 'workflows' / 'issue-pr-attention-monitor.yml'
+    text = workflow.read_text()
+    jobs = yaml.safe_load(text)['jobs']
+
+    assert "- cron: '47 6 * * *'" in text
+    assert 'issue_pr_attention_monitor.py census' in text
+    assert 'steps.census.outputs.slack_payload' in text
+    # The heartbeat may follow the pipeline's ordering, so the two search bursts
+    # do not collide, but must never inherit its silence or its failures.
+    assert jobs['coverage']['needs'] == ['reconcile']
+    assert jobs['coverage']['if'] == (
+        '${{ !cancelled() && '
+        "(github.repository == 'pydantic/pydantic-ai' || github.repository == 'pydantic/pydantic-ai-harness') && "
+        "(github.event.schedule == '47 6 * * *' || github.event_name == 'workflow_dispatch') }}"
+    )
+    assert jobs['coverage']['environment'] == 'pydantic-ai-triage'
+    assert jobs['coverage']['permissions'] == {'contents': 'read', 'issues': 'read', 'pull-requests': 'read'}
+    assert 'coverage' in jobs['alert']['needs']
 
 
 def test_monitor_imports_with_stdlib_only():

--- a/.github/workflows/issue-pr-attention-monitor.yml
+++ b/.github/workflows/issue-pr-attention-monitor.yml
@@ -3,6 +3,7 @@ name: Issue and PR attention operations
 on:
   schedule:
     - cron: '17 */6 * * *'
+    - cron: '47 6 * * *'
   workflow_dispatch: {}
   workflow_call:
     secrets:
@@ -95,8 +96,46 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: python .github/scripts/issue_pr_attention_monitor.py finalize
 
+  coverage:
+    # `needs` only orders this after reconcile's own searches, keeping the two
+    # search bursts inside GitHub's secondary rate limit; `!cancelled()` keeps
+    # the heartbeat unconditional, including when reconcile fails.
+    needs: [reconcile]
+    # Once a day, unconditionally: the notify job stays quiet both when nothing
+    # needs attention and when the pipeline is broken, so only a message that is
+    # always sent can tell those apart.
+    # Reusable-workflow contract: under `workflow_call` the `github` context is
+    # the caller's, so a caller repository gets this heartbeat only if it
+    # schedules its own `cron: '47 6 * * *'`.
+    if: ${{ !cancelled() && (github.repository == 'pydantic/pydantic-ai' || github.repository == 'pydantic/pydantic-ai-harness') && (github.event.schedule == '47 6 * * *' || github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: pydantic-ai-triage
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          persist-credentials: false
+      - name: Count repository-wide attention coverage
+        id: census
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python .github/scripts/issue_pr_attention_monitor.py census
+      - name: Post the daily coverage heartbeat to the triage channel
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          errors: true
+          payload: ${{ steps.census.outputs.slack_payload }}
+          webhook: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+
   alert:
-    needs: [reconcile, notify, finalize]
+    needs: [reconcile, notify, finalize, coverage]
     # A triage system that dies silently is worse than none: any failed job
     # in the pipeline reports privately through the same Slack webhook.
     if: ${{ !cancelled() && contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
- Closes: N/A (maintainer workflow follow-up to #7529)

## Summary

The attention pipeline's notify job stays quiet both when nothing needs attention and when the pipeline is silently broken — before #7529, wrong search qualifiers and missing PR permissions produced weeks of green runs and zero Slack messages, and nothing distinguished that from a genuinely quiet repository.

This change adds a once-daily unconditional coverage heartbeat so those two states can never look alike again:

- a new `census` subcommand in `issue_pr_attention_monitor.py` issues five count-only searches (open issues, open PRs, active queue, cooling escalations, unassigned) plus one probe for the most-stale unattended item — reading `total_count` from single-result pages, with no pagination, no per-item fetching, and no writes
- a new independent `coverage` job posts the one-line result to the triage channel on a dedicated `47 6 * * *` cron (and on `workflow_dispatch`); it `needs: [reconcile]` purely for ordering, so the two search bursts stay inside GitHub's secondary rate limit, while `!cancelled()` keeps the heartbeat firing even when reconcile fails
- the message carries counts and one item number only — issue and PR prose never reaches the channel
- a failed coverage run reports through the existing `alert` job

Example message:

> :telescope: Attention coverage for pydantic/pydantic-ai — 361 issues + 141 PRs open; queue: 14 active, 9 cooling; 274 unassigned; most stale unattended: #4812 (idle 412d).

Under `workflow_call` the `github` context belongs to the caller, so a caller repository (the proposed pydantic-ai-harness integration) receives the heartbeat only by scheduling its own `47 6 * * *` cron; this contract is documented in the workflow.

## Validation

- 106 GitHub-script tests pass; the new tests pin the exact search query strings, the `per_page=1` count-only contract, the `main()` → `slack_payload` wiring, and the coverage job's `if`/`needs`/permissions/environment/checkout pinning
- key tests mutation-checked: deleting the payload write or loosening the stale-probe query makes the suite fail
- targeted strict Pyright passed; Ruff lint and format passed; Zizmor reports no findings

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

