### PR TITLE
Accept any callable as a `FunctionModel` `function` or `stream_function`

### DIFF
--- a/docs/api/models/function.md
+++ b/docs/api/models/function.md
@@ -59,6 +59,40 @@ async def test_my_agent():
         assert result.output == 'hello world'
 ```
 
+The function can be any callable with the right signature, not just a plain function. An instance whose
+`__call__` is `async def` is awaited directly like an `async def` function, and can carry state or
+configuration between requests:
+
+```py {title="function_model_callable_instance.py"}
+from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+
+class CannedResponses:
+    def __init__(self, *responses: str):
+        self.responses = list(responses)
+
+    async def __call__(
+        self, messages: list[ModelMessage], info: AgentInfo
+    ) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(self.responses.pop(0))])
+
+
+model = FunctionModel(CannedResponses('hello', 'world'))
+agent = Agent(model)
+
+print(agent.run_sync('First').output)
+#> hello
+print(agent.run_sync('Second').output)
+#> world
+print(model.model_name)  # (1)!
+#> function:CannedResponses:
+```
+
+1. A callable instance has no `__name__`, so the generated model name uses its class name instead.
+
+_(This example is complete, it can be run "as is")_
+
 See [Unit testing with `FunctionModel`](../../testing.md#unit-testing-with-functionmodel) for detailed documentation.
 
 ::: pydantic_ai.models.function

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -258,6 +258,8 @@ async def test_forecast_future():
 2. Our function is slightly intelligent in that it tries to extract a date from the prompt, but just hard codes the location.
 3. We use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to replace the agent's model with our custom function.
 
+If your replacement model needs to carry state between requests, `FunctionModel` also accepts a callable instance with an `async def __call__` in place of a function; see the [`FunctionModel` API docs](api/models/function.md) for an example.
+
 ### Overriding model via pytest fixtures
 
 If you're writing lots of tests that all require model to be overridden, you can use [pytest fixtures](https://docs.pytest.org/en/6.2.x/fixture.html) to override the model with [`TestModel`][pydantic_ai.models.test.TestModel] or [`FunctionModel`][pydantic_ai.models.function.FunctionModel] in a reusable way.

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -323,7 +323,7 @@ StreamFunctionDef: TypeAlias = Callable[
 ]
 """A function used to generate a streamed response.
 
-Any callable with this signature works, including an instance with an `async def __call__`.
+Any callable with this signature works, including an instance whose `__call__` is an async generator.
 
 While this is defined as having return type of `AsyncIterator[str | DeltaToolCalls | DeltaThinkingCalls | BuiltinTools]`, it should
 really be considered as `AsyncIterator[str] | AsyncIterator[DeltaToolCalls] | AsyncIterator[DeltaThinkingCalls]`,

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -323,7 +323,10 @@ StreamFunctionDef: TypeAlias = Callable[
 ]
 """A function used to generate a streamed response.
 
-Any callable with this signature works, including an instance whose `__call__` is an async generator.
+Any callable with this signature works: an async generator function, a plain `def` returning an async
+iterator, or an instance with a `__call__` of either kind. What matters is the value returned, not the
+callable — an `async def __call__` that *returns* an async iterator instead of yielding does not match,
+and its coroutine is never awaited.
 
 While this is defined as having return type of `AsyncIterator[str | DeltaToolCalls | DeltaThinkingCalls | BuiltinTools]`, it should
 really be considered as `AsyncIterator[str] | AsyncIterator[DeltaToolCalls] | AsyncIterator[DeltaThinkingCalls]`,

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import inspect
 import re
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import asynccontextmanager
@@ -115,7 +114,8 @@ class FunctionModel(Model):
         Args:
             function: The function to call for non-streamed requests.
             stream_function: The function to call for streamed requests.
-            model_name: The name of the model. If not provided, a name is generated from the function names.
+            model_name: The name of the model. If not provided, a name is generated from the function names,
+                falling back to the class name for a callable that has no `__name__`.
             profile: The model profile to use.
             settings: Model-specific settings that will be used as defaults for this model.
         """
@@ -125,8 +125,14 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-        function_name = self.function.__name__ if self.function is not None else ''
-        stream_function_name = self.stream_function.__name__ if self.stream_function is not None else ''
+        function_name = (
+            getattr(self.function, '__name__', type(self.function).__name__) if self.function is not None else ''
+        )
+        stream_function_name = (
+            getattr(self.stream_function, '__name__', type(self.stream_function).__name__)
+            if self.stream_function is not None
+            else ''
+        )
         self._model_name = model_name or f'function:{function_name}:{stream_function_name}'
 
         # Use a default profile that supports JSON schema and object output if none provided
@@ -158,13 +164,14 @@ class FunctionModel(Model):
 
         assert self.function is not None, 'FunctionModel must receive a `function` to support non-streamed requests'
 
-        if inspect.iscoroutinefunction(self.function):
-            response = await self.function(messages, agent_info)
+        result: ModelResponse | Awaitable[ModelResponse]
+        if _utils.is_async_callable(self.function):
+            result = self.function(messages, agent_info)
         else:
-            # A plain `def` may still return an awaitable, which `run_in_executor` would leave un-awaited.
-            response_ = await _utils.await_maybe(await _utils.run_in_executor(self.function, messages, agent_info))
-            assert isinstance(response_, ModelResponse), response_
-            response = response_
+            result = await _utils.run_in_executor(self.function, messages, agent_info)
+        # A plain `def` may also return an awaitable, which `run_in_executor` would leave un-awaited.
+        response = await _utils.await_maybe(result)
+        assert isinstance(response, ModelResponse), response
         response.model_name = self._model_name
         # Add usage data if not already present
         if not response.usage.has_values():  # pragma: no branch
@@ -305,12 +312,18 @@ DeltaThinkingCalls: TypeAlias = dict[int, DeltaThinkingPart]
 BuiltinToolCallsReturns: TypeAlias = dict[int, NativeToolCallPart | NativeToolReturnPart]
 
 FunctionDef: TypeAlias = Callable[[list[ModelMessage], AgentInfo], ModelResponse | Awaitable[ModelResponse]]
-"""A function used to generate a non-streamed response."""
+"""A function used to generate a non-streamed response.
+
+Any callable with this signature works: a plain `def`, an `async def`, or an instance with a `__call__`
+method of either kind. An async callable is awaited directly; a sync one is run in a worker thread.
+"""
 
 StreamFunctionDef: TypeAlias = Callable[
     [list[ModelMessage], AgentInfo], AsyncIterator[str | DeltaToolCalls | DeltaThinkingCalls | BuiltinToolCallsReturns]
 ]
 """A function used to generate a streamed response.
+
+Any callable with this signature works, including an instance with an `async def __call__`.
 
 While this is defined as having return type of `AsyncIterator[str | DeltaToolCalls | DeltaThinkingCalls | BuiltinTools]`, it should
 really be considered as `AsyncIterator[str] | AsyncIterator[DeltaToolCalls] | AsyncIterator[DeltaThinkingCalls]`,

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -207,8 +207,46 @@ async def test_sync_callable_instance():
     assert result.output == snapshot('from the sync instance')
 
 
+class SyncCallableReturningCoroutine:
+    def __init__(self, text: str):
+        self.text = text
+
+    def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> Awaitable[ModelResponse]:
+        return self._respond()
+
+    async def _respond(self) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(self.text)])
+
+
+async def test_sync_callable_instance_returning_coroutine():
+    # The instance analogue of `sync_returning_coroutine`: `is_async_callable` is False either way, so this
+    # runs in the executor and `await_maybe` still has to resolve what it returned.
+    agent = Agent(FunctionModel(SyncCallableReturningCoroutine('coroutine awaited')))
+    result = await agent.run('Hello')
+    assert result.output == snapshot('coroutine awaited')
+
+
 async def test_stream_callable_instance():
     agent = Agent(FunctionModel(stream_function=AsyncCallableStreamFunction('hello world')))
+    async with agent.run_stream('Hello') as result:
+        assert await result.get_output() == snapshot('hello world')
+
+
+class SyncCallableStreamFunction:
+    def __init__(self, text: str):
+        self.text = text
+
+    def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        return self._stream()
+
+    async def _stream(self) -> AsyncIterator[str]:
+        yield self.text
+
+
+async def test_stream_sync_callable_instance():
+    # `request_stream` never inspects async-ness, so a sync `__call__` returning an async iterator streams
+    # just like an async-generator one -- the contract is about the returned value, not the callable.
+    agent = Agent(FunctionModel(stream_function=SyncCallableStreamFunction('hello world')))
     async with agent.run_stream('Hello') as result:
         assert await result.get_output() == snapshot('hello world')
 

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -195,6 +195,11 @@ async def test_async_callable_instance_does_not_need_a_worker_thread():
         result = await Agent(FunctionModel(AsyncCallableFunction('from the async instance'))).run('Hello')
         assert result.output == snapshot('from the async instance')
 
+        # `is_async_callable` unwraps `functools.partial`, so a wrapped async instance stays off the executor
+        # too. Output and model name are identical on both arms, so only the executor can pin this.
+        partial_agent = Agent(FunctionModel(functools.partial(AsyncCallableFunction('from the partial'))))
+        assert (await partial_agent.run('Hello')).output == snapshot('from the partial')
+
         # The counterpart proves the executor really is unusable: a genuinely sync callable still needs it.
         sync_agent = Agent(FunctionModel(SyncCallableFunction('from the sync instance')))
         with pytest.raises(RuntimeError, match='cannot schedule new futures'):

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -1,16 +1,13 @@
 import functools
 import json
 import re
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Awaitable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import timezone
 
-import anyio
 import pydantic_core
 import pytest
-from anyio.abc import TaskStatus
-from anyio.to_thread import current_default_thread_limiter
 from pydantic import BaseModel
 
 from pydantic_ai import (
@@ -187,41 +184,20 @@ def test_init_callable_instance() -> None:
     assert m2.model_name == 'function:AsyncCallableFunction:AsyncCallableStreamFunction'
 
 
-@asynccontextmanager
-async def saturated_worker_threads() -> AsyncGenerator[None]:
-    """Hold every worker-thread token, so anything offloaded to a thread waits instead of running."""
-    limiter = current_default_thread_limiter()
-    total_tokens = limiter.total_tokens
-    limiter.total_tokens = 1
-
-    async def hold_token(*, task_status: TaskStatus[None]) -> None:
-        async with limiter:
-            task_status.started()
-            await anyio.sleep_forever()
-
-    try:
-        async with anyio.create_task_group() as tg:
-            await tg.start(hold_token)
-            try:
-                yield
-            finally:
-                tg.cancel_scope.cancel()
-    finally:
-        limiter.total_tokens = total_tokens
-
-
 async def test_async_callable_instance_does_not_need_a_worker_thread():
     # A predicate that only recognizes `async def` sends an `async def __call__` to the executor, where a
-    # saturated thread pool blocks it indefinitely instead of running it on the event loop.
-    async with saturated_worker_threads():
-        agent = Agent(FunctionModel(AsyncCallableFunction('from the async instance')))
-        with anyio.fail_after(10):
-            result = await agent.run('Hello')
+    # saturated thread pool blocks it indefinitely instead of running it on the event loop. An executor that
+    # cannot accept work at all makes that routing observable: it's the *call* that gets submitted, so a
+    # thread-name assertion would not discriminate -- the coroutine's body awaits on the event loop either way.
+    executor = ThreadPoolExecutor(max_workers=1)
+    executor.shutdown(wait=True)
+    with Agent.using_thread_executor(executor):
+        result = await Agent(FunctionModel(AsyncCallableFunction('from the async instance'))).run('Hello')
         assert result.output == snapshot('from the async instance')
 
-        # The counterpart proves the pool really is saturated: a genuinely sync callable still needs a thread.
+        # The counterpart proves the executor really is unusable: a genuinely sync callable still needs it.
         sync_agent = Agent(FunctionModel(SyncCallableFunction('from the sync instance')))
-        with pytest.raises(TimeoutError), anyio.fail_after(0.1):
+        with pytest.raises(RuntimeError, match='cannot schedule new futures'):
             await sync_agent.run('Hello')
 
 

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -1,11 +1,16 @@
+import functools
 import json
 import re
-from collections.abc import AsyncIterator, Awaitable
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
+from contextlib import asynccontextmanager
 from dataclasses import asdict
 from datetime import timezone
 
+import anyio
 import pydantic_core
 import pytest
+from anyio.abc import TaskStatus
+from anyio.to_thread import current_default_thread_limiter
 from pydantic import BaseModel
 
 from pydantic_ai import (
@@ -141,6 +146,107 @@ def test_sync_function_returning_coroutine():
     agent = Agent(FunctionModel(sync_returning_coroutine))
     result = agent.run_sync('Hello')
     assert result.output == snapshot('coroutine awaited')
+
+
+class AsyncCallableFunction:
+    """A callable instance with an `async def __call__`, e.g. a custom model configured at construction."""
+
+    def __init__(self, text: str):
+        self.text = text
+
+    async def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(self.text)])
+
+
+class SyncCallableFunction:
+    def __init__(self, text: str):
+        self.text = text
+
+    def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(self.text)])
+
+
+class AsyncCallableStreamFunction:
+    def __init__(self, text: str):
+        self.text = text
+
+    async def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        yield self.text
+
+
+def test_init_callable_instance() -> None:
+    m = FunctionModel(function=AsyncCallableFunction('hello world'))
+    assert m.model_name == 'function:AsyncCallableFunction:'
+
+    m1 = FunctionModel(stream_function=AsyncCallableStreamFunction('hello world'))
+    assert m1.model_name == 'function::AsyncCallableStreamFunction'
+
+    m2 = FunctionModel(
+        function=AsyncCallableFunction('hello world'), stream_function=AsyncCallableStreamFunction('hello world')
+    )
+    assert m2.model_name == 'function:AsyncCallableFunction:AsyncCallableStreamFunction'
+
+
+@asynccontextmanager
+async def saturated_worker_threads() -> AsyncGenerator[None]:
+    """Hold every worker-thread token, so anything offloaded to a thread waits instead of running."""
+    limiter = current_default_thread_limiter()
+    total_tokens = limiter.total_tokens
+    limiter.total_tokens = 1
+
+    async def hold_token(*, task_status: TaskStatus[None]) -> None:
+        async with limiter:
+            task_status.started()
+            await anyio.sleep_forever()
+
+    try:
+        async with anyio.create_task_group() as tg:
+            await tg.start(hold_token)
+            try:
+                yield
+            finally:
+                tg.cancel_scope.cancel()
+    finally:
+        limiter.total_tokens = total_tokens
+
+
+async def test_async_callable_instance_does_not_need_a_worker_thread():
+    # A predicate that only recognizes `async def` sends an `async def __call__` to the executor, where a
+    # saturated thread pool blocks it indefinitely instead of running it on the event loop.
+    async with saturated_worker_threads():
+        agent = Agent(FunctionModel(AsyncCallableFunction('from the async instance')))
+        with anyio.fail_after(10):
+            result = await agent.run('Hello')
+        assert result.output == snapshot('from the async instance')
+
+        # The counterpart proves the pool really is saturated: a genuinely sync callable still needs a thread.
+        sync_agent = Agent(FunctionModel(SyncCallableFunction('from the sync instance')))
+        with pytest.raises(TimeoutError), anyio.fail_after(0.1):
+            await sync_agent.run('Hello')
+
+
+async def test_sync_callable_instance():
+    agent = Agent(FunctionModel(SyncCallableFunction('from the sync instance')))
+    result = await agent.run('Hello')
+    assert result.output == snapshot('from the sync instance')
+
+
+async def test_stream_callable_instance():
+    agent = Agent(FunctionModel(stream_function=AsyncCallableStreamFunction('hello world')))
+    async with agent.run_stream('Hello') as result:
+        assert await result.get_output() == snapshot('hello world')
+
+
+async def hello_named(_messages: list[ModelMessage], _agent_info: AgentInfo, *, name: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(f'hello {name}')])
+
+
+async def test_partial_function():
+    # `functools.partial` has no `__name__` either, so it hits the same fallback as a callable instance.
+    model = FunctionModel(functools.partial(hello_named, name='world'))
+    assert model.model_name == 'function:partial:'
+    result = await Agent(model).run('Hello')
+    assert result.output == snapshot('hello world')
 
 
 async def weather_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: lax no cover


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David reviewed and approved the plan; the code has not yet been reviewed line-by-line.

- Closes #7534

## Why we make these changes

`FunctionModel` cannot accept a callable that has no `__name__`, and mis-routes one that does get through.

`FunctionModel.__init__` reads `.__name__` unconditionally on **both** `function` and `stream_function`, so a class instance or a `functools.partial` raises `AttributeError` at construction — before dispatch is ever reached. Past that gate, `FunctionModel.request` classifies the callable with `inspect.iscoroutinefunction`, which is not `__call__`-aware, so an instance whose `__call__` is `async def` is offloaded to a worker thread. That is not merely a wasted round-trip: with the anyio worker-thread pool saturated it blocks indefinitely, while a plain `async def` completes.

`_utils.is_async_callable` is the predicate every other user-callable surface already uses (tools, system prompts, output validators, history processors, hooks). [#7265](https://github.com/pydantic/pydantic-ai/pull/7265) unified the *awaiting* at this site via `await_maybe` and left the predicate alone; this PR finishes the job.

## New public surface

None. No new symbols, no new parameters; `FunctionDef` and `StreamFunctionDef` keep their signatures.

<details>
<summary><b>Goal 1 — any callable can be a <code>function</code> or <code>stream_function</code></b></summary>

### Before → after

```python
class CannedResponses:
    def __init__(self, *responses: str):
        self.responses = list(responses)

    async def __call__(self, messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
        return ModelResponse(parts=[TextPart(self.responses.pop(0))])


FunctionModel(CannedResponses('hello', 'world'))
# before -> AttributeError: 'CannedResponses' object has no attribute '__name__'
# after  -> FunctionModel(model_name='function:CannedResponses:')

FunctionModel(functools.partial(model_function, name='world'))
# before -> AttributeError: 'functools.partial' object has no attribute '__name__'
# after  -> FunctionModel(model_name='function:partial:')
```

Both `function` and `stream_function` now derive their name with `getattr(fn, '__name__', type(fn).__name__)`. The fallback is the **class name**, not `repr` — `repr` embeds a memory address, which would make `model_name` non-deterministic in snapshots.

<details>
<summary>Playground</summary>

```python
import functools

from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart
from pydantic_ai.models.function import AgentInfo, FunctionModel


class CannedResponses:
    def __init__(self, *responses: str):
        self.responses = list(responses)

    async def __call__(self, messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
        return ModelResponse(parts=[TextPart(self.responses.pop(0))])


async def named(_messages: list[ModelMessage], _info: AgentInfo, *, name: str) -> ModelResponse:
    return ModelResponse(parts=[TextPart(f'hello {name}')])


instance_model = FunctionModel(CannedResponses('hello', 'world'))
agent = Agent(instance_model)
print(instance_model.model_name, agent.run_sync('First').output, agent.run_sync('Second').output)
#> function:CannedResponses: hello world

partial_model = FunctionModel(functools.partial(named, name='world'))
print(partial_model.model_name, Agent(partial_model).run_sync('Hello').output)
#> function:partial: hello world
```

</details>

**Tests:** [`test_init_callable_instance`](https://github.com/pydantic/pydantic-ai/pull/7589/files#diff-1eff18c4251314bb242af49d1074f8b7f3e4f5466578917d4c70e5bd7a0508d0R174), [`test_sync_callable_instance`](https://github.com/pydantic/pydantic-ai/pull/7589/files#diff-1eff18c4251314bb242af49d1074f8b7f3e4f5466578917d4c70e5bd7a0508d0R204), [`test_stream_callable_instance`](https://github.com/pydantic/pydantic-ai/pull/7589/files#diff-1eff18c4251314bb242af49d1074f8b7f3e4f5466578917d4c70e5bd7a0508d0R210), [`test_partial_function`](https://github.com/pydantic/pydantic-ai/pull/7589/files#diff-1eff18c4251314bb242af49d1074f8b7f3e4f5466578917d4c70e5bd7a0508d0R220)

**What changes for existing users:** nothing. Every one of these shapes raised `AttributeError` before, so no working code exists that this could alter.

</details>

<details>
<summary><b>Goal 2 — an <code>async def __call__</code> runs on the event loop, not a worker thread</b></summary>

### Before → after

With the anyio worker-thread pool saturated:

```python
executor = ThreadPoolExecutor(max_workers=1)
executor.shutdown(wait=True)          # stands in for a fully saturated pool
with Agent.using_thread_executor(executor):
    await Agent(FunctionModel(AsyncCallableInstance())).run('Hello')
    # before -> RuntimeError: cannot schedule new futures after shutdown
    # after  -> completes

    await Agent(FunctionModel(sync_function)).run('Hello')
    # -> RuntimeError, before and after: a sync callable genuinely needs a thread
```

In production the pool is saturated rather than shut down, and the symptom is an indefinite block instead of a `RuntimeError`.

The dispatch becomes:

```python
result: ModelResponse | Awaitable[ModelResponse]
if _utils.is_async_callable(self.function):
    result = self.function(messages, agent_info)
else:
    result = await _utils.run_in_executor(self.function, messages, agent_info)
# A plain `def` may also return an awaitable, which `run_in_executor` would leave un-awaited.
response = await _utils.await_maybe(result)
assert isinstance(response, ModelResponse), response
```

Annotating `result` keeps `is_async_callable`'s `TypeIs` from narrowing the `else` branch to a non-awaitable, so no `cast` and no type alias are needed, and the single `await_maybe` covers both branches — including the `def`-that-returns-a-coroutine shape [#7265](https://github.com/pydantic/pydantic-ai/pull/7265) fixed.

<details>
<summary>Playground</summary>

```python
from concurrent.futures import ThreadPoolExecutor

import anyio

from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart
from pydantic_ai.models.function import AgentInfo, FunctionModel


class AsyncCallable:
    async def __call__(self, _messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
        return ModelResponse(parts=[TextPart('from the async instance')])


def sync_function(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
    return ModelResponse(parts=[TextPart('from the sync function')])


async def main() -> None:
    executor = ThreadPoolExecutor(max_workers=1)
    executor.shutdown(wait=True)
    with Agent.using_thread_executor(executor):
        print((await Agent(FunctionModel(AsyncCallable())).run('Hello')).output)
        #> from the async instance   (before this PR: RuntimeError from the dead executor)

        try:
            await Agent(FunctionModel(sync_function)).run('Hello')
        except RuntimeError as exc:
            print(exc)
            #> cannot schedule new futures after shutdown


anyio.run(main)
```

</details>

**Test:** [`test_async_callable_instance_does_not_need_a_worker_thread`](https://github.com/pydantic/pydantic-ai/pull/7589/files#diff-1eff18c4251314bb242af49d1074f8b7f3e4f5466578917d4c70e5bd7a0508d0R187) — it runs both agents under `Agent.using_thread_executor` with a **shut-down** executor, so the async instance completing is proof it never reached the executor, and the sync counterpart raising `RuntimeError: cannot schedule new futures` proves the executor really is unusable. Verified to fail with the fix reverted.

**What changes for existing users:** nothing observable. The predicates disagree on exactly three shapes:

| callable | `iscoroutinefunction` | `is_async_callable` | constructible before |
|---|---|---|---|
| `async def` / `def` / lambda / bound methods / `partial(async def)` / `partial(def)` | *same* | *same* | — |
| async `__call__` instance | `False` | `True` | ❌ `AttributeError` |
| `partial(async __call__ instance)` | `False` | `True` | ❌ `AttributeError` |
| async `__call__` instance that also sets `__name__` | `False` | `True` | ✅ |

The first two could not be constructed at all before this PR. The third could — and its observable result is unchanged: `run_in_executor` only ever built the coroutine object, whose body awaited on the event loop either way, so the sole effect is that it stops borrowing a worker thread to do so.

</details>

## Notes for reviewers

- `request_stream` has no predicate — `PeekableAsyncStream` already accepts callable instances. The issue text claims an equivalent dispatch there; there isn't one. Only the construction gate blocked `stream_function` instances.
- The `assert isinstance(response, ModelResponse)` now covers the async branch too, turning an obscure downstream `AttributeError` into a clear failure. No type-checked code is affected.
- `models/function.py` held the last bare `inspect.iscoroutinefunction` classification of a user callable in `pydantic_ai`; `import inspect` is now unused and removed.
- The `pydantic_evals` sibling ([#7535](https://github.com/pydantic/pydantic-ai/pull/7535)) is independent — no file overlap.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
