### PR TITLE
fix(ag-ui): emit TEXT_MESSAGE_START before tool-only TOOL_CALL_START

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -145,6 +145,14 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
     _builtin_tool_call_ids: dict[str, str] = field(default_factory=dict[str, str])
     _error: bool = False
     _cancelled_run: bool = False
+    # Track whether a TextMessageStartEvent has been emitted for the current
+    # message_id.  When a response contains only tool calls (no TextPart),
+    # before_response() mints a synthetic message_id but handle_text_start()
+    # is never called, so _handle_tool_call_start() emits ToolCallStartEvent
+    # with a parent_message_id that no emitted event refers to.  The flag lets
+    # us emit a TextMessageStartEvent lazily when the first tool call arrives.
+    # See https://github.com/pydantic/pydantic-ai/issues/7527
+    _text_message_start_sent: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
         self._use_reasoning = parse_ag_ui_version(self.ag_ui_version) >= REASONING_VERSION
@@ -199,6 +207,7 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         # Prevent parts from a subsequent response being tied to parts from an earlier response.
         # See https://github.com/pydantic/pydantic-ai/issues/3316
         self.new_message_id()
+        self._text_message_start_sent = False
         return
         yield  # Make this an async generator
 
@@ -267,6 +276,7 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         else:
             message_id = self.new_message_id()
             yield TextMessageStartEvent(message_id=message_id)
+            self._text_message_start_sent = True
 
         if part.content:  # pragma: no branch
             yield TextMessageContentEvent(message_id=message_id, delta=part.content)
@@ -335,6 +345,14 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
     ) -> AsyncIterator[BaseEvent]:
         tool_call_id = tool_call_id or part.tool_call_id
         parent_message_id = self.message_id
+
+        # When a response contains only tool calls (no TextPart), no
+        # TextMessageStartEvent has been emitted for the synthetic message_id
+        # that before_response() created.  Emit one now so the client can
+        # build an assistant message to own the tool call.
+        if not self._text_message_start_sent:
+            yield TextMessageStartEvent(message_id=parent_message_id)
+            self._text_message_start_sent = True
 
         yield ToolCallStartEvent(
             tool_call_id=tool_call_id, tool_call_name=part.tool_name, parent_message_id=parent_message_id

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -8025,3 +8025,142 @@ async def test_tool_availability_delta_stream_matches_dumped_activity_message() 
     # The literal is a frontend-facing wire contract: deriving both sides from the shared constant
     # would let a rename drift silently.
     assert activity.activity_type == 'pydantic_ai_tool_availability_delta'
+
+
+async def test_tool_only_response_emits_text_message_start() -> None:
+    """Regression test for #7527: tool-only responses must emit TEXT_MESSAGE_START.
+
+    When a response contains only tool calls (no TextPart), before_response()
+    mints a synthetic message_id but no TEXT_MESSAGE_START is emitted.
+    TOOL_CALL_START then uses that synthetic ID as parentMessageId, which
+    refers to no event in the stream. This test verifies a TEXT_MESSAGE_START
+    is emitted before the first TOOL_CALL_START for a tool-only response.
+    """
+
+    async def stream_function(
+        messages: list[ModelMessage], agent_info: AgentInfo
+    ) -> AsyncIterator[DeltaToolCalls | str]:
+        if len(messages) == 1:
+            yield {0: DeltaToolCall(name='get_weather', json_args='{"location":"Paris"}')}
+        else:
+            yield 'Final result'
+
+    agent = Agent(
+        model=FunctionModel(stream_function=stream_function),
+        tools=[get_weather()],
+    )
+
+    thread_id = uuid_str()
+    run_inputs = [
+        create_input(
+            UserMessage(
+                id='msg_1',
+                content='Get weather for Paris',
+            ),
+            tools=[get_weather()],
+            thread_id=thread_id,
+        ),
+        create_input(
+            UserMessage(
+                id='msg_1',
+                content='Get weather for Paris',
+            ),
+            AssistantMessage(
+                id='msg_2',
+                tool_calls=[
+                    ToolCall(
+                        id='pyd_ai_00000000000000000000000000000003',
+                        type='function',
+                        function=FunctionCall(
+                            name='get_weather',
+                            arguments='{"location": "Paris"}',
+                        ),
+                    ),
+                ],
+            ),
+            ToolMessage(
+                id='msg_3',
+                content='Tool result',
+                tool_call_id='pyd_ai_00000000000000000000000000000003',
+            ),
+            thread_id=thread_id,
+        ),
+    ]
+
+    events = await run_and_collect_events(agent, *run_inputs)
+
+    assert events == snapshot(
+        [
+            {
+                'type': 'RUN_STARTED',
+                'timestamp': IsInt(),
+                'threadId': thread_id,
+                'runId': (run_id := IsSameStr()),
+            },
+            {
+                # The first response is tool-only: TEXT_MESSAGE_START must be
+                # emitted before TOOL_CALL_START so the client has a parent
+                # message to attach the tool call to.
+                'type': 'TEXT_MESSAGE_START',
+                'timestamp': IsInt(),
+                'messageId': IsStr(),
+                'role': 'assistant',
+            },
+            {
+                'type': 'TOOL_CALL_START',
+                'timestamp': IsInt(),
+                'toolCallId': (tool_call_id := IsSameStr()),
+                'toolCallName': 'get_weather',
+                'parentMessageId': IsStr(),
+            },
+            {
+                'type': 'TOOL_CALL_ARGS',
+                'timestamp': IsInt(),
+                'toolCallId': tool_call_id,
+                'delta': '{"location":"Paris"}',
+            },
+            {'type': 'TOOL_CALL_END', 'timestamp': IsInt(), 'toolCallId': tool_call_id},
+            # Tool call result via _handle_tool_result mints its own message_id.
+            {
+                'type': 'TOOL_CALL_RESULT',
+                'timestamp': IsInt(),
+                'messageId': IsStr(),
+                'type_': 'tool_call_result',
+                'role': 'tool',
+                'toolCallId': tool_call_id,
+                'content': '"Tool result"',
+            },
+            {
+                'type': 'RUN_FINISHED',
+                'timestamp': IsInt(),
+                'threadId': thread_id,
+                'runId': run_id,
+            },
+            {
+                'type': 'RUN_STARTED',
+                'timestamp': IsInt(),
+                'threadId': thread_id,
+                'runId': (run_id := IsSameStr()),
+            },
+            {
+                # Second response has a TextPart — normal TEXT_MESSAGE_START.
+                'type': 'TEXT_MESSAGE_START',
+                'timestamp': IsInt(),
+                'messageId': (message_id := IsSameStr()),
+                'role': 'assistant',
+            },
+            {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'timestamp': IsInt(),
+                'messageId': message_id,
+                'delta': 'Final result',
+            },
+            {'type': 'TEXT_MESSAGE_END', 'timestamp': IsInt(), 'messageId': message_id},
+            {
+                'type': 'RUN_FINISHED',
+                'timestamp': IsInt(),
+                'threadId': thread_id,
+                'runId': run_id,
+            },
+        ]
+    )


### PR DESCRIPTION
## Problem

When a model response contains only tool calls (no `TextPart`), `before_response()` mints a synthetic message ID via `new_message_id()`, but no `TEXT_MESSAGE_START` is ever emitted for it. `_handle_tool_call_start()` then uses that synthetic ID as `parent_message_id`, which no event in the stream refers to.

AG-UI clients receive a `TOOL_CALL_START` whose parent does not exist in the event stream. They cannot reliably reconstruct the assistant message that owns the tool call, producing orphaned `parentMessageId` references that break replay/persistence round-trips.

Fixes #7527.

## Root Cause

`before_response()` (L198-203 in `_event_stream.py`) calls `self.new_message_id()` but yields nothing — it is a bare `return; yield` to satisfy the async generator contract. Then `_handle_tool_call_start()` reads `self.message_id` as the `parent_message_id` for the `ToolCallStartEvent`. Since no `TextMessageStartEvent` was ever emitted for this synthetic ID, AG-UI clients receive a `TOOL_CALL_START` whose parent does not exist in the event stream.

## Fix

Track whether a `TextMessageStartEvent` has been emitted for the current `message_id` via a `_text_message_start_sent` flag (reset in `before_response()` after `new_message_id()`, set in `handle_text_start()` when a new message ID is minted).

In `_handle_tool_call_start()`, if no text start has been emitted yet, emit a `TextMessageStartEvent(message_id=parent_message_id)` before the `ToolCallStartEvent`. This gives clients a real assistant message to attach the tool call to, while preserving the synthetic-message-ID design from #3316.

## Why emit TEXT_MESSAGE_START rather than relying on the client reducer

David asked whether the server-side consumer can apply the reducer's `resolveOrCreateAssistantMessage` rule (case 3: `parentMessageId` not found → create new, keyed by `parentMessageId`). The reference client does handle this — but not all consumers do:

- **assistant-ui/react-ag-ui** (the reporter's consumer) creates a single assistant message wrapping both `TEXT_MESSAGE` and `TOOL_CALL` with the `parentMessageId`, but the ID has no reference back to any real stream event. When there are no tool calls, the assistant message ID is the `TEXT_MESSAGE` ID (correct). When there are only tool calls, the ID is a random UUID with no backend counterpart.
- The reporter needs message IDs to be stable across the AG-UI → Pydantic message round-trip so they can identify new incoming messages from the payload and avoid lossy transformations. Orphaned IDs break this.
- Even the reference client's case-3 path creates a message keyed by `parentMessageId`, but that message has no `TEXT_MESSAGE_START`/`TEXT_MESSAGE_END` pair — so it cannot be matched when the full conversation payload is sent back on the next request.

Emitting `TEXT_MESSAGE_START` ensures every consumer — not just the reference client — gets a consistent, addressable assistant message. The `TEXT_MESSAGE_END` is not emitted because there is no text content to close; the `ToolCallEndEvent` already signals the end of the tool-call portion.

## Regression Test

Added `test_tool_only_response_emits_text_message_start` which:
1. Sends a tool-only first response (no `TextPart`) and verifies `TEXT_MESSAGE_START` is emitted before `TOOL_CALL_START`
2. Sends a second response with a `TextPart` and verifies the normal `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END` flow still works correctly

The test uses `FunctionModel` with a two-turn `stream_function` and `snapshot` comparison for exact event sequence validation.

## Approach Alignment

This follows the approach I proposed in [my comment on #7527](https://github.com/pydantic/pydantic-ai/issues/7527#issuecomment-3054718849). David's question about whether the consumer can apply the reducer rule is addressed above — the fix is the right shape because it makes the stream self-consistent regardless of consumer implementation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

