### PR TITLE
Support mounting `Agent.to_web()` below path prefixes

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -207,7 +207,7 @@ inlined, so it needs no network access beyond your own server:
 from pydantic_ai.ui import OFFLINE_HTML_URL
 
 print(OFFLINE_HTML_URL)  # Use this URL to download the self-contained UI HTML file
-#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.1.0/offline/index.html
+#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.3.0/offline/index.html
 ```
 
 Download it once from a machine that has internet access, then move it into the air-gapped
@@ -240,5 +240,5 @@ is unchanged and still uses the split build:
 from pydantic_ai.ui import DEFAULT_HTML_URL
 
 print(DEFAULT_HTML_URL)
-#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.1.0/dist/index.html
+#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.3.0/dist/index.html
 ```

--- a/docs/web.md
+++ b/docs/web.md
@@ -134,6 +134,45 @@ Every route is checked, including `/api/health`. A health check or container pro
 
 Pass `allowed_hosts=['*']` to answer to any host, but only if something in front of the app already authenticates requests. Only list domains whose subdomains you control: a wildcard for a domain where anyone can obtain a subdomain re-opens the problem.
 
+## Mounting below a path
+
+The web app derives its public browser and API paths from each request's ASGI `root_path`. Mount it
+under a Starlette or FastAPI application and the UI stays below that mount automatically:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+web_app = agent.to_web()
+
+app = Starlette(routes=[Mount('/demo', app=web_app)])
+```
+
+This serves conversation pages below `/demo/` and calls the API below `/demo/api/`. A reverse proxy
+that strips a public prefix gets the same behavior when its ASGI integration sets `root_path` to that
+prefix.
+
+If the browser-visible paths do not match `root_path`, set them independently:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+app = agent.to_web(
+    base_path='/chat/',
+    api_path='/agent-api/',
+)
+```
+
+Both values must be absolute same-origin directory paths. `base_path` controls conversation URLs and
+navigation; `api_path` is the complete directory containing `configure` and `chat`. These settings
+describe public routing: they do not mount or move the returned app's internal routes, so the outer
+application or proxy must route those public paths to the app accordingly.
+
 ## Reserved Routes
 
 All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). The web UI app uses the following routes which should not be overwritten:
@@ -143,7 +182,8 @@ All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under
 - `/api/configure` - Frontend configuration (GET)
 - `/api/health` - Health check (GET)
 
-The app cannot currently be mounted at a subpath (e.g., `/chat`) because the UI expects these routes at the root. You can add additional routes to the app, but avoid conflicts with these reserved paths.
+You can add additional routes to the app, but avoid conflicts with these reserved paths. When the app
+is mounted below a path, the mount prefix is prepended to every route above.
 
 ## Custom HTML Source
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -173,9 +173,12 @@ navigation; `api_path` is the complete directory containing `configure` and `cha
 describe public routing: they do not mount or move the returned app's internal routes, so the outer
 application or proxy must route those public paths to the app accordingly.
 
-At the origin root, omitted settings are not injected. The UI keeps its own build defaults, including
-defaults provided by a custom `html_source`; an explicit setting overrides only its corresponding
-value.
+At the origin root, omitted settings are not injected, and the UI keeps its own build defaults.
+
+When settings are injected, three sources are layered, each overriding the one before it: the paths
+derived from `root_path`, then a `window.PYDANTIC_AI_CHAT_CONFIG` that a custom
+[`html_source`](#custom-html-source) sets for itself, then `base_path` and `api_path`. So a custom
+HTML file keeps control of any path it configures unless you pass that path explicitly.
 
 `clai web` always serves at the origin root; to serve below a prefix, build the app with
 `agent.to_web()` and mount or proxy it yourself.

--- a/docs/web.md
+++ b/docs/web.md
@@ -173,6 +173,10 @@ navigation; `api_path` is the complete directory containing `configure` and `cha
 describe public routing: they do not mount or move the returned app's internal routes, so the outer
 application or proxy must route those public paths to the app accordingly.
 
+At the origin root, omitted settings are not injected. The UI keeps its own build defaults, including
+defaults provided by a custom `html_source`; an explicit setting overrides only its corresponding
+value.
+
 ## Reserved Routes
 
 All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). The web UI app uses the following routes which should not be overwritten:

--- a/docs/web.md
+++ b/docs/web.md
@@ -177,6 +177,9 @@ At the origin root, omitted settings are not injected. The UI keeps its own buil
 defaults provided by a custom `html_source`; an explicit setting overrides only its corresponding
 value.
 
+`clai web` always serves at the origin root; to serve below a prefix, build the app with
+`agent.to_web()` and mount or proxy it yourself.
+
 ## Reserved Routes
 
 All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). The web UI app uses the following routes which should not be overwritten:

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -3803,6 +3803,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         instructions: str | None = None,
         html_source: str | Path | None = None,
         allowed_hosts: Sequence[str] | None = None,
+        base_path: str | None = None,
+        api_path: str | None = None,
     ) -> Starlette:
         """Create a Starlette app that serves a web chat UI for this agent.
 
@@ -3841,6 +3843,12 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 with a `421`, so that a website cannot reach the UI on your machine by pointing a
                 hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host,
                 only if something in front of the app already authenticates requests.
+            base_path: Absolute same-origin directory for browser navigation. By default, this is
+                derived from each request's ASGI `root_path`. This configures browser URLs only; it
+                does not mount the returned app at that path.
+            api_path: Absolute same-origin directory containing the `configure` and `chat` endpoints.
+                By default, this is the request's ASGI `root_path` followed by `/api/`. This configures
+                browser requests only; it does not change the app's internal `/api` mount.
 
         Returns:
             A configured Starlette application ready to be served (e.g., with uvicorn)
@@ -3872,6 +3880,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instructions=instructions,
             html_source=html_source,
             allowed_hosts=allowed_hosts,
+            base_path=base_path,
+            api_path=api_path,
         )
 
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -3844,11 +3844,13 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host,
                 only if something in front of the app already authenticates requests.
             base_path: Absolute same-origin directory for browser navigation. By default, this is
-                derived from each request's ASGI `root_path`. This configures browser URLs only; it
-                does not mount the returned app at that path.
+                derived from a non-root ASGI `root_path`; at the origin root, the UI keeps its build
+                default. This configures browser URLs only; it does not mount the returned app at
+                that path.
             api_path: Absolute same-origin directory containing the `configure` and `chat` endpoints.
-                By default, this is the request's ASGI `root_path` followed by `/api/`. This configures
-                browser requests only; it does not change the app's internal `/api` mount.
+                By default, this is a non-root ASGI `root_path` followed by `/api/`; at the origin
+                root, the UI keeps its build default. This configures browser requests only; it does
+                not change the app's internal `/api` mount.
 
         Returns:
             A configured Starlette application ready to be served (e.g., with uvicorn)

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 import tempfile
 import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, TypeVar
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 import anyio
 import anyio.to_thread
@@ -50,9 +49,7 @@ OutputDataT = TypeVar('OutputDataT')
 # may reject replacing a destination file while another thread has it open for reading.
 _CACHE_FILE_LOCK = threading.Lock()
 
-_HEAD_TAG_PATTERN = re.compile(rb'<head(?:\s[^>]*)?>', re.IGNORECASE)
-_SCRIPT_TAG_PATTERN = re.compile(rb'<script(?:\s|>)', re.IGNORECASE)
-_ILLEGAL_PATH_CHARS = frozenset('\\?#\t\n\r')
+_HTML_WHITESPACE = b'\t\n\f\r '
 
 
 async def _get_cache_dir() -> Path:
@@ -172,13 +169,85 @@ async def _get_cached_or_fetch(cache_name: str, url: str) -> bytes:
 
 def _normalize_same_origin_path(path: str, parameter: str) -> str:
     """Validate and normalize a same-origin directory path."""
-    if not path.startswith('/') or path.startswith('//') or _ILLEGAL_PATH_CHARS & set(path):
+    if (
+        not path.startswith('/')
+        or path.startswith('//')
+        or any(character in '\\?#' or ord(character) < 0x20 or ord(character) == 0x7F for character in path)
+        or any(unquote(segment) in ('.', '..') for segment in path.split('/'))
+    ):
         raise UserError(
             f'Invalid `{parameter}` {path!r}. '
             'Use an absolute same-origin path starting with exactly one `/`, '
-            'without backslashes, tabs, newlines, a query, or a fragment.'
+            'without control characters, backslashes, dot segments, a query, or a fragment.'
         )
     return path if path.endswith('/') else f'{path}/'
+
+
+def _path_config(root_path: str, base_path: str | None, api_path: str | None) -> dict[str, str]:
+    if root_path not in ('', '/'):
+        root_path = _normalize_same_origin_path(root_path, 'root_path')
+        return {
+            'basePath': base_path or root_path,
+            'apiPath': api_path or f'{root_path}api/',
+        }
+
+    config: dict[str, str] = {}
+    if base_path is not None:
+        config['basePath'] = base_path
+    if api_path is not None:
+        config['apiPath'] = api_path
+    return config
+
+
+def _inject_path_config(content: bytes, config: dict[str, str]) -> bytes:
+    serialized = json.dumps(config, ensure_ascii=True, separators=(',', ':'))
+    serialized = serialized.replace('&', r'\u0026').replace('<', r'\u003c').replace('>', r'\u003e')
+    bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={serialized};</script>'.encode()
+    position = _document_start(content)
+    return content[:position] + bootstrap + content[position:]
+
+
+def _document_start(content: bytes) -> int:
+    """Return the end of the real doctype or `html` start tag after the document preamble."""
+    bom_end = 3 if content.startswith(b'\xef\xbb\xbf') else 0
+    position = bom_end
+
+    while True:
+        while position < len(content) and content[position] in _HTML_WHITESPACE:
+            position += 1
+        if not content.startswith(b'<!--', position):
+            break
+        comment_end = content.find(b'-->', position + 4)
+        if comment_end == -1:
+            return bom_end
+        position = comment_end + 3
+
+    return _document_tag_end(content, position) or bom_end
+
+
+def _document_tag_end(content: bytes, position: int) -> int | None:
+    """Return the end of an `html` or doctype tag without stopping inside a quoted value."""
+    if content[position : position + len(b'<!doctype')].lower() == b'<!doctype':
+        name_end = position + len(b'<!doctype')
+    elif content[position : position + len(b'<html')].lower() == b'<html':
+        name_end = position + len(b'<html')
+    else:
+        return None
+
+    if name_end < len(content) and content[name_end] not in _HTML_WHITESPACE + b'>/':
+        return None
+
+    quote_character: int | None = None
+    for index in range(name_end, len(content)):
+        character = content[index]
+        if quote_character is not None:
+            if character == quote_character:
+                quote_character = None
+        elif character in b'\'"':
+            quote_character = character
+        elif character == ord('>'):
+            return index + 1
+    return None
 
 
 def create_web_app(
@@ -191,6 +260,7 @@ def create_web_app(
     html_source: str | Path | None = None,
     sdk_version: Literal[5, 6, 7] = BUNDLED_UI_SDK_VERSION,
     allowed_hosts: Sequence[str] | None = None,
+    *,
     base_path: str | None = None,
     api_path: str | None = None,
 ) -> Starlette:
@@ -228,11 +298,13 @@ def create_web_app(
             hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host, only
             if something in front of the app already authenticates requests.
         base_path: Absolute same-origin directory for browser navigation. By default, this is
-            derived from each request's ASGI `root_path`. This configures browser URLs only; it
-            does not mount the returned app at that path.
+            derived from a non-root ASGI `root_path`; at the origin root, the UI keeps its build
+            default. This configures browser URLs only; it does not mount the returned app at that
+            path.
         api_path: Absolute same-origin directory containing the `configure` and `chat` endpoints.
-            By default, this is the request's ASGI `root_path` followed by `/api/`. This configures
-            browser requests only; it does not change the app's internal `/api` mount.
+            By default, this is a non-root ASGI `root_path` followed by `/api/`; at the origin root,
+            the UI keeps its build default. This configures browser requests only; it does not
+            change the app's internal `/api` mount.
 
     Returns:
         A configured Starlette application ready to be served
@@ -270,24 +342,9 @@ def create_web_app(
     async def index(request: Request) -> Response:
         """Serve the chat UI from filesystem cache or CDN."""
         content = await _get_ui_html(html_source)
-        root_path = _normalize_same_origin_path(quote(request.scope.get('root_path', '') or '/', safe='/'), 'root_path')
-        config = json.dumps(
-            {'basePath': base_path or root_path, 'apiPath': api_path or f'{root_path}api/'},
-            ensure_ascii=True,
-            separators=(',', ':'),
-        )
-        # A JSON string may contain `</script>`, so escape every character with special meaning in
-        # HTML before embedding it in an executable script element.
-        config = config.replace('&', r'\u0026').replace('<', r'\u003c').replace('>', r'\u003e')
-        bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={config};</script>'.encode()
-
-        if match := _HEAD_TAG_PATTERN.search(content):
-            position = match.end()
-        elif match := _SCRIPT_TAG_PATTERN.search(content):
-            position = match.start()
-        else:
-            position = 0
-        content = content[:position] + bootstrap + content[position:]
+        root_path = quote(request.scope.get('root_path', ''), safe='/')
+        if config := _path_config(root_path, base_path, api_path):
+            content = _inject_path_config(content, config)
 
         return HTMLResponse(
             content=content,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -49,8 +49,6 @@ OutputDataT = TypeVar('OutputDataT')
 # may reject replacing a destination file while another thread has it open for reading.
 _CACHE_FILE_LOCK = threading.Lock()
 
-_HTML_WHITESPACE = b'\t\n\f\r '
-
 
 async def _get_cache_dir() -> Path:
     """Get the cache directory for storing UI HTML files.
@@ -183,71 +181,43 @@ def _normalize_same_origin_path(path: str, parameter: str) -> str:
     return path if path.endswith('/') else f'{path}/'
 
 
-def _path_config(root_path: str, base_path: str | None, api_path: str | None) -> dict[str, str]:
+def _path_config(root_path: str, base_path: str | None, api_path: str | None) -> tuple[dict[str, str], dict[str, str]]:
+    """Return the paths derived from the ASGI `root_path`, and the paths configured explicitly."""
+    derived: dict[str, str] = {}
     if root_path not in ('', '/'):
         root_path = _normalize_same_origin_path(root_path, 'root_path')
-        return {
-            'basePath': base_path or root_path,
-            'apiPath': api_path or f'{root_path}api/',
-        }
+        derived = {'basePath': root_path, 'apiPath': f'{root_path}api/'}
 
-    config: dict[str, str] = {}
+    explicit: dict[str, str] = {}
     if base_path is not None:
-        config['basePath'] = base_path
+        explicit['basePath'] = base_path
     if api_path is not None:
-        config['apiPath'] = api_path
-    return config
+        explicit['apiPath'] = api_path
+    return derived, explicit
 
 
-def _inject_path_config(content: bytes, config: dict[str, str]) -> bytes:
+def _serialize_config(config: dict[str, str]) -> str:
     serialized = json.dumps(config, ensure_ascii=True, separators=(',', ':'))
-    serialized = serialized.replace('&', r'\u0026').replace('<', r'\u003c').replace('>', r'\u003e')
-    bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={serialized};</script>'.encode()
-    position = _document_start(content)
-    return content[:position] + bootstrap + content[position:]
+    return serialized.replace('&', r'\u0026').replace('<', r'\u003c').replace('>', r'\u003e')
 
 
-def _document_start(content: bytes) -> int:
-    """Return the end of the real doctype or `html` start tag after the document preamble."""
-    bom_end = 3 if content.startswith(b'\xef\xbb\xbf') else 0
-    position = bom_end
+def _inject_path_config(content: bytes, derived: dict[str, str], explicit: dict[str, str]) -> bytes:
+    """Append a bootstrap that seeds the UI config with `derived` and overrides it with `explicit`.
 
-    while True:
-        while position < len(content) and content[position] in _HTML_WHITESPACE:
-            position += 1
-        if not content.startswith(b'<!--', position):
-            break
-        comment_end = content.find(b'-->', position + 4)
-        if comment_end == -1:
-            return bom_end
-        position = comment_end + 3
+    Position within the document is free: the UI only reads the config from a deferred
+    `type="module"` script, so this parser-blocking classic script runs first wherever it sits.
+    Appending also leaves the document preamble untouched, where anything inserted ahead of the
+    doctype would put the page in quirks mode.
 
-    return _document_tag_end(content, position) or bom_end
-
-
-def _document_tag_end(content: bytes, position: int) -> int | None:
-    """Return the end of an `html` or doctype tag without stopping inside a quoted value."""
-    if content[position : position + len(b'<!doctype')].lower() == b'<!doctype':
-        name_end = position + len(b'<!doctype')
-    elif content[position : position + len(b'<html')].lower() == b'<html':
-        name_end = position + len(b'<html')
-    else:
-        return None
-
-    if name_end < len(content) and content[name_end] not in _HTML_WHITESPACE + b'>/':
-        return None
-
-    quote_character: int | None = None
-    for index in range(name_end, len(content)):
-        character = content[index]
-        if quote_character is not None:
-            if character == quote_character:
-                quote_character = None
-        elif character in b'\'"':
-            quote_character = character
-        elif character == ord('>'):
-            return index + 1
-    return None
+    `Object.assign` gives a custom `html_source` that carries its own configuration precedence over
+    the derived paths, while explicit `base_path`/`api_path` arguments still win over both.
+    """
+    bootstrap = (
+        f'<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign('
+        f'{_serialize_config(derived)},window.PYDANTIC_AI_CHAT_CONFIG,{_serialize_config(explicit)}'
+        f');</script>'
+    ).encode()
+    return content + bootstrap
 
 
 def create_web_app(
@@ -344,8 +314,9 @@ def create_web_app(
         """Serve the chat UI from filesystem cache or CDN."""
         content = await _get_ui_html(html_source)
         root_path = quote(request.scope.get('root_path', ''), safe='/')
-        if config := _path_config(root_path, base_path, api_path):
-            content = _inject_path_config(content, config)
+        derived, explicit = _path_config(root_path, base_path, api_path)
+        if derived or explicit:
+            content = _inject_path_config(content, derived, explicit)
 
         return HTMLResponse(
             content=content,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -34,7 +34,7 @@ except ImportError as _import_error:  # pragma: no cover
         'you can use the `web` optional group — `pip install "pydantic-ai-slim[web]"`'
     ) from _import_error
 
-CHAT_UI_VERSION = '2.1.0'
+CHAT_UI_VERSION = '2.3.0'
 DEFAULT_HTML_URL = f'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@{CHAT_UI_VERSION}/dist/index.html'
 # `dist/index.html` references its stylesheet and its lazily-imported chunks on the CDN, so a copy
 # downloaded for self-hosting still reaches the public internet at runtime. `offline/index.html` is

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -311,7 +311,8 @@ def create_web_app(
 
     Raises:
         UserError: If an `allowed_hosts` entry is invalid, or if `base_path` or `api_path` is not an
-            absolute same-origin directory path.
+            absolute same-origin directory path. A request whose ASGI `root_path` is neither empty
+            nor an absolute same-origin directory path also raises `UserError` (surfaced as a 500).
     """
     # Normalized here rather than left to the middleware so a bad pattern is reported from this call
     # instead of from the first request: Starlette builds its middleware stack lazily. Normalizing is

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import re
 import tempfile
 import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, TypeVar
+from urllib.parse import quote
 
 import anyio
 import anyio.to_thread
 import httpx2
 
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.native_tools import AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 
@@ -45,6 +49,10 @@ OutputDataT = TypeVar('OutputDataT')
 # Cache operations run in worker threads. Serialize reads and atomic replacement because Windows
 # may reject replacing a destination file while another thread has it open for reading.
 _CACHE_FILE_LOCK = threading.Lock()
+
+_HEAD_TAG_PATTERN = re.compile(rb'<head(?:\s[^>]*)?>', re.IGNORECASE)
+_SCRIPT_TAG_PATTERN = re.compile(rb'<script(?:\s|>)', re.IGNORECASE)
+_ILLEGAL_PATH_CHARS = frozenset('\\?#\t\n\r')
 
 
 async def _get_cache_dir() -> Path:
@@ -162,6 +170,17 @@ async def _get_cached_or_fetch(cache_name: str, url: str) -> bytes:
     return content
 
 
+def _normalize_same_origin_path(path: str, parameter: str) -> str:
+    """Validate and normalize a same-origin directory path."""
+    if not path.startswith('/') or path.startswith('//') or _ILLEGAL_PATH_CHARS & set(path):
+        raise UserError(
+            f'Invalid `{parameter}` {path!r}. '
+            'Use an absolute same-origin path starting with exactly one `/`, '
+            'without backslashes, tabs, newlines, a query, or a fragment.'
+        )
+    return path if path.endswith('/') else f'{path}/'
+
+
 def create_web_app(
     agent: Agent[AgentDepsT, OutputDataT],
     models: ModelsParam = None,
@@ -172,6 +191,8 @@ def create_web_app(
     html_source: str | Path | None = None,
     sdk_version: Literal[5, 6, 7] = BUNDLED_UI_SDK_VERSION,
     allowed_hosts: Sequence[str] | None = None,
+    base_path: str | None = None,
+    api_path: str | None = None,
 ) -> Starlette:
     """Create a Starlette app that serves a web chat UI for the given agent.
 
@@ -206,17 +227,28 @@ def create_web_app(
             with a `421`, so that a website cannot reach the UI on your machine by pointing a
             hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host, only
             if something in front of the app already authenticates requests.
+        base_path: Absolute same-origin directory for browser navigation. By default, this is
+            derived from each request's ASGI `root_path`. This configures browser URLs only; it
+            does not mount the returned app at that path.
+        api_path: Absolute same-origin directory containing the `configure` and `chat` endpoints.
+            By default, this is the request's ASGI `root_path` followed by `/api/`. This configures
+            browser requests only; it does not change the app's internal `/api` mount.
 
     Returns:
         A configured Starlette application ready to be served
 
     Raises:
-        UserError: If an `allowed_hosts` entry is not a hostname, `*.example.com`, or `*`.
+        UserError: If an `allowed_hosts` entry is invalid, or if `base_path` or `api_path` is not an
+            absolute same-origin directory path.
     """
     # Normalized here rather than left to the middleware so a bad pattern is reported from this call
     # instead of from the first request: Starlette builds its middleware stack lazily. Normalizing is
     # idempotent, so the middleware doing it again over the same list is a no-op.
     allowed_hosts = [normalized_pattern(pattern) for pattern in allowed_hosts or ()]
+    if base_path is not None:
+        base_path = _normalize_same_origin_path(base_path, 'base_path')
+    if api_path is not None:
+        api_path = _normalize_same_origin_path(api_path, 'api_path')
 
     api_app = create_api_app(
         agent=agent,
@@ -238,6 +270,24 @@ def create_web_app(
     async def index(request: Request) -> Response:
         """Serve the chat UI from filesystem cache or CDN."""
         content = await _get_ui_html(html_source)
+        root_path = _normalize_same_origin_path(quote(request.scope.get('root_path', '') or '/', safe='/'), 'root_path')
+        config = json.dumps(
+            {'basePath': base_path or root_path, 'apiPath': api_path or f'{root_path}api/'},
+            ensure_ascii=True,
+            separators=(',', ':'),
+        )
+        # A JSON string may contain `</script>`, so escape every character with special meaning in
+        # HTML before embedding it in an executable script element.
+        config = config.replace('&', r'\u0026').replace('<', r'\u003c').replace('>', r'\u003e')
+        bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={config};</script>'.encode()
+
+        if match := _HEAD_TAG_PATTERN.search(content):
+            position = match.end()
+        elif match := _SCRIPT_TAG_PATTERN.search(content):
+            position = match.start()
+        else:
+            position = 0
+        content = content[:position] + bootstrap + content[position:]
 
         return HTMLResponse(
             content=content,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -890,6 +890,8 @@ def test_run_web_command_cli_models_passed_to_create_web_app(
     call_kwargs = mock_create_app.call_args.kwargs
     # CLI models passed as list; agent model merging/deduplication happens in create_web_app
     assert call_kwargs.get('models') == ['openai:gpt-5', 'anthropic:claude-sonnet-4-6']
+    assert 'base_path' not in call_kwargs
+    assert 'api_path' not in call_kwargs
 
 
 def test_agent_to_cli_sync_with_args(mocker: MockerFixture, env: TestEnv):

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -36,6 +36,7 @@ with try_import() as starlette_import_successful:
     import httpx2
     from starlette.applications import Starlette
     from starlette.responses import Response
+    from starlette.routing import Mount
     from starlette.testclient import TestClient
     from starlette.websockets import WebSocket, WebSocketDisconnect
 
@@ -522,6 +523,168 @@ def test_chat_app_index_caching(isolated_ui_cache: None):
         assert response1.content == response2.content
         assert response1.status_code == 200
         assert response2.status_code == 200
+
+
+def test_chat_app_cached_html_remains_raw_across_root_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_cache_dir', _fake_cache_dir(tmp_path))
+    _stub_cdn_fetch(monkeypatch, source)
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/first') as first_client:
+        first_response = first_client.get('/')
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/second/') as second_client:
+        second_response = second_client.get('/')
+
+    assert '"basePath":"/first/","apiPath":"/first/api/"' in first_response.text
+    assert '"basePath":"/second/","apiPath":"/second/api/"' in second_response.text
+    assert (tmp_path / f'{app_module.CHAT_UI_VERSION}.html').read_bytes() == source
+
+
+def test_chat_app_index_injects_root_path_defaults(monkeypatch: pytest.MonkeyPatch):
+    source = b'<html><head><script type="module" src="/app.js"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    bootstrap = '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/","apiPath":"/api/"};</script>'
+    assert response.status_code == 200
+    assert bootstrap in response.text
+    assert response.text.index(bootstrap) < response.text.index('<script type="module"')
+
+
+def test_chat_app_uses_mount_root_path(monkeypatch: pytest.MonkeyPatch):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    mounted_app = Starlette(routes=[Mount('/demo', app=Agent('test').to_web())])
+
+    with TestClient(mounted_app, base_url=LOCAL_BASE_URL) as client:
+        index_response = client.get('/demo/conversation-id')
+        configure_response = client.get('/demo/api/configure')
+
+    assert index_response.status_code == 200
+    assert (
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/demo/","apiPath":"/demo/api/"};</script>'
+        in index_response.text
+    )
+    assert configure_response.status_code == 200
+
+
+def test_chat_app_url_encodes_mount_root_path(monkeypatch: pytest.MonkeyPatch):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    mounted_app = Starlette(routes=[Mount('/demo?x', app=Agent('test').to_web())])
+
+    with TestClient(mounted_app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/demo%3Fx/')
+
+    assert response.status_code == 200
+    assert (
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG='
+        '{"basePath":"/demo%3Fx/","apiPath":"/demo%3Fx/api/"};</script>' in response.text
+    )
+
+
+def test_chat_app_uses_proxy_root_path(monkeypatch: pytest.MonkeyPatch):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/demo') as client:
+        response = client.get('/')
+
+    assert response.status_code == 200
+    assert (
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/demo/","apiPath":"/demo/api/"};</script>' in response.text
+    )
+
+
+@pytest.mark.parametrize(
+    ('base_path', 'api_path', 'expected_config'),
+    [
+        ('/chat', None, '{"basePath":"/chat/","apiPath":"/proxy/api/"}'),
+        (None, '/agent-api', '{"basePath":"/proxy/","apiPath":"/agent-api/"}'),
+        ('/chat', '/agent-api', '{"basePath":"/chat/","apiPath":"/agent-api/"}'),
+    ],
+)
+def test_agent_to_web_path_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    base_path: str | None,
+    api_path: str | None,
+    expected_config: str,
+):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    app = Agent('test').to_web(base_path=base_path, api_path=api_path)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/proxy') as client:
+        response = client.get('/')
+
+    assert response.status_code == 200
+    assert f'<script>window.PYDANTIC_AI_CHAT_CONFIG={expected_config};</script>' in response.text
+
+
+def test_chat_app_path_overrides_do_not_mount_routes(monkeypatch: pytest.MonkeyPatch):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    app = create_web_app(Agent('test'), base_path='/public/chat/', api_path='/agent-api/')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        assert client.get('/').status_code == 200
+        assert client.get('/api/configure').status_code == 200
+        assert client.get('/public/chat/').status_code == 404
+        assert client.get('/agent-api/configure').status_code == 404
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        'relative',
+        '//other.example/api/',
+        'https://other.example/api/',
+        r'/\other.example/',
+        '/\t/other.example/',
+        '/\n/other.example/',
+        '/\r/other.example/',
+        '/api?tenant=1',
+        '/api#v2',
+    ],
+)
+@pytest.mark.parametrize('parameter', ['base_path', 'api_path'])
+def test_chat_app_rejects_non_same_origin_path(parameter: Literal['base_path', 'api_path'], path: str):
+    with pytest.raises(UserError, match=rf'Invalid `{parameter}`'):
+        if parameter == 'base_path':
+            create_web_app(Agent('test'), base_path=path)
+        else:
+            create_web_app(Agent('test'), api_path=path)
+
+
+def test_chat_app_safely_injects_custom_html_per_response(tmp_path: Path):
+    source = b'<main>Custom UI</main><script type="module">start()</script>'
+    html_source = tmp_path / 'index.html'
+    html_source.write_bytes(source)
+    app = create_web_app(
+        Agent('test'),
+        html_source=html_source,
+        base_path='/</script><script>alert(1)</script>',
+    )
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/first') as first_client:
+        first_response = first_client.get('/')
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/second') as second_client:
+        second_response = second_client.get('/')
+
+    escaped_path = r'/\u003c/script\u003e\u003cscript\u003ealert(1)\u003c/script\u003e/'
+    assert escaped_path in first_response.text
+    assert '"apiPath":"/first/api/"' in first_response.text
+    assert '"apiPath":"/second/api/"' in second_response.text
+    assert '</script><script>alert(1)</script>' not in first_response.text
+    assert first_response.text.index('window.PYDANTIC_AI_CHAT_CONFIG') < first_response.text.index(
+        '<script type="module"'
+    )
+    assert html_source.read_bytes() == source
 
 
 @pytest.mark.anyio

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -573,7 +573,8 @@ def test_chat_app_uses_mount_root_path(monkeypatch: pytest.MonkeyPatch):
 
     assert index_response.status_code == 200
     assert (
-        '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/demo/","apiPath":"/demo/api/"};</script>'
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign('
+        '{"basePath":"/demo/","apiPath":"/demo/api/"},window.PYDANTIC_AI_CHAT_CONFIG,{});</script>'
         in index_response.text
     )
     assert configure_response.status_code == 200
@@ -589,8 +590,9 @@ def test_chat_app_url_encodes_mount_root_path(monkeypatch: pytest.MonkeyPatch):
 
     assert response.status_code == 200
     assert (
-        '<script>window.PYDANTIC_AI_CHAT_CONFIG='
-        '{"basePath":"/demo%3Fx/","apiPath":"/demo%3Fx/api/"};</script>' in response.text
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign('
+        '{"basePath":"/demo%3Fx/","apiPath":"/demo%3Fx/api/"},window.PYDANTIC_AI_CHAT_CONFIG,{});</script>'
+        in response.text
     )
 
 
@@ -604,7 +606,8 @@ def test_chat_app_uses_proxy_root_path(monkeypatch: pytest.MonkeyPatch):
 
     assert response.status_code == 200
     assert (
-        '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/demo/","apiPath":"/demo/api/"};</script>' in response.text
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign('
+        '{"basePath":"/demo/","apiPath":"/demo/api/"},window.PYDANTIC_AI_CHAT_CONFIG,{});</script>' in response.text
     )
 
 
@@ -627,10 +630,10 @@ def test_chat_app_malformed_root_path_is_server_error(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.parametrize(
-    ('base_path', 'api_path', 'expected_config'),
+    ('base_path', 'api_path', 'expected_explicit'),
     [
-        ('/chat', None, '{"basePath":"/chat/","apiPath":"/proxy/api/"}'),
-        (None, '/agent-api', '{"basePath":"/proxy/","apiPath":"/agent-api/"}'),
+        ('/chat', None, '{"basePath":"/chat/"}'),
+        (None, '/agent-api', '{"apiPath":"/agent-api/"}'),
         ('/chat', '/agent-api', '{"basePath":"/chat/","apiPath":"/agent-api/"}'),
     ],
 )
@@ -638,7 +641,7 @@ def test_agent_to_web_path_overrides(
     monkeypatch: pytest.MonkeyPatch,
     base_path: str | None,
     api_path: str | None,
-    expected_config: str,
+    expected_explicit: str,
 ):
     source = b'<html><head><script type="module"></script></head></html>'
     monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
@@ -648,7 +651,11 @@ def test_agent_to_web_path_overrides(
         response = client.get('/')
 
     assert response.status_code == 200
-    assert f'<script>window.PYDANTIC_AI_CHAT_CONFIG={expected_config};</script>' in response.text
+    assert (
+        f'<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign('
+        f'{{"basePath":"/proxy/","apiPath":"/proxy/api/"}},window.PYDANTIC_AI_CHAT_CONFIG,{expected_explicit});</script>'
+        in response.text
+    )
 
 
 def test_chat_app_path_overrides_do_not_mount_routes(monkeypatch: pytest.MonkeyPatch):
@@ -716,8 +723,8 @@ def test_chat_app_safely_injects_custom_html_per_response(tmp_path: Path):
     assert '"apiPath":"/first/api/"' in first_response.text
     assert '"apiPath":"/second/api/"' in second_response.text
     assert '</script><script>alert(1)</script>' not in first_response.text
-    assert first_response.text.index('window.PYDANTIC_AI_CHAT_CONFIG') < first_response.text.index(
-        '<script type="module"'
+    assert first_response.text.index('<script type="module"') < first_response.text.index(
+        'window.PYDANTIC_AI_CHAT_CONFIG'
     )
     assert html_source.read_bytes() == source
 
@@ -733,69 +740,37 @@ def test_chat_app_root_injects_only_explicit_overrides(monkeypatch: pytest.Monke
     with TestClient(api_app, base_url=LOCAL_BASE_URL) as client:
         api_response = client.get('/')
 
-    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/browser/"}' in base_response.text
+    assert (
+        'window.PYDANTIC_AI_CHAT_CONFIG=Object.assign({},window.PYDANTIC_AI_CHAT_CONFIG,{"basePath":"/browser/"});'
+        in base_response.text
+    )
     assert 'apiPath' not in base_response.text
-    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"apiPath":"/service/"}' in api_response.text
+    assert (
+        'window.PYDANTIC_AI_CHAT_CONFIG=Object.assign({},window.PYDANTIC_AI_CHAT_CONFIG,{"apiPath":"/service/"});'
+        in api_response.text
+    )
     assert 'basePath' not in api_response.text
 
 
-def test_chat_app_path_config_handles_bom_and_leading_comments(tmp_path: Path):
+def test_chat_app_path_config_layers_over_custom_html(tmp_path: Path):
     source = (
-        b'\xef\xbb\xbf<!-- template element: <html> -->'
-        + b'<!-- --><!-- -->' * 100
-        + b'<!doctype html><html><script type="module">start()</script></html>'
+        b'<!doctype html>'
+        b'<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/from-html/","apiPath":"/from-html/api/"};</script>'
+        b'<script type="module">start()</script>'
     )
     html_source = tmp_path / 'index.html'
     html_source.write_bytes(source)
-    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
+    app = create_web_app(Agent('test'), html_source=html_source, api_path='/agent-api/')
 
-    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/demo') as client:
         response = client.get('/')
 
-    config_index = response.text.index('window.PYDANTIC_AI_CHAT_CONFIG')
-    assert response.content.startswith(b'\xef\xbb\xbf')
-    assert response.text.index('-->') < config_index < response.text.index('type="module"')
-    assert html_source.read_bytes() == source
-
-
-def test_chat_app_path_config_precedes_unclosed_leading_comment(tmp_path: Path):
-    source = b'\xef\xbb\xbf \n<!-- unclosed comment with <script type="module">'
-    html_source = tmp_path / 'index.html'
-    html_source.write_bytes(source)
-    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
-
-    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
-        response = client.get('/')
-
-    assert response.content.startswith(b'\xef\xbb\xbf<script>window.PYDANTIC_AI_CHAT_CONFIG=')
-    assert response.text.index('PYDANTIC_AI_CHAT_CONFIG') < response.text.index('<!--')
-    assert html_source.read_bytes() == source
-
-
-def test_chat_app_path_config_handles_quoted_tag_end(tmp_path: Path):
-    source = b'<html data-template=">"> <script type="module">start()</script></html>'
-    html_source = tmp_path / 'index.html'
-    html_source.write_bytes(source)
-    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
-
-    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
-        response = client.get('/')
-
-    config_index = response.text.index('window.PYDANTIC_AI_CHAT_CONFIG')
-    assert response.text.index('data-template=">"') < config_index < response.text.index('type="module"')
-    assert html_source.read_bytes() == source
-
-
-@pytest.mark.parametrize('source', [b'<htmlx><script type="module">start()</script>', b'<html data-template="unclosed'])
-def test_chat_app_path_config_precedes_malformed_document_tag(tmp_path: Path, source: bytes):
-    html_source = tmp_path / 'index.html'
-    html_source.write_bytes(source)
-    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
-
-    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
-        response = client.get('/')
-
-    assert response.content.startswith(b'<script>window.PYDANTIC_AI_CHAT_CONFIG=')
+    assert response.content == (
+        source
+        + b'<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign('
+        + b'{"basePath":"/demo/","apiPath":"/demo/api/"},window.PYDANTIC_AI_CHAT_CONFIG,'
+        + b'{"apiPath":"/agent-api/"});</script>'
+    )
     assert html_source.read_bytes() == source
 
 

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -609,6 +609,24 @@ def test_chat_app_uses_proxy_root_path(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.parametrize(
+    'root_path',
+    [
+        '//evil',
+        '/a/../b',
+    ],
+)
+def test_chat_app_malformed_root_path_is_server_error(monkeypatch: pytest.MonkeyPatch, root_path: str):
+    source = b'<html><head><script type="module"></script></head></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path=root_path, raise_server_exceptions=False) as client:
+        response = client.get('/')
+
+    assert response.status_code == 500
+
+
+@pytest.mark.parametrize(
     ('base_path', 'api_path', 'expected_config'),
     [
         ('/chat', None, '{"basePath":"/chat/","apiPath":"/proxy/api/"}'),

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import os
 import threading
@@ -72,6 +73,13 @@ def test_agent_to_web():
     app = agent.to_web()
 
     assert isinstance(app, Starlette)
+
+
+def test_create_web_app_path_options_are_keyword_only():
+    signature = inspect.signature(create_web_app)
+
+    assert signature.parameters['base_path'].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters['api_path'].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 def test_agent_to_web_with_model_instances():
@@ -541,7 +549,7 @@ def test_chat_app_cached_html_remains_raw_across_root_paths(monkeypatch: pytest.
     assert (tmp_path / f'{app_module.CHAT_UI_VERSION}.html').read_bytes() == source
 
 
-def test_chat_app_index_injects_root_path_defaults(monkeypatch: pytest.MonkeyPatch):
+def test_chat_app_root_preserves_ui_build_defaults(monkeypatch: pytest.MonkeyPatch):
     source = b'<html><head><script type="module" src="/app.js"></script></head></html>'
     monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
     app = create_web_app(Agent('test'))
@@ -549,10 +557,9 @@ def test_chat_app_index_injects_root_path_defaults(monkeypatch: pytest.MonkeyPat
     with TestClient(app, base_url=LOCAL_BASE_URL) as client:
         response = client.get('/')
 
-    bootstrap = '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/","apiPath":"/api/"};</script>'
     assert response.status_code == 200
-    assert bootstrap in response.text
-    assert response.text.index(bootstrap) < response.text.index('<script type="module"')
+    assert response.content == source
+    assert 'PYDANTIC_AI_CHAT_CONFIG' not in response.text
 
 
 def test_chat_app_uses_mount_root_path(monkeypatch: pytest.MonkeyPatch):
@@ -641,13 +648,23 @@ def test_chat_app_path_overrides_do_not_mount_routes(monkeypatch: pytest.MonkeyP
 @pytest.mark.parametrize(
     'path',
     [
+        '',
         'relative',
         '//other.example/api/',
         'https://other.example/api/',
         r'/\other.example/',
+        '/\x00/other.example/',
+        '/\x08/other.example/',
         '/\t/other.example/',
         '/\n/other.example/',
         '/\r/other.example/',
+        '/\x1f/other.example/',
+        '/\x7f/other.example/',
+        '/../api/',
+        '/./api/',
+        '/%2e%2e/api/',
+        '/.%2E/api/',
+        '/%2E./api/',
         '/api?tenant=1',
         '/api#v2',
     ],
@@ -684,6 +701,83 @@ def test_chat_app_safely_injects_custom_html_per_response(tmp_path: Path):
     assert first_response.text.index('window.PYDANTIC_AI_CHAT_CONFIG') < first_response.text.index(
         '<script type="module"'
     )
+    assert html_source.read_bytes() == source
+
+
+def test_chat_app_root_injects_only_explicit_overrides(monkeypatch: pytest.MonkeyPatch):
+    source = b'<html><script type="module">start()</script></html>'
+    monkeypatch.setattr(app_module, '_get_ui_html', AsyncMock(return_value=source))
+    base_app = create_web_app(Agent('test'), base_path='/browser/')
+    api_app = create_web_app(Agent('test'), api_path='/service/')
+
+    with TestClient(base_app, base_url=LOCAL_BASE_URL) as client:
+        base_response = client.get('/')
+    with TestClient(api_app, base_url=LOCAL_BASE_URL) as client:
+        api_response = client.get('/')
+
+    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/browser/"}' in base_response.text
+    assert 'apiPath' not in base_response.text
+    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"apiPath":"/service/"}' in api_response.text
+    assert 'basePath' not in api_response.text
+
+
+def test_chat_app_path_config_handles_bom_and_leading_comments(tmp_path: Path):
+    source = (
+        b'\xef\xbb\xbf<!-- template element: <html> -->'
+        + b'<!-- --><!-- -->' * 100
+        + b'<!doctype html><html><script type="module">start()</script></html>'
+    )
+    html_source = tmp_path / 'index.html'
+    html_source.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    config_index = response.text.index('window.PYDANTIC_AI_CHAT_CONFIG')
+    assert response.content.startswith(b'\xef\xbb\xbf')
+    assert response.text.index('-->') < config_index < response.text.index('type="module"')
+    assert html_source.read_bytes() == source
+
+
+def test_chat_app_path_config_precedes_unclosed_leading_comment(tmp_path: Path):
+    source = b'\xef\xbb\xbf \n<!-- unclosed comment with <script type="module">'
+    html_source = tmp_path / 'index.html'
+    html_source.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert response.content.startswith(b'\xef\xbb\xbf<script>window.PYDANTIC_AI_CHAT_CONFIG=')
+    assert response.text.index('PYDANTIC_AI_CHAT_CONFIG') < response.text.index('<!--')
+    assert html_source.read_bytes() == source
+
+
+def test_chat_app_path_config_handles_quoted_tag_end(tmp_path: Path):
+    source = b'<html data-template=">"> <script type="module">start()</script></html>'
+    html_source = tmp_path / 'index.html'
+    html_source.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    config_index = response.text.index('window.PYDANTIC_AI_CHAT_CONFIG')
+    assert response.text.index('data-template=">"') < config_index < response.text.index('type="module"')
+    assert html_source.read_bytes() == source
+
+
+@pytest.mark.parametrize('source', [b'<htmlx><script type="module">start()</script>', b'<html data-template="unclosed'])
+def test_chat_app_path_config_precedes_malformed_document_tag(tmp_path: Path, source: bytes):
+    html_source = tmp_path / 'index.html'
+    html_source.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_source, base_path='/demo/')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert response.content.startswith(b'<script>window.PYDANTIC_AI_CHAT_CONFIG=')
     assert html_source.read_bytes() == source
 
 


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

`Agent.to_web()` currently serves its ASGI routes correctly when mounted below a prefix, but the browser UI still navigates and calls the API at root-relative paths. For non-root deployments, this injects the accepted [`window.PYDANTIC_AI_CHAT_CONFIG`](https://github.com/pydantic/ai-chat-ui/issues/46#issuecomment-5346234765) contract from each request's ASGI `root_path`, with explicit same-origin overrides for proxy topologies that cannot describe their public paths through `root_path`.

`@pydantic/ai-chat-ui@2.3.0` contains the accepted runtime contract and is now the pinned host artifact. `CHAT_UI_VERSION` is updated to `2.3.0`; both the split CDN runtime and offline artifact were verified against the contract.

Closes #7611

## New public surface

- `Agent.to_web(base_path=..., api_path=...)`

(`create_web_app` takes the same two arguments, but it lives in the private `pydantic_ai.ui._web` and is not exported from `pydantic_ai.ui`, so it adds no public surface of its own.)

<details>
<summary>Goal: derive browser paths from ASGI mounts and proxies</summary>

### Before → after

```python
mounted = Agent('openai:gpt-5.2').to_web()
# Before: browser navigation `/`; API `/api/`
# After under `/demo`: browser navigation `/demo/`; API `/demo/api/`
```

<details>
<summary>Playground</summary>

```python
from starlette.applications import Starlette
from starlette.routing import Mount

from pydantic_ai import Agent

web_app = Agent('openai:gpt-5.2').to_web()
app = Starlette(routes=[Mount('/demo', app=web_app)])
```

Run with `uvicorn app:app` and open `/demo/`.

</details>

**Test:** [`test_chat_app_uses_mount_root_path`](https://github.com/pydantic/pydantic-ai/blob/1de7a76fd/tests/test_ui_web.py#L565)

**What changes for existing users:** nothing; an empty `root_path` leaves the UI build defaults untouched.

</details>

<details>
<summary>Goal: support explicit same-origin routing topology</summary>

### Before → after

```python
app = agent.to_web()
# Before: public paths had to match ASGI `root_path`

app = agent.to_web(base_path='/chat/', api_path='/agent-api/')
# After: browser navigation `/chat/`; API `/agent-api/`
```

The overrides only describe browser-visible routing; they do not move the returned app's internal routes.

<details>
<summary>Playground</summary>

```python
from pydantic_ai import Agent

agent = Agent('openai:gpt-5.2')
app = agent.to_web(base_path='/chat/', api_path='/agent-api/')
```

</details>

**Test:** [`test_agent_to_web_path_overrides`](https://github.com/pydantic/pydantic-ai/blob/1de7a76fd/tests/test_ui_web.py#L619)

**What changes for existing users:** nothing; omitted parameters preserve UI build defaults at the origin root and derive from a non-root `root_path`.

</details>

<details>
<summary>Goal: inject request-scoped configuration without mutating cached HTML</summary>

### Before → after

```html
<!-- Before: cached/source HTML was served unchanged -->

<!-- After: each response gets a bootstrap appended, layering three config sources -->
<script>window.PYDANTIC_AI_CHAT_CONFIG=Object.assign({"basePath":"/demo/","apiPath":"/demo/api/"},window.PYDANTIC_AI_CHAT_CONFIG,{});</script>
```

The raw CDN cache and custom `html_source` remain byte-identical.

The bootstrap is appended rather than inserted into the preamble. The UI reads the config only from a deferred `type="module"` script, so this parser-blocking classic script runs first wherever it sits, and the document's doctype is never displaced. `Object.assign` layers three sources, each overriding the one before it: the paths derived from `root_path`, a custom `html_source`'s own `window.PYDANTIC_AI_CHAT_CONFIG`, then explicit `base_path`/`api_path`.

Path values are JSON-serialized with HTML-sensitive characters escaped, and explicit overrides reject values that browsers can resolve cross-origin.

<details>
<summary>Playground</summary>

Use the mounted app above through two different ASGI `root_path` values; each response receives its own bootstrap while both requests reuse the same cached HTML source.

</details>

**Test:** [`test_chat_app_cached_html_remains_raw_across_root_paths`](https://github.com/pydantic/pydantic-ai/blob/1de7a76fd/tests/test_ui_web.py#L536)

**What changes for existing users:** unconfigured root responses remain byte-identical; prefixed or explicitly overridden responses receive the bootstrap.

</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


