### PR TITLE
Correct the `fresh_logfire` comment: isolation comes from the teardown context reset

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -607,7 +607,9 @@ try:
         # later test in the worker. A leaked *non-sampled* span is the nasty case: parent-based
         # sampling then marks all descendant spans unsampled and exporters silently drop them
         # (seen as `context_subtree()` returning an empty tree in `tests/evals/test_otel.py`).
-        # Run each test in a clean context so no test inherits another's.
+        # The detach below resets the context to its pre-test snapshot, so no leaked `attach`
+        # outlives its test. (The clean context itself only shields sync test bodies: async bodies
+        # run in anyio's runner task, whose context is copied before this fixture attaches.)
         token = otel_context.attach(otel_context.Context())
         try:
             yield

--- a/tests/test_otel_context_isolation.py
+++ b/tests/test_otel_context_isolation.py
@@ -1,11 +1,12 @@
 """Tests in a worker process share the main-thread OTel context, so an `attach` without a matching
 `detach` in one test is visible to every later test in that worker. The `fresh_logfire` fixture
-guards against this by running each test in a clean context; these two tests pin that behavior.
+guards against this by resetting the context to its pre-test snapshot at teardown, so no leak
+outlives the test that made it; these two tests pin that behavior.
 
 They must run in order on the same worker (hence the shared `xdist_group`): the first deliberately
-leaks a non-sampled active span, the second asserts spans are still recorded. Without the fixture's
-clean context, parent-based sampling marks the second test's spans unsampled and exporters silently
-drop them, which surfaced as `context_subtree()` returning an empty tree in `tests/evals/test_otel.py`.
+leaks a non-sampled active span, the second asserts spans are still recorded. Without that reset,
+parent-based sampling marks the second test's spans unsampled and exporters silently drop them,
+which surfaced as `context_subtree()` returning an empty tree in `tests/evals/test_otel.py`.
 """
 
 from __future__ import annotations as _annotations


### PR DESCRIPTION
Follow-up to #7603, comments only — no behavior change.

An adversarial re-review of the merged fix showed the comment described a mechanism the code doesn't deliver for async tests: async test bodies run inside anyio's runner task, whose context is copied when the first autouse async fixture sets up — before `fresh_logfire` attaches the clean `Context()` (verified empirically: a marker attached at module import time is invisible to sync test bodies but still visible to async ones). What actually protects the next test is the teardown `detach`, which resets the worker's context to its pre-test snapshot so a leaked `attach` cannot outlive its test. The comment and regression-test docstring now say so.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

