### PR TITLE
fix: handle a CachePoint behind a replayed MCP tool result in Anthropic mapping

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -3362,9 +3362,15 @@ def _add_cache_control_param(
             'To cache system instructions or tool definitions, use the `anthropic_cache_instructions` or `anthropic_cache_tool_definitions` settings instead.'
         )
 
-    # Cast needed because BetaContentBlockParam is a union including response Block types (Pydantic models)
-    # that don't support dict operations, even though at runtime we only have request Param types (TypedDicts).
-    last_param = cast(dict[str, Any], params[-1])
+    # Cast needed because BetaContentBlockParam is a union including response Block types (Pydantic
+    # models) that don't support dict operations. A replayed MCP tool result leaves one of those as
+    # the last block (`BetaMCPToolResultBlock`), and its request-side counterpart declares
+    # `cache_control`, so attach the boundary on the block instead of crashing on a model instance.
+    last_param = params[-1]
+    if not is_str_dict(last_param):
+        if not hasattr(last_param, 'cache_control'):
+            last_param.cache_control = cache_control  # pyright: ignore[reportAttributeAccessIssue]
+        return
     if last_param['type'] not in _ANTHROPIC_CACHEABLE_PARAM_TYPES:
         raise UserError(f'Cache control not supported for param type: {last_param["type"]}')
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -647,6 +647,49 @@ def test_cache_control_last_cacheable_param_allows_empty_params():
     assert params == []
 
 
+def test_cache_point_after_replayed_mcp_tool_result_does_not_crash():
+    """A leading `CachePoint` behind a replayed MCP tool result must not crash mapping.
+
+    The replayed result renders as a `BetaMCPToolResultBlock` Pydantic model (not a TypedDict),
+    so `_add_cache_control_param` used to raise `TypeError` while subscripting it. The boundary is
+    attached to the block itself, which is what the request-side param type accepts. Unit test, not
+    VCR, because it never reaches a mocked HTTP call.
+    """
+    import asyncio
+
+    from pydantic_ai.messages import CachePoint, ModelRequest, ModelResponse, NativeToolReturnPart, UserPromptPart
+    from pydantic_ai.models import ModelRequestParameters
+    from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+    from pydantic_ai.native_tools import MCPServerTool
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+    history = [
+        ModelRequest(parts=[UserPromptPart(content='Search the docs.')]),
+        ModelResponse(
+            parts=[
+                NativeToolReturnPart(
+                    tool_name=f'{MCPServerTool.kind}:docs',
+                    content={'content': [{'type': 'text', 'text': '8.1'}], 'is_error': False},
+                    tool_call_id='mcptoolu_01AbCdEfGhIjKlMnOpQrStUv',
+                    provider_name='anthropic',
+                )
+            ],
+            provider_name='anthropic',
+        ),
+        ModelRequest(parts=[UserPromptPart(content=[CachePoint(), 'And the 2-year?'])]),
+    ]
+
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key='test-key'))
+    _, anthropic_messages = asyncio.run(model._map_message(history, ModelRequestParameters(), AnthropicModelSettings()))  # pyright: ignore[reportPrivateUsage]
+
+    assistant_content = anthropic_messages[1]['content']
+    assert isinstance(assistant_content, list)
+    result_block = assistant_content[-1]
+    assert isinstance(result_block, BaseModel)
+    assert getattr(result_block, 'type') == 'mcp_tool_result'
+    assert getattr(result_block, 'cache_control') == {'type': 'ephemeral', 'ttl': '5m'}
+
+
 def test_build_cache_control_includes_ttl():
     """Test that _build_cache_control includes TTL for all clients, including Bedrock."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

A `CachePoint` that opens a user message behind an assistant turn ending in a replayed MCP tool result crashes with:

```
TypeError: 'BetaMCPToolResultBlock' object is not subscriptable
```

The replayed native tool result renders as the `BetaMCPToolResultBlock` **Pydantic model** (not a request `TypedDict`), and `_add_cache_control_param` subscripts `params[-1]` without a runtime guard. The run never reaches the API.

## Fix

Attach the cache boundary to the block itself instead of indexing it. `BetaMCPToolResultBlock` sets `model_config = {'extra': 'allow'}`, and its request-side counterpart (`BetaRequestMCPToolResultBlockParam`) declares `cache_control`, so the attribute survives serialization and is accepted by the API. The `is_str_dict` path is unchanged (including the existing `Cache control not supported for param type: ...` error), and the `hasattr` guard avoids clobbering an existing boundary.

- `pydantic_ai/models/anthropic.py`: `_add_cache_control_param` walks to the block before falling back to the dict-only subscript path.
- `tests/models/test_anthropic.py`: added `test_cache_point_after_replayed_mcp_tool_result_does_not_crash` (fails on `main` with the reported `TypeError`, passes after).

## Verification

- Issue repro now maps cleanly; `cache_control={'type': 'ephemeral', 'ttl': '5m'}` lands on the `mcp_tool_result` block.
- Full `tests/models/test_anthropic.py` suite: 312 passed, 2 skipped.
- `ruff check`, `ruff format --check`, `pyright` clean on both files; no new mypy findings vs. `main`.

Closes #7546


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

