### PR TITLE
Add iFLYTEK Spark provider

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/spark.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/spark.py
@@ -1,0 +1,8 @@
+from __future__ import annotations as _annotations
+
+from . import ModelProfile
+
+
+def spark_model_profile(model_name: str) -> ModelProfile | None:
+    """Get the model profile for an iFLYTEK Spark model."""
+    return None

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -269,6 +269,10 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .snowflake import SnowflakeProvider
 
         return SnowflakeProvider
+    elif provider == 'spark':
+        from .spark import SparkProvider
+
+        return SparkProvider
     elif provider == 'voyageai':
         from .voyageai import VoyageAIProvider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/spark.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/spark.py
@@ -1,0 +1,93 @@
+from __future__ import annotations as _annotations
+
+import os
+from typing import Literal, overload
+
+from pydantic_ai import ModelProfile
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles import merge_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.spark import spark_model_profile
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:
+    raise ImportError(
+        'Please install the `openai` package to use the iFLYTEK Spark provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+else:
+    from ._openai_compatible import (
+        AsyncHTTPClient as _OpenAIHTTPClient,
+        OpenAICompatibleProvider as _OpenAICompatibleProvider,
+    )
+
+SparkModelName = Literal[
+    '4.0Ultra',
+    'generalv3.5',
+    'max-32k',
+    'generalv3',
+    'pro-128k',
+    'lite',
+]
+
+
+class SparkProvider(_OpenAICompatibleProvider):
+    """Provider for the iFLYTEK Spark (讯飞星火) API."""
+
+    @property
+    def name(self) -> str:
+        return 'spark'
+
+    @property
+    def base_url(self) -> str:
+        # OpenAI-compatible HTTP endpoint, authenticated with a Bearer API Password.
+        return 'https://spark-api-open.xf-yun.com/v1'
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    @staticmethod
+    def model_profile(model_name: str) -> ModelProfile | None:
+        profile = spark_model_profile(model_name)
+
+        # As the Spark API is OpenAI-compatible, assume OpenAIJsonSchemaTransformer unless
+        # json_schema_transformer is set explicitly. Spark supports JSON mode
+        # (response_format={'type': 'json_object'}).
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(supports_json_object_output=True),
+        )
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
+
+    @overload
+    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
+    ) -> None:
+        api_key = api_key or os.getenv('SPARK_API_KEY')
+        if not api_key and openai_client is None:
+            raise UserError(
+                'Set the `SPARK_API_KEY` environment variable or pass it via '
+                '`SparkProvider(api_key=...)` to use the iFLYTEK Spark provider.'
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+        else:
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/tests/providers/test_provider_names.py
+++ b/tests/providers/test_provider_names.py
@@ -36,6 +36,7 @@ with try_import() as imports_successful:
     from pydantic_ai.providers.openrouter import OpenRouterProvider
     from pydantic_ai.providers.ovhcloud import OVHcloudProvider
     from pydantic_ai.providers.snowflake import SnowflakeProvider
+    from pydantic_ai.providers.spark import SparkProvider
     from pydantic_ai.providers.together import TogetherProvider
     from pydantic_ai.providers.vercel import VercelProvider
     from pydantic_ai.providers.xai import XaiProvider
@@ -65,6 +66,7 @@ with try_import() as imports_successful:
         ('nebius', NebiusProvider, 'NEBIUS_API_KEY'),
         ('ovhcloud', OVHcloudProvider, 'OVHCLOUD_API_KEY'),
         ('snowflake', SnowflakeProvider, 'SNOWFLAKE_ACCOUNT'),
+        ('spark', SparkProvider, 'SPARK_API_KEY'),
         ('gateway/chat', OpenAIProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('gateway/groq', GroqProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('gateway/google', GoogleCloudProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),

--- a/tests/providers/test_spark.py
+++ b/tests/providers/test_spark.py
@@ -1,0 +1,53 @@
+import re
+
+import pytest
+
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    import openai
+
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.spark import SparkProvider
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='openai not installed')
+
+
+def test_spark_provider():
+    """Test basic iFLYTEK Spark provider initialization."""
+    provider = SparkProvider(api_key='api-key')
+    assert provider.name == 'spark'
+    assert provider.base_url == 'https://spark-api-open.xf-yun.com/v1'
+    assert isinstance(provider.client, openai.AsyncOpenAI)
+    assert provider.client.api_key == 'api-key'
+
+
+def test_spark_provider_need_api_key(env: TestEnv) -> None:
+    """Test that the iFLYTEK Spark provider requires an API key."""
+    env.remove('SPARK_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'Set the `SPARK_API_KEY` environment variable or pass it via `SparkProvider(api_key=...)`'
+            ' to use the iFLYTEK Spark provider.'
+        ),
+    ):
+        SparkProvider()
+
+
+def test_spark_pass_openai_client() -> None:
+    """Test passing a custom OpenAI client to the iFLYTEK Spark provider."""
+    openai_client = openai.AsyncOpenAI(api_key='api-key')
+    provider = SparkProvider(openai_client=openai_client)
+    assert provider.client == openai_client
+
+
+def test_spark_model_profile():
+    provider = SparkProvider(api_key='api-key')
+    model = OpenAIChatModel('4.0Ultra', provider=provider)
+    assert isinstance(model.profile, dict)
+    assert model.profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert model.profile.get('supports_json_object_output', False) is True


### PR DESCRIPTION
Adds **iFLYTEK Spark (讯飞星火)** as an OpenAI-compatible model provider, following
the same pattern as the DeepSeek / MoonshotAI / Nebius providers.

Spark is one of the major Chinese foundation models still missing from Pydantic
AI (DeepSeek, Alibaba/Qwen, MoonshotAI, Zai are already supported). It exposes an
OpenAI-compatible HTTP endpoint at `https://spark-api-open.xf-yun.com/v1`
authenticated with a single Bearer **API Password**, so `SparkProvider` is a thin
`_OpenAICompatibleProvider` subclass.

- `pydantic_ai_slim/pydantic_ai/providers/spark.py` — `SparkProvider` with
  `SPARK_API_KEY` env handling and OpenAI-compatible model-profile inference
- `pydantic_ai_slim/pydantic_ai/profiles/spark.py` — `spark_model_profile`
- Registered in `providers/__init__.py` (`infer_provider_class`)
- `tests/providers/test_spark.py` + entry in `tests/providers/test_provider_names.py`

Usage:

```python
from pydantic_ai import Agent
from pydantic_ai.models.openai import OpenAIChatModel
from pydantic_ai.providers.spark import SparkProvider

model = OpenAIChatModel('4.0Ultra', provider=SparkProvider(api_key='...'))
agent = Agent(model)
```

There's no linked issue — this mirrors the Nebius provider (#3124), which merged
the same way. Happy to open a tracking issue if a maintainer would prefer one.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md). (Purely additive — a new provider.)
- [x] I have added tests for the new provider.

### Notes

I wasn't able to run the full `make test` / lint suite locally; flagging so CI can
validate formatting. The base URL, the 6 public model ids (`4.0Ultra`,
`generalv3.5`, `max-32k`, `generalv3`, `pro-128k`, `lite`) and the API-Password
auth match iFLYTEK's OpenAI-compatible HTTP docs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

