### PR TITLE
Remove the expired `openai` and `google-genai` `exclude-newer` cutoffs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,14 +188,6 @@ pydantic-handlebars = false
 genai-prices = false
 logfire = false
 logfire-api = false
-# OpenAI 3.0 removes the SDK's transitive legacy HTTPX dependency and directly requires HTTPX2.
-# TODO(dsfaccini): Remove after 2026-08-19 01:56 UTC. https://github.com/pydantic/pydantic-ai/issues/7580
-# This admits only the reviewed 3.0.0 artifacts; later OpenAI artifacts remain quarantined.
-openai = "2026-08-12T01:55:49Z"
-# Google Gen AI 2.18.0 is the first release that accepts an injected HTTPX2 client.
-# TODO(dsfaccini): Remove after 2026-08-20 00:13 UTC. https://github.com/pydantic/pydantic-ai/issues/7580
-# This admits only the reviewed 2.18.0 artifacts; later Google Gen AI artifacts remain quarantined.
-google-genai = "2026-08-13T00:12:52Z"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -27,11 +27,9 @@ logfire = false
 pydantic-settings = false
 pydantic-handlebars = false
 genai-prices = false
-openai = "2026-08-12T01:55:49Z"
 pydantic-extra-types = false
 pydantic-core = false
 pydantic = false
-google-genai = "2026-08-13T00:12:52Z"
 logfire-api = false
 
 [manifest]


### PR DESCRIPTION
- Closes #7580

Both time gates have passed, so the two temporary pins from the HTTPX2 migration (#7351) come out: `openai` was due after 2026-08-19 01:56 UTC and `google-genai` after 2026-08-20 00:13 UTC. Removed both entries and their comments from `[tool.uv.exclude-newer-package]`, and regenerated `uv.lock` under the normal global policy.

Resolution is unchanged — `openai` stays at 3.0.0 and `google-genai` at 2.18.0. Removing a pin doesn't force an upgrade, and the rolling seven-day window wouldn't admit the newer artifacts yet anyway: `openai` 3.1.0 was published 14 Aug and `google-genai` 2.18.1 on 13 Aug at 22:13 UTC, both inside the window. So the lock diff is just the two recorded cutoffs leaving the manifest, with no version churn, and later releases of either SDK stay quarantined until the window reaches them on its own. `uv lock --check` passes.

I left `mcp-types = "2026-07-30T00:00:00Z"` alone. By its own comment's rule it looks redundant now — the window starts 13 Aug, 2.0.0 was published 28 Jul, and there's been no release since — but that's a separate pin with a separate rationale, so it seemed better to raise it than to fold it in here. Happy to add it to this PR if you'd prefer.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

