### PR TITLE
Add instrumentation version 6, emitting tool results under `role: 'tool'`

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -295,6 +295,8 @@ Pydantic AI follows the [OpenTelemetry Semantic Conventions for Generative AI sy
 
 Versions 2, 3, and 4 are deprecated compatibility formats. Passing one of these versions to [`InstrumentationSettings`][pydantic_ai.models.instrumented.InstrumentationSettings] emits a [`PydanticAIDeprecationWarning`][pydantic_ai.agent.PydanticAIDeprecationWarning]; use version 5 unless you are temporarily preserving an older telemetry pipeline.
 
+Version 6 is opt-in: it changes the role of messages you already receive, so pass it explicitly once your telemetry consumer is ready for the new role.
+
 #### Version 2 (deprecated)
 
 Uses the newer OpenTelemetry GenAI spec and stores messages in the following attributes:
@@ -338,6 +340,15 @@ Note: The `modality` field is only included for image, audio, and video content 
 Builds on version 4 with improved handling of deferred tool calls:
 
 - [`CallDeferred`][pydantic_ai.exceptions.CallDeferred] and [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] exceptions no longer record an exception event or set the span status to ERROR — the span is left as UNSET, since deferrals are control flow, not errors.
+
+#### Version 6 (opt-in)
+
+Builds on version 5 by giving tool results the message role the [GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json) pair with the `tool_call_response` parts they carry:
+
+- Old (v2-5): a tool result is a `tool_call_response` part inside a `{"role": "user"}` message
+- New (v6): it moves to a `{"role": "tool"}` message
+
+This applies to tool returns and to retries that answer a tool call. A retry that answers nothing — output validation, a `ModelRetry` from a validator — stays on `user`, which is the role it reaches the model as. A request whose parts span both roles is emitted as consecutive messages in part order rather than one merged message.
 
 ---
 

--- a/pydantic_ai_slim/pydantic_ai/_otel_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/_otel_messages.py
@@ -105,7 +105,7 @@ class ThinkingPart(TypedDict):
 MessagePart: TypeAlias = 'TextPart | ToolCallPart | ToolCallResponsePart | MediaUrlPart | UriPart | FilePart | BinaryDataPart | BlobPart | ThinkingPart'
 
 
-Role = Literal['system', 'user', 'assistant']
+Role = Literal['system', 'user', 'assistant', 'tool']
 
 
 class ChatMessage(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import itertools
 import time
 import warnings
@@ -30,9 +31,12 @@ from .. import _otel_messages
 from .._run_context import RunContext
 from .._warnings import PydanticAIDeprecationWarning
 from ..messages import (
+    BaseToolReturnPart,
     ModelMessage,
     ModelRequest,
+    ModelRequestPart,
     ModelResponse,
+    RetryPromptPart,
     SystemPromptPart,
     ToolAvailabilityDeltaPart,
 )
@@ -72,7 +76,7 @@ class InstrumentationSettings:
     include_binary_content: bool = True
     include_content: bool = True
     include_model_request_parameters: bool = True
-    version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION
+    version: Literal[2, 3, 4, 5, 6] = DEFAULT_INSTRUMENTATION_VERSION
     use_aggregated_usage_attribute_names: bool = True
 
     def __init__(
@@ -83,7 +87,7 @@ class InstrumentationSettings:
         include_binary_content: bool = True,
         include_content: bool = True,
         include_model_request_parameters: bool = True,
-        version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION,
+        version: Literal[2, 3, 4, 5, 6] = DEFAULT_INSTRUMENTATION_VERSION,
         use_aggregated_usage_attribute_names: bool = True,
     ):
         """Create instrumentation options.
@@ -125,6 +129,10 @@ class InstrumentationSettings:
                 Version 5 is the same as version 4, but CallDeferred and ApprovalRequired exceptions
                     no longer record an exception event or set the span status to ERROR — the span is left
                     as UNSET, since deferrals are control flow, not errors.
+                Version 6 is the same as version 5, but tool results are emitted in a message with
+                    `role='tool'` rather than `role='user'`, which is the role the GenAI semantic
+                    conventions pair with the `tool_call_response` parts they carry. Opt in to it when
+                    your telemetry consumer keys on the message role; it is not the default.
             use_aggregated_usage_attribute_names: Whether to use `gen_ai.aggregated_usage.*` attribute names
                 for token usage on agent run spans instead of the standard `gen_ai.usage.*` names.
                 Defaults to True to prevent double-counting in observability backends that aggregate span
@@ -143,9 +151,10 @@ class InstrumentationSettings:
         self.include_content = include_content
         self.include_model_request_parameters = include_model_request_parameters
 
-        if version not in (2, 3, 4, 5):
-            raise ValueError('Instrumentation version must be one of 2, 3, 4, or 5.')
+        if version not in (2, 3, 4, 5, 6):
+            raise ValueError('Instrumentation version must be one of 2, 3, 4, 5, or 6.')
         # TODO(v3): remove instrumentation format versions 2, 3, and 4
+        # TODO(v3): default to instrumentation format version 6
         if version in (2, 3, 4):
             warnings.warn(
                 'Instrumentation format versions 2, 3, and 4 are deprecated; use `version=5` instead.',
@@ -197,17 +206,15 @@ class InstrumentationSettings:
         result: list[_otel_messages.ChatMessage] = []
         for message in messages:
             if isinstance(message, ModelRequest):
-                for is_system, group in itertools.groupby(
-                    message.parts, key=lambda p: isinstance(p, SystemPromptPart | ToolAvailabilityDeltaPart)
+                for role, group in itertools.groupby(
+                    message.parts, key=functools.partial(_otel_message_role, version=self.version)
                 ):
                     message_parts: list[_otel_messages.MessagePart] = []
                     for part in group:
                         if hasattr(part, 'otel_message_parts'):
                             message_parts.extend(part.otel_message_parts(self))
 
-                    result.append(
-                        _otel_messages.ChatMessage(role='system' if is_system else 'user', parts=message_parts)
-                    )
+                    result.append(_otel_messages.ChatMessage(role=role, parts=message_parts))
             elif isinstance(message, ModelResponse):  # pragma: no branch
                 otel_message = _otel_messages.OutputMessage(role='assistant', parts=message.otel_message_parts(self))
                 if message.finish_reason is not None:
@@ -398,3 +405,33 @@ class InstrumentedModel(WrapperModel):
                         response_stream.get(),
                         time_to_first_chunk=response_stream.time_to_first_chunk(request_start),
                     )
+
+
+def _otel_message_role(part: ModelRequestPart, version: int) -> _otel_messages.Role:
+    """The GenAI role of the message a request part belongs in.
+
+    Consecutive parts sharing a role make up one message, so a request carrying a tool return and a
+    user prompt splits into a `tool` message followed by a `user` one.
+
+    From version 6 on, a part that renders as a `tool_call_response` takes the `tool` role the
+    semantic conventions pair it with, which is also the channel the adapters send it on: a tool
+    return and a retry naming a tool both reach OpenAI as `role='tool'`, a retry naming none as
+    `role='user'`. Earlier versions keep those parts on `user`, so a consumer written against them
+    keeps reading the role it was built for.
+
+    `ToolAvailabilityDeltaPart` gets `system` as the least-bad fit in a closed vocabulary, not as a
+    mirror of the wire. `Role` is `system | user | assistant | tool` and none of those means "the set
+    of tools changed", while the wire form varies by model: a real `SystemPromptPart` where there is
+    no native channel, a `role='system'` entry carrying `tool_addition` blocks on Anthropic, a
+    roleless `additional_tools` item on OpenAI Responses, a tool-search exchange where schemas are
+    withheld. `tool` is the one role that would actively mislead, being paired with
+    `tool_call_response`.
+    """
+    if isinstance(part, SystemPromptPart | ToolAvailabilityDeltaPart):
+        return 'system'
+    elif version >= 6 and (
+        isinstance(part, BaseToolReturnPart) or (isinstance(part, RetryPromptPart) and part.tool_name is not None)
+    ):
+        return 'tool'
+    else:
+        return 'user'

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -479,7 +479,7 @@ def test_safe_to_json_falls_back_on_lone_surrogates():
 
 
 def test_instrumentation_settings_rejects_removed_version():
-    with pytest.raises(ValueError, match='Instrumentation version must be one of 2, 3, 4, or 5'):
+    with pytest.raises(ValueError, match='Instrumentation version must be one of 2, 3, 4, 5, or 6'):
         InstrumentationSettings(version=1)  # pyright: ignore[reportArgumentType]
 
 
@@ -971,6 +971,74 @@ def test_messages_to_otel_message_parts_tool_availability_delta(include_content:
         [{'type': 'text', 'content': 'Tool availability changed: +lookup_exchange_rate'}]
     )
     assert user_message['role'] == 'user'
+
+
+def test_messages_to_otel_messages_request_roles_v6():
+    """From version 6 a request splits into one message per role, in part order.
+
+    A tool return and a retry that answers a tool call both render as a `tool_call_response`, which
+    the GenAI semantic conventions put in a `tool` message. A retry that answers nothing renders as
+    text and reaches the model as user content, so it starts a new message.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[SystemPromptPart(content='Be brief.'), UserPromptPart(content='Convert 10 EUR.')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='convert', args={'amount': 10}, tool_call_id='call_1')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='convert', content='11 USD', tool_call_id='call_1'),
+                RetryPromptPart(content='Unknown currency.', tool_name='convert', tool_call_id='call_2'),
+                RetryPromptPart(content='Output did not validate.'),
+                UserPromptPart(content='Thanks.'),
+            ]
+        ),
+    ]
+    assert InstrumentationSettings(include_content=True, version=6).messages_to_otel_messages(messages) == snapshot(
+        [
+            {'role': 'system', 'parts': [{'type': 'text', 'content': 'Be brief.'}]},
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Convert 10 EUR.'}]},
+            {
+                'role': 'assistant',
+                'parts': [{'type': 'tool_call', 'id': 'call_1', 'name': 'convert', 'arguments': {'amount': 10}}],
+            },
+            {
+                'role': 'tool',
+                'parts': [
+                    {'type': 'tool_call_response', 'id': 'call_1', 'name': 'convert', 'result': '11 USD'},
+                    {
+                        'type': 'tool_call_response',
+                        'id': 'call_2',
+                        'name': 'convert',
+                        'result': """\
+Unknown currency.
+
+Fix the errors and try again.\
+""",
+                    },
+                ],
+            },
+            {
+                'role': 'user',
+                'parts': [
+                    {
+                        'type': 'text',
+                        'content': """\
+Validation feedback:
+Output did not validate.
+
+Fix the errors and try again.\
+""",
+                    },
+                    {'type': 'text', 'content': 'Thanks.'},
+                ],
+            },
+        ]
+    )
+
+    # Every earlier version keeps the tool results on `user`, in the single message they shared there.
+    settings = InstrumentationSettings(include_content=True)
+    assert [message['role'] for message in settings.messages_to_otel_messages(messages)] == snapshot(
+        ['system', 'user', 'assistant', 'user']
+    )
 
 
 def test_messages_to_otel_messages_multimodal_v3(document_content: BinaryContent):


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David has not reviewed the code. He reviewed the two design decisions — version 6 being non-default, and the tool-availability delta keeping `system` — and directed the rest.

- Closes #7235

## Why we make these changes

`messages_to_otel_messages` grouped a `ModelRequest`'s parts by `isinstance(p, SystemPromptPart | ToolAvailabilityDeltaPart)` and labelled the result `'system' if is_system else 'user'`. A tool result therefore arrived as a `tool_call_response` part inside a `role: "user"` message, while the [GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-spans.md) pair that part with `role: "tool"`. `Role` had no `'tool'` member, so the right role was not representable. The reporter exports these spans to Databricks/MLflow, where the message role is what their consumers key on.

This is a **changed value on telemetry we already emit**, not an addition, so it ships as instrumentation format **version 6** and versions 2–5 keep emitting `user`. That follows [#4661](https://github.com/pydantic/pydantic-ai/pull/4661), which took a new version to flip a span status on already-emitted telemetry while shipping its purely-additive half to every version in the same PR. Version 6 is **not** the default — [#4219](https://github.com/pydantic/pydantic-ai/pull/4219) and #4661 both shipped non-default, and the default flips at a major (`TODO(v3)` marker added next to the existing one).

The issue's second symptom — `ToolAvailabilityDeltaPart` appearing as a mid-conversation `system` message — is **not** changed, on any version. The semconv role vocabulary is exactly `system | user | assistant | tool` and none of those means "the set of tools changed"; `tool` is the one that would actively mislead, being the role paired with `tool_call_response`. `system` is also the mapping [#6793](https://github.com/pydantic/pydantic-ai/pull/6793) chose deliberately when it introduced the part. The reasoning is recorded in `_otel_message_role`'s docstring so it doesn't get re-reported.

## New public surface

- **`InstrumentationSettings(version=6)`** — the only new value; `version` widens to `Literal[2, 3, 4, 5, 6]`.

`_otel_messages.Role` gains `'tool'` unconditionally rather than per version: it is a private type describing what the field can hold, and only the mapping is gated.

<details>
<summary><b>Goal — a tool result carries the role the semantic conventions give it</b></summary>

**Before** — one `user` message holding everything the request sent:

```python
InstrumentationSettings(include_content=True).messages_to_otel_messages(history)
# -> [{'role': 'system',    'parts': [text]},
#     {'role': 'user',      'parts': [text]},
#     {'role': 'assistant', 'parts': [tool_call]},
#     {'role': 'user',      'parts': [tool_call_response, tool_call_response, text]}]
```

**After**, on version 6 — the request splits by role, in part order:

```python
InstrumentationSettings(include_content=True, version=6).messages_to_otel_messages(history)
# -> [{'role': 'system',    'parts': [text]},
#     {'role': 'user',      'parts': [text]},
#     {'role': 'assistant', 'parts': [tool_call]},
#     {'role': 'tool',      'parts': [tool_call_response, tool_call_response]},
#     {'role': 'user',      'parts': [text]}]
```

A retry that answers a tool call goes to `tool` with the returns; a retry that answers nothing stays `user`, which is the role it reaches the model as — `openai.py` maps exactly this split to `role='tool'` / `role='user'` on the wire.

<details>
<summary>Playground</summary>

```python
from pydantic_ai.messages import (
    ModelRequest, ModelResponse, RetryPromptPart, SystemPromptPart,
    ToolCallPart, ToolReturnPart, UserPromptPart,
)
from pydantic_ai.models.instrumented import InstrumentationSettings

history = [
    ModelRequest(parts=[SystemPromptPart(content='Be brief.'), UserPromptPart(content='Convert 10 EUR.')]),
    ModelResponse(parts=[ToolCallPart(tool_name='convert', args={'amount': 10}, tool_call_id='call_1')]),
    ModelRequest(
        parts=[
            ToolReturnPart(tool_name='convert', content='11 USD', tool_call_id='call_1'),
            RetryPromptPart(content='Unknown currency.', tool_name='convert', tool_call_id='call_2'),
            RetryPromptPart(content='Output did not validate.'),
            UserPromptPart(content='Thanks.'),
        ]
    ),
]

for version in (5, 6):
    settings = InstrumentationSettings(include_content=True, version=version)
    print(version, [m['role'] for m in settings.messages_to_otel_messages(history)])
# 5 ['system', 'user', 'assistant', 'user']
# 6 ['system', 'user', 'assistant', 'tool', 'user']
```
</details>

**Test**: [`test_messages_to_otel_messages_request_roles_v6`](https://github.com/pydantic/pydantic-ai/pull/7582/files#diff-8326cebbf4d68ab4d5c125c51fbf861db592726c35783b355c76c030f7f49264R976)

**What changes for existing users: nothing.** Version 5 stays the default and its output is byte-identical — the same test pins `['system', 'user', 'assistant', 'user']` for the default alongside the version 6 snapshot, and every existing snapshot across `tests/test_logfire.py`, `tests/test_include_binary_content.py`, `tests/test_messages.py`, `tests/test_history_processor.py` and `tests/models/test_snowflake.py` is unchanged.
</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
