### PR TITLE
Fix `format_as_xml` serializing plain `Enum` members by their repr

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/format_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/format_prompt.py
@@ -140,7 +140,13 @@ class _ToXml:
             element.text = value.value if isinstance(value, Enum) else value
         elif isinstance(value, bytes | bytearray):
             element.text = value.decode(errors='ignore')
-        elif isinstance(value, bool | int | float | Enum):
+        elif isinstance(value, Enum):
+            # Serialize enums by their value (matching the str-subclass enum branch
+            # above and Pydantic's `model_dump(mode='json')`), so a plain `Enum`
+            # renders the same whether it is bare or nested in a dict, dataclass or
+            # model, rather than leaking its `ClassName.MEMBER` repr.
+            element.text = str(value.value)
+        elif isinstance(value, bool | int | float):
             element.text = str(value)
         elif isinstance(value, date | time):
             element.text = value.isoformat()

--- a/tests/test_format_as_xml.py
+++ b/tests/test_format_as_xml.py
@@ -58,7 +58,7 @@ class ExamplePydanticFields(BaseModel):
         pytest.param(42, snapshot('<examples>42</examples>'), id='int'),
         pytest.param(None, snapshot('<examples>null</examples>'), id='null'),
         # regression test for https://github.com/pydantic/pydantic-ai/pull/4131
-        pytest.param(ExampleEnum.FOO, snapshot('<examples>ExampleEnum.FOO</examples>'), id='enum'),
+        pytest.param(ExampleEnum.FOO, snapshot('<examples>1</examples>'), id='enum'),
         pytest.param(ExampleStrEnum.FOO, snapshot('<examples>foo</examples>'), id='str enum'),
         pytest.param(
             ExampleDataclass(name='John', age=42),
@@ -160,6 +160,24 @@ class ExamplePydanticFields(BaseModel):
 def test_root_tag(input_obj: Any, output: str):
     assert format_as_xml(input_obj, root_tag='examples', item_tag='example', include_field_info=False) == output
     assert format_as_xml(input_obj, root_tag='examples', item_tag='example', include_field_info='once') == output
+
+
+def test_enum_value_consistent_across_containers():
+    # A plain `Enum` must serialize by its value the same way regardless of the
+    # container it sits in, rather than leaking its `ClassName.MEMBER` repr when
+    # bare or nested in a dict/dataclass.
+    @dataclass
+    class EnumDataclass:
+        color: ExampleEnum
+
+    class EnumModel(BaseModel):
+        color: ExampleEnum
+
+    bare = format_as_xml(ExampleEnum.FOO, root_tag='color')
+    assert bare == snapshot('<color>1</color>')
+    assert format_as_xml({'color': ExampleEnum.FOO}) == snapshot('<color>1</color>')
+    assert format_as_xml(EnumDataclass(color=ExampleEnum.FOO)) == snapshot('<color>1</color>')
+    assert format_as_xml(EnumModel(color=ExampleEnum.FOO)) == snapshot('<color>1</color>')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`format_as_xml` serializes a plain `Enum` member differently depending on the container it's in, and leaks the `ClassName.MEMBER` repr into the output.

```python
class Color(Enum):
    RED = 'red'

format_as_xml(Color.RED, root_tag='color')     # <color>Color.RED</color>   ← repr
format_as_xml({'color': Color.RED})            # <color>Color.RED</color>   ← repr
format_as_xml(MyModel(color=Color.RED))        # <color>red</color>         ← value
```

## Why

In `_ToXml._set_scalar_text`, a plain `Enum` falls into the numeric branch and is rendered via `str(value)`:

```python
elif isinstance(value, bool | int | float | Enum):
    element.text = str(value)
```

For a non-`str` enum, `str(member)` is the `ClassName.MEMBER` repr. This is inconsistent with the two other enum paths, which both emit the **value**:
- str-subclass enums (a few lines up): `element.text = value.value`
- enums nested in a Pydantic model: serialized via `model_dump(mode='json')`

So the same enum yields different XML based on whether it is bare / in a dict / dataclass vs in a model, and pushes Python class/member identifiers into the LLM prompt that `format_as_xml` is meant to build. (The enum output here was captured incidentally by #4131, which was about `Decimal`/`UUID` — not a deliberate choice.)

## How

Serialize enums by their value, matching the str-enum branch and `model_dump(mode='json')`:

```diff
-        elif isinstance(value, bool | int | float | Enum):
+        elif isinstance(value, Enum):
+            element.text = str(value.value)
+        elif isinstance(value, bool | int | float):
             element.text = str(value)
```

str-subclass enums are still handled by the earlier `isinstance(value, str)` branch; `IntEnum`/plain `Enum` now use their `.value`.

## Tests

- Updated the incidental `id='enum'` snapshot (`ExampleEnum.FOO`, whose value is `1`) from `<examples>ExampleEnum.FOO</examples>` to `<examples>1</examples>`.
- Added `test_enum_value_consistent_across_containers`, asserting a plain `Enum` serializes identically bare and inside a dict, dataclass and `BaseModel`.

Both **fail on `main`** (repr is emitted) and pass with this change; the full `tests/test_format_as_xml.py` suite stays green (36 passed).

---

- [x] I have reviewed the AI-assisted changes in this PR for correctness.

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

