### PR TITLE
Recognize `m.youtube.com` URLs in `VideoUrl`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -350,7 +350,7 @@ class VideoUrl(FileUrl):
         """True if the URL has a YouTube domain."""
         parsed = urlparse(self.url)
         hostname = parsed.hostname
-        return hostname in ('youtu.be', 'youtube.com', 'www.youtube.com')
+        return hostname in ('youtu.be', 'youtube.com') or (hostname is not None and hostname.endswith('.youtube.com'))
 
     @property
     def format(self) -> VideoFormat:

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -348,9 +348,11 @@ class VideoUrl(FileUrl):
     @property
     def is_youtube(self) -> bool:
         """True if the URL has a YouTube domain."""
-        parsed = urlparse(self.url)
-        hostname = parsed.hostname
-        return hostname in ('youtu.be', 'youtube.com') or (hostname is not None and hostname.endswith('.youtube.com'))
+        # Exact hosts, not a `.youtube.com` suffix match: Gemini rejects
+        # `music.youtube.com` as a `file_uri` with 400 INVALID_ARGUMENT, so a suffix
+        # match would hand it a URL it cannot resolve. Add a host here only once the
+        # provider has been observed to accept it.
+        return urlparse(self.url).hostname in ('youtu.be', 'youtube.com', 'www.youtube.com', 'm.youtube.com')
 
     @property
     def format(self) -> VideoFormat:

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -347,11 +347,16 @@ class VideoUrl(FileUrl):
 
     @property
     def is_youtube(self) -> bool:
-        """True if the URL has a YouTube domain."""
-        # Exact hosts, not a `.youtube.com` suffix match: Gemini rejects
-        # `music.youtube.com` as a `file_uri` with 400 INVALID_ARGUMENT, so a suffix
-        # match would hand it a URL it cannot resolve. Add a host here only once the
-        # provider has been observed to accept it.
+        """True if the URL is on a YouTube host that models can resolve directly.
+
+        This is a specific set of hosts rather than every YouTube-owned domain, so
+        `music.youtube.com` is deliberately not one of them.
+        """
+        # Exact hosts, not a `.youtube.com` suffix match: Google rejects
+        # `music.youtube.com` as a `file_uri` with 400 INVALID_ARGUMENT, on the Gemini API
+        # and on Vertex alike, so a suffix match would hand it a URL it cannot resolve.
+        # Membership is also read by `download_item`, so a host added here stops being
+        # downloadable on every other provider too — verify both before extending this.
         return urlparse(self.url).hostname in ('youtu.be', 'youtube.com', 'www.youtube.com', 'm.youtube.com')
 
     @property

--- a/tests/models/cassettes/test_google/test_google_model_mobile_youtube_video_url_input.yaml
+++ b/tests/models/cassettes/test_google/test_google_model_mobile_youtube_video_url_input.yaml
@@ -1,0 +1,86 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '338'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: Explain me this video in a few sentences
+        - fileData:
+            fileUri: https://m.youtube.com/watch?v=lCdaVNyHtjU
+            mimeType: video/mp4
+        role: user
+      generationConfig:
+        responseModalities:
+        - TEXT
+      systemInstruction:
+        parts:
+        - text: You are a helpful chatbot.
+        role: user
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '1077'
+      content-type:
+      - application/json; charset=UTF-8
+      server-timing:
+      - gfet4t7; dur=6189
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - content:
+          parts:
+          - text: This video demonstrates an AI assistant within a code editor analyzing recent 404 HTTP responses from a
+              logfile database. The AI queries the database, identifies common patterns related to specific endpoints, request
+              types, timeline issues, and authentication problems. Finally, it provides a detailed analysis of these patterns
+              along with actionable recommendations to resolve the identified issues.
+          role: model
+        finishReason: STOP
+        index: 0
+      modelVersion: gemini-2.5-flash
+      responseId: JiyGasHJHe-wjMcP4aqWmQg
+      usageMetadata:
+        cacheTokensDetails:
+        - modality: AUDIO
+          tokenCount: 1881
+        - modality: TEXT
+          tokenCount: 15
+        - modality: VIDEO
+          tokenCount: 15483
+        cachedContentTokenCount: 17379
+        candidatesTokenCount: 68
+        promptTokenCount: 17713
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 16
+        - modality: VIDEO
+          tokenCount: 15780
+        - modality: AUDIO
+          tokenCount: 1917
+        serviceTier: standard
+        thoughtsTokenCount: 821
+        totalTokenCount: 18602
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -794,9 +794,11 @@ async def test_google_model_mobile_youtube_video_url_input(
 ):
     """`m.youtube.com` share links resolve as a `file_uri`, like any other YouTube host.
 
-    The request body proves we send the URL rather than downloading it, and the recorded usage
-    proves Gemini resolved it to the video rather than to the watch page: it bills video and
-    audio prompt tokens, which a downloaded `text/html` page could not produce.
+    What catches a regression here is the cassette itself, not the request-body snapshot: drop
+    the host from `VideoUrl.is_youtube` and `_resolve_file` falls through to `download_item`,
+    whose live GET has no recorded interaction, so replay fails before the snapshot is reached.
+    The recorded usage is what proves Gemini resolved the URL to the video rather than to the
+    watch page — it bills video and audio prompt tokens, which a `text/html` page could not.
     """
     m = GoogleModel('gemini-2.5-flash', provider=google_provider)
     agent = Agent(m, instructions='You are a helpful chatbot.')

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -87,6 +87,7 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 from .._inline_snapshot import Is, snapshot
+from ..cassette_utils import single_request_body
 from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, try_import
 from ..parts_from_messages import part_types_from_messages
 
@@ -785,6 +786,56 @@ async def test_google_model_youtube_video_url_input(allow_model_requests: None, 
     )
     assert result.output == snapshot(
         'This video demonstrates using an AI agent to analyze recent 404 HTTP responses from a service. The user asks the agent, "Logfire," to identify patterns in these errors. The agent then queries a Logfire database, extracts relevant information like URL paths, HTTP methods, and timestamps, and presents a detailed analysis covering common error-prone endpoints, request patterns, timeline-related issues, and potential configuration or authentication problems. Finally, it offers a list of actionable recommendations to address these issues.'
+    )
+
+
+async def test_google_model_mobile_youtube_video_url_input(
+    allow_model_requests: None, google_provider: GoogleProvider, vcr: Cassette
+):
+    """`m.youtube.com` share links resolve as a `file_uri`, like any other YouTube host.
+
+    The request body proves we send the URL rather than downloading it, and the recorded usage
+    proves Gemini resolved it to the video rather than to the watch page: it bills video and
+    audio prompt tokens, which a downloaded `text/html` page could not produce.
+    """
+    m = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    agent = Agent(m, instructions='You are a helpful chatbot.')
+
+    result = await agent.run(
+        [
+            'Explain me this video in a few sentences',
+            VideoUrl(url='https://m.youtube.com/watch?v=lCdaVNyHtjU'),
+        ]
+    )
+    assert single_request_body(vcr) == snapshot(
+        {
+            'contents': [
+                {
+                    'parts': [
+                        {'text': 'Explain me this video in a few sentences'},
+                        {'fileData': {'fileUri': 'https://m.youtube.com/watch?v=lCdaVNyHtjU', 'mimeType': 'video/mp4'}},
+                    ],
+                    'role': 'user',
+                }
+            ],
+            'generationConfig': {'responseModalities': ['TEXT']},
+            'systemInstruction': {'parts': [{'text': 'You are a helpful chatbot.'}], 'role': 'user'},
+        }
+    )
+    assert result.output == snapshot(
+        'This video demonstrates an AI assistant within a code editor analyzing recent 404 HTTP responses from a logfile database. The AI queries the database, identifies common patterns related to specific endpoints, request types, timeline issues, and authentication problems. Finally, it provides a detailed analysis of these patterns along with actionable recommendations to resolve the identified issues.'
+    )
+    assert result.usage.details == snapshot(
+        {
+            'cached_content_tokens': 17379,
+            'thoughts_tokens': 821,
+            'text_prompt_tokens': 16,
+            'video_prompt_tokens': 15780,
+            'audio_prompt_tokens': 1917,
+            'audio_cache_tokens': 1881,
+            'text_cache_tokens': 15,
+            'video_cache_tokens': 15483,
+        }
     )
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -108,7 +108,6 @@ def test_video_url():
         pytest.param('https://www.youtube.com/lCdaVNyHtjU', True, id='www.youtube.com'),
         pytest.param('https://youtube.com/lCdaVNyHtjU', True, id='youtube.com'),
         pytest.param('https://m.youtube.com/watch?v=lCdaVNyHtjU', True, id='m.youtube.com'),
-        pytest.param('https://music.youtube.com/watch?v=lCdaVNyHtjU', True, id='music.youtube.com'),
         pytest.param('https://youtube.com.example.com/video.mp4', False, id='youtube.com.example.com'),
         pytest.param('https://dummy.com/video.mp4', False, id='dummy.com'),
     ],
@@ -118,6 +117,23 @@ def test_youtube_video_url(url: str, is_youtube: bool):
     assert video_url.is_youtube is is_youtube
     assert video_url.media_type == 'video/mp4'
     assert video_url.format == 'mp4'
+
+
+def test_music_youtube_video_url_is_not_youtube():
+    """`music.youtube.com` is deliberately not a YouTube host.
+
+    Gemini rejects it as a `file_uri` with 400 INVALID_ARGUMENT, so recognizing it would hand
+    the provider a URL it cannot resolve. Staying unrecognized also means an extension-less
+    watch URL has no media type to infer, which is what the raise below pins.
+    """
+    video_url = VideoUrl(url='https://music.youtube.com/watch?v=lCdaVNyHtjU')
+    assert video_url.is_youtube is False
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape('Could not infer media type from video URL: https://music.youtube.com/watch?v=lCdaVNyHtjU'),
+    ):
+        video_url.media_type
 
 
 @pytest.mark.parametrize(

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -107,6 +107,9 @@ def test_video_url():
         pytest.param('https://youtu.be/lCdaVNyHtjU', True, id='youtu.be'),
         pytest.param('https://www.youtube.com/lCdaVNyHtjU', True, id='www.youtube.com'),
         pytest.param('https://youtube.com/lCdaVNyHtjU', True, id='youtube.com'),
+        pytest.param('https://m.youtube.com/watch?v=lCdaVNyHtjU', True, id='m.youtube.com'),
+        pytest.param('https://music.youtube.com/watch?v=lCdaVNyHtjU', True, id='music.youtube.com'),
+        pytest.param('https://youtube.com.example.com/video.mp4', False, id='youtube.com.example.com'),
         pytest.param('https://dummy.com/video.mp4', False, id='dummy.com'),
     ],
 )

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -122,9 +122,12 @@ def test_youtube_video_url(url: str, is_youtube: bool):
 def test_music_youtube_video_url_is_not_youtube():
     """`music.youtube.com` is deliberately not a YouTube host.
 
-    Gemini rejects it as a `file_uri` with 400 INVALID_ARGUMENT, so recognizing it would hand
+    Google rejects it as a `file_uri` with 400 INVALID_ARGUMENT, so recognizing it would hand
     the provider a URL it cannot resolve. Staying unrecognized also means an extension-less
     watch URL has no media type to infer, which is what the raise below pins.
+
+    Not a VCR test: with the host unrecognized the `ValueError` is raised locally, before
+    anything reaches the wire, so there is no exchange to record.
     """
     video_url = VideoUrl(url='https://music.youtube.com/watch?v=lCdaVNyHtjU')
     assert video_url.is_youtube is False


### PR DESCRIPTION
> This pull request body was written by Claude Code using claude-opus-5 on behalf of David.
> David decided the scope of the change and has not reviewed the implementation.

Closes #7591

## Why we make these changes

`VideoUrl.is_youtube` matched an exact host tuple that omitted `m.youtube.com` — the host YouTube's own mobile share sheet produces. Unrecognized hosts don't take the YouTube `file_uri` path; they fall through to `download_item`, which fetches the **watch page** and sends that HTML as the video. Measured on `main`: `m.youtube.com/watch?v=…` 302s to `www.youtube.com/watch?app=desktop&v=…` and returns 1.1 MB of `text/html`. The model receives a web page, and nothing errors.

This adds `m.youtube.com` to the allowlist, verified against the provider rather than against the URL grammar.

**It deliberately does not generalize to `*.youtube.com`.** Gemini rejects `music.youtube.com` as a `file_uri`, so a suffix match would sweep in a host the provider cannot resolve — trading a silent failure for a hard 400. `music.youtube.com` therefore stays unrecognized and its behavior is **byte-identical to `main`**. The residual bug it represents is filed as #7620.

## New public surface

None. `VideoUrl.is_youtube` already existed; only which hosts it matches changed.

<details>
<summary><b>Goal:</b> <code>m.youtube.com</code> links reach Gemini as a <code>file_uri</code></summary>

**Before → after**

```python
from pydantic_ai import VideoUrl

VideoUrl(url='https://m.youtube.com/watch?v=lCdaVNyHtjU').is_youtube
# before -> False   (watch page downloaded, 1.1 MB text/html sent as the video)
# after  -> True    (URL passed straight through as file_uri)

VideoUrl(url='https://music.youtube.com/watch?v=lCdaVNyHtjU').is_youtube
# before -> False
# after  -> False   (unchanged — Gemini 400s this host as a file_uri)

VideoUrl(url='https://youtube.com.example.com/video.mp4').is_youtube
# before -> False
# after  -> False   (unchanged — now covered by a regression test)
```

<details>
<summary>Playground</summary>

```python
import os

from pydantic_ai import Agent, VideoUrl
from pydantic_ai.models.google import GoogleModel
from pydantic_ai.providers.google import GoogleProvider

agent = Agent(GoogleModel('gemini-2.5-flash', provider=GoogleProvider(api_key=os.environ['GOOGLE_API_KEY'])))

result = agent.run_sync(
    [
        'Explain me this video in a few sentences',
        VideoUrl(url='https://m.youtube.com/watch?v=lCdaVNyHtjU'),
    ]
)
print(result.output)
print(result.usage.details)
# -> {'video_prompt_tokens': 15780, ...}  proof the video was ingested, not the HTML page
```
</details>

<details>
<summary>Provider verification — one live recording per host</summary>

Same video (`lCdaVNyHtjU`), same prompt, same model (`gemini-2.5-flash`), one cassette each:

| Host | HTTP | `VIDEO` prompt tokens |
|---|---|---|
| `youtu.be` | 200 | 15780 |
| `youtube.com` | 200 | 15780 |
| `www.youtube.com` | 200 | 15780 |
| `m.youtube.com` | 200 | 15780 |
| `music.youtube.com` | **400 `INVALID_ARGUMENT`** | — |

The identical token count across the four accepted hosts is what proves Gemini resolved the same
video each time, rather than returning a plausible-sounding summary.

The rejection reproduced on three separate live recordings:

```yaml
request:
  parts:
  - text: Explain me this video in a few sentences
  - fileData:
      fileUri: https://music.youtube.com/watch?v=lCdaVNyHtjU
      mimeType: video/mp4
  uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
response:
  error:
    code: 400
    message: Request contains an invalid argument.
    status: INVALID_ARGUMENT
```

Only the `m.youtube.com` recording ships. A test asserting the 400 would replay our own cassette
forever — it could never notice Google adding support later, while quietly passing. The exclusion is
recorded as a comment on the allowlist instead.
</details>

**Test:** [`m.youtube.com` reaches Gemini as a `file_uri`](https://github.com/pydantic/pydantic-ai/pull/7592/files#diff-ad9a21cbd7d2c6c7f1864ff51e4d1113e9cb75939d09c2fdfa09a8e2c9b7ab9bR792) · [`music.youtube.com` stays excluded](https://github.com/pydantic/pydantic-ai/pull/7592/files#diff-8baafe6a89af128a8229ee94b2d39e6579d0e9272ba859a292441c10253a32a9R122) · [host allowlist regression cases](https://github.com/pydantic/pydantic-ai/pull/7592/files#diff-8baafe6a89af128a8229ee94b2d39e6579d0e9272ba859a292441c10253a32a9R111)

**What changes for existing users:** `m.youtube.com` video URLs stop being downloaded as HTML and start resolving as YouTube. Two consequences, both matching how `youtu.be` and `www.youtube.com` already behave: they now raise `UserError('Downloading YouTube videos is not supported.')` on non-Gemini providers, replacing a silent 1.1 MB HTML upload with the error the project already defines for this case; and `force_download=True` no longer downloads them (verified: it raises that same `UserError`, byte-identical to `www.youtube.com` with the flag set). Every other host, including `music.youtube.com`, behaves exactly as before.
</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
