### PR TITLE
Document the YouTube hosts `GoogleModel` accepts as video URLs

### DIFF
--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -337,6 +337,8 @@ result = agent.run_sync(
 print(result.output)
 ```
 
+Only `youtu.be`, `youtube.com`, `www.youtube.com`, and `m.youtube.com` are recognized as YouTube hosts and handed to the model as a video URL. Any other YouTube domain falls back to the ordinary file URL path, which on the Gemini API downloads the URL, so the model receives the watch page rather than the video. `music.youtube.com` is excluded deliberately: Google rejects it as a `file_uri` with a 400, on the Gemini API and on Vertex alike.
+
 Files can be uploaded via the [Files API](https://ai.google.dev/gemini-api/docs/files) and passed as URLs:
 
 ```py {title="file_upload.py" test="skip"}


### PR DESCRIPTION
`docs/models/google.md` shows a YouTube example using `www.youtube.com`, but never says which YouTube hosts actually work. The allowlist is exact and lives only in a source docstring: `VideoUrl.is_youtube` (`pydantic_ai_slim/pydantic_ai/messages.py:360`) matches `youtu.be`, `youtube.com`, `www.youtube.com` and `m.youtube.com`, and nothing else.

The part worth writing down is what happens when a host misses. `GoogleModel._resolve_file` only passes a video straight through as a `file_uri` when `is_youtube` is true (`models/google.py:1258`). Otherwise it falls to the generic `FileUrl` branch, and on the Gemini API that calls `download_item`, which fetches the URL. For a YouTube link that means the model gets the watch page instead of the video. It fails quietly too: the `UserError('Downloading YouTube videos is not supported.')` guard in `download_item` only fires when `is_youtube` is true, so an unrecognized host never reaches it.

I kept the download sentence scoped to the Gemini API on purpose. On Vertex the same URL takes the `else` at `models/google.py:1269` and goes out as a `file_uri` instead, so saying it is always downloaded would be wrong.

`music.youtube.com` gets named explicitly because it is the case people keep hitting: #7591 and #7620 both reported YouTube hosts not being recognized, and #7593 and #7638 both proposed a `*.youtube.com` suffix match before #7592 landed the exact-host list instead. The reason it cannot be a suffix match is already in the code comment, that Google rejects `music.youtube.com` as a `file_uri` with a 400 on the Gemini API and on Vertex alike, so I reused that rather than invent a new explanation.

Docs only, no behavior change. Ran `uv run pytest tests/test_examples.py -k google` (19 passed, 16 skipped).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

About me: I'm a freshman in college, so I traced this through `messages.py` and `models/google.py` rather than assume I knew the behavior, and I used Claude Code to check my reasoning before writing it up. My first draft claimed the fallback always downloads, which reading the Vertex branch showed was wrong, so I narrowed it. If you'd rather this live in `docs/input.md` next to the other file-URL caveats, or be trimmed to one sentence, just say and I'll move it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

