### PR TITLE
Don't send Anthropic `thinking` blocks with an empty signature

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1916,9 +1916,9 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                         )
                         assistant_content_params.append(tool_use_block_param)
                     elif isinstance(response_part, ThinkingPart):
-                        if (
-                            response_part.provider_name == self.system and response_part.signature is not None
-                        ):  # pragma: no branch
+                        # An empty signature (e.g. from an interrupted stream) is never valid,
+                        # so fall back to tagged text rather than triggering a 400 from the API.
+                        if response_part.provider_name == self.system and response_part.signature:
                             if response_part.id == 'redacted_thinking':
                                 assistant_content_params.append(
                                     BetaRedactedThinkingBlockParam(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -3544,6 +3544,48 @@ I should provide practical advice for different methods of crossing a river.\
     )
 
 
+async def test_anthropic_model_empty_thinking_signature_sent_as_text(allow_model_requests: None):
+    """A thinking part with an empty signature (e.g. left behind by an interrupted stream)
+    must not be replayed as a `thinking` block: the API rejects empty signatures with a 400.
+    It falls back to tagged text instead, like thinking parts from other providers.
+    """
+    c = completion_message([BetaTextBlock(text='ok', type='text')], BetaUsage(input_tokens=5, output_tokens=10))
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(m)
+
+    message_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Think about crossing the street.')]),
+        ModelResponse(
+            parts=[ThinkingPart(content='I was interrupted mid-thought', signature='', provider_name='anthropic')],
+            provider_name='anthropic',
+        ),
+    ]
+
+    await agent.run('Continue.', message_history=message_history)
+
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert completion_kwargs['messages'] == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'Think about crossing the street.', 'type': 'text'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'text': """\
+<thinking>
+I was interrupted mid-thought
+</thinking>\
+""",
+                        'type': 'text',
+                    }
+                ],
+            },
+            {'role': 'user', 'content': [{'text': 'Continue.', 'type': 'text'}]},
+        ]
+    )
+
+
 async def test_anthropic_model_thinking_part_redacted(allow_model_requests: None, anthropic_api_key: str):
     m = AnthropicModel('claude-sonnet-4-5-20250929', provider=AnthropicProvider(api_key=anthropic_api_key))
     settings = AnthropicModelSettings(anthropic_thinking={'type': 'enabled', 'budget_tokens': 1024})


### PR DESCRIPTION
Fixes #7597

### Problem

When a streamed Anthropic response is interrupted mid-thinking, the partial `ThinkingPart` is left with `signature=""` (streaming starts thinking parts with an empty signature and fills it in via a later delta that never arrives). If that history is later replayed with `message_history=...`, `_map_message` sends the block back because the guard only checks `signature is not None` — and an empty string passes. The API rejects it:

```
status_code: 400, body: {'type': 'error', 'error': {'type': 'invalid_request_error',
'message': 'messages.N.content.0: Invalid `signature` in `thinking` block'}}
```

Every retry fails the same way, so the conversation is permanently stuck.

### Fix

Treat an empty signature the same as a missing one: the part falls through to the existing tagged-text fallback (`<thinking>...</thinking>`), which the API accepts. This is the model-layer counterpart of #5534, which fixed the same failure for the Vercel AI adapter only — this covers every source of message history (saved sessions, other adapters, hand-built histories).

Confirmed against the live API with a real bricked conversation: unpatched it reproduces the 400, with this change it completes normally.

### Note for reviewers

The index in Anthropic's error message appears to be relative to the prompt-cache boundary rather than the request's message list (verified: it does not shift when the conversation tail changes, and matched the offset past the cached prefix). Mentioning it here since it makes this failure very confusing to trace back to the offending message.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

