### PR TITLE
Run each test in a clean OTel context so leaked ambient spans can't break other tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,6 +587,7 @@ def no_instrumentation_by_default():
 
 try:
     import logfire
+    from opentelemetry import context as otel_context
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
     logfire.DEFAULT_LOGFIRE_INSTANCE.config.ignore_no_config = True
@@ -601,6 +602,17 @@ try:
         # into other tests sharing the xdist worker (e.g. stray `POST` spans in `test_temporal` snapshots).
         if _httpx_instrumentor._is_instrumented_by_opentelemetry:  # pyright: ignore[reportPrivateUsage]
             _httpx_instrumentor.uninstrument()
+        # The worker's main-thread OTel context also persists across tests: an `attach` without a
+        # matching `detach` leaves its values (an active span, suppression flags) visible to every
+        # later test in the worker. A leaked *non-sampled* span is the nasty case: parent-based
+        # sampling then marks all descendant spans unsampled and exporters silently drop them
+        # (seen as `context_subtree()` returning an empty tree in `tests/evals/test_otel.py`).
+        # Run each test in a clean context so no test inherits another's.
+        token = otel_context.attach(otel_context.Context())
+        try:
+            yield
+        finally:
+            otel_context.detach(token)
 
 except ImportError:
     pass

--- a/tests/test_otel_context_isolation.py
+++ b/tests/test_otel_context_isolation.py
@@ -1,0 +1,51 @@
+"""Tests in a worker process share the main-thread OTel context, so an `attach` without a matching
+`detach` in one test is visible to every later test in that worker. The `fresh_logfire` fixture
+guards against this by running each test in a clean context; these two tests pin that behavior.
+
+They must run in order on the same worker (hence the shared `xdist_group`): the first deliberately
+leaks a non-sampled active span, the second asserts spans are still recorded. Without the fixture's
+clean context, parent-based sampling marks the second test's spans unsampled and exporters silently
+drop them, which surfaced as `context_subtree()` returning an empty tree in `tests/evals/test_otel.py`.
+"""
+
+from __future__ import annotations as _annotations
+
+import pytest
+from opentelemetry import context as otel_context, trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+from .conftest import try_import
+
+with try_import() as imports_successful:
+    from pydantic_evals.otel._context_subtree import context_subtree
+    from pydantic_evals.otel.span_tree import SpanTree
+
+with try_import() as logfire_import_successful:
+    import logfire
+    from logfire.testing import CaptureLogfire
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='pydantic-evals not installed'),
+    pytest.mark.skipif(not logfire_import_successful(), reason='logfire not installed'),
+    pytest.mark.xdist_group('otel_context_isolation'),
+]
+
+
+def test_leak_non_sampled_span_into_ambient_context():
+    """Simulate a test that leaks: attach a non-sampled active span and never detach it."""
+    ctx = trace.set_span_in_context(
+        NonRecordingSpan(SpanContext(trace_id=0x1234, span_id=0x5678, is_remote=True, trace_flags=TraceFlags(0)))
+    )
+    otel_context.attach(ctx)
+
+
+@pytest.mark.anyio
+async def test_spans_recorded_despite_leak_in_previous_test(capfire: CaptureLogfire):
+    """The previous test's leaked non-sampled span must not make this test's spans invisible."""
+    assert capfire
+    with context_subtree() as tree:
+        with logfire.span('root'):
+            pass
+    assert isinstance(tree, SpanTree)
+    assert len(tree.roots) == 1
+    assert tree.roots[0].name == 'root'

--- a/tests/test_otel_context_isolation.py
+++ b/tests/test_otel_context_isolation.py
@@ -37,6 +37,7 @@ def test_leak_non_sampled_span_into_ambient_context():
         NonRecordingSpan(SpanContext(trace_id=0x1234, span_id=0x5678, is_remote=True, trace_flags=TraceFlags(0)))
     )
     otel_context.attach(ctx)
+    assert not trace.get_current_span().get_span_context().trace_flags.sampled
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes a one-off CI flake on main ([run 32220241128](https://github.com/pydantic/pydantic-ai/actions/runs/32220241128/job/96105187047)): `tests/evals/test_otel.py::test_context_subtree_concurrent` failed with an empty span tree.

Tests sharing an xdist worker also share the main-thread OTel context, so a test that calls `otel_context.attach()` without detaching leaves its context (e.g. a non-sampled active span from traceparent propagation) visible to every later test in that worker. Parent-based sampling then marks all later spans unsampled and exporters silently drop them. `fresh_logfire` now attaches a clean `Context()` per test; the regression test is an ordered `xdist_group` pair that reproduces the CI failure without the fix. See the commit message for the full mechanism.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

