### PR TITLE
Harden docs preview dispatch

### DIFF
--- a/.github/scripts/test_docs_preview_workflow.py
+++ b/.github/scripts/test_docs_preview_workflow.py
@@ -1,0 +1,27 @@
+"""Regression tests for the cross-repository docs preview dispatcher."""
+
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parents[1] / 'workflows' / 'docs-preview.yml'
+
+
+def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
+    """The secret-bearing public workflow must remain a dispatcher only."""
+    workflow = WORKFLOW.read_text()
+
+    assert 'pull_request_target:' in workflow
+    assert "github.event.label.name == 'trigger:docs'" in workflow
+    assert 'actions/checkout@' not in workflow
+    assert '/collaborators/${ACTOR}/permission' in workflow
+    assert 'admin|maintain|write)' in workflow
+    assert 'permission-contents: write' in workflow
+    assert workflow.index('Verify a maintainer triggered the preview') < workflow.index('Generate app token')
+
+
+def test_public_comments_do_not_disclose_private_workflow_links() -> None:
+    """Public comments should not link users to inaccessible private runs."""
+    workflow = WORKFLOW.read_text()
+
+    assert 'github.com/pydantic/unified-docs' not in workflow
+    assert 'The preview build for commit' in workflow
+    assert 'has been queued' in workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           .github/scripts/test_issue_pr_attention_monitor.py
           .github/scripts/test_agentic_workflow_guard.py
           .github/scripts/test_agent_spend_report.py
+          .github/scripts/test_docs_preview_workflow.py
           .github/scripts/test_protect_github_dir.py
 
       # The tests above import the shim inside this job's workspace venv, which is not

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -11,8 +11,8 @@ name: Docs Preview
 
 on:
   # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so fork PRs can
-  # access the DOCS_APP credentials. The dispatch is gated on a maintainer adding the
-  # `trigger:docs` label, and this workflow does not check out or execute PR code.
+  # access the DOCS_APP credentials. The dispatch explicitly verifies that the label
+  # actor has write access, and this workflow does not check out or execute PR code.
   pull_request_target:
     types: [labeled]
 
@@ -32,6 +32,21 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Verify a maintainer triggered the preview
+        env:
+          ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq .permission)
+          case "$permission" in
+            admin|maintain|write) ;;
+            *)
+              echo "${ACTOR} does not have permission to dispatch a docs preview" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Generate app token (for dispatching to unified-docs)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -40,6 +55,7 @@ jobs:
           private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: unified-docs
+          permission-contents: write
 
       - name: Dispatch preview build
         env:
@@ -67,7 +83,7 @@ jobs:
           body=$(cat <<EOF
           ## Docs Preview — queued
 
-          The preview build for commit \`${sha7}\` has been dispatched to [pydantic/unified-docs](https://github.com/pydantic/unified-docs/actions/workflows/docs-preview.yml). This comment will be updated with the preview URL once the build completes.
+          The preview build for commit \`${sha7}\` has been queued. This comment will be updated with the preview URL once the build completes.
           EOF
           )
 
@@ -91,7 +107,7 @@ jobs:
           body=$(cat <<EOF
           ## Docs Preview — dispatch failed
 
-          The dispatch to pydantic/unified-docs failed. See [the workflow run](${RUN_URL}) for details.
+          The preview request could not be queued. See [the workflow run](${RUN_URL}) for details.
 
           <sub>Re-add the \`trigger:docs\` label to retry.</sub>
           EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,7 @@ include = [
     ".github/scripts/test_agentic_workflow_guard.py",
     ".github/scripts/agent_spend_report.py",
     ".github/scripts/test_agent_spend_report.py",
+    ".github/scripts/test_docs_preview_workflow.py",
     ".github/scripts/test_protect_github_dir.py",
 ]
 
@@ -323,6 +324,7 @@ quote-style = "single"
 ".github/scripts/test_issue_pr_attention_monitor.py" = ["D"]
 ".github/scripts/test_agentic_workflow_guard.py" = ["D"]
 ".github/scripts/test_agent_spend_report.py" = ["D"]
+".github/scripts/test_docs_preview_workflow.py" = ["D"]
 ".github/scripts/test_protect_github_dir.py" = ["D"]
 
 [tool.pyright]


### PR DESCRIPTION
## Problem

The label-driven docs preview dispatcher accepted any pull-request actor and exposed private receiver details in public comments. Its GitHub App token also relied on implicit permissions.

## Solution

- require the actor requesting `docs-preview` to have write, maintain, or admin permission on this repository
- keep `pull_request_target` limited to metadata validation and dispatch; it never checks out or executes pull-request code
- scope the GitHub App token to this repository and the single `contents: write` permission needed for `repository_dispatch`
- remove private workflow names and links from public queued and failure comments
- add an executable workflow contract test to CI

## Rollout

Deploy the corresponding private receiver hardening before merging this dispatcher change.

## Validation

- `uv run pytest -q .github/scripts/test_docs_preview_workflow.py`
- `uv run ruff format --check .github/scripts/test_docs_preview_workflow.py`
- `uv run ruff check .github/scripts/test_docs_preview_workflow.py`
- `uvx zizmor .github/workflows/docs-preview.yml`
- pre-commit and pre-push hooks

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

