### PR TITLE
Guard released API compatibility in CI

### DIFF
--- a/.github/api-compatibility-allowlist.json
+++ b/.github/api-compatibility-allowlist.json
@@ -1,0 +1,3 @@
+{
+  "allowed_breakages": []
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,15 @@
 <!-- and assigned to you. Unassigned PRs may be auto-closed. -->
 <!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->
 
+<!-- For a version-policy-permitted compatibility impact, add the `compatibility impact` label -->
+<!-- and place this warning immediately after the PR's opening explanation: -->
+<!-- > [!WARNING] -->
+<!-- > **Compatibility impact:** Existing code that ... may ... -->
+<!-- > -->
+<!-- > **Why this can ship in a minor release:** ... -->
+<!-- > -->
+<!-- > **Migration:** ... -->
+
 <!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
 <!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->
 
@@ -15,4 +24,5 @@
 
 - [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
 - [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
+- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
 - [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
       - docs
       - chore
   categories:
+    - title: ⚠️ Compatibility Notes
+      labels:
+        - compatibility impact
     - title: 🚀 Features
       labels:
         - feature

--- a/.github/scripts/check_api_compatibility.py
+++ b/.github/scripts/check_api_compatibility.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+
+PACKAGES = {
+    'pydantic_ai': 'pydantic_ai_slim',
+    'pydantic_graph': 'pydantic_graph',
+    'pydantic_evals': 'pydantic_evals',
+    'clai': 'clai',
+}
+_FINDING_RE = re.compile(r'^(?P<path>.*):(?P<line>\d+): (?P<message>.*)$')
+
+
+class Waiver(BaseModel):
+    model_config = ConfigDict(extra='forbid', frozen=True)
+
+    against: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+    fingerprint: Annotated[str, StringConstraints(pattern=r'^[0-9a-f]{64}$')]
+    reason: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+    pull_request: Annotated[str, StringConstraints(pattern=r'^https://github\.com/pydantic/pydantic-ai/pull/\d+$')]
+
+
+class Allowlist(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    allowed_breakages: list[Waiver]
+
+
+@dataclass(frozen=True)
+class Finding:
+    package: str
+    path: str
+    line: int
+    message: str
+
+    @property
+    def fingerprint(self) -> str:
+        value = f'{self.package}\0{self.message}'.encode()
+        return hashlib.sha256(value).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Compare the public Python API with a released Git tag.')
+    parser.add_argument('--against', required=True, help='Released Git tag to compare against.')
+    parser.add_argument(
+        '--allowlist',
+        type=Path,
+        default=Path('.github/api-compatibility-allowlist.json'),
+        help='Exact reviewed compatibility-impact waivers.',
+    )
+    args = parser.parse_args()
+
+    waivers = load_waivers(args.allowlist)
+    used_waivers: set[tuple[str, str]] = set()
+    failed = False
+    for package, search_path in PACKAGES.items():
+        findings = run_griffe(package, search_path, args.against)
+        for finding in findings:
+            waiver_key = (args.against, finding.fingerprint)
+            waiver = waivers.get(waiver_key)
+            if waiver is None:
+                failed = True
+                emit_annotation(
+                    'error',
+                    finding,
+                    f'{finding.message} [fingerprint: {finding.fingerprint}]. '
+                    'Preserve compatibility or follow the allowed compatibility-impact process.',
+                )
+            else:
+                used_waivers.add(waiver_key)
+                emit_annotation(
+                    'warning',
+                    finding,
+                    f'{finding.message} Allowed by {waiver.pull_request}: {waiver.reason}',
+                )
+
+    unused_waivers = {key for key in waivers if key[0] == args.against} - used_waivers
+    for _, fingerprint in sorted(unused_waivers):
+        failed = True
+        print(f'::error::Unused API compatibility waiver for {args.against}: {fingerprint}')
+
+    if failed:
+        raise SystemExit(1)
+
+
+def load_waivers(path: Path) -> dict[tuple[str, str], Waiver]:
+    allowlist = Allowlist.model_validate_json(path.read_text(encoding='utf-8'))
+    waivers: dict[tuple[str, str], Waiver] = {}
+    for waiver in allowlist.allowed_breakages:
+        key = (waiver.against, waiver.fingerprint)
+        if key in waivers:
+            raise ValueError(f'{path}: duplicate waiver for {waiver.against}: {waiver.fingerprint}')
+        waivers[key] = waiver
+    return waivers
+
+
+def run_griffe(package: str, search_path: str, against: str) -> list[Finding]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-m',
+            'griffecli',
+            'check',
+            package,
+            '--search',
+            search_path,
+            '--against',
+            against,
+            '--format',
+            'oneline',
+            '--no-color',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in {0, 1}:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(result.returncode)
+    return parse_findings(package, result.stdout)
+
+
+def parse_findings(package: str, output: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for output_line in output.splitlines():
+        match = _FINDING_RE.fullmatch(output_line)
+        if match is None:
+            raise ValueError(f'Unexpected Griffe output: {output_line!r}')
+        findings.append(
+            Finding(
+                package=package,
+                path=match.group('path'),
+                line=int(match.group('line')),
+                message=match.group('message'),
+            )
+        )
+    return findings
+
+
+def emit_annotation(level: str, finding: Finding, message: str) -> None:
+    escaped = message.replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+    print(f'::{level} file={finding.path},line={finding.line}::{escaped}')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/check_api_compatibility.py
+++ b/.github/scripts/check_api_compatibility.py
@@ -44,7 +44,7 @@ class Finding:
 
     @property
     def fingerprint(self) -> str:
-        value = f'{self.package}\0{self.message}'.encode()
+        value = f'{self.package}\0{self.path}\0{self.message}'.encode()
         return hashlib.sha256(value).hexdigest()
 
 

--- a/.github/scripts/test_check_api_compatibility.py
+++ b/.github/scripts/test_check_api_compatibility.py
@@ -8,12 +8,14 @@ import pytest
 from check_api_compatibility import Finding, emit_annotation, load_waivers, parse_findings
 
 
-def test_fingerprint_ignores_source_location():
+def test_fingerprint_identifies_the_exact_finding():
     first = Finding('pydantic_ai', 'old.py', 1, 'Thing.method(arg): Parameter was added as required')
-    moved = Finding('pydantic_ai', 'new.py', 99, first.message)
+    moved = Finding('pydantic_ai', 'new.py', first.line, first.message)
+    shifted = Finding(first.package, first.path, 99, first.message)
     other_package = Finding('pydantic_graph', first.path, first.line, first.message)
 
-    assert first.fingerprint == moved.fingerprint
+    assert first.fingerprint != moved.fingerprint
+    assert first.fingerprint == shifted.fingerprint
     assert first.fingerprint != other_package.fingerprint
 
 

--- a/.github/scripts/test_check_api_compatibility.py
+++ b/.github/scripts/test_check_api_compatibility.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import check_api_compatibility
+import pytest
+from check_api_compatibility import Finding, emit_annotation, load_waivers, parse_findings
+
+
+def test_fingerprint_ignores_source_location():
+    first = Finding('pydantic_ai', 'old.py', 1, 'Thing.method(arg): Parameter was added as required')
+    moved = Finding('pydantic_ai', 'new.py', 99, first.message)
+    other_package = Finding('pydantic_graph', first.path, first.line, first.message)
+
+    assert first.fingerprint == moved.fingerprint
+    assert first.fingerprint != other_package.fingerprint
+
+
+def test_parse_findings():
+    output = (
+        'pydantic_ai/messages.py:12: RequestPart: Attribute value was changed: Old -> New\n'
+        'pydantic_ai/tools.py:34: Tool.run(ctx): Parameter was added as required\n'
+    )
+
+    assert parse_findings('pydantic_ai', output) == [
+        Finding('pydantic_ai', 'pydantic_ai/messages.py', 12, 'RequestPart: Attribute value was changed: Old -> New'),
+        Finding('pydantic_ai', 'pydantic_ai/tools.py', 34, 'Tool.run(ctx): Parameter was added as required'),
+    ]
+
+
+def test_parse_findings_rejects_unknown_output():
+    with pytest.raises(ValueError, match='Unexpected Griffe output'):
+        parse_findings('pydantic_ai', 'not a finding')
+
+
+def test_load_waivers(tmp_path: Path):
+    finding = Finding('pydantic_ai', 'messages.py', 12, 'RequestPart: Attribute value was changed: Old -> New')
+    path = tmp_path / 'allowlist.json'
+    path.write_text(
+        json.dumps(
+            {
+                'allowed_breakages': [
+                    {
+                        'against': 'v2.32.1',
+                        'fingerprint': finding.fingerprint,
+                        'reason': 'The version policy permits adding public union members.',
+                        'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/123',
+                    }
+                ]
+            }
+        ),
+        encoding='utf-8',
+    )
+
+    assert load_waivers(path)[('v2.32.1', finding.fingerprint)].reason == (
+        'The version policy permits adding public union members.'
+    )
+
+
+def test_main_fails_for_unapproved_breakage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    finding = Finding('pydantic_ai', 'messages.py', 12, 'RequestPart: Attribute value was changed: Old -> New')
+    path = tmp_path / 'allowlist.json'
+    path.write_text('{"allowed_breakages": []}', encoding='utf-8')
+
+    def run_griffe(package: str, search_path: str, against: str) -> list[Finding]:
+        assert (package, search_path, against) == ('pydantic_ai', 'pydantic_ai_slim', 'v2.32.1')
+        return [finding]
+
+    monkeypatch.setattr(check_api_compatibility, 'PACKAGES', {'pydantic_ai': 'pydantic_ai_slim'})
+    monkeypatch.setattr(check_api_compatibility, 'run_griffe', run_griffe)
+    monkeypatch.setattr('sys.argv', ['check_api_compatibility.py', '--against', 'v2.32.1', '--allowlist', str(path)])
+
+    with pytest.raises(SystemExit, match='1'):
+        check_api_compatibility.main()
+
+    output = capsys.readouterr().out
+    assert '::error file=messages.py,line=12::' in output
+    assert finding.fingerprint in output
+
+
+def test_main_warns_for_approved_breakage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    finding = Finding('pydantic_ai', 'messages.py', 12, 'RequestPart: Attribute value was changed: Old -> New')
+    path = tmp_path / 'allowlist.json'
+    path.write_text(
+        json.dumps(
+            {
+                'allowed_breakages': [
+                    {
+                        'against': 'v2.32.1',
+                        'fingerprint': finding.fingerprint,
+                        'reason': 'The version policy permits this change.',
+                        'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/123',
+                    }
+                ]
+            }
+        ),
+        encoding='utf-8',
+    )
+
+    def run_griffe(package: str, search_path: str, against: str) -> list[Finding]:
+        return [finding]
+
+    monkeypatch.setattr(check_api_compatibility, 'PACKAGES', {'pydantic_ai': 'pydantic_ai_slim'})
+    monkeypatch.setattr(check_api_compatibility, 'run_griffe', run_griffe)
+    monkeypatch.setattr('sys.argv', ['check_api_compatibility.py', '--against', 'v2.32.1', '--allowlist', str(path)])
+
+    check_api_compatibility.main()
+
+    output = capsys.readouterr().out
+    assert '::warning file=messages.py,line=12::' in output
+    assert 'Allowed by https://github.com/pydantic/pydantic-ai/pull/123' in output
+
+
+def test_main_rejects_unused_waiver_for_current_baseline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    path = tmp_path / 'allowlist.json'
+    path.write_text(
+        json.dumps(
+            {
+                'allowed_breakages': [
+                    {
+                        'against': 'v2.32.1',
+                        'fingerprint': '0' * 64,
+                        'reason': 'The version policy permits this change.',
+                        'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/123',
+                    }
+                ]
+            }
+        ),
+        encoding='utf-8',
+    )
+
+    monkeypatch.setattr(check_api_compatibility, 'PACKAGES', {})
+    monkeypatch.setattr('sys.argv', ['check_api_compatibility.py', '--against', 'v2.32.1', '--allowlist', str(path)])
+
+    with pytest.raises(SystemExit, match='1'):
+        check_api_compatibility.main()
+
+    assert '::error::Unused API compatibility waiver for v2.32.1' in capsys.readouterr().out
+
+
+_INVALID_ALLOWLISTS: list[tuple[object, str]] = [
+    ({}, 'allowed_breakages'),
+    ({'allowed_breakages': {}}, 'list_type'),
+    ({'allowed_breakages': [{}]}, 'fingerprint'),
+    (
+        {
+            'allowed_breakages': [
+                {
+                    'against': 'v2.32.1',
+                    'fingerprint': 'bad',
+                    'reason': 'reason',
+                    'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/1',
+                }
+            ]
+        },
+        'string_pattern_mismatch',
+    ),
+    (
+        {
+            'allowed_breakages': [
+                {
+                    'against': 'v2.32.1',
+                    'fingerprint': '0' * 64,
+                    'reason': '',
+                    'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/1',
+                }
+            ]
+        },
+        'string_too_short',
+    ),
+    (
+        {
+            'allowed_breakages': [
+                {'against': 'v2.32.1', 'fingerprint': '0' * 64, 'reason': 'reason', 'pull_request': 'not-a-pr'}
+            ]
+        },
+        'string_pattern_mismatch',
+    ),
+    (
+        {
+            'allowed_breakages': [
+                {
+                    'against': 'v2.32.1',
+                    'fingerprint': '0' * 64,
+                    'reason': 'reason',
+                    'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/1',
+                },
+                {
+                    'against': 'v2.32.1',
+                    'fingerprint': '0' * 64,
+                    'reason': 'reason',
+                    'pull_request': 'https://github.com/pydantic/pydantic-ai/pull/2',
+                },
+            ]
+        },
+        'duplicate waiver',
+    ),
+]
+
+
+@pytest.mark.parametrize('value, error', _INVALID_ALLOWLISTS)
+def test_load_waivers_rejects_invalid_entries(tmp_path: Path, value: object, error: str):
+    path = tmp_path / 'allowlist.json'
+    path.write_text(json.dumps(value), encoding='utf-8')
+
+    with pytest.raises(ValueError, match=error):
+        load_waivers(path)
+
+
+def test_emit_annotation_escapes_workflow_commands(capsys: pytest.CaptureFixture[str]):
+    finding = Finding('pydantic_ai', 'messages.py', 12, 'message')
+
+    emit_annotation('error', finding, '100%\nfailed')
+
+    assert capsys.readouterr().out == '::error file=messages.py,line=12::100%25%0Afailed\n'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         run: >-
           uv run pytest
           .github/scripts/test_pydantic_ai_runner.py
+          .github/scripts/test_check_api_compatibility.py
           .github/scripts/test_issue_pr_attention_monitor.py
           .github/scripts/test_agentic_workflow_guard.py
           .github/scripts/test_agent_spend_report.py
@@ -137,7 +138,26 @@ jobs:
           # re-sync the venv and drop the out-of-band harness install above.
           UV_NO_SYNC: "1"
 
-      - run: uv build --all-packages
+      # Run inside `lint`, which finishes several minutes before the test/coverage critical path.
+      - name: Check public API compatibility with the latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UV_NO_SYNC: "1"
+        run: |
+          # Exclude the tag being built: once its GitHub release exists, `gh release view`
+          # would otherwise compare the release to itself and make this gate a no-op.
+          release_tag=$(gh release list --repo pydantic/pydantic-ai --limit 20 \
+            --exclude-drafts --exclude-pre-releases --json tagName \
+            | jq -r --arg current "$GITHUB_REF_NAME" \
+              'map(select(.tagName != $current))[0].tagName // empty')
+          if [ -z "$release_tag" ]; then
+            echo '::error::Could not find a prior stable release for the API compatibility baseline.'
+            exit 1
+          fi
+          git fetch --depth=1 origin tag "$release_tag"
+          uv run python .github/scripts/check_api_compatibility.py --against "$release_tag"
+
+      - run: uv build --all-packages --no-sources
       - run: uv run python .github/scripts/check_http_dependencies.py
       - run: ls -lh dist/
       - run: uvx twine check --strict dist/*
@@ -624,7 +644,16 @@ jobs:
         with:
           enable-cache: false
 
-      - run: uv build --all-packages
+      - run: uv build --all-packages --no-sources
+
+      - name: Smoke-test release wheels outside the workspace
+        run: |
+          smoke_dir=$(mktemp -d)
+          uv venv "$smoke_dir"
+          uv pip install --python "$smoke_dir/bin/python" dist/*.whl
+          "$smoke_dir/bin/python" -I -c "import clai, pydantic_ai, pydantic_evals, pydantic_graph"
+          "$smoke_dir/bin/pai" --help
+          "$smoke_dir/bin/clai" --help
 
       - name: Inspect package version
         id: inspect_package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  lint:
-    name: lint
+  quality:
+    name: quality checks
     runs-on: ubuntu-latest
     # `pull-requests: read` is for the lock-regeneration guard's PR file listing. Reading
     # it works today on `contents: read` alone only because this repo is public; declaring
@@ -91,7 +91,7 @@ jobs:
       # Every check except lock freshness reads the tree alone, so run them on `main`
       # too. Two independently-green PRs can still merge into a drifted `main` — the
       # classic case being one that bumps the gh-aw compiler while another adds a lock
-      # at the old version — and without this the drift first surfaces as a red `lint`
+      # at the old version — and without this the drift first surfaces as a red `quality checks`
       # on whichever contributor next opens a PR, about workflows they never touched.
       - name: Check agentic workflow policy
         env:
@@ -138,7 +138,7 @@ jobs:
           # re-sync the venv and drop the out-of-band harness install above.
           UV_NO_SYNC: "1"
 
-      # Run inside `lint`, which finishes several minutes before the test/coverage critical path.
+      # Run inside `quality checks`, which finishes several minutes before the test/coverage critical path.
       - name: Check public API compatibility with the latest release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -162,7 +162,7 @@ jobs:
       - run: ls -lh dist/
       - run: uvx twine check --strict dist/*
 
-  # mypy and lint are a bit slower than other jobs, so we run them separately
+  # mypy and quality checks are a bit slower than other jobs, so we run them separately
   mypy:
     runs-on: ubuntu-latest
     steps:
@@ -581,7 +581,7 @@ jobs:
   check:
     if: always()
     needs:
-      - lint
+      - quality
       - mypy
       - docs-assets
       - test

--- a/agent_docs/api-design.md
+++ b/agent_docs/api-design.md
@@ -6,6 +6,19 @@
 
 ## Rules
 
+### Compatibility impacts
+
+- Treat previously valid user code that now needs modification as a compatibility impact.
+- Preserve compatibility unless the bridge retains incorrect behavior, creates a permanent legacy-only API, or makes the contract contradictory.
+- When no valid bridge exists, identify the exact exception in `docs/version-policy.md`.
+- Without an applicable exception, deprecate the old behavior before removal or wait for a major release.
+- Treat non-underscore symbols on public modules and classes as public by default. A missing docstring alone does not make a symbol internal.
+- Treat additions to released public unions as compatibility-relevant changes. Inspect attributes common to prior arms and exhaustive consumers.
+- Do not add semantically false fields only to preserve a union's previous structural shape.
+- For every permitted compatibility impact, add the `compatibility impact` label and a release note.
+- Add a `[!WARNING]` PR section that names affected code, the policy exception, and the migration.
+- Add an exact API-check waiver when the deterministic compatibility gate reports the permitted change.
+
 <!-- rule:146 -->
 - Prefix implementation details with underscore (`_`) and exclude from `__all__` — prevents accidental API surface expansion and signals internal-only usage — Keeps the public API surface minimal and clearly separates internal implementation from stable public interfaces, preventing backward compatibility obligations for internal code.
 <!-- rule:29 -->

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -17,6 +17,8 @@ The following changes will **NOT** be considered breaking changes, and may occur
 
 In all cases we will aim to minimize churn and do so only when justified by the increase of quality of Pydantic AI for users.
 
+When one of these permitted changes requires existing code to change, its pull request and release note will include a prominent **compatibility impact** warning and migration guidance.
+
 ## Beta Features
 
 At Pydantic, we like to move quickly and innovate! To that end, minor releases may introduce beta features (indicated by a `beta` module) that are active works in progress. While in its beta phase, a feature's API and behaviors may not be stable, and it's very possible that changes made to the feature will not be backward-compatible. We aim to move beta features out of beta within a few months after initial release, once users have had a chance to provide feedback and test the feature in production.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,12 @@ dev = [
     # BlockBuster minor releases may add breaking detection rules; keep this test detector on 1.5.x.
     "blockbuster>=1.5.26,<1.6",
 ]
-lint = ["mypy>=1.11.2", "pyright>=1.1.408", "ruff>=0.14.14"]
+lint = [
+    "griffecli>=2.1.0,<3",
+    "mypy>=1.11.2",
+    "pyright>=1.1.408",
+    "ruff>=0.14.14",
+]
 [tool.hatch.build.targets.wheel]
 bypass-selection = true
 exclude = ["/pydantic_ai_slim/pydantic_ai/.agents"]
@@ -257,7 +262,9 @@ include = [
     "tests/**/*.py",
     "docs/**/*.py",
     ".github/scripts/ci_duration.py",
+    ".github/scripts/check_api_compatibility.py",
     ".github/scripts/test_ci_duration.py",
+    ".github/scripts/test_check_api_compatibility.py",
     ".github/scripts/pydantic_ai_gh_aw_shim/**/*.py",
     ".github/scripts/test_pydantic_ai_runner.py",
     ".github/scripts/issue_pr_attention_monitor.py",
@@ -319,7 +326,9 @@ quote-style = "single"
 "tests/**/*.py" = ["D"]
 "docs/**/*.py" = ["D"]
 ".github/scripts/ci_duration.py" = ["D"]
+".github/scripts/check_api_compatibility.py" = ["D"]
 ".github/scripts/test_ci_duration.py" = ["D"]
+".github/scripts/test_check_api_compatibility.py" = ["D"]
 ".github/scripts/test_pydantic_ai_runner.py" = ["D"]
 ".github/scripts/test_issue_pr_attention_monitor.py" = ["D"]
 ".github/scripts/test_agentic_workflow_guard.py" = ["D"]
@@ -342,7 +351,9 @@ include = [
     "examples",
     "clai",
     ".github/scripts/ci_duration.py",
+    ".github/scripts/check_api_compatibility.py",
     ".github/scripts/test_ci_duration.py",
+    ".github/scripts/test_check_api_compatibility.py",
     ".github/scripts/pydantic_ai_gh_aw_shim",
     ".github/scripts/test_pydantic_ai_runner.py",
     ".github/scripts/issue_pr_attention_monitor.py",
@@ -360,6 +371,7 @@ executionEnvironments = [
     # the test file, not under the project root) the same way the runtime
     # `sys.path.insert(...)` at the top of the test does.
     { root = ".github/scripts/test_ci_duration.py", extraPaths = [".github/scripts"], reportUnusedFunction = false, reportPrivateImportUsage = false },
+    { root = ".github/scripts/test_check_api_compatibility.py", extraPaths = [".github/scripts"], reportUnusedFunction = false, reportPrivateImportUsage = false },
     { root = ".github/scripts/test_pydantic_ai_runner.py", extraPaths = [".github/scripts"], reportUnusedFunction = false, reportPrivateImportUsage = false },
 ]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -2331,12 +2331,25 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.0.0"
+name = "griffecli"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c6/90f85d47af96300d629b38c25b71aad9467a620cac964a39280e822efc8a/griffecli-2.1.0.tar.gz", hash = "sha256:2ff68dbee9395fdb668b10374c51683392d697b226ac60159798f4add1ee716c", size = 56913, upload-time = "2026-06-19T12:05:43.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2f/513232ec1d5f5da182e4ce45a11427e37dd210844a9e2bca451fc9661fb3/griffecli-2.1.0-py3-none-any.whl", hash = "sha256:6e22b1423d562ddc510997b4be1fe89de59e19dcff78831c0f4bfc3b8134a718", size = 9500, upload-time = "2026-06-19T12:05:37.517Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -5336,6 +5349,7 @@ dev = [
     { name = "tavily-python" },
 ]
 lint = [
+    { name = "griffecli" },
     { name = "mypy" },
     { name = "pyright" },
     { name = "ruff" },
@@ -5405,6 +5419,7 @@ dev = [
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
 lint = [
+    { name = "griffecli", specifier = ">=2.1.0,<3" },
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "ruff", specifier = ">=0.14.14" },


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

CI validates the repository against itself, but it does not compare the public API with the latest release. A signature or public-union change can therefore pass tests and type checking while requiring downstream users to change otherwise valid code.

This adds a released-API baseline gate, makes permitted compatibility impacts visible in pull requests and generated release notes, and smoke-tests release wheels before they reach the publishing job.

The API comparison takes about 10 seconds locally and runs in `quality checks`, which finishes several minutes before the test/coverage critical path. The isolated wheel smoke runs only for tags.

## New public surface

None.

<details>
<summary><strong>Goal 1: Detect released API breakage</strong></summary>

**Before → after:** CI checked only the current source tree → CI compares `pydantic_ai`, `pydantic_graph`, `pydantic_evals`, and `clai` with the latest stable release.

<details>
<summary>Playground</summary>

```bash
uv run python .github/scripts/check_api_compatibility.py --against v2.32.1
```

</details>

**Test:** [compatibility gate behavior](https://github.com/pydantic/pydantic-ai/pull/7652/files#diff-d5374e33ca442feca71ca73534af8a1796f8a72af7b43a4a362df4ef0edfe7c5R63)

Approved findings require a fingerprinted waiver scoped to the exact release baseline, a reason, and the approving PR. Unapproved findings and unused current-baseline waivers fail closed.

**What changes for existing users:** nothing.

</details>

<details>
<summary><strong>Goal 2: Make permitted compatibility impacts explicit</strong></summary>

**Before → after:** permitted impacts could blend into ordinary feature notes → the PR template, API-design rules, version policy, label, and generated changelog all carry a visible compatibility path and migration requirement.

**Test:** [API-design rule](https://github.com/pydantic/pydantic-ai/pull/7652/files#diff-0e43c3b791715917c23d8e91f847ba20185b37cb9c6b93149cde0a105a0794caR9), [version policy](https://github.com/pydantic/pydantic-ai/pull/7652/files#diff-6efc7564fc9fd431ad1d8d57dedb1765b0e3e720b5b114c96be7fbe7eb56c761R20), [PR template](https://github.com/pydantic/pydantic-ai/pull/7652/files#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR9), and [release category](https://github.com/pydantic/pydantic-ai/pull/7652/files#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R7).

**What changes for existing users:** release notes make any required migration prominent.

</details>

<details>
<summary><strong>Goal 3: Verify the exact release artifacts</strong></summary>

**Before → after:** tag CI built workspace-aware wheels and published them → tag CI builds with `--no-sources`, installs every wheel in an isolated environment, imports all packages, and exercises both CLIs before upload.

**Test:** [tag-only isolated-wheel smoke](https://github.com/pydantic/pydantic-ai/pull/7652/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR649)

**What changes for existing users:** nothing unless a broken artifact would otherwise have been published.

</details>

## Verification

- [x] Compatibility-script tests pass.
- [x] Released API comparison passes.
- [x] Isolated wheel install/import/CLI smoke passes.
- [x] Formatting, linting, workflow validation, and whole-repository type checking pass.

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
