### PR TITLE
Run test matrices on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,22 +199,7 @@ jobs:
 
   test:
     name: test on ${{ matrix.python-version }} (${{ matrix.install.name }})
-    # Use Ubicloud 4-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
-    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
-    # `github.event.pull_request` is null on push/tag runs, so those need their own clause to
-    # reach Ubicloud -- without it main and release runs silently fall back to `ubuntu-latest`.
-    runs-on: >-
-      ${{
-        !contains(github.event.pull_request.labels.*.name, 'ci:slow')
-        && matrix.install.name == 'all-extras'
-        && (
-          github.event_name == 'push'
-          || github.event.pull_request.head.repo.full_name == github.repository
-          || contains(github.event.pull_request.labels.*.name, 'ci:fast')
-        )
-        && 'ubicloud-premium-4'
-        || 'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -319,10 +304,7 @@ jobs:
           path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
           key: ${{ steps.sentence-transformers-cache.outputs.cache-primary-key }}
 
-      # `-n logical`, not `-n auto`: xdist `auto` counts *physical* cores, which
-      # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
-      # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
-      # on ubuntu-latest (already 4). See PR benchmark.
+      # `-n logical`, not `-n auto`: use every logical CPU exposed by the runner.
       - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
@@ -336,20 +318,7 @@ jobs:
 
   test-lowest-versions:
     name: test on ${{ matrix.python-version }} (lowest-versions)
-    # Use Ubicloud 4-core runners for maintainers or opted in via 'ci:fast' label
-    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
-    # See the note on the `test` job for why push/tag runs need their own clause.
-    runs-on: >-
-      ${{
-        !contains(github.event.pull_request.labels.*.name, 'ci:slow')
-        && (
-          github.event_name == 'push'
-          || github.event.pull_request.head.repo.full_name == github.repository
-          || contains(github.event.pull_request.labels.*.name, 'ci:fast')
-        )
-        && 'ubicloud-premium-4'
-        || 'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -429,7 +398,7 @@ jobs:
           path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
           key: ${{ steps.sentence-transformers-cache.outputs.cache-primary-key }}
 
-      # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
+      # `-n logical` (see note on the `test` job): use every logical CPU.
       - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions


### PR DESCRIPTION
- Closes: N/A, CI runner configuration only

### Summary

- run the all-extras and lowest-version test matrices on `ubuntu-latest`
- remove the Ubicloud-specific `ci:fast` and `ci:slow` routing
- retain `-n logical` so pytest uses every logical CPU exposed by the runner

Pydantic AI is a public repository, so its standard GitHub-hosted Linux runners do not consume paid Actions minutes. This removes an unnecessary third-party runner dependency without changing matrix coverage or test behavior.

### Validation

- `pre-commit run --files .github/workflows/ci.yml`
- `actionlint .github/workflows/ci.yml`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

