### PR TITLE
Add the harness `PlaywrightBrowser` docs page to the navigation

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -294,6 +294,10 @@ navigation:
             path: "browser-use.md"
             source: "harness"
             slug: "harness/browser-use"
+          - page: "Playwright Browser"
+            path: "playwright.md"
+            source: "harness"
+            slug: "harness/playwright"
       - section: "Reasoning, Planning & Delegation"
         slug: ""
         contents:


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Registers `playwright.md` (source: harness) in the "Web & Research" section, beside Browser Use. The page ships from pydantic/pydantic-ai-harness#420, so this should merge after that PR lands -- until then the entry would point at a page that does not exist yet.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

