### PR TITLE
Cap anthropic dependency to <1

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -76,7 +76,7 @@ logfire = ["logfire[httpx]>=4.39.0", "opentelemetry-instrumentation-httpx>=0.65b
 openai = ["openai>=3.0.0", "tiktoken>=0.12.0"]
 cohere = ["cohere>=5.20.6; platform_system != 'Emscripten'"]
 google = ["google-genai>=2.18.0"]
-anthropic = ["anthropic>=0.108.0"]
+anthropic = ["anthropic>=0.108.0,<1"]
 xai = ["xai-sdk>=1.14.0"]
 groq = ["groq>=0.25.0"]
 openrouter = ["openai>=3.0.0"]


### PR DESCRIPTION
Hey! We're releasing v1 of the `anthropic` SDK shortly. Your `anthropic` dependency has no upper bound, so your users will start getting 1.0, which would break `pydantic-ai-slim`.

This PR adds an `anthropic<1` constraint to prevent any potential breakage until you can fully migrate to v1.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

