### PR TITLE
Fix stale `UIEventStream` part state on cancellation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from pydantic_ai import _utils
 
-from ..exceptions import RunCancelled
+from ..exceptions import RunCancelled, UnexpectedModelBehavior
 from ..messages import (
     INTERRUPTED_TOOL_RETURN_CONTENT,
     AgentStreamEvent,
@@ -136,6 +136,10 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
     """
     _open_part_index: int = 0
     """The index of the part tracked by `_open_part`, used to reconstruct its `PartEndEvent` on error."""
+    _open_part_deltas: list[TextPartDelta | ThinkingPartDelta | ToolCallPartDelta] = field(
+        default_factory=list[TextPartDelta | ThinkingPartDelta | ToolCallPartDelta]
+    )
+    """Deltas used to bring `_open_part` up to date only if a synthetic end event is needed."""
 
     def new_message_id(self) -> str:
         """Generate and store a new message ID."""
@@ -221,10 +225,21 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
                 if isinstance(event, PartStartEvent):
                     async for e in self._turn_to('response'):
                         yield e
+                elif isinstance(event, PartDeltaEvent) and event.index == self._open_part_index:
+                    match event.delta, self._open_part:
+                        case TextPartDelta() as delta, TextPart():
+                            self._open_part_deltas.append(delta)
+                        case ThinkingPartDelta() as delta, ThinkingPart():
+                            self._open_part_deltas.append(delta)
+                        case ToolCallPartDelta() as delta, ToolCallPart() | NativeToolCallPart():
+                            self._open_part_deltas.append(delta)
+                        case _:
+                            pass
                 elif isinstance(event, PartEndEvent):
                     # Only one part is open at a time, so this end is for `_open_part` (or it's already
                     # `None` for a part kind that isn't tracked); clearing unconditionally is safe either way.
                     self._open_part = None
+                    self._open_part_deltas.clear()
                 elif isinstance(event, ToolCallEvent):
                     tool_call_id = event.part.tool_call_id
                     kind: Literal['function', 'output'] = (
@@ -264,13 +279,29 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
                 ):
                     self._open_part = event.part
                     self._open_part_index = event.index
+                    self._open_part_deltas.clear()
         except Exception as exc:  # `exc` to avoid shadowing by `async for e in` below
             # Close the open message part before emitting the error, so a client that aborts at the
             # error chunk (like the AI SDK) doesn't leave it stuck in a streaming state. This comes
             # first: it's a response-side event, whereas the tool-call cleanup below turns to the
             # request side, and everything after the error chunk is dropped.
             if (part := self._open_part) is not None:
+                for delta in self._open_part_deltas:
+                    match delta, part:
+                        case TextPartDelta() as text_delta, TextPart():
+                            part = text_delta.apply(part)
+                        case ThinkingPartDelta() as thinking_delta, ThinkingPart():
+                            part = thinking_delta.apply(part)
+                        case ToolCallPartDelta() as tool_delta, ToolCallPart() | NativeToolCallPart():
+                            # Adapters can forward mixed dict/JSON argument deltas that `apply()` rejects.
+                            try:
+                                part = tool_delta.apply(part)
+                            except UnexpectedModelBehavior:
+                                pass
+                        case _:
+                            pass
                 self._open_part = None
+                self._open_part_deltas.clear()
                 async for e in self.handle_part_end(PartEndEvent(index=self._open_part_index, part=part)):
                     yield e
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from pydantic_ai import _utils
 
-from ..exceptions import RunCancelled, UnexpectedModelBehavior
+from ..exceptions import RunCancelled
 from ..messages import (
     INTERRUPTED_TOOL_RETURN_CONTENT,
     AgentStreamEvent,
@@ -146,6 +146,20 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
         self.message_id = str(uuid4())
         return self.message_id
 
+    def _record_part_delta(self, event: PartDeltaEvent) -> None:
+        if event.index != self._open_part_index:
+            return
+
+        match event.delta, self._open_part:
+            case TextPartDelta() as delta, TextPart():
+                self._open_part_deltas.append(delta)
+            case ThinkingPartDelta() as delta, ThinkingPart():
+                self._open_part_deltas.append(delta)
+            case ToolCallPartDelta() as delta, ToolCallPart() | NativeToolCallPart():
+                self._open_part_deltas.append(delta)
+            case _:
+                pass
+
     @property
     def response_headers(self) -> Mapping[str, str] | None:
         """Response headers to return to the frontend."""
@@ -225,16 +239,6 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
                 if isinstance(event, PartStartEvent):
                     async for e in self._turn_to('response'):
                         yield e
-                elif isinstance(event, PartDeltaEvent) and event.index == self._open_part_index:
-                    match event.delta, self._open_part:
-                        case TextPartDelta() as delta, TextPart():
-                            self._open_part_deltas.append(delta)
-                        case ThinkingPartDelta() as delta, ThinkingPart():
-                            self._open_part_deltas.append(delta)
-                        case ToolCallPartDelta() as delta, ToolCallPart() | NativeToolCallPart():
-                            self._open_part_deltas.append(delta)
-                        case _:
-                            pass
                 elif isinstance(event, PartEndEvent):
                     # Only one part is open at a time, so this end is for `_open_part` (or it's already
                     # `None` for a part kind that isn't tracked); clearing unconditionally is safe either way.
@@ -269,8 +273,14 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
                     tool_call_id = event.part.tool_call_id
                     self._pending_tool_calls.pop(tool_call_id, None)
 
+                delta_recorded = False
                 async for e in self.handle_event(event):
+                    if isinstance(event, PartDeltaEvent) and not delta_recorded:
+                        self._record_part_delta(event)
+                        delta_recorded = True
                     yield e
+                if isinstance(event, PartDeltaEvent) and not delta_recorded:
+                    self._record_part_delta(event)
 
                 # Mark the part open only after its start event has been emitted, so a start hook that
                 # raises mid-emit doesn't leave the error path closing a part the client never saw.
@@ -287,19 +297,19 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
             # request side, and everything after the error chunk is dropped.
             if (part := self._open_part) is not None:
                 for delta in self._open_part_deltas:
-                    match delta, part:
-                        case TextPartDelta() as text_delta, TextPart():
-                            part = text_delta.apply(part)
-                        case ThinkingPartDelta() as thinking_delta, ThinkingPart():
-                            part = thinking_delta.apply(part)
-                        case ToolCallPartDelta() as tool_delta, ToolCallPart() | NativeToolCallPart():
-                            # Adapters can forward mixed dict/JSON argument deltas that `apply()` rejects.
-                            try:
+                    # Synthetic cleanup must not replace the original stream error.
+                    try:
+                        match delta, part:
+                            case TextPartDelta() as text_delta, TextPart():
+                                part = text_delta.apply(part)
+                            case ThinkingPartDelta() as thinking_delta, ThinkingPart():
+                                part = thinking_delta.apply(part)
+                            case ToolCallPartDelta() as tool_delta, ToolCallPart() | NativeToolCallPart():
                                 part = tool_delta.apply(part)
-                            except UnexpectedModelBehavior:
+                            case _:
                                 pass
-                        case _:
-                            pass
+                    except Exception:
+                        pass
                 self._open_part = None
                 self._open_part_deltas.clear()
                 async for e in self.handle_part_end(PartEndEvent(index=self._open_part_index, part=part)):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -887,6 +887,42 @@ async def test_run_stream_cancelled_run_closes_tools_as_interrupted():
     )
 
 
+class PartEndEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
+    def encode_event(self, event: str | PartEndEvent) -> str:
+        return repr(event)  # pragma: no cover
+
+    async def before_stream(self) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+    async def after_stream(self) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+    async def before_response(self) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+    async def after_response(self) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+    async def handle_event(self, event: NativeEvent) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+    async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
+        yield event
+
+    async def on_cancelled(self, cancelled: RunCancelled) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+    async def on_error(self, error: Exception) -> AsyncIterator[str | PartEndEvent]:
+        return
+        yield
+
+
 @pytest.mark.parametrize(
     ('part', 'deltas', 'expected_part'),
     [
@@ -927,13 +963,6 @@ async def test_cancelled_part_end_contains_accumulated_part(
     deltas: list[TextPartDelta | ThinkingPartDelta | ToolCallPartDelta],
     expected_part: TextPart | ThinkingPart | ToolCallPart | NativeToolCallPart,
 ):
-    class PartEndEventStream(UIEventStream[None, PartEndEvent, None, str]):
-        def encode_event(self, event: PartEndEvent) -> str:
-            return repr(event)  # pragma: no cover
-
-        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[PartEndEvent]:
-            yield event
-
     async def event_generator() -> AsyncIterator[NativeEvent]:
         yield PartStartEvent(index=0, part=part)
         for delta in deltas:
@@ -946,13 +975,6 @@ async def test_cancelled_part_end_contains_accumulated_part(
 
 
 async def test_cancelled_part_end_ignores_delta_for_different_part():
-    class PartEndEventStream(UIEventStream[None, PartEndEvent, None, str]):
-        def encode_event(self, event: PartEndEvent) -> str:
-            return repr(event)  # pragma: no cover
-
-        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[PartEndEvent]:
-            yield event
-
     async def event_generator() -> AsyncIterator[NativeEvent]:
         yield PartStartEvent(index=0, part=TextPart(content='Hello'))
         yield PartDeltaEvent(index=1, delta=TextPartDelta(content_delta=' world'))
@@ -977,17 +999,12 @@ async def test_cancelled_part_end_ignores_delta_for_different_part():
 async def test_part_end_delta_matches_handler_output_on_error(
     yield_delta: bool, expected_events: list[str | PartEndEvent]
 ):
-    class FailingEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
-        def encode_event(self, event: str | PartEndEvent) -> str:
-            return repr(event)  # pragma: no cover
-
-        async def handle_text_delta(self, delta: TextPartDelta) -> AsyncIterator[str | PartEndEvent]:
-            if yield_delta:
-                yield delta.content_delta
-            raise RuntimeError('handler failed')
-
-        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
-            yield event
+    class FailingEventStream(PartEndEventStream):
+        async def handle_event(self, event: NativeEvent) -> AsyncIterator[str | PartEndEvent]:
+            if isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                if yield_delta:
+                    yield event.delta.content_delta
+                raise RuntimeError('handler failed')
 
     async def event_generator() -> AsyncIterator[NativeEvent]:
         yield PartStartEvent(index=0, part=TextPart(content='Hello'))
@@ -999,13 +1016,7 @@ async def test_part_end_delta_matches_handler_output_on_error(
 
 
 async def test_part_cleanup_error_does_not_replace_stream_error():
-    class ErrorEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
-        def encode_event(self, event: str | PartEndEvent) -> str:
-            return repr(event)  # pragma: no cover
-
-        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
-            yield event
-
+    class ErrorEventStream(PartEndEventStream):
         async def on_error(self, error: Exception) -> AsyncIterator[str | PartEndEvent]:
             yield f'{type(error).__name__}: {error}'
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -945,13 +945,27 @@ async def test_cancelled_part_end_contains_accumulated_part(
     assert events == [PartEndEvent(index=0, part=expected_part)]
 
 
-async def test_part_end_contains_delta_when_handler_fails_after_yield():
+@pytest.mark.parametrize(
+    ('yield_delta', 'expected_events'),
+    [
+        pytest.param(
+            True,
+            [' world', PartEndEvent(index=0, part=TextPart(content='Hello world'))],
+            id='after-yield',
+        ),
+        pytest.param(False, [PartEndEvent(index=0, part=TextPart(content='Hello'))], id='before-yield'),
+    ],
+)
+async def test_part_end_delta_matches_handler_output_on_error(
+    yield_delta: bool, expected_events: list[str | PartEndEvent]
+):
     class FailingEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
         def encode_event(self, event: str | PartEndEvent) -> str:
             return repr(event)
 
         async def handle_text_delta(self, delta: TextPartDelta) -> AsyncIterator[str | PartEndEvent]:
-            yield delta.content_delta
+            if yield_delta:
+                yield delta.content_delta
             raise RuntimeError('handler failed')
 
         async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
@@ -963,7 +977,37 @@ async def test_part_end_contains_delta_when_handler_fails_after_yield():
 
     events = [event async for event in FailingEventStream().transform_stream(event_generator())]
 
-    assert events == [' world', PartEndEvent(index=0, part=TextPart(content='Hello world'))]
+    assert events == expected_events
+
+
+async def test_part_cleanup_error_does_not_replace_stream_error():
+    class ErrorEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
+        def encode_event(self, event: str | PartEndEvent) -> str:
+            return repr(event)
+
+        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
+            yield event
+
+        async def on_error(self, error: Exception) -> AsyncIterator[str | PartEndEvent]:
+            yield f'{type(error).__name__}: {error}'
+
+    def raise_cleanup_error(_: dict[str, Any] | None) -> dict[str, Any]:
+        raise ValueError('cleanup failed')
+
+    async def event_generator() -> AsyncIterator[NativeEvent]:
+        yield PartStartEvent(index=0, part=ThinkingPart(content='Thinking'))
+        yield PartDeltaEvent(
+            index=0,
+            delta=ThinkingPartDelta(content_delta='...', provider_details=raise_cleanup_error),
+        )
+        raise RuntimeError('stream failed')
+
+    events = [event async for event in ErrorEventStream().transform_stream(event_generator())]
+
+    assert events == [
+        PartEndEvent(index=0, part=ThinkingPart(content='Thinking')),
+        'RuntimeError: stream failed',
+    ]
 
 
 async def test_run_stream_on_cancel():

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -929,7 +929,7 @@ async def test_cancelled_part_end_contains_accumulated_part(
 ):
     class PartEndEventStream(UIEventStream[None, PartEndEvent, None, str]):
         def encode_event(self, event: PartEndEvent) -> str:
-            return repr(event)
+            return repr(event)  # pragma: no cover
 
         async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[PartEndEvent]:
             yield event
@@ -943,6 +943,24 @@ async def test_cancelled_part_end_contains_accumulated_part(
     events = [event async for event in PartEndEventStream(run_input=None).transform_stream(event_generator())]
 
     assert events == [PartEndEvent(index=0, part=expected_part)]
+
+
+async def test_cancelled_part_end_ignores_delta_for_different_part():
+    class PartEndEventStream(UIEventStream[None, PartEndEvent, None, str]):
+        def encode_event(self, event: PartEndEvent) -> str:
+            return repr(event)  # pragma: no cover
+
+        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[PartEndEvent]:
+            yield event
+
+    async def event_generator() -> AsyncIterator[NativeEvent]:
+        yield PartStartEvent(index=0, part=TextPart(content='Hello'))
+        yield PartDeltaEvent(index=1, delta=TextPartDelta(content_delta=' world'))
+        raise RunCancelled('The agent run was cancelled.')
+
+    events = [event async for event in PartEndEventStream().transform_stream(event_generator())]
+
+    assert events == [PartEndEvent(index=0, part=TextPart(content='Hello'))]
 
 
 @pytest.mark.parametrize(
@@ -961,7 +979,7 @@ async def test_part_end_delta_matches_handler_output_on_error(
 ):
     class FailingEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
         def encode_event(self, event: str | PartEndEvent) -> str:
-            return repr(event)
+            return repr(event)  # pragma: no cover
 
         async def handle_text_delta(self, delta: TextPartDelta) -> AsyncIterator[str | PartEndEvent]:
             if yield_delta:
@@ -983,7 +1001,7 @@ async def test_part_end_delta_matches_handler_output_on_error(
 async def test_part_cleanup_error_does_not_replace_stream_error():
     class ErrorEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
         def encode_event(self, event: str | PartEndEvent) -> str:
-            return repr(event)
+            return repr(event)  # pragma: no cover
 
         async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
             yield event

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -887,6 +887,85 @@ async def test_run_stream_cancelled_run_closes_tools_as_interrupted():
     )
 
 
+@pytest.mark.parametrize(
+    ('part', 'deltas', 'expected_part'),
+    [
+        pytest.param(
+            TextPart(content='The'),
+            [TextPartDelta(content_delta=' quick brown fox'), TextPartDelta(content_delta=' jumps over')],
+            TextPart(content='The quick brown fox jumps over'),
+            id='text',
+        ),
+        pytest.param(
+            ThinkingPart(content='Looking'),
+            [ThinkingPartDelta(content_delta=' for an'), ThinkingPartDelta(content_delta=' answer')],
+            ThinkingPart(content='Looking for an answer'),
+            id='thinking',
+        ),
+        pytest.param(
+            ToolCallPart(tool_name='search', args=None, tool_call_id='call_1'),
+            [
+                ToolCallPartDelta(args_delta='{"query":', tool_call_id='call_1'),
+                ToolCallPartDelta(args_delta='"pydantic"}', tool_call_id='call_1'),
+            ],
+            ToolCallPart(tool_name='search', args='{"query":"pydantic"}', tool_call_id='call_1'),
+            id='tool-call',
+        ),
+        pytest.param(
+            NativeToolCallPart(tool_name='code_execution', args=None, tool_call_id='call_2'),
+            [
+                ToolCallPartDelta(args_delta='{"code":', tool_call_id='call_2'),
+                ToolCallPartDelta(args_delta='"print(1)"}', tool_call_id='call_2'),
+            ],
+            NativeToolCallPart(tool_name='code_execution', args='{"code":"print(1)"}', tool_call_id='call_2'),
+            id='native-tool-call',
+        ),
+    ],
+)
+async def test_cancelled_part_end_contains_accumulated_part(
+    part: TextPart | ThinkingPart | ToolCallPart | NativeToolCallPart,
+    deltas: list[TextPartDelta | ThinkingPartDelta | ToolCallPartDelta],
+    expected_part: TextPart | ThinkingPart | ToolCallPart | NativeToolCallPart,
+):
+    class PartEndEventStream(UIEventStream[None, PartEndEvent, None, str]):
+        def encode_event(self, event: PartEndEvent) -> str:
+            return repr(event)
+
+        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[PartEndEvent]:
+            yield event
+
+    async def event_generator() -> AsyncIterator[NativeEvent]:
+        yield PartStartEvent(index=0, part=part)
+        for delta in deltas:
+            yield PartDeltaEvent(index=0, delta=delta)
+        raise RunCancelled('The agent run was cancelled.')
+
+    events = [event async for event in PartEndEventStream(run_input=None).transform_stream(event_generator())]
+
+    assert events == [PartEndEvent(index=0, part=expected_part)]
+
+
+async def test_part_end_contains_delta_when_handler_fails_after_yield():
+    class FailingEventStream(UIEventStream[None, str | PartEndEvent, None, str]):
+        def encode_event(self, event: str | PartEndEvent) -> str:
+            return repr(event)
+
+        async def handle_text_delta(self, delta: TextPartDelta) -> AsyncIterator[str | PartEndEvent]:
+            yield delta.content_delta
+            raise RuntimeError('handler failed')
+
+        async def handle_part_end(self, event: PartEndEvent) -> AsyncIterator[str | PartEndEvent]:
+            yield event
+
+    async def event_generator() -> AsyncIterator[NativeEvent]:
+        yield PartStartEvent(index=0, part=TextPart(content='Hello'))
+        yield PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=' world'))
+
+    events = [event async for event in FailingEventStream().transform_stream(event_generator())]
+
+    assert events == [' world', PartEndEvent(index=0, part=TextPart(content='Hello world'))]
+
+
 async def test_run_stream_on_cancel():
     agent = Agent(model=TestModel())
 


### PR DESCRIPTION
- Closes #7610

### Summary

`UIEventStream` now retains compatible deltas for the currently open part and applies them when an error or cancellation requires a synthetic `PartEndEvent`. This makes the end payload match the content already streamed to UI adapters.

Deltas are only folded during exceptional cleanup, avoiding repeated full-string reconstruction on successful streams. Mixed dict/JSON tool arguments remain best-effort so this bookkeeping does not reject streams adapters already accept.

Regression coverage includes text, thinking, function tool calls, native tool calls, and a handler that yields a delta before failing.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

