### PR TITLE
ci: validate Pydantic AI docs before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,17 @@ jobs:
       # Check all documentation images are tinified. You will need a Tinify API key to fix failures.
       - run: uvx tinicly docs --check
 
+  # Validate the exact PR revision with Unified Docs' production navigation
+  # compiler. This is deliberately separate from docs-assets: images can be
+  # valid while navigation points to a page supplied by another repository that
+  # has not landed yet.
+  unified-docs-contract:
+    if: github.event_name == 'pull_request'
+    uses: pydantic/unified-docs/.github/workflows/validate-upstream-docs.yml@eb7333758b7eed848adbe2fcd0c37b514450b366
+    with:
+      library: ai
+      source: pydantic/pydantic-ai@${{ github.event.pull_request.head.sha }}
+
   test:
     name: test on ${{ matrix.python-version }} (${{ matrix.install.name }})
     # Use Ubicloud 4-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
@@ -563,6 +574,7 @@ jobs:
       - lint
       - mypy
       - docs-assets
+      - unified-docs-contract
       - test
       - test-lowest-versions
       - test-temporal-latest


### PR DESCRIPTION
## Summary

- add a required Unified Docs contract check for every Pydantic AI pull request
- validate the exact PR SHA with Unified Docs’ production navigation compiler
- surface missing cross-repository documentation files before they can block publication

## Verification

- `uv run pre-commit run --files .github/workflows/ci.yml`
- `actionlint .github/workflows/ci.yml`
- Confirmed the pinned reusable-workflow SHA is publicly resolvable

## Dependency

Depends on pydantic/unified-docs#211, which introduces the secretless reusable contract workflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

