### PR TITLE
Make pending-message enqueue thread-safe

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import _thread
 import asyncio
 import dataclasses
 import inspect
@@ -419,6 +420,9 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     # passing it to a `replace(ctx, ...=...)`) would silently break in-step tool reveals.
     loaded_capability_ids: set[str]
     discovered_tool_names: set[str]
+
+    _pending_messages_lock: _thread.LockType
+    """Private per-run lock shared by pending-message producers and the drain capability."""
 
     native_tools: list[AgentNativeTool[DepsT]] = dataclasses.field(repr=False)
     tool_manager: ToolManager[DepsT]
@@ -2362,6 +2366,7 @@ def build_run_context(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT
         loaded_capability_ids=ctx.deps.loaded_capability_ids,
         discovered_tool_names=ctx.deps.discovered_tool_names,
         pending_messages=ctx.state.pending_messages,
+        _pending_messages_lock=ctx.deps._pending_messages_lock,  # pyright: ignore[reportPrivateUsage]
         _cancellation=ctx.deps.cancellation,
         _event_stream_buffer=ctx.state.event_stream_buffer,
         _mcp_tool_defs_cache=ctx.state.mcp_tool_defs_cache,

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import _thread
 import dataclasses
 import sys
 from collections.abc import Generator, Sequence
@@ -153,6 +154,8 @@ class RunContext(Generic[RunContextAgentDepsT]):
     Managed by the framework: read it if useful, but use [`enqueue`][pydantic_ai.tools.RunContext.enqueue]
     to add messages rather than mutating it directly.
     """
+    _pending_messages_lock: _thread.LockType | None = field(default=None, repr=False)
+    """Private per-run lock protecting pending-message enqueue and drain transactions."""
 
     _cancellation: RunCancellation | None = field(default=None, repr=False)
     """Private implementation detail — not part of the public API; do not read or write.
@@ -419,10 +422,9 @@ class RunContext(Generic[RunContextAgentDepsT]):
 
         Safe to call from anywhere a `RunContext` is available — async tools,
         sync tools (auto-wrapped in a thread executor by Pydantic AI), and
-        capability hooks. The drain only iterates the queue between graph nodes
-        (in `before_model_request` and `after_node_run`), never concurrently
-        with the tool body, so `list.append` from a worker thread doesn't race
-        the drain.
+        capability hooks. Enqueue and each queue drain transaction share a
+        per-run lock, so a sync tool can enqueue from a worker thread without
+        racing a drain.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -461,8 +463,18 @@ class RunContext(Generic[RunContextAgentDepsT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self.pending_messages.append(pending)
+        with self._pending_messages_guard():
+            self.pending_messages.append(pending)
         return pending.enqueue_id
+
+    @contextmanager
+    def _pending_messages_guard(self) -> Generator[None]:
+        """Serialize pending-message queue mutation with its drain transaction."""
+        if self._pending_messages_lock is None:
+            yield
+        else:
+            with self._pending_messages_lock:
+                yield
 
     def cancel(self) -> None:
         """Cancel the agent run this context belongs to.

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -5,6 +5,7 @@ import contextvars
 import dataclasses
 import functools
 import inspect
+import threading
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable, Generator, Sequence
 from contextlib import (
@@ -1477,6 +1478,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         graph = _agent_graph.build_agent_graph(self.name, self._deps_type, output_type_)
 
         # Build the initial state
+        pending_messages_lock = threading.Lock()
         state = _agent_graph.GraphAgentState(
             message_history=list(message_history) if message_history else [],
             usage=usage,
@@ -1552,6 +1554,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             else DEFAULT_INSTRUMENTATION_VERSION,
             run_step=0,
             pending_messages=state.pending_messages,
+            _pending_messages_lock=pending_messages_lock,
             run_id=state.run_id,
             conversation_id=state.conversation_id,
             _cancellation=cancellation,
@@ -1740,6 +1743,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             capabilities=capabilities_dict,
             loaded_capability_ids=loaded_capability_ids,
             discovered_tool_names=discovered_tool_names,
+            _pending_messages_lock=pending_messages_lock,
             native_tools=cap_native_tools,
             tool_manager=tool_manager,
             tracer=tracer,

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
@@ -56,6 +56,48 @@ def _stamped_messages(
     return messages
 
 
+def _drain_at_end(
+    ctx: RunContext[Any],
+    result: _agent_graph.AgentNode[Any, Any] | End[FinalResult[Any]],
+) -> _agent_graph.AgentNode[Any, Any] | End[FinalResult[Any]]:
+    """Drain both priorities and build the end-of-run redirect."""
+    assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
+    # Pi-mono parity: drain `'asap'` first so anything that arrived during the
+    # final step (e.g. a background task completing while the model produced
+    # its final response) gets delivered before `'when_idle'` messages, and the
+    # agent gets another turn rather than terminating with the message lost.
+    leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
+    when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
+    if not leftover_asap and not when_idle:
+        return result
+
+    drained = [*leftover_asap, *when_idle]
+    stamped = [
+        (
+            pending,
+            _stamped_messages(pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id),
+        )
+        for pending in drained
+    ]
+    messages = [message for _, pending_messages in stamped for message in pending_messages]
+    # `final` becomes the redirect node's request; `_stamped_messages` already
+    # stamped it, which is harmless because the lifecycle stamps it again.
+    final = messages[-1]
+    if not isinstance(final, ModelRequest):
+        raise UserError(
+            'Enqueued content must end with a `ModelRequest` so the agent has a request to respond to, '
+            f'but the last queued message is a `{type(final).__name__}`.'
+        )
+    for pending, pending_messages in stamped:
+        for message in pending_messages:
+            if message is not final:
+                ctx.messages.append(message)
+        ctx._emit_event(  # pyright: ignore[reportPrivateUsage]
+            EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, messages=tuple(pending_messages))
+        )
+    return ModelRequestNode(request=final)
+
+
 class PendingMessageDrainCapability(AbstractCapability[Any]):
     """Drains the pending message queue at appropriate times.
 
@@ -100,14 +142,15 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
         messages exactly as delivered here.
         """
         assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
-        drained = _drain_by_priority(ctx.pending_messages, 'asap')
-        for pending in drained:
-            messages = _stamped_messages(
-                pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id
-            )
-            request_context.messages.extend(messages)
-            ctx.messages.extend(messages)
-            ctx._emit_event(EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, messages=tuple(messages)))  # pyright: ignore[reportPrivateUsage]
+        with ctx._pending_messages_guard():  # pyright: ignore[reportPrivateUsage]
+            drained = _drain_by_priority(ctx.pending_messages, 'asap')
+            for pending in drained:
+                messages = _stamped_messages(
+                    pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id
+                )
+                request_context.messages.extend(messages)
+                ctx.messages.extend(messages)
+                ctx._emit_event(EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, messages=tuple(messages)))  # pyright: ignore[reportPrivateUsage]
         return request_context
 
     async def after_node_run(
@@ -136,43 +179,5 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
         if not isinstance(result, End):
             return result
 
-        assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
-        # Pi-mono parity: drain `'asap'` first so anything that arrived during the
-        # final step (e.g. a background task completing while the model produced
-        # its final response) gets delivered before `'when_idle'` messages, and the
-        # agent gets another turn rather than terminating with the message lost.
-        leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
-        when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
-        if not leftover_asap and not when_idle:
-            return result
-
-        drained = [*leftover_asap, *when_idle]
-        stamped = [
-            (
-                pending,
-                _stamped_messages(pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id),
-            )
-            for pending in drained
-        ]
-        messages = [message for _, pending_messages in stamped for message in pending_messages]
-        # `final` becomes the redirect node's request; `ModelRequestNode._prepare_request`
-        # will re-stamp it during the graph lifecycle. `_stamped_messages` already
-        # stamped it, which is harmless (the lifecycle stamp overwrites). `from_content`
-        # guarantees each `PendingMessage` ends in a `ModelRequest`, but a producer can
-        # construct `PendingMessage` (or mutate `RunContext.pending_messages`) directly, so
-        # we check rather than assert. Every message except `final` is appended to history
-        # before the redirect.
-        final = messages[-1]
-        if not isinstance(final, ModelRequest):
-            raise UserError(
-                'Enqueued content must end with a `ModelRequest` so the agent has a request to respond to, '
-                f'but the last queued message is a `{type(final).__name__}`.'
-            )
-        for pending, pending_messages in stamped:
-            for message in pending_messages:
-                if message is not final:
-                    ctx.messages.append(message)
-            ctx._emit_event(  # pyright: ignore[reportPrivateUsage]
-                EnqueuedMessagesEvent(enqueue_id=pending.enqueue_id, messages=tuple(pending_messages))
-            )
-        return ModelRequestNode(request=final)
+        with ctx._pending_messages_guard():  # pyright: ignore[reportPrivateUsage]
+            return _drain_at_end(ctx, result)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_run_context.py
@@ -41,12 +41,20 @@ _REHYDRATORS: tuple[tuple[str, type[Any], TypeAdapter[Any]], ...] = (
 # Fields that `serialize_run_context` doesn't carry but that are still readable inside an activity,
 # as `None` unless the framework attaches something: `agent` and `root_capability` are re-attached
 # from the worker's agent instance, `pending_messages` is replaced by an `EnqueueGuard` so
-# `ctx.enqueue()` raises an explanation, and `tool_manager` is documented to be `None` inside
+# `ctx.enqueue()` raises an explanation, `_pending_messages_lock` is `None` because there is no
+# live workflow-side queue to protect, and `tool_manager` is documented to be `None` inside
 # activities — `available_tool_names` then reads the snapshot serialized at dispatch time (see
 # the property override below), or falls back to `discovered_tool_names` without one.
 # `realtime_session` is a live session object that cannot cross the boundary, and its contract
 # already makes `None` mean "not available here".
-_NONE_UNLESS_ATTACHED = ('agent', 'root_capability', 'pending_messages', 'tool_manager', 'realtime_session')
+_NONE_UNLESS_ATTACHED = (
+    'agent',
+    'root_capability',
+    'pending_messages',
+    '_pending_messages_lock',
+    'tool_manager',
+    'realtime_session',
+)
 
 # Defaulted rather than guarded when a payload doesn't carry it. Unlike the guarded fields, the
 # dataclass default can't be mistaken for real run state here: empty means "no anchored evidence",

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -520,10 +520,9 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
 
         Designed to be called from the same event loop driving `agent.iter()`. If
         you're forwarding events from a different thread (e.g. a webhook handler
-        running on its own loop or thread), marshal the call back onto the agent's
-        loop first (e.g. `loop.call_soon_threadsafe(agent_run.enqueue, msg)`).
-        The drain's `queue[:] = remaining` pattern in `_drain_by_priority` isn't
-        atomic against concurrent appends from a different thread.
+        running on its own loop or thread), the pending-message queue mutation is
+        synchronized with the run's drain. Delivery still occurs on the agent's
+        event loop.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -549,7 +548,8 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self._graph_run.state.pending_messages.append(pending)
+        with self._graph_run.deps._pending_messages_lock:  # pyright: ignore[reportPrivateUsage]
+            self._graph_run.state.pending_messages.append(pending)
         return pending.enqueue_id
 
     def cancel(self) -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 import anyio
 import pytest
+from blockbuster import BlockBuster
 from opentelemetry.trace import NoOpTracer
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
@@ -60,6 +61,7 @@ from pydantic_ai.capabilities import (
     XSearch,
 )
 from pydantic_ai.capabilities._dynamic import ResolvedDynamicCapability
+from pydantic_ai.capabilities._pending_messages import PendingMessageDrainCapability
 from pydantic_ai.capabilities.abstract import AbstractCapability
 from pydantic_ai.capabilities.combined import CombinedCapability
 from pydantic_ai.capabilities.hooks import Hooks, HookTimeoutError
@@ -17419,6 +17421,76 @@ async def test_enqueue_from_agent_run():
             ),
         ]
     )
+
+
+async def test_sync_enqueue_waits_for_pending_message_drain(blockbuster: BlockBuster | None):
+    """A sync-tool enqueue cannot be lost while a drain replaces the queue contents."""
+
+    loop = asyncio.get_running_loop()
+    iter_started = asyncio.Event()
+    release_iter = threading.Event()
+
+    class BlockingPendingMessages(list[PendingMessage]):
+        def __iter__(self):
+            loop.call_soon_threadsafe(iter_started.set)
+            assert release_iter.wait(timeout=1)
+            return super().__iter__()
+
+    queue = BlockingPendingMessages()
+    ctx = RunContext(
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        pending_messages=queue,
+        _pending_messages_lock=threading.Lock(),
+        _event_stream_buffer=[],
+    )
+    request_context = ModelRequestContext(
+        model=TestModel(),
+        messages=[],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
+    capability = PendingMessageDrainCapability()
+    drain_errors: list[BaseException] = []
+
+    def drain() -> None:
+        try:
+            asyncio.run(capability.before_model_request(ctx, request_context))
+        except BaseException as exc:  # pragma: no cover - assertion below reports unexpected errors
+            drain_errors.append(exc)
+
+    if blockbuster is not None:
+        blockbuster.deactivate()
+    try:
+        drain_thread = threading.Thread(target=drain)
+        drain_thread.start()
+        await asyncio.wait_for(iter_started.wait(), timeout=1)
+
+        enqueue_started = asyncio.Event()
+        enqueue_finished = threading.Event()
+
+        def enqueue() -> None:
+            loop.call_soon_threadsafe(enqueue_started.set)
+            ctx.enqueue('from sync tool')
+            enqueue_finished.set()
+
+        enqueue_thread = threading.Thread(target=enqueue)
+        enqueue_thread.start()
+        await asyncio.wait_for(enqueue_started.wait(), timeout=1)
+        assert not enqueue_finished.is_set()
+
+        release_iter.set()
+        await asyncio.to_thread(drain_thread.join, 1)
+        await asyncio.to_thread(enqueue_thread.join, 1)
+        assert not drain_errors
+        assert not drain_thread.is_alive()
+        assert not enqueue_thread.is_alive()
+        assert enqueue_finished.is_set()
+        assert len(queue) == 1
+    finally:
+        if blockbuster is not None:
+            blockbuster.activate()
 
 
 async def test_bare_async_for_drains_pending_messages():

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1959,6 +1959,7 @@ def test_cache_key_run_context_projection_is_exhaustive():
         '_mcp_tool_defs_cache',  # live per-run memo of MCP tool defs, reconstructed from messages
         '_event_stream_buffer',  # live per-run event buffer drained in flow code, not a task input
         'realtime_session',  # live RealtimeSession, not hashable run state; sessions don't run inside Prefect tasks
+        '_pending_messages_lock',  # runtime-only synchronization for the live queue, not behavioral cache-key state
         '_cancellation',  # runtime-only cancellation controller; carries no run inputs and must not fork the cache key
     }
     ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4524,6 +4524,7 @@ def test_temporal_run_context_serialization_is_exhaustive():
         '_mcp_tool_defs_cache',  # run-local cache read/written in workflow code; never needed inside an activity
         '_event_stream_buffer',  # run-local event buffer drained in workflow code; a public emit surface for activities is a follow-up
         'realtime_session',  # live RealtimeSession, not serializable; realtime sessions don't run inside Temporal activities
+        '_pending_messages_lock',  # runtime-only thread lock protecting the workflow-side queue; cannot cross the activity boundary
         '_cancellation',  # runtime-only controller holding a live asyncio task reference; cannot cross the activity boundary
     }
     ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())


### PR DESCRIPTION
Closes #7634.

A capability can let the graph continue while a synchronous tool still runs. If that tool calls `ctx.enqueue()`, its worker thread can append while the pending-message drain replaces the queue contents, losing the message.

This adds one runtime-only lock per run and shares it across `RunContext.enqueue()`, `AgentRun.enqueue()`, and complete pending-message drain transactions. `GraphAgentState.pending_messages` remains a plain list, so durable serialization is unchanged.

This is needed by pydantic/pydantic-ai-harness#222.

### Tests

- `uv run pytest tests/test_capabilities.py -q` (899 passed)
- focused Ruff and Pyright checks passed

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


