### PR TITLE
Fix PromptedOutput template rejecting literal JSON braces

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import inspect
 import json
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
@@ -717,7 +718,13 @@ class StructuredTextOutputSchema(OutputSchema[OutputDataT], ABC):
         if '{schema}' not in template:
             template = '\n\n'.join([template, '{schema}'])
 
-        return template.format(schema=json.dumps(schema))
+        # Only substitute the documented `{schema}` placeholder (honoring `{{`/`}}`
+        # escaping); leave every other literal brace untouched. Using `str.format` over
+        # the whole template treated a literal JSON example (e.g. `{"name": "x"}`) as a
+        # format field and raised `KeyError` before the model request. See #7485.
+        schema_json = json.dumps(schema)
+        replacements = {'{{': '{', '}}': '}', '{schema}': schema_json}
+        return re.sub(r'\{\{|\}\}|\{schema\}', lambda m: replacements[m.group(0)], template)
 
 
 class NativeOutputSchema(StructuredTextOutputSchema[OutputDataT]):

--- a/tests/test_agent_output_schemas.py
+++ b/tests/test_agent_output_schemas.py
@@ -14,6 +14,7 @@ from pydantic_ai import (
     TextOutput,
     ToolOutput,
 )
+from pydantic_ai._output import PromptedOutputSchema
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.output import OutputObjectDefinition
@@ -751,3 +752,27 @@ async def test_output_type_description(output_type: type, expected_schema: dict[
 async def test_nested_output_type_description(output_type: type, expected_schema: dict[str, object]):
     agent: Agent[object, str] = Agent('test', output_type=output_type)
     assert remove_schema_descriptions(agent.output_json_schema()) == expected_schema
+
+
+def test_prompted_output_template_preserves_literal_braces():
+    """Regression test for #7485.
+
+    `PromptedOutput.template` documents `{schema}` as the only placeholder. A literal JSON
+    example in the template used to be interpreted as a `str.format` field and raised
+    `KeyError` before the model request. Only `{schema}` should be substituted; other
+    braces stay literal, and `{{`/`}}` escaping is still honored.
+    """
+    object_def = OutputObjectDefinition(
+        json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}}
+    )
+
+    # A literal JSON example must be preserved, and `{schema}` substituted.
+    result = PromptedOutputSchema.build_instructions(
+        'Return JSON {"name": "x"} matching {schema}', object_def
+    )
+    assert '{"name": "x"}' in result
+    assert json.dumps(object_def.json_schema) in result
+
+    # Escaped braces still unescape (backward compatibility).
+    escaped = PromptedOutputSchema.build_instructions('Use {{ and }} with {schema}', object_def)
+    assert 'Use { and } with' in escaped


### PR DESCRIPTION
Fixes #7485.

### Problem
`StructuredTextOutputSchema.build_instructions()` applied `str.format(schema=...)` to the **entire** `PromptedOutput.template`. A literal JSON example in the template is then parsed as another format field and raises `KeyError` before any model request:

```python
PromptedOutputSchema.build_instructions('Return JSON {"name": "x"} matching {schema}', object_def)
# KeyError: '"name"'
```

The documented contract only promises `{schema}` as the placeholder, so users shouldn't have to escape every other brace.

### Fix
Substitute only the documented `{schema}` placeholder (still honoring `{{`/`}}` escaping for backward compatibility) and leave all other literal braces untouched:

```python
schema_json = json.dumps(schema)
replacements = {'{{': '{', '}}': '}', '{schema}': schema_json}
return re.sub(r'\{\{|\}\}|\{schema\}', lambda m: replacements[m.group(0)], template)
```

### Tests
Adds `test_prompted_output_template_preserves_literal_braces` in `tests/test_agent_output_schemas.py`: asserts a literal JSON example survives while `{schema}` is substituted, and that `{{`/`}}` still unescape.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

