### PR TITLE
Harden docs navigation dispatcher outcomes

### DIFF
--- a/.github/scripts/test_docs_navigation_workflow.py
+++ b/.github/scripts/test_docs_navigation_workflow.py
@@ -11,6 +11,7 @@ def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
 
     assert 'pull_request_target:' in workflow
     assert "github.event.label.name == 'trigger:docs'" in workflow
+    assert 'docs-navigation-${{ github.event.pull_request.number }}-${{ github.event.label.name }}' in workflow
     assert 'timeout-minutes: 5' in workflow
     assert 'actions/checkout@' not in workflow
     assert '/collaborators/${ACTOR}/permission' in workflow

--- a/.github/scripts/test_docs_navigation_workflow.py
+++ b/.github/scripts/test_docs_navigation_workflow.py
@@ -34,5 +34,7 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert 'preview URL' not in workflow
     assert '--paginate --slurp' in workflow
     assert 'startswith("## Docs Preview")' in workflow
+    assert '| last).url // empty' in workflow
+    assert "steps.verify.outcome == 'failure'" in workflow
     assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
     assert "steps.acknowledge.outcome == 'failure'" in workflow

--- a/.github/scripts/test_docs_navigation_workflow.py
+++ b/.github/scripts/test_docs_navigation_workflow.py
@@ -33,3 +33,6 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert 'has been queued' in workflow
     assert 'preview URL' not in workflow
     assert '--paginate --slurp' in workflow
+    assert 'startswith("## Docs Preview")' in workflow
+    assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
+    assert "steps.acknowledge.outcome == 'failure'" in workflow

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -18,7 +18,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: docs-preview-${{ github.event.pull_request.number }}
+  group: docs-navigation-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -58,6 +58,7 @@ jobs:
           permission-contents: write
 
       - name: Dispatch navigation check
+        id: dispatch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -73,6 +74,7 @@ jobs:
             -f "client_payload[source_sha]=${HEAD_SHA}"
 
       - name: Acknowledge on PR
+        id: acknowledge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -97,7 +99,7 @@ jobs:
           fi
 
       - name: Comment failure on PR
-        if: failure()
+        if: failure() && (steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -110,6 +112,22 @@ jobs:
           The navigation check could not be queued. See [the workflow run](${RUN_URL}) for details.
 
           <sub>Re-add the \`trigger:docs\` label to retry.</sub>
+          EOF
+          )
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
+
+      - name: Report acknowledgement failure on PR
+        if: failure() && steps.dispatch.outcome == 'success' && steps.acknowledge.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(cat <<EOF
+          ## Docs Navigation Check — queued
+
+          Navigation validation was queued, but this workflow could not post its normal acknowledgement. See [the workflow run](${RUN_URL}) for details.
           EOF
           )
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -33,6 +33,7 @@ jobs:
 
     steps:
       - name: Verify a maintainer triggered the check
+        id: verify
         env:
           ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
@@ -91,7 +92,7 @@ jobs:
 
           # Update an existing navigation or legacy preview comment on reruns.
           existing=$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-            --jq '[.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))][0].url // empty')
+            --jq '([.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))] | last).url // empty')
           if [ -n "$existing" ]; then
             gh api -X PATCH "$existing" -f body="$body"
           else
@@ -99,7 +100,7 @@ jobs:
           fi
 
       - name: Comment failure on PR
-        if: failure() && (steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
+        if: failure() && (steps.verify.outcome == 'failure' || steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- scope docs-navigation concurrency by PR and label, preventing unrelated label events from cancelling active validation
- report app-token/dispatch failures separately from acknowledgement failures
- preserve legacy comment matching and cover the workflow contract with focused regression tests

Follow-up to #7617 after the same races were identified during review of the equivalent Logfire workflow.

## Verification

- `uv run pytest -q .github/scripts/test_docs_navigation_workflow.py`
- `uv run ruff check .github/scripts/test_docs_navigation_workflow.py`
- `uv run ruff format --check .github/scripts/test_docs_navigation_workflow.py`
- `actionlint .github/workflows/docs-navigation.yml`
- `uvx zizmor .github/workflows/docs-navigation.yml`