### PR TITLE
Preserve legacy MCP and realtime docs routes

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -587,6 +587,8 @@ navigation:
       - page: "Client"
         path: "mcp/client.md"
         slug: "mcp/client"
+        aliases:
+          - "mcp/fastmcp-client"
       - page: "Server"
         path: "mcp/server.md"
         slug: "mcp/server"
@@ -1182,6 +1184,9 @@ redirects:
   - from: "realtime"
     to: "realtime/overview"
     status: 302
+  - from: "overview/realtime"
+    to: "realtime/overview"
+    status: 302
   - from: "core-concepts"
     to: "core-concepts/agent"
     status: 302
@@ -1228,11 +1233,11 @@ redirects:
     to: "capabilities/thinking/index.md"
   # Content that moved outside the documentation site.
   - from: "a2a"
-    to: "https://github.com/pydantic/fasta2a"
+    to: "https://github.com/datalayer/fasta2a"
   - from: "integrations/a2a"
-    to: "https://github.com/pydantic/fasta2a"
+    to: "https://github.com/datalayer/fasta2a"
   - from: "api/fasta2a"
-    to: "https://github.com/pydantic/fasta2a"
+    to: "https://github.com/datalayer/fasta2a"
   - from: "mcp/run-python"
     to: "https://github.com/pydantic/mcp-run-python"
   - from: "graph/tree/main/pydantic_graph"
@@ -1248,3 +1253,5 @@ redirects:
     to: "overview/:splat"
   - from: "integrations/durable_execution/*"
     to: "capabilities/durable_execution/:splat"
+  - from: "overview/realtime/*"
+    to: "realtime/:splat"


### PR DESCRIPTION
## Summary

- preserve the former FastMCP client and realtime documentation URLs through source-owned aliases
- send retired A2A documentation URLs directly to the maintained Fasta2a repository
- keep legacy public links working when unified-docs generates the deployed redirect table

## Validation

- compiled with a production unified-docs build using this local checkout
- verified the generated exact and splat redirects for the MCP and realtime aliases
- verified the navigation diff against the rebased `main` branch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

