### PR TITLE
Support path prefixes in `Agent.to_web()`

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -136,14 +136,57 @@ Pass `allowed_hosts=['*']` to answer to any host, but only if something in front
 
 ## Reserved Routes
 
-All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). The web UI app uses the following routes which should not be overwritten:
+All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). Relative to where the web UI app is mounted, it uses the following routes which should not be overwritten:
 
 - `/` and `/{id}` - Serves the chat UI
 - `/api/chat` - Chat endpoint (POST, OPTIONS). Requires `Content-Type: application/json`; other content types are rejected with `415`.
 - `/api/configure` - Frontend configuration (GET)
 - `/api/health` - Health check (GET)
 
-The app cannot currently be mounted at a subpath (e.g., `/chat`) because the UI expects these routes at the root. You can add additional routes to the app, but avoid conflicts with these reserved paths.
+You can add additional routes to the app, but avoid conflicts with these reserved paths.
+
+## Mounting below a path prefix
+
+The web app derives its public browser and API paths from the request's ASGI `root_path`. This means
+you can mount it below a path such as `/demo` without additional configuration:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+chat_app = agent.to_web()
+app = Starlette(routes=[Mount('/demo', app=chat_app)])
+```
+
+Conversation URLs stay below `/demo/`, and the UI calls `/demo/api/configure` and
+`/demo/api/chat`. A reverse proxy that strips a public prefix should set the equivalent ASGI
+`root_path`; for example, use `uvicorn my_module:app --root-path /demo` when Uvicorn is responsible
+for supplying it.
+
+If the browser-facing routing does not match `root_path`, set `base_path` and `api_path` explicitly:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+app = agent.to_web(
+    base_path='/chat/',
+    api_path='/services/agent/',
+)
+```
+
+`base_path` is the same-origin directory for conversation URLs and navigation. `api_path` is the
+same-origin directory containing the `configure` and `chat` endpoints. Both values are normalized
+to end in `/` and must be absolute paths without an origin, query, or fragment.
+
+These options describe public browser paths; they do not mount the returned Starlette app or move
+its routes. Configure your ASGI application or reverse proxy to route those public paths to the
+corresponding UI and API routes. Each option is independent: an omitted value still derives from
+the request's non-root `root_path`. With no path prefix or explicit override, the UI keeps its own
+build defaults; this preserves custom builds whose UI path differs from `/`.
 
 ## Custom HTML Source
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -3803,6 +3803,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         instructions: str | None = None,
         html_source: str | Path | None = None,
         allowed_hosts: Sequence[str] | None = None,
+        base_path: str | None = None,
+        api_path: str | None = None,
     ) -> Starlette:
         """Create a Starlette app that serves a web chat UI for this agent.
 
@@ -3841,6 +3843,14 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 with a `421`, so that a website cannot reach the UI on your machine by pointing a
                 hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host,
                 only if something in front of the app already authenticates requests.
+            base_path: Public same-origin directory for conversation URLs and browser navigation.
+                Defaults to a non-root ASGI `root_path`; at the origin root, the UI keeps its build
+                default. This only configures the browser UI; it does not mount the returned app at
+                this path.
+            api_path: Public same-origin directory containing the `configure` and `chat` endpoints.
+                Defaults to `<root_path>/api/` for a non-root ASGI `root_path`; at the origin root,
+                the UI keeps its `/api/` default. This only configures the browser UI; it does not
+                move the returned app's `/api` routes.
 
         Returns:
             A configured Starlette application ready to be served (e.g., with uvicorn)
@@ -3872,6 +3882,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instructions=instructions,
             html_source=html_source,
             allowed_hosts=allowed_hosts,
+            base_path=base_path,
+            api_path=api_path,
         )
 
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import re
 import tempfile
 import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, TypeVar
+from urllib.parse import urlsplit
 
 import anyio
 import anyio.to_thread
 import httpx2
 
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.native_tools import AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 
@@ -45,6 +49,53 @@ OutputDataT = TypeVar('OutputDataT')
 # Cache operations run in worker threads. Serialize reads and atomic replacement because Windows
 # may reject replacing a destination file while another thread has it open for reading.
 _CACHE_FILE_LOCK = threading.Lock()
+_DOCUMENT_START_RE = re.compile(
+    rb'\A(?:\xef\xbb\xbf)?(?:\s|<!--.*?-->)*(?:<!doctype\b[^>]*>|<html\b[^>]*>)',
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+def _normalize_same_origin_path(path: str, parameter: str) -> str:
+    """Validate and normalize a same-origin directory path."""
+    parsed = urlsplit(path)
+    if (
+        not path.startswith('/')
+        or path.startswith('//')
+        or '\\' in path
+        or parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or parsed.path != path
+    ):
+        raise UserError(f'`{parameter}` must be an absolute same-origin path without a query or fragment')
+    return f'{path.rstrip("/")}/'
+
+
+def _path_config(root_path: str, base_path: str | None, api_path: str | None) -> dict[str, str]:
+    if root_path not in ('', '/'):
+        root_path = _normalize_same_origin_path(root_path, 'root_path')
+        return {
+            'basePath': base_path or root_path,
+            'apiPath': api_path or f'{root_path}api/',
+        }
+
+    config: dict[str, str] = {}
+    if base_path is not None:
+        config['basePath'] = base_path
+    if api_path is not None:
+        config['apiPath'] = api_path
+    return config
+
+
+def _inject_path_config(content: bytes, config: dict[str, str]) -> bytes:
+    serialized = json.dumps(config, ensure_ascii=True, separators=(',', ':'))
+    serialized = serialized.replace('&', r'\u0026').replace('<', r'\u003c').replace('>', r'\u003e')
+    bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={serialized};</script>'.encode()
+
+    document_start = _DOCUMENT_START_RE.search(content)
+    insert_at = document_start.end() if document_start else 0
+    return content[:insert_at] + b'\n' + bootstrap + content[insert_at:]
 
 
 async def _get_cache_dir() -> Path:
@@ -172,6 +223,9 @@ def create_web_app(
     html_source: str | Path | None = None,
     sdk_version: Literal[5, 6, 7] = BUNDLED_UI_SDK_VERSION,
     allowed_hosts: Sequence[str] | None = None,
+    *,
+    base_path: str | None = None,
+    api_path: str | None = None,
 ) -> Starlette:
     """Create a Starlette app that serves a web chat UI for the given agent.
 
@@ -206,17 +260,30 @@ def create_web_app(
             with a `421`, so that a website cannot reach the UI on your machine by pointing a
             hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host, only
             if something in front of the app already authenticates requests.
+        base_path: Public same-origin directory for conversation URLs and browser navigation.
+            Defaults to a non-root ASGI `root_path`; at the origin root, the UI keeps its build
+            default. This only configures the browser UI; it does not mount the returned app at
+            this path.
+        api_path: Public same-origin directory containing the `configure` and `chat` endpoints.
+            Defaults to `<root_path>/api/` for a non-root ASGI `root_path`; at the origin root, the
+            UI keeps its `/api/` default. This only configures the browser UI; it does not move the
+            returned app's `/api` routes.
 
     Returns:
         A configured Starlette application ready to be served
 
     Raises:
-        UserError: If an `allowed_hosts` entry is not a hostname, `*.example.com`, or `*`.
+        UserError: If an `allowed_hosts` entry is not a hostname, `*.example.com`, or `*`, or if
+            `base_path` or `api_path` is not an absolute same-origin path.
     """
     # Normalized here rather than left to the middleware so a bad pattern is reported from this call
     # instead of from the first request: Starlette builds its middleware stack lazily. Normalizing is
     # idempotent, so the middleware doing it again over the same list is a no-op.
     allowed_hosts = [normalized_pattern(pattern) for pattern in allowed_hosts or ()]
+    if base_path is not None:
+        base_path = _normalize_same_origin_path(base_path, 'base_path')
+    if api_path is not None:
+        api_path = _normalize_same_origin_path(api_path, 'api_path')
 
     api_app = create_api_app(
         agent=agent,
@@ -238,6 +305,9 @@ def create_web_app(
     async def index(request: Request) -> Response:
         """Serve the chat UI from filesystem cache or CDN."""
         content = await _get_ui_html(html_source)
+        config = _path_config(request.scope.get('root_path', ''), base_path, api_path)
+        if config:
+            content = _inject_path_config(content, config)
 
         return HTMLResponse(
             content=content,

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -36,6 +36,7 @@ with try_import() as starlette_import_successful:
     import httpx2
     from starlette.applications import Starlette
     from starlette.responses import Response
+    from starlette.routing import Mount
     from starlette.testclient import TestClient
     from starlette.websockets import WebSocket, WebSocketDisconnect
 
@@ -298,7 +299,177 @@ def test_chat_app_index_endpoint(isolated_ui_cache: None):
         assert response.headers['content-type'] == 'text/html; charset=utf-8'
         assert 'cache-control' in response.headers
         assert response.headers['cache-control'] == 'public, max-age=3600'
-        assert len(response.content) > 0
+        assert response.content == b'<html>Test UI</html>'
+
+
+def test_chat_app_root_custom_html_preserves_ui_defaults(tmp_path: Path):
+    """An unprefixed app leaves a custom build's own `basePath` and `apiPath` defaults intact."""
+    html = b'<html><script type="module">start()</script></html>'
+    html_file = tmp_path / 'ui.html'
+    html_file.write_bytes(html)
+    app = create_web_app(Agent('test'), html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert response.content == html
+    assert 'PYDANTIC_AI_CHAT_CONFIG' not in response.text
+
+
+def test_chat_app_mounted_path_config(tmp_path: Path):
+    """A Starlette mount supplies the browser paths through request-scoped ASGI `root_path`."""
+    html_file = tmp_path / 'ui.html'
+    html_file.write_text('<!doctype html><html><head><script type="module">start()</script></head></html>')
+    chat_app = create_web_app(Agent('test'), html_source=html_file)
+    app = Starlette(routes=[Mount('/demo', app=chat_app)])
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/demo/conversation-id')
+        configure_response = client.get('/demo/api/configure')
+
+    assert response.status_code == 200
+    assert (
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/demo/","apiPath":"/demo/api/"};</script>' in response.text
+    )
+    assert configure_response.status_code == 200
+
+
+def test_chat_app_proxy_root_path_config(tmp_path: Path):
+    """A stripped-prefix proxy can describe the public paths with ASGI `root_path`."""
+    html_file = tmp_path / 'ui.html'
+    html_file.write_text('<html><script type="module">start()</script></html>')
+    app = create_web_app(Agent('test'), html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/proxy') as client:
+        response = client.get('/proxy/')
+        configure_response = client.get('/proxy/api/configure')
+
+    assert response.status_code == 200
+    assert (
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/proxy/","apiPath":"/proxy/api/"};</script>'
+        in response.text
+    )
+    assert configure_response.status_code == 200
+
+
+def test_agent_to_web_explicit_path_config(tmp_path: Path):
+    """Explicit public paths override `root_path` without changing the app's own routes."""
+    html_file = tmp_path / 'ui.html'
+    html_file.write_text('<html><script type="module">start()</script></html>')
+    app = Agent('test').to_web(base_path='/browser', api_path='/services/agent', html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+        configure_response = client.get('/api/configure')
+        public_override_response = client.get('/services/agent/configure')
+
+    assert response.status_code == 200
+    assert (
+        '<script>window.PYDANTIC_AI_CHAT_CONFIG='
+        '{"basePath":"/browser/","apiPath":"/services/agent/"};</script>' in response.text
+    )
+    assert configure_response.status_code == 200
+    assert public_override_response.status_code == 404
+
+
+def test_chat_app_path_config_overrides_are_independent(tmp_path: Path):
+    html_file = tmp_path / 'ui.html'
+    html_file.write_text('<html><script type="module">start()</script></html>')
+    agent = Agent('test')
+    base_override_app = create_web_app(agent, html_source=html_file, base_path='/browser/')
+    api_override_app = create_web_app(agent, html_source=html_file, api_path='/service/')
+
+    with TestClient(base_override_app, base_url=LOCAL_BASE_URL, root_path='/proxy') as client:
+        base_override_response = client.get('/proxy/')
+    with TestClient(api_override_app, base_url=LOCAL_BASE_URL, root_path='/proxy') as client:
+        api_override_response = client.get('/proxy/')
+
+    assert (
+        'window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/browser/","apiPath":"/proxy/api/"}' in base_override_response.text
+    )
+    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/proxy/","apiPath":"/service/"}' in api_override_response.text
+
+
+def test_chat_app_root_path_config_only_emits_explicit_overrides(tmp_path: Path):
+    html_file = tmp_path / 'ui.html'
+    html_file.write_text('<html><script type="module">start()</script></html>')
+    agent = Agent('test')
+    base_override_app = create_web_app(agent, html_source=html_file, base_path='/browser/')
+    api_override_app = create_web_app(agent, html_source=html_file, api_path='/service/')
+
+    with TestClient(base_override_app, base_url=LOCAL_BASE_URL) as client:
+        base_override_response = client.get('/')
+    with TestClient(api_override_app, base_url=LOCAL_BASE_URL) as client:
+        api_override_response = client.get('/')
+
+    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"basePath":"/browser/"}' in base_override_response.text
+    assert 'apiPath' not in base_override_response.text
+    assert 'window.PYDANTIC_AI_CHAT_CONFIG={"apiPath":"/service/"}' in api_override_response.text
+    assert 'basePath' not in api_override_response.text
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        '',
+        'relative/',
+        '//other.example/path/',
+        'https://other.example/path/',
+        '/path/?query',
+        '/path/#fragment',
+        '/bad\\path/',
+    ],
+)
+def test_chat_app_path_config_rejects_non_same_origin_paths(path: str):
+    agent = Agent('test')
+
+    with pytest.raises(UserError, match='`base_path` must be an absolute same-origin path'):
+        create_web_app(agent, base_path=path)
+    with pytest.raises(UserError, match='`api_path` must be an absolute same-origin path'):
+        create_web_app(agent, api_path=path)
+
+
+def test_chat_app_path_config_bootstrap_is_safe_and_precedes_module(tmp_path: Path):
+    """The per-response bootstrap cannot close its script and leaves the source file unchanged."""
+    html = b'<script type="module">start()</script>'
+    html_file = tmp_path / 'ui.html'
+    html_file.write_bytes(html)
+    app = create_web_app(
+        Agent('test'),
+        html_source=html_file,
+        base_path='/demo/</script>/',
+        api_path='/api/&/',
+    )
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert response.status_code == 200
+    assert (
+        'window.PYDANTIC_AI_CHAT_CONFIG='
+        '{"basePath":"/demo/\\u003c/script\\u003e/","apiPath":"/api/\\u0026/"};' in response.text
+    )
+    assert '</script>/' not in response.text
+    assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG') < response.text.index('type="module"')
+    assert html_file.read_bytes() == html
+
+
+def test_chat_app_path_config_skips_leading_html_comments(tmp_path: Path):
+    """HTML-looking text inside a leading comment cannot swallow the injected bootstrap."""
+    html = (
+        b'\xef\xbb\xbf<!-- template element: <html> -->'
+        b'<!doctype html><html><script type="module">start()</script></html>'
+    )
+    html_file = tmp_path / 'ui.html'
+    html_file.write_bytes(html)
+    app = create_web_app(Agent('test'), html_source=html_file, base_path='/demo/')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    config_index = response.text.index('window.PYDANTIC_AI_CHAT_CONFIG')
+    assert response.content.startswith(b'\xef\xbb\xbf')
+    assert response.text.index('-->') < config_index < response.text.index('type="module"')
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

- Closes #7611

## Summary

- derive the chat UI's public navigation and API directories from request-scoped ASGI `root_path`
- add independent, validated same-origin `base_path` and `api_path` overrides to `Agent.to_web()` and `create_web_app()`
- inject `window.PYDANTIC_AI_CHAT_CONFIG` per response while keeping cached and custom source HTML unchanged
- document mounted, stripped-prefix proxy, and explicit-routing deployments

## Release dependency

This PR must remain draft and must not be merged until a released `@pydantic/ai-chat-ui` version implements the accepted runtime contract from pydantic/ai-chat-ui#46.

`CHAT_UI_VERSION` intentionally remains at `2.1.0`. Once the compatible UI version is released, this PR still needs to update that constant, verify the released default and offline artifacts, and rerun the integration checks before it can be marked ready.

## Test plan

- [x] Web UI test module passes
- [x] Updated documentation examples pass
- [x] Commit-hook formatting, lint, type checking, and cassette validation pass
- [x] Independent pre-push review has no remaining findings

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

