### PR TITLE
Add Background Tools to docs navigation

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -323,6 +323,10 @@ navigation:
             path: "advisor.md"
             source: "harness"
             slug: "harness/advisor"
+          - page: "Background Tools"
+            path: "background-tools.md"
+            source: "harness"
+            slug: "harness/background-tools"
       - section: "Context Management"
         slug: ""
         contents:


### PR DESCRIPTION
Adds the Harness Background Tools page to the unified docs navigation.

Companion to pydantic/pydantic-ai-harness#222.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

