### PR TITLE
Document and test AG-UI response identity lifecycle

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md
+++ b/pydantic_ai_slim/pydantic_ai/ui/AGENTS.md
@@ -21,6 +21,26 @@ One without the other is the trap: a protocol-specific property with a generic n
 
 The agent run is not a sink for the leftovers, either: `RunContext.metadata` is attached to the run span, so routing client-submitted text there by default would put unbounded untrusted content into every user's traces.
 
+## AG-UI response identities follow real `Agent` turn transitions
+
+Each model response gets a fresh AG-UI parent message ID. A regular
+`FunctionToolCallEvent` moves `UIEventStream` from the response turn to the
+request turn; its result is emitted in that request turn, and the next
+response's `PartStartEvent` invokes `before_response()` to replace the parent
+ID. This is the lifecycle established by [#3325](https://github.com/pydantic/pydantic-ai/pull/3325).
+
+Native tool returns differ because another native call can follow inside the
+same model response. That path uses a one-off result ID without replacing the
+response parent; regular tool results intentionally retain the request-turn ID
+mutation. The distinction was retained explicitly in
+[#6659](https://github.com/pydantic/pydantic-ai/pull/6659#discussion_r3632483479).
+
+Regression tests for cross-response identity must run through the supported
+`Agent` and `AGUIAdapter` boundary. A synthetic stream that includes a regular
+tool result must include its preceding `FunctionToolCallEvent`; otherwise it
+does not exercise a production-reachable turn sequence. Assert relationships
+between emitted string IDs, not between matcher objects.
+
 ## The event stream is an encoder, so it owns what it emits
 
 `UIEventStream.run_input` is optional because a stream is constructible with no request behind it: transports that carry native events out of band — a durable execution workflow, a queue, a websocket fan-out — encode at an API edge the adapter never reaches ([6970](https://github.com/pydantic/pydantic-ai/issues/6970)).

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -429,6 +429,10 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         else:
             output = _tool_return_content(result)
 
+        # Regular tool results arrive after `ToolCallEvent` moved the stream to the request turn.
+        # The next model response starts with `PartStartEvent`, whose request-to-response transition
+        # replaces this ID in `before_response()`. Native tool returns differ: another native call can
+        # follow inside the same response, so that path must use a one-off ID without mutating this one.
         message_id = self.new_message_id()
         yield ToolCallResultEvent(
             message_id=message_id,

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -4584,7 +4584,7 @@ async def test_event_stream_multiple_responses_with_tool_calls():
             {
                 'type': 'TOOL_CALL_RESULT',
                 'timestamp': IsInt(),
-                'messageId': (result_message_id := IsSameStr()),
+                'messageId': IsStr(),
                 'toolCallId': 'tool_call_2',
                 'content': 'Bye!',
                 'role': 'tool',
@@ -4645,7 +4645,94 @@ async def test_event_stream_multiple_responses_with_tool_calls():
         ]
     )
 
-    assert result_message_id != new_message_id
+    first_response_id = next(
+        event['parentMessageId']
+        for event in events
+        if event['type'] == 'TOOL_CALL_START' and event['toolCallId'] == 'tool_call_1'
+    )
+    result_message_id = next(
+        event['messageId']
+        for event in events
+        if event['type'] == 'TOOL_CALL_RESULT' and event['toolCallId'] == 'tool_call_2'
+    )
+    next_response_id = next(
+        event['parentMessageId']
+        for event in events
+        if event['type'] == 'TOOL_CALL_START' and event['toolCallId'] == 'tool_call_3'
+    )
+    assert first_response_id != next_response_id
+    assert result_message_id != next_response_id
+
+
+async def test_agent_multiple_responses_use_distinct_parent_message_ids() -> None:
+    """Each model response gets a fresh AG-UI parent through the supported `Agent` lifecycle."""
+
+    async def stream_function(
+        messages: list[ModelMessage], _agent_info: AgentInfo
+    ) -> AsyncIterator[DeltaToolCalls | str]:
+        tool_returns = list(iter_message_parts(messages, ModelRequest, ToolReturnPart))
+        if len(tool_returns) < 2:
+            call_number = len(tool_returns) + 1
+            yield {
+                0: DeltaToolCall(
+                    name='ping',
+                    json_args='{}',
+                    tool_call_id=f'call-{call_number}',
+                )
+            }
+        else:
+            yield 'done'
+
+    agent = Agent(FunctionModel(stream_function=stream_function))
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    events = await run_and_collect_events(
+        agent,
+        create_input(UserMessage(id='msg-1', content='Call twice, then finish')),
+    )
+    identity_events = [
+        {key: event[key] for key in ('type', 'toolCallId', 'parentMessageId', 'messageId') if key in event}
+        for event in events
+        if event['type'] in ('TOOL_CALL_START', 'TOOL_CALL_RESULT', 'TEXT_MESSAGE_START')
+    ]
+    assert identity_events == snapshot(
+        [
+            {
+                'type': 'TOOL_CALL_START',
+                'toolCallId': 'call-1',
+                'parentMessageId': IsStr(),
+            },
+            {
+                'type': 'TOOL_CALL_RESULT',
+                'toolCallId': 'call-1',
+                'messageId': IsStr(),
+            },
+            {
+                'type': 'TOOL_CALL_START',
+                'toolCallId': 'call-2',
+                'parentMessageId': IsStr(),
+            },
+            {
+                'type': 'TOOL_CALL_RESULT',
+                'toolCallId': 'call-2',
+                'messageId': IsStr(),
+            },
+            {
+                'type': 'TEXT_MESSAGE_START',
+                'messageId': IsStr(),
+            },
+        ]
+    )
+    emitted_ids = {
+        'first_response': identity_events[0]['parentMessageId'],
+        'first_result': identity_events[1]['messageId'],
+        'second_response': identity_events[2]['parentMessageId'],
+        'final_response': identity_events[4]['messageId'],
+    }
+    assert len(set(emitted_ids.values())) == 4
 
 
 async def test_timestamps_are_set():


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

A synthetic AG-UI event stream can omit the required `FunctionToolCallEvent` and manufacture a stale parent-message ID that a real `Agent` stream cannot produce. The valid lifecycle enters the request turn for an ordinary function tool and mints a fresh parent when the next model response begins.

This records that existing contract without changing production behavior. It also makes the regular-tool/native-tool distinction discoverable next to the implementation.

## New public surface

None.

## Summary

- Compare emitted parent IDs in the existing multi-response regression instead of comparing matcher objects.
- Add an integration test through `Agent` and `AGUIAdapter` with ordinary function calls across two model responses.
- Document why regular tool results mutate the current ID while native tool returns use a one-off ID.

## Test plan

- Focused AG-UI lifecycle regression tests pass.
- Formatting, lint, and type checking pass.

Related to #7491 and #7493.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

