### PR TITLE
Warm the lazy `pandas` import before arming BlockBuster in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,16 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 from ._inline_snapshot import Builder, Custom, customize
 from .cassette_utils import check_cache_prefix_stability
 
+# `logfire` builds its JSON schema lookup table on first use with a lazy `import pandas`
+# (`logfire/_internal/json_schema.py`), and importing pandas reads timezone data from disk. When
+# that first import happens inside an async test with the detector configured below armed, the read
+# is reported as blocking and aborts the import, leaving a partially initialized `pandas` in
+# `sys.modules` that every later import in the session trips over. Importing it here means the
+# detector never sees a first import. The read genuinely blocks, so this stays regardless of what
+# BlockBuster reports: https://github.com/pydantic/pydantic-ai/issues/7446.
+with suppress(ImportError):
+    import pandas  # pyright: ignore[reportUnusedImport] # noqa: F401
+
 T = TypeVar('T')
 
 __all__ = (
@@ -347,7 +357,7 @@ def anyio_backend():
 # fixed (e.g. offloaded to a thread with `anyio.to_thread.run_sync`) rather than exempted.
 BLOCKBUSTER_EXEMPTIONS: list[tuple[str, str, str | tuple[str, ...]]] = [
     # coverage reads Python source files while collecting coverage data. Remove these once
-    # https://github.com/cbornet/blockbuster/pull/63 is released in a compatible version.
+    # https://github.com/cbornet/blockbuster/pull/69 is released in a compatible version.
     ('os.stat', 'coverage/python.py', 'get_python_source'),
     ('io.BufferedReader.read', 'coverage/python.py', 'read_python_source'),
     # pytest-examples locates the source line of a captured `print()` with `Path.samefile`, so an


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.
>
> David decided the approach and has not reviewed the implementation.

- Closes #7446

`logfire` builds its JSON schema lookup table on first use with a lazy `import pandas` (`logfire/_internal/json_schema.py::type_to_schema`), and importing pandas reads timezone data from disk via `dateutil.tz`. When that first import happens inside an async test with BlockBuster armed and a `pydantic_evals` frame on the stack, the detector aborts the import, leaving a partially initialized `pandas` in `sys.modules`; every later import in the session then fails with `_pandas_datetime_CAPI`, which is what the three `test_tool_search_eval` cases report. Importing pandas at `tests/conftest.py` module scope means the detector never sees a first import.

The read genuinely blocks, so this is permanent rather than a workaround waiting on an upstream release. An exemption would excuse a call that the list's own contract says should be fixed instead — and could not have covered the variant described below in any case.

`tests/test_temporal.py` already carries the same eager import for the same class of failure with a narrower trigger. That one stays: it lives inside Temporal's `imports_passed_through()`.

Verified by mutation: with the warm-up, `pytest tests/test_tool_search.py -k tool_search_eval` passes 3/3; without it, fails 3/3.

### Also here

The coverage exemptions' removal condition pointed at [cbornet/blockbuster#63](https://github.com/cbornet/blockbuster/pull/63), which is **closed, not merged** — a condition that can never be met. Repointed to [#69](https://github.com/cbornet/blockbuster/pull/69), which carries the same two allowances and is merged, but sits above the 1.5.27 version bump and so is still unreleased. The pin bump belongs with the release that ships #69, together with deleting the two exemptions.

<details><summary>The root cause differs from the issue body, by platform</summary>

The issue traced this to `blockbuster.file_read_exclude` raising `AttributeError` on a `tarfile._FileInFile`. That is a real upstream bug, but it is not what fails here. The aborting exception depends on which timezone backend `dateutil` finds:

- **Python 3.13, this repo's env:** `dateutil/tz/tz.py::_read_tzfile` reads a real `TZif` file, so BlockBuster raises `BlockingError: Blocking call to io.BufferedReader.read` — a correct detection of a genuinely blocking read.
- **Python 3.14, the issue's env:** `dateutil` falls back to its bundled `dateutil-zoneinfo.tar.gz`, so the read goes through a `tarfile.ExFileObject` and hits the `fileno` bug.

Same event, different exception. Two consequences: an upstream blockbuster fix does not fix this repo, and a `BLOCKBUSTER_EXEMPTIONS` entry could not have fixed the second variant either, because `can_block_predicate` runs before the stack walk in `_wrap_blocking`, so the `AttributeError` escapes before any exemption is consulted.

The upstream half is fixed separately in [cbornet/blockbuster#70](https://github.com/cbornet/blockbuster/pull/70).
</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
