### PR TITLE
Make `pushing-commits-to-the-repo` the canonical PR guide

### DIFF
--- a/.agents/skills/add-new-model/SKILL.md
+++ b/.agents/skills/add-new-model/SKILL.md
@@ -124,15 +124,13 @@ If snapshot tests changed: `uv run pytest <file> --inline-snapshot=fix` then ver
 
 ## Step 8 — PR
 
-Terse, not botty. Structure:
+Follow the `pushing-commits-to-the-repo` skill for the title, body, template, and final metadata
+check. Keep the model-specific evidence concise:
 
 - One sentence: what model(s) were added.
-- Bulleted file list with one-line "what changed" per file.
 - "Verified via probe / mirror of #NNNN" — explicit about which changes were API-verified vs assumed-by-mirror.
 - Flag pre-existing latent bugs found but deliberately not fixed.
 - Link the prior add-model PR for context.
-
-Include the [PR template](.github/pull_request_template.md), fill in the issue number, and check the "AI generated code" box in the GitHub UI yourself — `gh pr create` cannot set it.
 
 ## Provider-specific landmines
 

--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: pushing-commits-to-the-repo
-description: What to do when you open a PR and every time you push — label the PR, run a local
-  review, watch CI to green, triage every review comment to a reply and a reaction, and escalate
-  genuine design trade-offs to maintainers. Use whenever you open a PR or push a commit to one.
+description: Open and advance a PR — write a current title and body, label it, review before every
+  push, watch CI, and triage every comment. Use whenever you open a PR or push a commit to one.
 ---
 
 # pushing-commits-to-the-repo
@@ -11,6 +10,36 @@ Pushing starts a loop; it does not end the task. **Work stops only when CI is gr
 is left unresolved.**
 
 ## When you open the PR
+
+### Write the title and body
+
+Follow the title and template rules in the root `AGENTS.md`.
+
+Keep visible body content within 40 lines. Exclude template lines and collapsed `<details>`
+contents from the count. For a feature or behavior change, use this order:
+
+1. **Why we make these changes** — State the problem and decision in a few sentences. Link the issue.
+2. **New public surface** — List each new maintained symbol. Write `none` when there is none.
+3. **User-visible behavior** — Show the smallest before-and-after example. Replace it with a
+   call-path diff when the changed call chain explains the behavior; do not include both.
+4. **Verification** — Link the exact proving tests from the PR diff. Put a minimal runnable
+   playground in `<details>` only when it helps reviewers reproduce the behavior.
+5. **What changes for existing users** — State the effect in one sentence. `Nothing` is valid.
+
+Use one collapsed `<details>` section per goal only when the PR has multiple independent goals.
+For a trivial PR, use the issue link, a short summary, and the test plan.
+
+#### User-visible call-path diff
+
+Use one fenced `diff` tree from the public entry point to the changed observable result.
+
+- Format each node as `path/file.py :: Class.method()` or `path/file.py :: function()`.
+- Indent each callee beneath its caller with `└─`. Preserve enough unchanged nodes to show each edge.
+- Collapse irrelevant intermediate calls as `… unchanged machinery …`.
+- Include arguments only when they explain the change.
+- Include results only on relevant leaves.
+- Keep the shared caller prefix unmarked. Mark only diverging nodes, relevant arguments, or results.
+- Target 12 content lines inside the fence. Never exceed 20; collapse secondary branches instead.
 
 Apply a label — the repo triages and filters by them. Fetch the real list first with
 `gh label list --limit 100`, because the set changes and a guessed label silently fails to
@@ -76,3 +105,16 @@ before handing the PR back or requesting merge:
   instructions. Don't apply the label to those PRs; the red check is the guard working.
 - **Afterwards, re-enter the loop.** The review posts comments that need the same triage as any
   other.
+
+## Before handing the PR back
+
+Run this final metadata check after CI, comments, and any selected `douwebot` review have settled:
+
+1. Dispatch a fresh subagent that has not worked on the PR.
+2. Give it the PR URL, linked issue, current `base...HEAD` diff, final test status, title, and body.
+3. Ask it to check only the title and body against this section and the root `AGENTS.md`.
+4. Require either `current` or an exact replacement title and body.
+5. Apply every correction. Code changes restart the post-push loop; metadata-only changes do not.
+6. After a replacement, repeat the check with another fresh subagent.
+7. Hand the PR back only after the check reports `current`.
+8. Report the human-only AI-code checkbox separately.

--- a/.claude/skills/address-feedback/SKILL.md
+++ b/.claude/skills/address-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: address-feedback
-description: Find and address unresolved PR review comments for the current branch, then summarize the changes and help reply to and resolve threads after user approval.
+description: Find and address unresolved PR review comments for the current branch, then continue
+  the canonical push, reply, reaction, and resolution workflow.
 ---
 
 # Address PR Review Feedback
@@ -16,9 +17,9 @@ Find and address all review comments on the PR for the current branch. For each 
 
 3. **Fix the code**: Make the necessary changes to address each comment.
 
-4. **Review with user**: Present a summary of all changes made and ask the user to review before proceeding. Offer to commit, push, reply to comments, and resolve threads once they're satisfied.
+4. **Continue the PR loop**: Follow `pushing-commits-to-the-repo` from its `Before you push` section.
 
-5. **Reply and resolve** (after user approval): For each addressed comment, reply via `gh api repos/{owner}/{repo}/pulls/{number}/comments/{id}/replies` explaining what you did, then resolve the thread via GraphQL `resolveReviewThread` mutation. To find thread IDs, query `repository.pullRequest.reviewThreads` via GraphQL.
+5. **Use the canonical close-out**: Apply every required reply, reaction, and resolution step from that workflow. For each completed comment, explain what changed or why no change was needed. Then resolve the thread via GraphQL `resolveReviewThread`. Leave threads open only when a decision or another person's response is pending.
 
 Always read the relevant code before making changes.
 


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

- Closes #7622

## Why we make these changes

Detailed PR-body guidance currently lives in a private maintainer overlay, while the tracked `pushing-commits-to-the-repo` skill owns the PR lifecycle. This makes the body format unavailable to other contributors and agent harnesses, and it lets PR metadata drift after review-driven code changes.

This PR makes the tracked skill canonical for both body structure and final metadata reconciliation.

## New public surface

none

## User-visible behavior

- Before: agents outside the private setup receive no detailed body format, and a green review loop can hand back stale metadata.
- After: PR agents receive one concise body format, including an optional call-path tree, and a fresh subagent verifies the settled title and body.

## Verification

- `make format && make lint`
- Independent instruction review: no findings after revision.
- Forward-tested against [PR #7277](https://github.com/pydantic/pydantic-ai/pull/7277), producing a ten-line user-visible call path.
- Audited all tracked non-`docs/` Markdown instruction files for competing PR guidance.

## What changes for existing users

PR authors using repository instructions get a shorter, shared body format and a final metadata check; library runtime behavior is unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

