### PR TITLE
Add GLM-5.3 support to `ZaiModel`

### DIFF
--- a/docs/models/zai.md
+++ b/docs/models/zai.md
@@ -44,7 +44,7 @@ agent = Agent(model)
 
 ## Thinking mode
 
-Z.AI's `glm-5.2`, `glm-5.1`, `glm-5`, `glm-4.7`, `glm-4.6` (hybrid thinking), and `glm-4.5` (interleaved thinking) models support thinking/reasoning mode, where the model produces reasoning content before the final response. This includes the `glm-4.6v` and `glm-4.5v` vision models. Configure this through the unified [`thinking`][pydantic_ai.settings.ModelSettings.thinking] setting:
+Z.AI's `glm-5.3`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-4.7`, `glm-4.6` (hybrid thinking), and `glm-4.5` (interleaved thinking) models support thinking/reasoning mode, where the model produces reasoning content before the final response. This includes the `glm-4.6v` and `glm-4.5v` vision models. Configure this through the unified [`thinking`][pydantic_ai.settings.ModelSettings.thinking] setting:
 
 ```python
 from pydantic_ai import Agent
@@ -57,7 +57,7 @@ agent = Agent(
 ...
 ```
 
-`thinking=True` enables thinking and `thinking=False` disables it. On GLM-5.2, an explicit effort level (`'minimal'`/`'low'`/`'medium'`/`'high'`/`'xhigh'`) is forwarded to Z.AI as `reasoning_effort`; on other GLM models, which don't expose effort granularity, the effort levels all collapse to enabled. Omit the field to use each model's default behavior.
+`thinking=True` enables thinking and `thinking=False` disables it (except on GLM-5.3, which always reasons and ignores `thinking=False`). On GLM-5.2 and GLM-5.3, an explicit effort level (`'minimal'`/`'low'`/`'medium'`/`'high'`/`'xhigh'`) is forwarded to Z.AI as `reasoning_effort`; on other GLM models, which don't expose effort granularity, the effort levels all collapse to enabled. Omit the field to use each model's default behavior.
 
 ### Preserved thinking
 

--- a/pydantic_ai_slim/pydantic_ai/models/_known_model_names.py
+++ b/pydantic_ai_slim/pydantic_ai/models/_known_model_names.py
@@ -692,6 +692,7 @@ KnownModelName = TypeAliasType(
         'zai:glm-5-turbo',
         'zai:glm-5.1',
         'zai:glm-5.2',
+        'zai:glm-5.3',
         'zai:glm-5v-turbo',
     ],
 )

--- a/pydantic_ai_slim/pydantic_ai/models/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/zai.py
@@ -26,6 +26,7 @@ except ImportError as _import_error:  # pragma: no cover
 __all__ = ('ZaiModel', 'ZaiModelName', 'ZaiModelSettings')
 
 LatestZaiModelNames = Literal[
+    'glm-5.3',
     'glm-5.2',
     'glm-5.1',
     'glm-5',
@@ -154,7 +155,7 @@ def _zai_settings_to_openai_settings(
         model_settings: The 'ZaiModelSettings' object to transform.
         model_request_parameters: The request parameters carrying the resolved unified `thinking` value.
         supports_thinking: Whether the model supports thinking, gating the default `clear_thinking`.
-        supports_reasoning_effort: Whether the model accepts a per-request `reasoning_effort` (GLM-5.2).
+        supports_reasoning_effort: Whether the model accepts a per-request `reasoning_effort` (GLM-5.2 and GLM-5.3).
 
     Returns:
         An 'OpenAIChatModelSettings' object with equivalent settings.

--- a/pydantic_ai_slim/pydantic_ai/profiles/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/zai.py
@@ -7,15 +7,21 @@ class ZaiModelProfile(ModelProfile, total=False):
     """Profile for Z.AI (Zhipu AI) GLM models."""
 
     zai_supports_reasoning_effort: bool
-    """Whether the model accepts a per-request `reasoning_effort` level (GLM-5.2)."""
+    """Whether the model accepts a per-request `reasoning_effort` level (GLM-5.2 and GLM-5.3)."""
 
 
-_REASONING_EFFORT_MODEL_PREFIXES = ('glm-5.2',)
+_REASONING_EFFORT_MODEL_PREFIXES = ('glm-5.3', 'glm-5.2')
 """Model name prefixes for GLM models that accept the per-request `reasoning_effort` parameter.
 
 GLM-5.2 introduced per-request reasoning effort. Add released models here as they gain support (like the
 OpenAI profile's enumerated `gpt-5.x` set — concrete ids, not a derived "and newer"). On earlier GLM models
 the effort levels collapse to thinking on/off.
+"""
+
+_ALWAYS_THINKING_MODEL_PREFIXES = ('glm-5.3',)
+"""Model name prefixes for GLM models that always reason and reject `thinking.type: 'disabled'` (GLM-5.3).
+
+Like `_REASONING_EFFORT_MODEL_PREFIXES`, list concrete released ids only.
 """
 
 
@@ -24,8 +30,9 @@ def zai_model_profile(model_name: str) -> ModelProfile | None:
 
     Marks thinking-capable models (`glm-5`, `glm-4.7`, `glm-4.6`, `glm-4.5`) via `supports_thinking=True`.
     This includes the `glm-4.6v` and `glm-4.5v` vision models, which also support thinking mode per the
-    Z.AI docs. GLM-5.2 additionally accepts a per-request reasoning effort level, flagged via
-    `zai_supports_reasoning_effort=True`.
+    Z.AI docs. GLM-5.2 and GLM-5.3 additionally accept a per-request reasoning effort level, flagged via
+    `zai_supports_reasoning_effort=True`. GLM-5.3 always reasons and cannot disable thinking, flagged via
+    `thinking_always_enabled=True`.
 
     The provider-specific request/response shape (e.g. the `reasoning_content` field used by Z.AI's API)
     is configured in `ZaiProvider.model_profile()` rather than here. Providers that serve GLM models under
@@ -38,5 +45,6 @@ def zai_model_profile(model_name: str) -> ModelProfile | None:
         return None
     return ZaiModelProfile(
         supports_thinking=True,
+        thinking_always_enabled=model_lower.startswith(_ALWAYS_THINKING_MODEL_PREFIXES),
         zai_supports_reasoning_effort=model_lower.startswith(_REASONING_EFFORT_MODEL_PREFIXES),
     )

--- a/tests/models/cassettes/test_zai/test_zai_glm_5_3_reasoning_effort.yaml
+++ b/tests/models/cassettes/test_zai/test_zai_glm_5_3_reasoning_effort.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '183'
+      content-type:
+      - application/json
+      host:
+      - api.z.ai
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is 2 + 2?
+        role: user
+      model: glm-5.3
+      reasoning_effort: low
+      stream: false
+      thinking:
+        clear_thinking: false
+        type: enabled
+    uri: https://api.z.ai/api/paas/v4/chat/completions
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '447'
+      content-type:
+      - application/json; charset=UTF-8
+      keep-alive:
+      - timeout=6
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      - Origin
+      - Access-Control-Request-Method
+      - Access-Control-Request-Headers
+      - Origin
+      - Access-Control-Request-Method
+      - Access-Control-Request-Headers
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          content: 2 + 2 = 4
+          role: assistant
+      created: 1787149299
+      id: 20260819222138738fbdcfb64f4924
+      model: glm-5.3
+      object: chat.completion
+      request_id: 20260819222138738fbdcfb64f4924
+      usage:
+        completion_tokens: 9
+        completion_tokens_details:
+          reasoning_tokens: 0
+        prompt_tokens: 20
+        prompt_tokens_details:
+          cached_tokens: 0
+        total_tokens: 29
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_zai.py
+++ b/tests/models/test_zai.py
@@ -219,6 +219,26 @@ async def test_zai_reasoning_effort(allow_model_requests: None, zai_api_key: str
     assert request_body['reasoning_effort'] == 'high'
 
 
+async def test_zai_glm_5_3_reasoning_effort(allow_model_requests: None, zai_api_key: str, vcr: Cassette):
+    """On GLM-5.3, an explicit unified thinking effort level is forwarded as `extra_body.reasoning_effort`,
+    like on GLM-5.2.
+
+    Recorded against the real Z.AI API to confirm GLM-5.3 accepts the `reasoning_effort` parameter
+    (it supports `low`/`high`/`max` per the Z.AI docs); VCR matchers aren't sensitive to the request body.
+    At `low` effort the recorded response carries no `reasoning_content` for this trivial prompt.
+    """
+    provider = ZaiProvider(api_key=zai_api_key)
+    model = ZaiModel('glm-5.3', provider=provider)
+    settings = ModelSettings(thinking='low')
+    response = await model_request(model, [ModelRequest.user_text_prompt('What is 2 + 2?')], model_settings=settings)
+    assert response.parts == snapshot([TextPart(content='2 + 2 = 4')])
+
+    assert len(vcr.requests) == 1  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    request_body = json.loads(vcr.requests[0].body)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    assert request_body['thinking'] == {'type': 'enabled', 'clear_thinking': False}
+    assert request_body['reasoning_effort'] == 'low'
+
+
 async def test_zai_thinking_stream(allow_model_requests: None, zai_api_key: str):
     provider = ZaiProvider(api_key=zai_api_key)
     model = ZaiModel('glm-4.7', provider=provider)

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -86,6 +86,14 @@ def test_zai_provider_model_profile(mocker: MockerFixture):
     assert profile_5_2.get('supports_thinking') is True
     assert profile_5_2.get('zai_supports_reasoning_effort') is True
 
+    # GLM-5.3 always reasons and no longer supports disabling thinking.
+    profile_5_3 = provider.model_profile('glm-5.3')
+    zai_model_profile_mock.assert_called_with('glm-5.3')
+    assert profile_5_3 is not None
+    assert profile_5_3.get('supports_thinking') is True
+    assert profile_5_3.get('thinking_always_enabled') is True
+    assert profile_5_3.get('zai_supports_reasoning_effort') is True
+
     profile_air = provider.model_profile('glm-4.5-air')
     zai_model_profile_mock.assert_called_with('glm-4.5-air')
     assert profile_air is not None

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1415,6 +1415,7 @@ def test_model_json_schema_with_capabilities():
                         'zai:glm-5-turbo',
                         'zai:glm-5.1',
                         'zai:glm-5.2',
+                        'zai:glm-5.3',
                         'zai:glm-5v-turbo',
                     ],
                     'type': 'string',


### PR DESCRIPTION
- Closes #7599

Adds Z.AI's GLM-5.3 (`glm-5.3`), released 2026-08-14 and live on the Z.AI API.

Per Z.AI's announcement, GLM-5.3 scales post-training on the GLM-5.2 base, so the request surface is unchanged from GLM-5.2: thinking support is already covered by the existing `glm-5` profile prefix, and it accepts the same per-request `reasoning_effort` parameter. The one difference per the [GLM-5.3 docs](https://docs.z.ai/guides/llm/glm-5.3) is that reasoning is always on and can no longer be disabled, so the profile sets `thinking_always_enabled=True` and a `thinking=False` setting is dropped instead of being sent as `thinking.type: 'disabled'`, which the API rejects.

### Files

- `pydantic_ai_slim/pydantic_ai/profiles/zai.py` — add `glm-5.3` to the `reasoning_effort` allowlist; new `_ALWAYS_THINKING_MODEL_PREFIXES` mapped to `thinking_always_enabled`.
- `pydantic_ai_slim/pydantic_ai/models/zai.py` and `models/_known_model_names.py` — add `glm-5.3` to `LatestZaiModelNames` / `KnownModelName`.
- `docs/models/zai.md` — mention GLM-5.3 in the thinking mode section.
- Tests: profile mapping assertions in `tests/providers/test_zai.py`, `KnownModelName` snapshot in `tests/test_capabilities.py`, and one VCR test in `tests/models/test_zai.py` recorded against the live API.

### Verification (live Z.AI API)

- `glm-5.3` responds on `https://api.z.ai/api/paas/v4` and returns `reasoning_content` by default.
- `reasoning_effort: 'low'` is accepted (recorded in the new cassette). At `low` effort the model returned no `reasoning_content` for the trivial prompt, which the snapshot reflects.
- `thinking.type: 'disabled'` is rejected with error 1210: "This model always engages in thinking and cannot be disabled; please use low, high, or max" — the basis for `thinking_always_enabled=True`. The drop-on-`False` mechanics are already covered generically in `tests/test_thinking.py`, so no extra cassette for that.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
