### PR TITLE
Support path prefixes in `Agent.to_web()`

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -134,6 +134,54 @@ Every route is checked, including `/api/health`. A health check or container pro
 
 Pass `allowed_hosts=['*']` to answer to any host, but only if something in front of the app already authenticates requests. Only list domains whose subdomains you control: a wildcard for a domain where anyone can obtain a subdomain re-opens the problem.
 
+## Mounting Below a Path Prefix
+
+When the web app is [mounted](https://www.starlette.io/routing/#submounting-routes) below a path, it
+uses the request's ASGI `root_path` for both browser navigation and API requests:
+
+```python
+from starlette.applications import Starlette
+
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+app = Starlette()
+app.mount('/demo', agent.to_web())
+```
+
+The UI is then available at `/demo/`. Conversation URLs remain below `/demo/`, and the browser
+requests `/demo/api/configure` and `/demo/api/chat`.
+
+A reverse proxy that strips the public prefix should set the equivalent ASGI `root_path`. For
+example, when the proxy maps public `/demo/` requests to this app's `/`, run Uvicorn with:
+
+```bash
+uvicorn my_module:app --root-path /demo
+```
+
+If the public UI and API paths cannot be represented by `root_path`, configure them independently:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+app = agent.to_web(
+    base_path='/chat/',
+    api_path='/services/agent-api/',
+)
+```
+
+Both overrides must be absolute same-origin paths. `api_path` is the complete public directory
+containing `configure` and `chat`; the example makes the browser request
+`/services/agent-api/configure` and `/services/agent-api/chat`.
+
+These settings describe public browser routing only. They do not mount the returned app or change
+its internal `/api` routes, so the surrounding application or proxy must route the configured
+public paths to the app. An omitted override continues to derive from `root_path`; without a mount,
+proxy prefix, or override, the existing `/` and `/api/` paths are unchanged.
+
 ## Reserved Routes
 
 All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under-a-hostname). The web UI app uses the following routes which should not be overwritten:
@@ -143,7 +191,8 @@ All routes are answered only for [allowed `Host` headers](#reaching-the-ui-under
 - `/api/configure` - Frontend configuration (GET)
 - `/api/health` - Health check (GET)
 
-The app cannot currently be mounted at a subpath (e.g., `/chat`) because the UI expects these routes at the root. You can add additional routes to the app, but avoid conflicts with these reserved paths.
+When mounted, each route is relative to the mount path. You can add additional routes to the app,
+but avoid conflicts with these reserved paths.
 
 ## Custom HTML Source
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -3803,6 +3803,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         instructions: str | None = None,
         html_source: str | Path | None = None,
         allowed_hosts: Sequence[str] | None = None,
+        base_path: str | None = None,
+        api_path: str | None = None,
     ) -> Starlette:
         """Create a Starlette app that serves a web chat UI for this agent.
 
@@ -3841,9 +3843,18 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 with a `421`, so that a website cannot reach the UI on your machine by pointing a
                 hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host,
                 only if something in front of the app already authenticates requests.
+            base_path: Public same-origin directory for conversation URLs and browser navigation.
+                Defaults to the request's ASGI `root_path`. This only configures browser URLs; it
+                does not mount the returned app at this path.
+            api_path: Public same-origin directory containing the `configure` and `chat` endpoints.
+                Defaults to `<root_path>/api/`. This only configures browser requests; it does not
+                change the returned app's internal `/api` routes.
 
         Returns:
             A configured Starlette application ready to be served (e.g., with uvicorn)
+
+        Raises:
+            UserError: If a public path override is not an absolute same-origin path.
 
         Example:
             ```python
@@ -3872,6 +3883,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instructions=instructions,
             html_source=html_source,
             allowed_hosts=allowed_hosts,
+            base_path=base_path,
+            api_path=api_path,
         )
 
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Literal, TypeVar
+from urllib.parse import quote, unquote
 
 import anyio
 import anyio.to_thread
@@ -54,17 +55,16 @@ class _ChatConfigInsertionParser(HTMLParser):
     def __init__(self, source: str):
         super().__init__(convert_charrefs=False)
         self._line_starts = [0, *(index + 1 for index, character in enumerate(source) if character == '\n')]
-        self.head_end: int | None = None
-        self.script_start: int | None = None
+        self.doctype_end: int | None = None
+        self.first_tag_start: int | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        offset = self._offset()
-        if tag == 'head' and self.head_end is None:
-            start_tag = self.get_starttag_text()
-            assert start_tag is not None
-            self.head_end = offset + len(start_tag)
-        elif tag == 'script' and self.script_start is None:
-            self.script_start = offset
+        if self.first_tag_start is None:
+            self.first_tag_start = self._offset()
+
+    def handle_decl(self, decl: str) -> None:
+        if self.doctype_end is None and decl.lower().startswith('doctype'):
+            self.doctype_end = self._offset() + len(decl) + 3
 
     def _offset(self) -> int:
         line, column = self.getpos()
@@ -77,6 +77,8 @@ def _normalize_public_path(path: str, parameter: str) -> str:
             f"Invalid `{parameter}` {path!r}. Use an absolute same-origin path such as '/chat/' "
             'without a query or fragment.'
         )
+    if any(unquote(segment) in ('.', '..') for segment in path.split('/')):
+        raise UserError(f'Invalid `{parameter}` {path!r}. Path segments must not be `.` or `..`.')
     return f'{path.rstrip("/")}/'
 
 
@@ -93,7 +95,7 @@ def _inject_chat_config(content: bytes, *, base_path: str, api_path: str) -> byt
     parser = _ChatConfigInsertionParser(source)
     parser.feed(source)
     insertion_point = min(
-        (point for point in (parser.head_end, parser.script_start) if point is not None),
+        (point for point in (parser.doctype_end, parser.first_tag_start) if point is not None),
         default=len(content),
     )
 
@@ -303,7 +305,7 @@ def create_web_app(
     async def index(request: Request) -> Response:
         """Serve the chat UI from filesystem cache or CDN."""
         content = await _get_ui_html(html_source)
-        root_path = _normalize_public_path(request.scope.get('root_path') or '/', 'root_path')
+        root_path = _normalize_public_path(quote(request.scope.get('root_path') or '/', safe='/'), 'root_path')
         content = _inject_chat_config(
             content,
             base_path=normalized_base_path or root_path,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -51,24 +51,23 @@ OutputDataT = TypeVar('OutputDataT')
 _CACHE_FILE_LOCK = threading.Lock()
 
 
+class _ChatConfigInsertionFound(Exception):
+    pass
+
+
 class _ChatConfigInsertionParser(HTMLParser):
-    def __init__(self, source: str):
+    def __init__(self):
         super().__init__(convert_charrefs=False)
-        self._line_starts = [0, *(index + 1 for index, character in enumerate(source) if character == '\n')]
-        self.doctype_end: int | None = None
-        self.first_tag_start: int | None = None
+        self.position: tuple[int, int, int] | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if self.first_tag_start is None:
-            self.first_tag_start = self._offset()
+        self.position = (*self.getpos(), 0)
+        raise _ChatConfigInsertionFound
 
     def handle_decl(self, decl: str) -> None:
-        if self.doctype_end is None and decl.lower().startswith('doctype'):
-            self.doctype_end = self._offset() + len(decl) + 3
-
-    def _offset(self) -> int:
-        line, column = self.getpos()
-        return self._line_starts[line - 1] + column
+        if decl.lower().startswith('doctype'):
+            self.position = (*self.getpos(), len(decl) + 3)
+            raise _ChatConfigInsertionFound
 
 
 def _normalize_public_path(path: str, parameter: str) -> str:
@@ -92,12 +91,18 @@ def _inject_chat_config(content: bytes, *, base_path: str, api_path: str) -> byt
     bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={config};</script>'.encode()
 
     source = content.decode('latin-1')
-    parser = _ChatConfigInsertionParser(source)
-    parser.feed(source)
-    insertion_point = min(
-        (point for point in (parser.doctype_end, parser.first_tag_start) if point is not None),
-        default=len(content),
-    )
+    parser = _ChatConfigInsertionParser()
+    try:
+        parser.feed(source)
+    except _ChatConfigInsertionFound:
+        assert parser.position is not None
+        line, column, trailing_characters = parser.position
+        insertion_point = 0
+        for _ in range(line - 1):
+            insertion_point = source.index('\n', insertion_point) + 1
+        insertion_point += column + trailing_characters
+    else:
+        insertion_point = len(content)
 
     return content[:insertion_point] + bootstrap + content[insertion_point:]
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import re
 import tempfile
 import threading
 from collections.abc import Sequence
@@ -13,6 +15,7 @@ import anyio.to_thread
 import httpx2
 
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.native_tools import AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 
@@ -45,6 +48,50 @@ OutputDataT = TypeVar('OutputDataT')
 # Cache operations run in worker threads. Serialize reads and atomic replacement because Windows
 # may reject replacing a destination file while another thread has it open for reading.
 _CACHE_FILE_LOCK = threading.Lock()
+_OPENING_HEAD_RE = re.compile(rb'<head(?:\s[^>]*)?>', re.IGNORECASE)
+_OPENING_SCRIPT_RE = re.compile(rb'<script(?:\s|>)', re.IGNORECASE)
+
+
+def _normalize_public_path(path: str, parameter: str) -> str:
+    if not path.startswith('/') or path.startswith('//') or any(character in path for character in '\\?#\t\n\r'):
+        raise UserError(
+            f"Invalid `{parameter}` {path!r}. Use an absolute same-origin path such as '/chat/' "
+            'without a query or fragment.'
+        )
+    return f'{path.rstrip("/")}/'
+
+
+def _first_uncommented_match(content: bytes, pattern: re.Pattern[bytes]) -> re.Match[bytes] | None:
+    lower_content = content.lower()
+    search_from = 0
+    while match := pattern.search(content, search_from):
+        comment_start = lower_content.find(b'<!--', search_from)
+        if comment_start == -1 or match.start() < comment_start:
+            return match
+        comment_end = lower_content.find(b'-->', comment_start + 4)
+        if comment_end == -1:
+            return None
+        search_from = comment_end + 3
+    return None
+
+
+def _inject_chat_config(content: bytes, *, base_path: str, api_path: str) -> bytes:
+    config = json.dumps(
+        {'basePath': base_path, 'apiPath': api_path},
+        ensure_ascii=True,
+        separators=(',', ':'),
+    )
+    config = config.replace('&', '\\u0026').replace('<', '\\u003c').replace('>', '\\u003e')
+    bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={config};</script>'.encode()
+
+    if head_match := _first_uncommented_match(content, _OPENING_HEAD_RE):
+        insertion_point = head_match.end()
+    elif script_match := _first_uncommented_match(content, _OPENING_SCRIPT_RE):
+        insertion_point = script_match.start()
+    else:
+        insertion_point = len(content)
+
+    return content[:insertion_point] + bootstrap + content[insertion_point:]
 
 
 async def _get_cache_dir() -> Path:
@@ -172,6 +219,9 @@ def create_web_app(
     html_source: str | Path | None = None,
     sdk_version: Literal[5, 6, 7] = BUNDLED_UI_SDK_VERSION,
     allowed_hosts: Sequence[str] | None = None,
+    *,
+    base_path: str | None = None,
+    api_path: str | None = None,
 ) -> Starlette:
     """Create a Starlette app that serves a web chat UI for the given agent.
 
@@ -206,17 +256,26 @@ def create_web_app(
             with a `421`, so that a website cannot reach the UI on your machine by pointing a
             hostname it controls at you (DNS rebinding). Pass `['*']` to answer to any host, only
             if something in front of the app already authenticates requests.
+        base_path: Public same-origin directory for conversation URLs and browser navigation.
+            Defaults to the request's ASGI `root_path`. This only configures browser URLs; it does
+            not mount the returned app at this path.
+        api_path: Public same-origin directory containing the `configure` and `chat` endpoints.
+            Defaults to `<root_path>/api/`. This only configures browser requests; it does not
+            change the returned app's internal `/api` routes.
 
     Returns:
         A configured Starlette application ready to be served
 
     Raises:
-        UserError: If an `allowed_hosts` entry is not a hostname, `*.example.com`, or `*`.
+        UserError: If an `allowed_hosts` entry is not a hostname, `*.example.com`, or `*`, or if a
+            public path override is not an absolute same-origin path.
     """
     # Normalized here rather than left to the middleware so a bad pattern is reported from this call
     # instead of from the first request: Starlette builds its middleware stack lazily. Normalizing is
     # idempotent, so the middleware doing it again over the same list is a no-op.
     allowed_hosts = [normalized_pattern(pattern) for pattern in allowed_hosts or ()]
+    normalized_base_path = _normalize_public_path(base_path, 'base_path') if base_path is not None else None
+    normalized_api_path = _normalize_public_path(api_path, 'api_path') if api_path is not None else None
 
     api_app = create_api_app(
         agent=agent,
@@ -238,6 +297,12 @@ def create_web_app(
     async def index(request: Request) -> Response:
         """Serve the chat UI from filesystem cache or CDN."""
         content = await _get_ui_html(html_source)
+        root_path = _normalize_public_path(request.scope.get('root_path') or '/', 'root_path')
+        content = _inject_chat_config(
+            content,
+            base_path=normalized_base_path or root_path,
+            api_path=normalized_api_path or f'{root_path}api/',
+        )
 
         return HTMLResponse(
             content=content,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 import tempfile
 import threading
 from collections.abc import Sequence
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Literal, TypeVar
 
@@ -48,8 +48,27 @@ OutputDataT = TypeVar('OutputDataT')
 # Cache operations run in worker threads. Serialize reads and atomic replacement because Windows
 # may reject replacing a destination file while another thread has it open for reading.
 _CACHE_FILE_LOCK = threading.Lock()
-_OPENING_HEAD_RE = re.compile(rb'<head(?:\s[^>]*)?>', re.IGNORECASE)
-_OPENING_SCRIPT_RE = re.compile(rb'<script(?:\s|>)', re.IGNORECASE)
+
+
+class _ChatConfigInsertionParser(HTMLParser):
+    def __init__(self, source: str):
+        super().__init__(convert_charrefs=False)
+        self._line_starts = [0, *(index + 1 for index, character in enumerate(source) if character == '\n')]
+        self.head_end: int | None = None
+        self.script_start: int | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        offset = self._offset()
+        if tag == 'head' and self.head_end is None:
+            start_tag = self.get_starttag_text()
+            assert start_tag is not None
+            self.head_end = offset + len(start_tag)
+        elif tag == 'script' and self.script_start is None:
+            self.script_start = offset
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self._line_starts[line - 1] + column
 
 
 def _normalize_public_path(path: str, parameter: str) -> str:
@@ -61,20 +80,6 @@ def _normalize_public_path(path: str, parameter: str) -> str:
     return f'{path.rstrip("/")}/'
 
 
-def _first_uncommented_match(content: bytes, pattern: re.Pattern[bytes]) -> re.Match[bytes] | None:
-    lower_content = content.lower()
-    search_from = 0
-    while match := pattern.search(content, search_from):
-        comment_start = lower_content.find(b'<!--', search_from)
-        if comment_start == -1 or match.start() < comment_start:
-            return match
-        comment_end = lower_content.find(b'-->', comment_start + 4)
-        if comment_end == -1:
-            return None
-        search_from = comment_end + 3
-    return None
-
-
 def _inject_chat_config(content: bytes, *, base_path: str, api_path: str) -> bytes:
     config = json.dumps(
         {'basePath': base_path, 'apiPath': api_path},
@@ -84,12 +89,13 @@ def _inject_chat_config(content: bytes, *, base_path: str, api_path: str) -> byt
     config = config.replace('&', '\\u0026').replace('<', '\\u003c').replace('>', '\\u003e')
     bootstrap = f'<script>window.PYDANTIC_AI_CHAT_CONFIG={config};</script>'.encode()
 
-    if head_match := _first_uncommented_match(content, _OPENING_HEAD_RE):
-        insertion_point = head_match.end()
-    elif script_match := _first_uncommented_match(content, _OPENING_SCRIPT_RE):
-        insertion_point = script_match.start()
-    else:
-        insertion_point = len(content)
+    source = content.decode('latin-1')
+    parser = _ChatConfigInsertionParser(source)
+    parser.feed(source)
+    insertion_point = min(
+        (point for point in (parser.head_end, parser.script_start) if point is not None),
+        default=len(content),
+    )
 
     return content[:insertion_point] + bootstrap + content[insertion_point:]
 

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -324,6 +324,17 @@ def test_chat_app_uses_mount_root_path(isolated_ui_cache: None):
         assert client.get('/demo/api/configure').status_code == 200
 
 
+def test_chat_app_percent_encodes_mount_root_path(isolated_ui_cache: None):
+    outer_app = Starlette()
+    outer_app.mount('/demo?x', create_web_app(Agent('test')))
+
+    with TestClient(outer_app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/demo%3Fx/')
+
+    assert response.status_code == 200
+    assert _chat_config(response.text) == {'basePath': '/demo%3Fx/', 'apiPath': '/demo%3Fx/api/'}
+
+
 def test_chat_app_uses_proxy_root_path(isolated_ui_cache: None):
     app = create_web_app(Agent('test'))
 
@@ -349,12 +360,16 @@ def test_agent_to_web_public_path_overrides(tmp_path: Path):
 
 
 def test_chat_app_public_path_overrides_are_independent(isolated_ui_cache: None):
-    app = create_web_app(Agent('test'), base_path='/browser')
+    app = create_web_app(Agent('test'), api_path='/services/agent-api')
 
     with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/proxy') as client:
         response = client.get('/')
+        api_response = client.get('/proxy/api/configure')
+        public_path_response = client.get('/services/agent-api/configure')
 
-    assert _chat_config(response.text) == {'basePath': '/browser/', 'apiPath': '/proxy/api/'}
+    assert _chat_config(response.text) == {'basePath': '/proxy/', 'apiPath': '/services/agent-api/'}
+    assert api_response.status_code == 200
+    assert public_path_response.status_code == 404
 
 
 @pytest.mark.parametrize(
@@ -366,6 +381,8 @@ def test_chat_app_public_path_overrides_are_independent(isolated_ui_cache: None)
         '/path?query',
         '/path#fragment',
         '/path\\part',
+        '/../api',
+        '/%2e%2e//other.example/api',
         '/\t/other.example/path',
         '/\n/other.example/path',
         '/\r/other.example/path',
@@ -422,6 +439,21 @@ def test_chat_app_bootstrap_ignores_script_contents(tmp_path: Path):
 
     assert _chat_config(response.text) == {'basePath': '/', 'apiPath': '/api/'}
     assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=') < response.text.index('const template')
+
+
+@pytest.mark.parametrize('element', ['title', 'textarea', 'template'])
+def test_chat_app_bootstrap_precedes_inert_html_contents(tmp_path: Path, element: str):
+    source = f'<!doctype html><{element}>x<head>y</{element}><script type="module">start()</script>'.encode()
+    html_file = tmp_path / 'index.html'
+    html_file.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert _chat_config(response.text) == {'basePath': '/', 'apiPath': '/api/'}
+    assert response.text.index('<!doctype html>') < response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=')
+    assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=') < response.text.index(f'<{element}>')
 
 
 @pytest.mark.anyio

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -65,6 +65,13 @@ def _fake_cache_dir(path: Path) -> Callable[[], Awaitable[Path]]:
     return get_cache_dir
 
 
+def _chat_config(html: str) -> dict[str, str]:
+    prefix = 'window.PYDANTIC_AI_CHAT_CONFIG='
+    start = html.index(prefix) + len(prefix)
+    end = html.index(';</script>', start)
+    return json.loads(html[start:end])
+
+
 def test_agent_to_web():
     """Test the Agent.to_web() method."""
     agent = Agent('test')
@@ -287,7 +294,7 @@ def isolated_ui_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _stub_cdn_fetch(monkeypatch, b'<html>Test UI</html>')
 
 
-def test_chat_app_index_endpoint(isolated_ui_cache: None):
+def test_chat_app_index_endpoint(isolated_ui_cache: None, tmp_path: Path):
     """Test that the index endpoint serves HTML with proper caching headers."""
     agent = Agent('test')
     app = create_web_app(agent)
@@ -299,6 +306,109 @@ def test_chat_app_index_endpoint(isolated_ui_cache: None):
         assert 'cache-control' in response.headers
         assert response.headers['cache-control'] == 'public, max-age=3600'
         assert len(response.content) > 0
+        assert _chat_config(response.text) == {'basePath': '/', 'apiPath': '/api/'}
+
+    cache_file = tmp_path / f'{app_module.CHAT_UI_VERSION}.html'
+    assert cache_file.read_bytes() == b'<html>Test UI</html>'
+
+
+def test_chat_app_uses_mount_root_path(isolated_ui_cache: None):
+    agent = Agent('test')
+    outer_app = Starlette()
+    outer_app.mount('/demo', agent.to_web())
+
+    with TestClient(outer_app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/demo/conversation-id')
+        assert response.status_code == 200
+        assert _chat_config(response.text) == {'basePath': '/demo/', 'apiPath': '/demo/api/'}
+        assert client.get('/demo/api/configure').status_code == 200
+
+
+def test_chat_app_uses_proxy_root_path(isolated_ui_cache: None):
+    app = create_web_app(Agent('test'))
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/demo') as client:
+        response = client.get('/')
+        assert response.status_code == 200
+        assert _chat_config(response.text) == {'basePath': '/demo/', 'apiPath': '/demo/api/'}
+
+
+def test_agent_to_web_public_path_overrides(tmp_path: Path):
+    source = b"""<!doctype html>
+<html><head><script type="module" src="/assets/app.js"></script></head></html>"""
+    html_file = tmp_path / 'index.html'
+    html_file.write_bytes(source)
+    app = Agent('test').to_web(base_path='/chat', api_path='/services/agent-api', html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/ignored') as client:
+        response = client.get('/')
+
+    assert _chat_config(response.text) == {'basePath': '/chat/', 'apiPath': '/services/agent-api/'}
+    assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=') < response.text.index('type="module"')
+    assert html_file.read_bytes() == source
+
+
+def test_chat_app_public_path_overrides_are_independent(isolated_ui_cache: None):
+    app = create_web_app(Agent('test'), base_path='/browser')
+
+    with TestClient(app, base_url=LOCAL_BASE_URL, root_path='/proxy') as client:
+        response = client.get('/')
+
+    assert _chat_config(response.text) == {'basePath': '/browser/', 'apiPath': '/proxy/api/'}
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        'relative',
+        '//other.example/path',
+        'https://other.example/path',
+        '/path?query',
+        '/path#fragment',
+        '/path\\part',
+        '/\t/other.example/path',
+        '/\n/other.example/path',
+        '/\r/other.example/path',
+    ],
+)
+@pytest.mark.parametrize('parameter', ['base_path', 'api_path'])
+def test_chat_app_rejects_non_same_origin_path(parameter: Literal['base_path', 'api_path'], path: str):
+    with pytest.raises(UserError, match=f'Invalid `{parameter}`'):
+        if parameter == 'base_path':
+            create_web_app(Agent('test'), base_path=path)
+        else:
+            create_web_app(Agent('test'), api_path=path)
+
+
+def test_chat_app_bootstrap_serialization_is_script_safe(tmp_path: Path):
+    source = b'<!doctype html><script type="module">start()</script>'
+    html_file = tmp_path / 'index.html'
+    html_file.write_bytes(source)
+    path = '/</script><script>alert("unsafe")</script>'
+    app = create_web_app(Agent('test'), base_path=path, api_path=path, html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert _chat_config(response.text) == {'basePath': f'{path}/', 'apiPath': f'{path}/'}
+    bootstrap = response.text.split('<script type="module">', 1)[0]
+    assert bootstrap.count('<script>') == 1
+    assert '</script><script>alert' not in bootstrap
+    assert '\\u003c/script\\u003e' in bootstrap
+
+
+def test_chat_app_bootstrap_ignores_html_comments(tmp_path: Path):
+    source = b'<!-- template uses <head> --><html><head><script type="module">start()</script></head></html>'
+    html_file = tmp_path / 'index.html'
+    html_file.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert _chat_config(response.text) == {'basePath': '/', 'apiPath': '/api/'}
+    assert response.text.index('-->') < response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=')
+    assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=') < response.text.index('type="module"')
 
 
 @pytest.mark.anyio

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -411,6 +411,19 @@ def test_chat_app_bootstrap_ignores_html_comments(tmp_path: Path):
     assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=') < response.text.index('type="module"')
 
 
+def test_chat_app_bootstrap_ignores_script_contents(tmp_path: Path):
+    source = b"""<!doctype html><script>const template = "<head>";</script><script type="module">start()</script>"""
+    html_file = tmp_path / 'index.html'
+    html_file.write_bytes(source)
+    app = create_web_app(Agent('test'), html_source=html_file)
+
+    with TestClient(app, base_url=LOCAL_BASE_URL) as client:
+        response = client.get('/')
+
+    assert _chat_config(response.text) == {'basePath': '/', 'apiPath': '/api/'}
+    assert response.text.index('window.PYDANTIC_AI_CHAT_CONFIG=') < response.text.index('const template')
+
+
 @pytest.mark.anyio
 async def test_get_ui_html_cdn_fetch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Test that _get_ui_html fetches from CDN when filesystem cache misses."""


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

- Closes #7611

Derive the chat UI's public navigation and API directories from each request's ASGI `root_path`, with independent `base_path` and `api_path` overrides for proxy topologies that cannot be represented by `root_path`.

The raw HTML remains cached unchanged. Each response receives a script-safe `window.PYDANTIC_AI_CHAT_CONFIG` bootstrap before the UI module executes. The path validation keeps generated requests same-origin and avoids browser URL-normalization escapes.

### Release dependency

This draft depends on [pydantic/ai-chat-ui#47](https://github.com/pydantic/ai-chat-ui/pull/47) being merged and released. `CHAT_UI_VERSION` is intentionally unchanged because no released UI version consumes the runtime configuration yet. Before this PR can leave draft, it must be updated to the compatible released UI artifact and verified against both the default CDN and offline HTML.

### Verification

- Web UI tests pass.
- Changed documentation examples pass.
- Formatting, lint, type checking, and cassette checks pass.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

