### PR TITLE
fix: sort OpenAI embedding response by index to preserve input order

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -143,7 +143,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e
 
-        embeddings = [item.embedding for item in response.data]
+        embeddings = [item.embedding for item in sorted(response.data, key=lambda item: item.index)]
 
         return EmbeddingResult(
             embeddings=embeddings,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -108,6 +108,33 @@ async def test_openai_embedding_model_blocks_requests_when_disabled():
             await model.embed('hello', input_type='query')
 
 
+@pytest.mark.skipif(not openai_imports_successful(), reason='openai not installed')
+async def test_openai_embed_preserves_input_order():
+    """Regression test: embeddings must align with inputs even when the API returns items out of order."""
+    mock_client = AsyncMock()
+
+    item_b = MagicMock()
+    item_b.embedding = [0.4, 0.5, 0.6]
+    item_b.index = 1
+
+    item_a = MagicMock()
+    item_a.embedding = [0.1, 0.2, 0.3]
+    item_a.index = 0
+
+    mock_response = MagicMock()
+    mock_response.data = [item_b, item_a]  # intentionally reversed
+    mock_response.usage = None
+    mock_response.model = 'test-model'
+
+    mock_client.embeddings.create.return_value = mock_response
+
+    provider = OpenAIProvider(openai_client=mock_client)
+    model = OpenAIEmbeddingModel('test-model', provider=provider)
+
+    result = await model.embed(['first', 'second'], input_type='query')
+    assert result.embeddings == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
 @pytest.mark.skipif(not cohere_imports_successful(), reason='cohere not installed')
 async def test_cohere_embedding_model_blocks_requests_when_disabled():
     model = CohereEmbeddingModel('embed-v4.0', provider=CohereProvider(api_key='test-key'))


### PR DESCRIPTION
Closes #7284

OpenAIEmbeddingModel.embed() builds its result list directly from response.data without re-sorting by the per-item index field. When the OpenAI API returns embeddings out of input order, callers silently get misaligned results — embeddings[i] no longer corresponds to inputs[i].

The fix sorts response.data by item.index before extracting embeddings, matching the defensive approach used by litellm and the legacy OpenAI client.

# Before
embeddings = [item.embedding for item in response.data]

# After
embeddings = [item.embedding for item in sorted(response.data, key=lambda item: item.index)]

A regression test mocks a reversed response ([index=1, index=0]) and asserts the output aligns with input order.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

