### PR TITLE
Require version boundaries for documented behavior changes

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -40,6 +40,7 @@
 - Cross-reference alternatives and explain trade-offs when documenting overlapping features — Prevents users from missing better-suited options or implementing duplicate functionality when multiple approaches exist (e.g., `UsageLimits` vs rate-limiting, provider-specific implementations)
 <!-- rule:1112 -->
 - Document default behavior and use cases for all configurable features — helps users decide when to override defaults — Users can't make informed configuration choices without knowing what happens by default and when alternatives are appropriate
+- When docs contrast prior and current Pydantic AI behavior, name the first version with the current behavior. Do not repeat a version already supplied by the page or section. Do not add historical prose when current behavior alone is sufficient.
 <!-- rule:135 -->
 - Use actual, currently available model names in documentation examples — prevents user confusion and copy-paste errors with non-existent models — Ensures users can run documentation examples without modification and avoids frustration from referencing models that don't exist yet or are hypothetical
 <!-- rule:508 -->


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

Documentation that already contrasts prior and current Pydantic AI behavior should identify when the current behavior began. The rule stays narrow: it does not require historical prose when documenting current behavior is sufficient.

## New public surface

None.

## Test plan

- Pre-commit hooks
- Focused instruction review

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

