### PR TITLE
Fix the PR template link in the `add-new-model` skill

### DIFF
--- a/.agents/skills/add-new-model/SKILL.md
+++ b/.agents/skills/add-new-model/SKILL.md
@@ -132,7 +132,7 @@ Terse, not botty. Structure:
 - Flag pre-existing latent bugs found but deliberately not fixed.
 - Link the prior add-model PR for context.
 
-Include the [PR template](.github/pull_request_template.md), fill in the issue number, and check the "AI generated code" box in the GitHub UI yourself — `gh pr create` cannot set it.
+Include the [PR template](../../../.github/pull_request_template.md), fill in the issue number, and check the "AI generated code" box in the GitHub UI yourself — `gh pr create` cannot set it.
 
 ## Provider-specific landmines
 


### PR DESCRIPTION
`.agents/skills/add-new-model/SKILL.md:135` links the PR template as `.github/pull_request_template.md`. The identical sentence lives in `AGENTS.md:71`, where that path is right because AGENTS.md sits at the repo root. The skill file is three directories down, so the link resolves to `.agents/skills/add-new-model/.github/pull_request_template.md` and 404s when you click it on GitHub.

Changed it to `../../../.github/pull_request_template.md`, which I verified resolves to the real file.

Two reasons it went unnoticed, in case they're useful: it's the only relative markdown link anywhere under `.agents/skills/` (every other link in those files is an absolute GitHub URL), and the weekly lychee run can't see it because `.github/workflows/lychee.toml` sets `scheme = ["https", "http"]`, which skips relative links deliberately.

No issue linked, since the template lists broken links as a trivial fix.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

A bit about me: I'm a freshman in college, still getting comfortable in a codebase this big. I read this diff line by line myself and used Claude Code as a second opinion on the reasoning before opening it. If the convention you'd prefer is a plain backticked path (the way every other repo file is referenced in that skill) rather than a working relative link, tell me and I'll switch it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

