### PR TITLE
Fix pending-message drain dropping a concurrent worker-thread enqueue

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import dataclasses
+import threading
 import inspect
 import time
 from asyncio import Task
@@ -430,6 +431,9 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
 
     cancellation: RunCancellation = dataclasses.field(default_factory=RunCancellation, repr=False)
     """The run's first-party cancellation controller. Runtime-only: holds a live task reference."""
+
+    pending_messages_lock: threading.Lock = dataclasses.field(default_factory=threading.Lock, repr=False)
+    """Runtime-only lock shared by enqueue and drain. Not part of durable serialization."""
 
     model_id: str | None = None
     """The model-id string `model` was resolved from, if the run's model came from a string.
@@ -2362,6 +2366,7 @@ def build_run_context(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT
         loaded_capability_ids=ctx.deps.loaded_capability_ids,
         discovered_tool_names=ctx.deps.discovered_tool_names,
         pending_messages=ctx.state.pending_messages,
+        _pending_messages_lock=ctx.deps.pending_messages_lock,
         _cancellation=ctx.deps.cancellation,
         _event_stream_buffer=ctx.state.event_stream_buffer,
         _mcp_tool_defs_cache=ctx.state.mcp_tool_defs_cache,

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import sys
+import threading
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -152,6 +153,13 @@ class RunContext(Generic[RunContextAgentDepsT]):
     [`enqueue`][pydantic_ai.tools.RunContext.enqueue] would have nowhere to drain to and so raises.
     Managed by the framework: read it if useful, but use [`enqueue`][pydantic_ai.tools.RunContext.enqueue]
     to add messages rather than mutating it directly.
+    """
+
+    _pending_messages_lock: threading.Lock | None = field(default=None, repr=False)
+    """Private implementation detail — not part of the public API; do not read or write.
+
+    Runtime-only lock shared with drain so a worker-thread `enqueue` cannot be lost to
+    `queue[:] = remaining`. `None` in synthetic contexts that aren't backed by a running agent.
     """
 
     _cancellation: RunCancellation | None = field(default=None, repr=False)
@@ -419,10 +427,9 @@ class RunContext(Generic[RunContextAgentDepsT]):
 
         Safe to call from anywhere a `RunContext` is available — async tools,
         sync tools (auto-wrapped in a thread executor by Pydantic AI), and
-        capability hooks. The drain only iterates the queue between graph nodes
-        (in `before_model_request` and `after_node_run`), never concurrently
-        with the tool body, so `list.append` from a worker thread doesn't race
-        the drain.
+        capability hooks. Enqueue and drain share a per-run lock so a worker
+        thread can append while drain iterates `queue[:] = remaining` without
+        losing the message.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -461,7 +468,12 @@ class RunContext(Generic[RunContextAgentDepsT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self.pending_messages.append(pending)
+        lock = self._pending_messages_lock
+        if lock is None:
+            self.pending_messages.append(pending)
+        else:
+            with lock:
+                self.pending_messages.append(pending)
         return pending.enqueue_id
 
     def cancel(self) -> None:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 from pydantic_ai._agent_graph import ModelRequestNode
@@ -100,7 +101,9 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
         messages exactly as delivered here.
         """
         assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
-        drained = _drain_by_priority(ctx.pending_messages, 'asap')
+        lock = ctx._pending_messages_lock
+        with lock if lock is not None else nullcontext():
+            drained = _drain_by_priority(ctx.pending_messages, 'asap')
         for pending in drained:
             messages = _stamped_messages(
                 pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id
@@ -141,8 +144,10 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
         # final step (e.g. a background task completing while the model produced
         # its final response) gets delivered before `'when_idle'` messages, and the
         # agent gets another turn rather than terminating with the message lost.
-        leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
-        when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
+        lock = ctx._pending_messages_lock
+        with lock if lock is not None else nullcontext():
+            leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
+            when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
         if not leftover_asap and not when_idle:
             return result
 

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -522,8 +522,8 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         you're forwarding events from a different thread (e.g. a webhook handler
         running on its own loop or thread), marshal the call back onto the agent's
         loop first (e.g. `loop.call_soon_threadsafe(agent_run.enqueue, msg)`).
-        The drain's `queue[:] = remaining` pattern in `_drain_by_priority` isn't
-        atomic against concurrent appends from a different thread.
+        Enqueue and drain share a per-run lock, so a concurrent append cannot be
+        lost to drain's `queue[:] = remaining`.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -549,7 +549,8 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self._graph_run.state.pending_messages.append(pending)
+        with self._graph_run.deps.pending_messages_lock:
+            self._graph_run.state.pending_messages.append(pending)
         return pending.enqueue_id
 
     def cancel(self) -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -17446,6 +17446,81 @@ async def test_bare_async_for_drains_pending_messages():
         )
 
 
+class TestPendingMessageEnqueueLock:
+    @pytest.fixture
+    def blockbuster_enabled(self) -> bool:
+        # The interleaving is forced with Event.wait inside drain's `queue[:] = remaining`.
+        # That wait is test-only; BlockBuster still sees a library drain frame on the stack.
+        return False
+
+    async def test_enqueue_during_drain_does_not_lose_message(self):
+        """A worker-thread `enqueue` must not be dropped by drain's `queue[:] = remaining`.
+
+        `RunContext.enqueue` is documented as safe from sync tools, but a capability can let the
+        graph continue while a worker thread still runs. Drain iterates `pending_messages` and
+        then replaces the list; an append in that window is lost unless enqueue and drain share a
+        lock. This is a unit test because the race is an internal queue mutation, not a VCR-visible
+        model exchange.
+        """
+        from pydantic_ai.capabilities._pending_messages import PendingMessageDrainCapability
+
+        lock = threading.Lock()
+        queued = PendingMessage.from_content('already-queued')
+        assert queued is not None
+
+        window_open = threading.Event()
+        worker_reached_enqueue = threading.Event()
+        worker_done = threading.Event()
+        enqueued_id: str | None = None
+
+        class RaceWindowQueue(list[PendingMessage]):
+            def __setitem__(self, key: Any, value: Any) -> None:
+                if isinstance(key, slice):
+                    window_open.set()
+                    assert worker_reached_enqueue.wait(timeout=2)
+                    # No lock around drain: the worker has already appended, and waiting lets
+                    # `queue[:] = remaining` drop it. Shared lock: the worker is blocked in
+                    # `enqueue`, so proceed and let the append land on the remaining list.
+                    if not lock.locked():
+                        assert worker_done.wait(timeout=2)
+                super().__setitem__(key, value)
+
+        queue: list[PendingMessage] = RaceWindowQueue([queued])
+        ctx = RunContext(
+            deps=None,
+            model=TestModel(),
+            usage=RunUsage(),
+            pending_messages=queue,
+            messages=[],
+            run_id='run',
+            conversation_id='conv',
+            _event_stream_buffer=[],
+        )
+        ctx._pending_messages_lock = lock  # pyright: ignore[reportPrivateUsage]
+
+        def worker() -> None:
+            nonlocal enqueued_id
+            assert window_open.wait(timeout=2)
+            worker_reached_enqueue.set()
+            enqueued_id = ctx.enqueue('from-worker')
+            worker_done.set()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        request_context = ModelRequestContext(
+            model=ctx.model,
+            messages=[],
+            model_settings=None,
+            model_request_parameters=ModelRequestParameters(),
+        )
+        await PendingMessageDrainCapability().before_model_request(ctx, request_context)
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert enqueued_id is not None
+        remaining_ids = {msg.enqueue_id for msg in ctx.pending_messages or []}
+        assert enqueued_id in remaining_ids, 'concurrent enqueue was lost during drain'
+
+
 async def test_pending_messages_accessible_on_run_context():
     """RunContext.pending_messages is accessible and initially empty."""
 


### PR DESCRIPTION
Fixes #7634.

`RunContext.enqueue` appends to `pending_messages` from a worker thread (sync tools). Drain iterates that list and then does `queue[:] = remaining`. When a capability lets the graph continue while the worker is still running, the slice assignment can drop the append.

This adds one runtime-only lock per agent run, shared by `RunContext.enqueue`, `AgentRun.enqueue`, and each drain transaction. `GraphAgentState.pending_messages` stays a plain list.

A regression test forces the interleaving: without the lock the worker append is lost; with it, the message remains on the queue after drain.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

