### PR TITLE
Fix the possessive in the new model contribution rule

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -155,7 +155,7 @@ adds the `trigger:docs` label.
 To avoid an excessive workload for the maintainers of Pydantic AI, we can't accept all model contributions, so we're setting the following rules for when we'll accept new models and when we won't. This should hopefully reduce the chances of disappointment and wasted work.
 
 - To add a new model with an extra dependency, that dependency needs > 500k monthly downloads from PyPI consistently over 3 months or more
-- To add a new model which uses another models logic internally and has no extra dependencies, that model's GitHub org needs > 20k stars in total
+- To add a new model which uses another model's logic internally and has no extra dependencies, that model's GitHub org needs > 20k stars in total
 - For any other model that's just a custom URL and API key, we're happy to add a one-paragraph description with a link and instructions on the URL to use
 - For any other model that requires more logic, we recommend you release your own Python package `pydantic-ai-xxx`, which depends on [`pydantic-ai-slim`](install.md#slim-install) and implements a model that inherits from our [`Model`][pydantic_ai.models.Model] ABC
 


### PR DESCRIPTION
Corrects the possessive in `docs/contributing.md`: "another models logic" is now "another model's logic". The contribution rule itself is unchanged; this only fixes the grammar in the new-model eligibility guidance.

I checked the patch with `git diff --check` and confirmed there are no merge-conflict markers. No issue is linked because the contributing guide explicitly allows typo and small documentation fixes without an issue.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

