### PR TITLE
fix: dispatch async callable FunctionModel instances

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -1,13 +1,12 @@
 from __future__ import annotations as _annotations
 
-import inspect
 import re
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import KW_ONLY, dataclass, field
 from datetime import datetime
 from itertools import chain
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
 from typing_extensions import assert_never, overload
 
@@ -125,7 +124,9 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-        function_name = self.function.__name__ if self.function is not None else ''
+        function_name = (
+            getattr(self.function, '__name__', type(self.function).__name__) if self.function is not None else ''
+        )
         stream_function_name = self.stream_function.__name__ if self.stream_function is not None else ''
         self._model_name = model_name or f'function:{function_name}:{stream_function_name}'
 
@@ -158,11 +159,16 @@ class FunctionModel(Model):
 
         assert self.function is not None, 'FunctionModel must receive a `function` to support non-streamed requests'
 
-        if inspect.iscoroutinefunction(self.function):
-            response = await self.function(messages, agent_info)
+        if _utils.is_async_callable(self.function):
+            response = await cast(Callable[..., Awaitable[ModelResponse]], self.function)(messages, agent_info)
         else:
             # A plain `def` may still return an awaitable, which `run_in_executor` would leave un-awaited.
-            response_ = await _utils.await_maybe(await _utils.run_in_executor(self.function, messages, agent_info))
+            response_ = await _utils.await_maybe(
+                cast(
+                    ModelResponse | Awaitable[ModelResponse],
+                    await _utils.run_in_executor(self.function, messages, agent_info),
+                )
+            )
             assert isinstance(response_, ModelResponse), response_
             response = response_
         response.model_name = self._model_name

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -7,6 +7,7 @@ from datetime import timezone
 import pydantic_core
 import pytest
 from pydantic import BaseModel
+from pytest_mock import MockerFixture
 
 from pydantic_ai import (
     Agent,
@@ -141,6 +142,21 @@ def test_sync_function_returning_coroutine():
     agent = Agent(FunctionModel(sync_returning_coroutine))
     result = agent.run_sync('Hello')
     assert result.output == snapshot('coroutine awaited')
+
+
+class AsyncCallableModel:
+    async def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('async callable awaited directly')])
+
+
+async def test_async_callable_instance_does_not_use_executor(mocker: MockerFixture):
+    run_in_executor = mocker.patch('pydantic_ai.models.function._utils.run_in_executor')
+    agent = Agent(FunctionModel(AsyncCallableModel()))
+
+    result = await agent.run('Hello')
+
+    assert result.output == 'async callable awaited directly'
+    run_in_executor.assert_not_called()
 
 
 async def weather_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: lax no cover


### PR DESCRIPTION
## Summary\n\nFixes #7534.\n\nFunctionModel callable instances with an async __call__ are now detected through the existing async-callable predicate and awaited directly instead of taking the executor path. Added regression coverage for async callable instances.\n\n## Validation\n\n- Focused pytest: 2 passed, 17 deselected\n- ruff format/check\n- pyright\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

