### PR TITLE
Avoid mutating root logger during docstring parsing

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_griffe.py
+++ b/pydantic_ai_slim/pydantic_ai/_griffe.py
@@ -1,9 +1,7 @@
 from __future__ import annotations as _annotations
 
-import logging
 import re
 from collections.abc import Callable
-from contextlib import contextmanager
 from inspect import Signature
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -45,7 +43,9 @@ def doc_descriptions(
     # These options are only valid for Google-style docstrings
     # https://mkdocstrings.github.io/griffe/reference/docstrings/#google-options
     parser_options = (
-        GoogleOptions(returns_named_value=False, returns_multiple_items=False) if docstring_style == 'google' else None
+        GoogleOptions(returns_named_value=False, returns_multiple_items=False, warnings=False)
+        if docstring_style == 'google'
+        else {'warnings': False}
     )
     docstring = Docstring(
         doc,
@@ -54,8 +54,7 @@ def doc_descriptions(
         parent=parent,
         parser_options=parser_options,
     )
-    with _disable_griffe_logging():
-        sections = docstring.parse()
+    sections = docstring.parse()
 
     params = {}
     if parameters := next((p for p in sections if p.kind == DocstringSectionKind.parameters), None):
@@ -167,12 +166,3 @@ _docstring_style_patterns: list[tuple[str, list[str], DocstringStyle]] = [
         'numpy',
     ),
 ]
-
-
-@contextmanager
-def _disable_griffe_logging():
-    # Hacky, but suggested here: https://github.com/mkdocstrings/griffe/issues/293#issuecomment-2167668117
-    old_level = logging.root.getEffectiveLevel()
-    logging.root.setLevel(logging.ERROR)
-    yield
-    logging.root.setLevel(old_level)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 import time
 from collections.abc import Callable
@@ -1065,6 +1066,23 @@ def test_suppress_griffe_logging(caplog: LogCaptureFixture):
     # Without suppressing griffe logging, we get:
     # assert caplog.messages == snapshot(['<module>:4: No type or annotation for returned value 1'])
     assert caplog.messages == snapshot([])
+
+
+def test_griffe_parse_failure_does_not_change_root_log_level(monkeypatch: pytest.MonkeyPatch):
+    root = logging.getLogger()
+    monkeypatch.setattr(root, 'level', root.level)
+    root.setLevel(logging.INFO)
+
+    def fail_parse(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError('simulated Griffe parser failure')
+
+    monkeypatch.setattr('pydantic_ai._griffe.Docstring.parse', fail_parse)
+
+    agent = Agent(FunctionModel(get_json_schema))
+    with pytest.raises(RuntimeError, match='simulated Griffe parser failure'):
+        agent.tool_plain(tool_without_return_annotation_in_docstring)
+
+    assert root.level == logging.INFO
 
 
 async def missing_parameter_descriptions_docstring(foo: int, bar: str) -> str:  # pragma: no cover


### PR DESCRIPTION
## Summary
- use Griffe's native `warnings=False` parser option instead of changing the process-wide root logger level
- prevent parser exceptions and concurrent tool registration from leaving application logging at `ERROR`
- retain warning suppression for Google, NumPy, and Sphinx docstrings

## Test plan
- `uvx uv@latest run pytest tests/test_tools.py::test_suppress_griffe_logging tests/test_tools.py::test_griffe_parse_failure_does_not_change_root_log_level -q`
- `uvx uv@latest run ruff check pydantic_ai_slim/pydantic_ai/_griffe.py tests/test_tools.py`
- `uvx uv@latest run ruff format --check pydantic_ai_slim/pydantic_ai/_griffe.py tests/test_tools.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

