### PR TITLE
Recognize YouTube subdomains in `VideoUrl`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -350,7 +350,11 @@ class VideoUrl(FileUrl):
         """True if the URL has a YouTube domain."""
         parsed = urlparse(self.url)
         hostname = parsed.hostname
-        return hostname in ('youtu.be', 'youtube.com', 'www.youtube.com')
+        return (
+            hostname == 'youtu.be'
+            or hostname == 'youtube.com'
+            or (hostname is not None and hostname.endswith('.youtube.com'))
+        )
 
     @property
     def format(self) -> VideoFormat:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -107,6 +107,9 @@ def test_video_url():
         pytest.param('https://youtu.be/lCdaVNyHtjU', True, id='youtu.be'),
         pytest.param('https://www.youtube.com/lCdaVNyHtjU', True, id='www.youtube.com'),
         pytest.param('https://youtube.com/lCdaVNyHtjU', True, id='youtube.com'),
+        pytest.param('https://m.youtube.com/lCdaVNyHtjU', True, id='m.youtube.com'),
+        pytest.param('https://music.youtube.com/lCdaVNyHtjU', True, id='music.youtube.com'),
+        pytest.param('https://youtube.com.example.com/video.mp4', False, id='youtube.com.example.com'),
         pytest.param('https://dummy.com/video.mp4', False, id='dummy.com'),
     ],
 )


### PR DESCRIPTION
- Closes #7591

### What

`VideoUrl.is_youtube` now recognizes `youtube.com` subdomains such as `m.youtube.com` and `music.youtube.com`, while still excluding deceptive suffixes such as `youtube.com.example.com`.

### Tests

- `uv run pytest tests/test_messages.py::test_youtube_video_url`
- `uv run pytest tests/models/test_google.py -k youtube_video_url`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

