### PR TITLE
Document the `running output function` span rename and the duplicated agent name attribute

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -299,6 +299,8 @@ Versions 2, 3, and 4 are deprecated compatibility formats. Passing one of these 
 
 Version 6 is opt-in: it changes the role of messages you already receive, so pass it explicitly once your telemetry consumer is ready for the new role.
 
+Agent run spans carry the agent name under both `agent_name` and `gen_ai.agent.name` at every version, so a dashboard keyed on either name keeps working when you change versions.
+
 #### Version 2 (deprecated)
 
 Uses the newer OpenTelemetry GenAI spec and stores messages in the following attributes:
@@ -316,6 +318,7 @@ Builds on version 2 with the following improvements:
 - **Spec-compliant span names:**
     - `agent run` becomes `invoke_agent {gen_ai.agent.name}` (with the agent name filled in)
     - `running tool` becomes `execute_tool {gen_ai.tool.name}` (with the tool name filled in)
+    - `running output function` becomes `execute_tool {gen_ai.tool.name}`, so output tools and output functions share the span name used for other tools
 - **Spec-compliant attribute names:**
     - `tool_arguments` becomes `gen_ai.tool.call.arguments`
     - `tool_response` becomes `gen_ai.tool.call.result`


### PR DESCRIPTION
Two gaps in the "Configuring data format" section of `docs/logfire.md`, both from #4458, which asked for a clearer account of what changes between instrumentation versions.

The version 3 list presents itself as the full set of renames, but it covers four of the six fields that actually differ. `InstrumentationNames.for_version` (`pydantic_ai_slim/pydantic_ai/_instrumentation.py:691`) also changes the output-tool span from `running output function` to `execute_tool`, applied through `get_output_tool_span_name` at `capabilities/instrumentation.py:585`. `tests/test_logfire.py::test_logfire_output_function_v2_v3` asserts exactly that: `running output function` on version 2, `execute_tool final_result` on version 3. Someone upgrading and grepping for their output-function spans currently has nothing in the docs to explain where they went. Added it as a third bullet, using `{gen_ai.tool.name}` because the span name and that attribute are both set from the same `span_target` (`capabilities/instrumentation.py:557,585`).

The issue also asked why `agent_name` and `gen_ai.agent.name` are duplicated. They are both set unconditionally on the run span at `capabilities/instrumentation.py:170-171`, at every version, and `realtime/_instrumentation.py:111` mirrors it with a comment explaining the intent. That is deliberate and useful to know before you change versions, so I stated it once in the intro rather than inside a single version's section.

The sixth differing field is `agent_name_attr`, and I left the docs alone there on purpose: it is set per version but never read, so `agent_name` is not actually renamed and documenting a rename would be wrong. I also left #4458's dashboard-migration bullet alone rather than inventing guidance I cannot verify, so this does not close the issue.

Ran `uv run pytest tests/test_examples.py -k logfire`. Four failures there reproduce identically on unmodified main in my environment (Python 3.14 local), so they are not from this change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

Context on me: I'm a college freshman still learning how a project this size fits together. I traced both claims to the code and the tests before writing the prose, and used Claude Code to pressure-test my reasoning, but I read every line myself and stand behind it. If you'd rather keep the deprecated-version sections lean and skip the extra bullet, I'm happy to trim it down to just the duplicated-attribute note.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

