### PR TITLE
Add a LangChain migration skill

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: migrating-langchain-to-pydantic-ai
+description: Migrate Python LangChain or LangGraph applications to Pydantic AI. Use for LangChain agents, chains, LCEL, or direct LangGraph graphs, persistence, interrupts, and streaming. Do not use for migrations centered on `create_deep_agent` or Deep Agents harness features.
+---
+
+# Migrate LangChain and LangGraph to Pydantic AI
+
+Preserve behavior, not framework shape. Migrate the smallest behaviorally complete slice and leave application infrastructure outside that slice unchanged.
+
+## Work from the running application
+
+1. Read repository instructions, dependency files, tests, and the actual runtime entrypoints. Identify the installed LangChain, LangGraph, and Pydantic AI versions.
+2. Trace one representative request through prompts, retrieval, model and tool calls, state, persistence, interrupts, emitted events, tracing/metrics callbacks, and the public result. Inspect every caller and sibling endpoint that consumes the migrated component; a narrow implementation slice can still have several public contracts. Include keyword parameter names and the sync, async, callback, and streaming forms callers actually use. Record only contracts those paths actually use.
+3. Run the cheapest useful baseline. When the migration surface is broad or unclear, search dependency files and source for `langchain`, `langgraph`, `langsmith`, and `deepagents`, then confirm findings against imports, factories, and call sites.
+4. Classify the slice before choosing a target:
+   - **Chain or LCEL pipeline:** keep deterministic retrieval and transformation in plain Python; use a Pydantic AI agent only where a model/tool loop adds value.
+   - **LangChain agent:** normally use one reusable `pydantic_ai.Agent` with typed dependencies, tools, and outputs.
+   - **Direct LangGraph workflow:** use plain async Python for simple fixed control flow, or `pydantic_graph` when explicit typed nodes and branching remain useful. Treat persistence as a separate design decision.
+   - **Product runtime:** retain queues, configured database backends, sandboxes, auth, schedulers, webhooks, tracing, and transport adapters unless the user placed them in scope. Extend an existing application seam before creating a parallel persistence or provider subsystem.
+5. Add or preserve deterministic characterization tests, then migrate one vertical slice behind the existing public boundary.
+6. Run the original tests and focused parity tests. Classify each observed contract by its evidence; never describe the migration as one-to-one merely because the happy path or trace shape looks similar.
+
+Read [Concept Mapping](references/CONCEPT-MAPPING.md) for the detected source features. Read [Semantic Gaps](references/SEMANTIC-GAPS.md) only for state, middleware, retries, approval, concurrency, streaming, or other behavior where similar-looking APIs may differ. Use [Workaround Recipes](references/WORKAROUND-RECIPES.md) after a concrete gap is identified, not as a mandatory checklist. Read [Logfire Verification](references/LOGFIRE-VERIFICATION.md) when adding observability, comparing source and target runs, or debugging a semantic difference. Read [Verification and Cutover](references/VERIFICATION-AND-CUTOVER.md) before a production cutover.
+
+## Explain semantic differences
+
+When an observed source contract has no direct equivalent, explain it to the user before making a consequential design choice. State the source behavior, how the proposed Pydantic AI design differs, the user-visible or operational impact, and the available choices. Recommend one option and name its residual risk. Keep this proportional: do not turn ordinary import or naming changes into semantic warnings.
+
+## Match rigor to risk
+
+- For a stateless chain or ordinary agent port, focused characterization tests and a short residual-risk note are enough. Do not require a semantic-gap register or durability exercise for behavior the source does not have.
+- For middleware, structured output transport, retrieval, tool retries, or streaming, probe the affected contract against the installed versions.
+- For checkpointed graphs, interrupts, approvals, durable execution, concurrent fan-out, or external side effects, create a migration ledger. Separate dependencies, messages, workflow state, checkpoint state, and long-term memory. Fit those owners into the repository's existing backend-selection and service interfaces where possible. Test restart, replay, correlation, authorization, and idempotency only to the extent the source promises them.
+- A `deepagents` dependency alone is not a reason to stop. If the active slice calls `create_deep_agent` or relies on its planning, skills, filesystem, subagent, sandbox, memory, or deployment contracts, report that it is a harness migration and ask whether those contracts are in scope. Do not assume another migration skill is installed.
+
+## Pydantic AI defaults
+
+- Put authenticated identity, service clients, and configuration in typed dependencies, never model-chosen tool arguments.
+- Strengthen observed unstable seams, not the whole application: parameterize the agent's dependency and output types, and validate terminal choices, persisted workflow records, and framework adapters. Preserve stable public wire shapes and do not invent types for paths outside the migrated slice.
+- Preserve public request, response, error, and event shapes with a small adapter while callers migrate.
+- Keep retrieval, storage, provider, and transport integrations in place when they are outside the requested slice. Transitional LangChain integrations are acceptable when named and bounded.
+- Use Pydantic models for terminal structured output when that preserves the contract; retain an existing parser when changing the wire contract would expand the migration.
+- Do not force an `Agent` onto deterministic LCEL or `pydantic_graph` onto every `StateGraph`.
+- Inspect the installed Pydantic AI API before choosing model classes, provider transports, hooks, streaming methods, or durable integrations.
+- When adding Pydantic AI, prefer a currently supported stable release. Use the newest compatible release unless that would expand the migration through an unrelated major/runtime upgrade; explain and pin any exception. Resolve the whole project from a clean environment and run an import probe because an existing environment can hide incompatible transitive versions. Prefer `pydantic-ai-slim` with only the required provider and integration extras when the dependency surface is bounded, and use the full distribution when its broader integrations are actually needed. Do not pin an older release merely to match a remembered example.
+- If the source already uses LangSmith, Langfuse, or another observability system, do not replace it silently. Explain that Logfire is the first-party Pydantic AI integration and normally provides the most direct agent, model, tool, retry, error, usage, and timing experience. Contrast that with the continuity of retaining the current system, including its dashboards, alerts, evaluations, retention, and export pipeline; recommend a choice and obtain agreement before switching. Offer Logfire at application startup when no tracing system exists or the user chooses it, make content capture an explicit privacy decision, and keep executable contract tests as the authority for parity.
+
+## Completion
+
+The slice is complete when every observed contract is either preserved by an executable check, intentionally changed by an accepted decision, or explicitly not applicable. An untested contract is `unverified`, not equivalent; an unresolved requested contract is unfinished work, not completion evidence. Constrain the slice or ask the user to accept the deferral. Remove LangChain or LangGraph dependencies only after no retained path needs them.

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/agents/openai.yaml
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Migrate LangChain to Pydantic AI"
+  short_description: "Migrate LangChain and LangGraph safely"
+  default_prompt: "Use $migrating-langchain-to-pydantic-ai to migrate the smallest complete LangChain or LangGraph slice to Pydantic AI while preserving its observed contracts with proportionate tests."

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/CONCEPT-MAPPING.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/CONCEPT-MAPPING.md
@@ -1,0 +1,235 @@
+# LangChain and Pydantic AI Concept Mapping
+
+Use this reference to select Pydantic AI primitives. Preserve behavior rather than matching class names.
+
+## Contents
+
+- [Core agent loop](#core-agent-loop)
+- [Typed invariants at unstable seams](#typed-invariants-at-unstable-seams)
+- [Tools and runtime context](#tools-and-runtime-context)
+- [Structured output](#structured-output)
+- [Middleware and lifecycle](#middleware-and-lifecycle)
+- [State, memory, and persistence](#state-memory-and-persistence)
+- [Graphs and multi-agent systems](#graphs-and-multi-agent-systems)
+- [Streaming, testing, and observability](#streaming-testing-and-observability)
+- [Transitional bridges](#transitional-bridges)
+- [Migration traps](#migration-traps)
+
+## Core agent loop
+
+| LangChain / LangGraph | Pydantic AI default | Migration note |
+|---|---|---|
+| LCEL prompt/retriever/parser pipeline | plain Python around a model call or `Agent` | Keep deterministic retrieval, formatting, and routing explicit. Do not introduce an agent loop when the source performs one model call. |
+| `create_agent(model, tools, system_prompt=...)` | `Agent(model, tools=..., instructions=...)` | Keep one reusable agent unless construction genuinely varies per request. |
+| `agent.invoke({"messages": ...})` | `await agent.run(prompt, deps=..., message_history=...)` | Consume `result.output`; do not expose Pydantic AI message objects at the public boundary. |
+| `ainvoke` | `await agent.run(...)` | Pydantic AI is async-first; use `run_sync` only at synchronous edges. |
+| `RunnableConfig.configurable` | typed dependency object and explicit run arguments | Split application configuration from model-visible content. |
+| `context_schema` / `ToolRuntime.context` | `deps_type` / `RunContext.deps` | Put DB clients, authenticated identity, config, and service gateways in dependencies. |
+| prompt templates | `instructions` or `system_prompt` | Use `instructions` for current-agent policy and `system_prompt` only when prior prompts must survive history; multiple LangChain dynamic prompts may replace rather than compose. |
+| `init_chat_model` | provider-prefixed model string or model instance | Preserve provider settings explicitly; verify the installed provider API. |
+
+Preserve model transport as well as the model name. LangChain's `ChatOpenAI`, an OpenAI Responses model, an Azure deployment, and an OpenAI-compatible local endpoint can share a model label while using different request protocols and settings. Inspect the installed Pydantic AI provider constructors and test every configured branch without making a live request; leave unknown custom endpoints as an explicit integration gap.
+
+Minimal translation:
+
+```python {lint="skip"}
+# ruff: noqa: F704, F821, Q000
+# LangChain
+from langchain.agents import create_agent
+
+agent = create_agent(
+    model="provider:model",
+    tools=[lookup_order],
+    system_prompt="Help authenticated customers with orders.",
+)
+result = await agent.ainvoke(
+    {"messages": [{"role": "user", "content": "Where is order 123?"}]},
+    context=runtime_context,
+)
+```
+
+```python {noqa="F704,F821"}
+# ruff: noqa: F704, F821
+# Pydantic AI
+from dataclasses import dataclass
+
+from pydantic_ai import Agent, RunContext
+
+
+@dataclass
+class Deps:
+    customer_id: str
+    orders: 'OrderService'
+
+
+agent = Agent(
+    'provider:model',
+    deps_type=Deps,
+    instructions='Help authenticated customers with orders.',
+)
+
+
+@agent.tool
+async def lookup_order(ctx: RunContext[Deps], order_id: str) -> str:
+    return await ctx.deps.orders.lookup_for_customer(ctx.deps.customer_id, order_id)
+
+
+result = await agent.run('Where is order 123?', deps=deps)
+print(result.output)
+```
+
+The dependency boundary is a security boundary: the model chooses `order_id`, but cannot choose `customer_id` or the service client.
+
+## Typed invariants at unstable seams
+
+Use types to make an observed migration decision executable, not to remodel stable application code. The following seams caused real ambiguity in migrated applications:
+
+| Observed source ambiguity | Target invariant | Evidence to require |
+|---|---|---|
+| free-form config or runtime context mixes trusted identity, services, and model inputs | a dependency dataclass plus `Agent[DepsT, OutputT]`; only model-chosen values appear in tool parameters | static checking plus a captured tool schema and model request |
+| a string, dictionary, or graph control value can mean several terminal states, such as answer versus request-more-input | a Pydantic model or explicit output union for the states the source actually reaches | every variant validates and every application branch is exercised; remember that including `str` permits plain text to terminate the run |
+| graph state mixes public messages, model protocol history, pending resume state, owner, and persistence version | distinct public DTOs, `list[ModelMessage]`, and a typed workflow record; serialize model history with `ModelMessagesTypeAdapter` when the installed version provides it | storage round-trip, continuation, ownership, and resume tests against the real backend |
+| provider names and settings are passed through loose strings and dictionaries | retain the source enum or typed configuration and map it to a concrete Pydantic AI `Model` | construct every configured branch without a live request and probe provider-specific settings |
+
+Do not claim semantic parity from static typing alone. Types can expose missing cases and validate boundaries; they cannot prove timing, retries, persistence, side effects, or framework lifecycle behavior.
+
+## Tools and runtime context
+
+| Source pattern | Target pattern |
+|---|---|
+| `@tool` plain function | `@agent.tool_plain` or `Tool(fn)` |
+| tool with `ToolRuntime` | `@agent.tool` with first parameter `RunContext[Deps]` |
+| `BaseTool` subclass | Prefer a normal typed function; use `Tool` or `Tool.from_schema` only when dynamic schema is necessary. |
+| toolkit | `FunctionToolset`, another `AbstractToolset`, or a focused capability |
+| MCP adapter | Pydantic AI MCP toolset or `MCP` capability |
+| tools filtered by user/state | tool `prepare=...`, `PrepareTools`, a wrapper toolset, or capability loading |
+| runtime-discovered large catalog | deferred tools/tool search; avoid rebuilding the schema every turn |
+| tool retry middleware | `Hooks.on.tool_execute` or service-client retry for same-handler local retry; `ModelRetry`, tool `retries=...`, validators, and transport retry remain separate domains |
+| approval middleware | `DeferredToolRequests` and `DeferredToolResults` |
+| tool artifacts | `ToolReturn` with distinct model content, return value, and metadata |
+
+Preserve tool name, description, JSON schema, concurrency, idempotency, timeout, retry, approval, auth, and error-to-model semantics. A successful wrapper import does not prove tool parity.
+
+## Structured output
+
+| LangChain | Pydantic AI |
+|---|---|
+| `response_format=Schema` | `output_type=Schema`, but select the output transport explicitly when parity matters |
+| provider strategy | `NativeOutput(Schema)` when native enforcement is required |
+| tool strategy | `ToolOutput(Schema)`; this is the portable default for Pydantic models |
+| manual parser / non-JSON text | `TextOutput(parser)` |
+| dynamic JSON schema | `StructuredDict(schema, name=...)` |
+| retry after invalid response | output validation and `ModelRetry` / configured retries |
+
+Do not include `str` in a union when the run must end with structured output; plain text would be a valid terminal result.
+
+LangChain may auto-select provider-native structured output for a bare schema. A bare Pydantic AI structured `output_type` defaults to tool output. Use `NativeOutput`, `ToolOutput`, `PromptedOutput`, or `TextOutput` deliberately and characterize the chosen provider/model.
+
+## Middleware and lifecycle
+
+Map each middleware by the behavior it owns:
+
+| LangChain middleware behavior | Pydantic AI target |
+|---|---|
+| dynamic system prompt | dynamic `@agent.instructions` |
+| before/after model or tool | `Hooks` lifecycle hook; wrapper decorators include `on.model_request` and `on.tool_execute` |
+| reusable prompt + tools + hooks + settings | custom `AbstractCapability` |
+| trim/summarize messages | `ProcessHistory` with an explicitly tested summary and pairing policy |
+| filter/rename tool definitions | tool `prepare`, `PrepareTools`, or wrapper toolset |
+| validate tool arguments | `args_validator` or tool-validation hook |
+| dynamic model selection/fallback | model instance/wrapper such as `FallbackModel`, or select the model at the app boundary |
+| model call limit | `UsageLimits` and explicit application limits |
+| tool error conversion | catch the expected exception in the tool and raise `ModelRetry` only for model-correctable failures |
+| logging/tracing | Logfire instrumentation or hooks for application metrics |
+| guardrail | input/output validation hook; keep authorization inside tools/services |
+| inject a mid-run user message | `RunContext.enqueue` or `AgentRun.enqueue` |
+
+Reproduce hook ordering explicitly. Combining several source middleware objects into one opaque hook makes parity harder to inspect and test.
+
+## State, memory, and persistence
+
+Separate four concepts that LangGraph often stores together:
+
+1. **Run dependencies:** immutable or service-like values used during one run -> `deps_type` and `RunContext.deps`.
+2. **Conversation messages:** model request/response history -> persist serialized Pydantic AI messages and pass `message_history`.
+3. **Workflow state:** plan, counters, fan-out results, approvals, domain progress -> typed application state or `pydantic_graph` state.
+4. **Long-term memory:** cross-thread facts -> an explicit repository/service in dependencies.
+
+| LangGraph feature | Migration choice |
+|---|---|
+| `MessagesState` | Pydantic AI message history plus separately typed workflow state |
+| custom reducers | plain update functions or `pydantic_graph` joins/reducers |
+| checkpointer/thread | application persistence or a durable execution integration |
+| store | explicit storage service in typed dependencies |
+| time travel/fork | durable workflow-specific implementation; do not infer this from message history |
+| `interrupt()` for missing user input | application-owned pending conversational state and resume |
+| `interrupt()` or HITL around a protected tool | deferred tool request plus authenticated, durable application correlation and resume |
+| replay after failure | Temporal, DBOS, Prefect, Restate, or another explicit durable boundary |
+
+Never label a migration complete because chat messages survive if the old system also promised checkpoint replay, pending writes, thread forks, or exactly-once side-effect protection.
+
+Pydantic AI may repair dangling tool calls and orphaned tool results before the model request, while LangGraph `add_messages` merges by message ID. Compare the actual model-visible history when converting stored threads.
+
+## Graphs and multi-agent systems
+
+Choose by topology:
+
+- Use one Pydantic AI `Agent` for a normal model/tool loop.
+- Use plain async Python for a fixed sequence, bounded loop, or `asyncio.gather` fan-out.
+- Use delegation via tools when a parent agent remains in control and consumes child output.
+- Use programmatic hand-off when application code chooses the next specialist.
+- Use `pydantic_graph` when explicit typed nodes, branches, joins, or inspectable workflow state add value.
+- Use parent tools that call typed child agents for model-selected delegation; define child history, dependencies, usage, result, and failure propagation explicitly.
+- Add a durable execution integration when the workflow must survive process failure; a graph alone is not durability.
+
+Translate `Command(goto=..., update=...)` into an explicit next-node value plus a typed state update. Preserve fan-out limits, cancellation, exception aggregation, and ordering when translating LangGraph `Send` or parallel branches. For Pydantic Graph fan-out, return branch-local results, carry a source index through the join when order matters, and use `ReducerContext.cancel_sibling_tasks()` only when early completion is the intended reducer contract.
+
+## Streaming, testing, and observability
+
+| LangChain ecosystem | Pydantic ecosystem |
+|---|---|
+| `stream` / `astream` values, updates, messages | `run_stream`, `run_stream_events`, `event_stream_handler`, or `iter` |
+| fake chat models | `TestModel` or `FunctionModel` under `agent.override(...)` |
+| trajectory/eval datasets | `pydantic_evals` cases, datasets, and evaluators |
+| LangSmith traces | Pydantic AI Logfire instrumentation and application-owned OpenTelemetry spans; LangSmith can export source traces to the same backend for comparison |
+| graph state inspection | typed state plus application persistence/graph inspection |
+
+Define an application-owned event schema at the UI/API boundary. Adapt both implementations to it during migration; do not make clients depend directly on either framework's event classes.
+
+Use Logfire to inspect model calls, tools, retries, errors, usage, and timing, then prove public contracts with executable tests. In particular, model time to first chunk is not client time to first event. See [Logfire-Assisted Migration Verification](LOGFIRE-VERIFICATION.md).
+
+Do not substitute `run_stream()` for `run()` without a separate trajectory test. `run_stream()` commits the first matching output as it streams; co-emitted tools and retries can therefore produce a different terminal result from a complete `run()`.
+
+## Transitional bridges
+
+Pydantic AI can wrap LangChain tools:
+
+```python {noqa="F821"}
+# ruff: noqa: F821
+from pydantic_ai import Agent
+from pydantic_ai.ext.langchain import LangChainToolset, tool_from_langchain
+
+single_tool = tool_from_langchain(existing_langchain_tool)
+toolset = LangChainToolset(existing_toolkit.get_tools())
+
+agent = Agent('provider:model', tools=[single_tool], toolsets=[toolset])
+```
+
+Use this only to create a vertical slice while tool internals are ported. The wrapper delegates argument validation to the LangChain tool, retains LangChain dependencies, and can conceal framework-specific callbacks or runtime assumptions. Add a removal issue and a parity test for every bridge.
+
+Audit LangChain-only flags such as `return_direct`: the wrapper invokes the tool but does not automatically preserve the source agent's stop-after-tool routing. When the call is a model-selected terminal action, represent it as a named output function with `ToolOutput` and prove one execution plus the source model-call count.
+
+Keep an existing retriever or LCEL pipeline behind a narrow tool/service interface if rewriting it would block agent migration. Port it later when the agent boundary is stable.
+
+## Migration traps
+
+- Translating `state_schema` to `deps_type` and then mutating dependencies as workflow state.
+- Passing authenticated identity, tenant, or credentials as model-chosen tool parameters.
+- Treating all middleware as hooks even when behavior belongs in a tool or model wrapper.
+- Reusing LangChain message objects in Pydantic AI history.
+- Moving deterministic branches into prompts to avoid learning `pydantic_graph`.
+- Replacing checkpointers with an in-memory message list.
+- Keeping both observability SDKs without defining trace ownership and correlation.
+- Testing only final text while tool trajectory, approval, and side effects changed.
+
+Primary references: [Pydantic AI agents](https://pydantic.dev/docs/ai/core-concepts/agent/), [tools](https://pydantic.dev/docs/ai/tools-toolsets/tools/), [hooks](https://pydantic.dev/docs/ai/core-concepts/hooks/), [third-party tools](https://pydantic.dev/docs/ai/tools-toolsets/third-party-tools/), [multi-agent patterns](https://pydantic.dev/docs/ai/guides/multi-agent-applications/), and [durable execution](https://pydantic.dev/docs/ai/integrations/durable_execution/overview/).

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/CONCEPT-MAPPING.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/CONCEPT-MAPPING.md
@@ -116,14 +116,14 @@ Preserve tool name, description, JSON schema, concurrency, idempotency, timeout,
 |---|---|
 | `response_format=Schema` | `output_type=Schema`, but select the output transport explicitly when parity matters |
 | provider strategy | `NativeOutput(Schema)` when native enforcement is required |
-| tool strategy | `ToolOutput(Schema)`; this is the portable default for Pydantic models |
+| tool strategy | `ToolOutput(Schema)` when tool transport is required |
 | manual parser / non-JSON text | `TextOutput(parser)` |
 | dynamic JSON schema | `StructuredDict(schema, name=...)` |
 | retry after invalid response | output validation and `ModelRetry` / configured retries |
 
 Do not include `str` in a union when the run must end with structured output; plain text would be a valid terminal result.
 
-LangChain may auto-select provider-native structured output for a bare schema. A bare Pydantic AI structured `output_type` defaults to tool output. Use `NativeOutput`, `ToolOutput`, `PromptedOutput`, or `TextOutput` deliberately and characterize the chosen provider/model.
+LangChain may auto-select provider-native structured output for a bare schema. A bare Pydantic AI structured `output_type` follows the selected model profile's default, which may be tool, native, or prompted output. Use `NativeOutput`, `ToolOutput`, `PromptedOutput`, or `TextOutput` explicitly when wire behavior matters, and characterize the chosen provider/model.
 
 ## Middleware and lifecycle
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/LOGFIRE-VERIFICATION.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/LOGFIRE-VERIFICATION.md
@@ -1,0 +1,113 @@
+# Logfire-Assisted Migration Verification
+
+Use Logfire to expose what the migrated Pydantic AI application actually did. Treat it as diagnostic and corroborating evidence, not as proof that two frameworks have identical semantics.
+
+## Contents
+
+- [Choose with the user](#choose-with-the-user)
+- [Instrument deliberately](#instrument-deliberately)
+- [Compare source and target runs](#compare-source-and-target-runs)
+- [Observe streaming at both boundaries](#observe-streaming-at-both-boundaries)
+- [Protect sensitive content](#protect-sensitive-content)
+- [Test without exporting](#test-without-exporting)
+- [Know what traces cannot prove](#know-what-traces-cannot-prove)
+
+## Choose with the user
+
+When the source already has observability, present the decision before changing it. Recommend Logfire as the first-party Pydantic AI experience, but do not treat that recommendation as authorization to replace an established system.
+
+| Choice | When it fits | Cost or residual |
+|---|---|---|
+| retain the existing system | continuity and a narrow agent-runtime migration matter most | prove that nested Pydantic AI model/tool lifecycles remain visible; an outer framework span is insufficient |
+| add Logfire temporarily alongside it | sanitized shadow comparison or migration debugging justifies dual telemetry | duplicate export, privacy, sampling, cost, and trace-correlation concerns; set a removal condition |
+| switch to Logfire | the user wants native Pydantic AI instrumentation and accepts an observability migration | migrate or retire dashboards, alerts, evaluations, trace ingestion, retention/privacy controls, credentials, and operational documentation |
+
+Explain which option you recommend, why it fits the application, what will change for operators, and what remains unverified. If observability was not placed in scope, retain it and offer the recommendation rather than expanding the migration.
+
+## Instrument deliberately
+
+Configure Logfire during application startup, before constructing or running agents, and install Pydantic AI instrumentation once:
+
+```python
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic_ai(
+    include_content=False,
+    include_binary_content=False,
+)
+```
+
+Name reusable agents so their runs are distinguishable. Instrument a specific agent instead of all agents when the application has a narrower trace or privacy boundary. Inspect the installed `logfire` and `pydantic_ai` versions before passing instrumentation settings: telemetry data-format versions evolve independently of the Pydantic AI package, and their event roles and attributes can differ.
+
+The default instrumentation can expose agent runs, model requests, tool calls, retries, errors, token usage, and timing. Add small application spans around boundaries that Pydantic AI does not own, such as retrieval, persistence, queues, approval records, public streaming, and external writes. Reuse the application's request, thread, tenant, and idempotency correlation identifiers as safe attributes; do not put secrets in them.
+
+Inventory the source model/tool callback lifecycle and application metrics before replacing it. Keeping a LangSmith, Langfuse, or other callback on an outer LangGraph node does not automatically instrument a nested Pydantic AI call. Preserve the existing model/tool observations through a tested adapter or make an explicit observability change; verify success, token, completion, and error paths plus parent correlation.
+
+Do not add one span per token. Prefer a bounded set of spans and metrics: first event, terminal event, event counts, queue delay, cancellation, and failure.
+
+## Compare source and target runs
+
+During a shadow or replay comparison:
+
+1. Run the same sanitized input, dependencies, model settings, and deterministic fixtures through the source and target behind the same application boundary.
+2. Send both traces to the same OpenTelemetry backend when practical. LangChain and LangGraph can export LangSmith OpenTelemetry traces to Logfire; set `LANGSMITH_OTEL_ENABLED=true` and `LANGSMITH_TRACING=true` before importing those frameworks. Set `LANGSMITH_OTEL_ONLY=true` only when intentionally sending exclusively through OpenTelemetry rather than also retaining LangSmith export. Keep source and target trace namespaces distinct.
+3. Normalize comparable facts instead of diffing raw spans. Compare model-request count, tool calls and their causal relationships, safe arguments and results, retries, errors, usage, latency, model-visible messages when allowed, and application boundary events. Use application sequence IDs or executable assertions—not raw span arrival order—when tool order is a contract.
+4. Investigate every unexplained difference. A trace that merely looks similar is not equivalence evidence.
+5. Link a validated claim to the executable test that establishes it and use the trace to explain the trajectory.
+
+Do not dual-run side-effectful agents unless tools are dry-run, sandboxed, or protected by durable idempotency keys. Observing a single write does not prove exactly-once behavior.
+
+## Observe streaming at both boundaries
+
+Keep these measurements separate:
+
+- **Instrumented model-call boundary:** Pydantic AI can record the time from issuing the streaming request until the wrapped response surfaces its first chunk. This includes transport and client-SDK behavior; it is not provider-internal timing.
+- **Application boundary:** measure when the API, SSE, or WebSocket consumer receives its first public event and its terminal event.
+
+Model time to first chunk does not prove client time to first event. A service can buffer an entire agent run after the model begins streaming. Test the public client contract for:
+
+- exact event schema and order;
+- incremental delivery rather than post-run buffering;
+- tool, retry, partial-output, final-result, and terminal-error events that the source exposes;
+- correlation identifiers and usage placement;
+- disconnect and cancellation propagation;
+- backpressure and bounded buffering;
+- reconnect or resume behavior, when promised;
+- cleanup and late producer errors after an early consumer exit.
+
+Choose the Pydantic AI streaming API from the required lifecycle. `run_stream()` may stop at the first matching final output. Use `run(event_stream_handler=...)`, `run_stream_events()`, or `iter()` when the contract requires complete tool execution or lower-level event control. When handling raw events, assemble both initial part events and later deltas. A Logfire trace can reveal the resulting trajectory, but only a real client test proves delivery behavior.
+
+## Protect sensitive content
+
+Pydantic AI instrumentation includes prompts, completions, tool arguments, and tool results by default. That data may contain personal, proprietary, credential, or tenant information.
+
+- Prefer `InstrumentationSettings(include_content=False)` when raw content is unnecessary or unsafe. Structural telemetry remains useful.
+- Do not assume generic scrubbing makes LLM content safe. Logfire deliberately does not apply generic regex scrubbing to free-form LLM message attributes because it would be both noisy and incomplete. Define organization-specific controls and retention rules before enabling content capture.
+- Avoid full HTTPX header/body capture as a default. It is a temporary diagnostic escalation that can expose provider authorization and raw payloads; Bedrock and other non-HTTPX transports need separate treatment.
+- Sanitize shadow inputs and comparison attributes. Keep authenticated identity and secrets out of model-visible content and trace attributes.
+
+State the privacy choice and its consequence: with content disabled, traces cannot substantiate prompt, argument, or output equivalence.
+
+## Test without exporting
+
+Use Logfire's in-memory test exporter or Pytest `capfire` fixture to assert a small stable set of spans and attributes without sending telemetry to a remote project. Test that important application spans correlate with the agent run and that failures/cancellation are observable. Avoid full raw-trace snapshots as the only assertion; telemetry schemas change and raw traces include incidental data.
+
+For short-lived commands, workers, or tests, flush telemetry at shutdown rather than on every request. Sampling can omit spans. SDK tail sampling is process-local and can fragment a distributed trace; use collector-side tail sampling when the entire distributed trace must share a decision. Never use sampled production traces as exhaustive parity evidence.
+
+Instrument every service participating in the tested path and verify trace-context propagation across HTTP, queues, workers, and detached tasks. An application-created background task can outlive its request span or lose its parent; retain a safe business correlation ID and do not treat a broken trace tree as proof that work did not happen. Likewise, cancellation can leave incomplete telemetry, so resource and side-effect assertions remain authoritative.
+
+## Know what traces cannot prove
+
+Logfire can help demonstrate that an exercised run used the expected model, tools, retry path, observed token usage, and timing. It cannot by itself prove:
+
+- deterministic output equivalence from a nondeterministic model;
+- public streaming delivery, backpressure, reconnect, or cancellation;
+- checkpoint, fork, replay, or process-restart semantics;
+- authorization or tenant isolation;
+- exactly-once external side effects;
+- behavior that was not instrumented or was removed by sampling.
+
+Use deterministic characterization tests, provider integration tests, real clients, persistence/restart probes, database and side-effect assertions, and security tests for those claims. Report missing telemetry as missing evidence, not a passing result.
+
+Primary references: [Pydantic AI with Logfire](https://pydantic.dev/docs/logfire/integrations/llms/pydanticai/), [Pydantic AI instrumentation settings](https://pydantic.dev/docs/ai/api/models/instrumented/), [LangChain and LangGraph with Logfire](https://pydantic.dev/docs/logfire/integrations/llms/langchain/), [Pydantic AI streaming](https://pydantic.dev/docs/ai/core-concepts/agent/#streaming), [Logfire scrubbing](https://pydantic.dev/docs/logfire/instrument/scrubbing/), [Logfire sampling](https://pydantic.dev/docs/logfire/instrument/sampling/), and [Logfire testing](https://pydantic.dev/docs/logfire/reference/testing/).

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/SEMANTIC-GAPS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/SEMANTIC-GAPS.md
@@ -91,7 +91,7 @@ Sync Pydantic AI tools may run in worker threads while async tools run on the ev
 The same schema type does not imply the same wire strategy:
 
 - LangChain may automatically choose `ProviderStrategy` when the selected model supports provider-native structured output, otherwise `ToolStrategy`.
-- Pydantic AI uses tool output for a plain structured `output_type` by default. Select `NativeOutput`, `ToolOutput`, `PromptedOutput`, or `TextOutput` deliberately when wire behavior matters.
+- Pydantic AI resolves a plain structured `output_type` through the selected model profile's default, which may be tool, native, or prompted output. Select `NativeOutput`, `ToolOutput`, `PromptedOutput`, or `TextOutput` explicitly when wire behavior matters.
 - LangChain returns structured output in agent state (commonly `structured_response`); Pydantic AI returns `result.output`. Preserve the application's public result DTO instead of exposing either shape.
 - Pydantic AI unions that include `str` permit plain text to end the run. Exclude it when structured output is mandatory.
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/SEMANTIC-GAPS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/SEMANTIC-GAPS.md
@@ -25,7 +25,7 @@ For a checkpointed, side-effectful, approval-gated, or otherwise high-risk slice
 
 Classify each observed contract with the evidence statuses in [Verification and Cutover](VERIFICATION-AND-CUTOVER.md): `verified-equivalent`, `verified-adapter`, `intentional-change`, `external-owner`, `not-applicable`, `unverified`, or `blocked`. A promising native API remains `unverified` until its parity probe passes. A source behavior may be non-equivalent internally while a tested adapter earns `verified-adapter` at the public boundary.
 
-Never use “native” to mean “the names look similar.” Do not leave `redesign` as the proposed solution: follow the affected row into [Validated Workaround Recipes](WORKAROUND-RECIPES.md), implement the smallest viable construction, and classify the resulting contract. Record installed versions and link each verified claim to an executable test; use traces, source lines, and official documentation as supporting evidence.
+Never use "native" to mean "the names look similar." Do not leave `redesign` as the proposed solution: follow the affected row into [Validated Workaround Recipes](WORKAROUND-RECIPES.md), implement the smallest viable construction, and classify the resulting contract. Record installed versions and link each verified claim to an executable test; use traces, source lines, and official documentation as supporting evidence.
 
 ## Prompts and message history
 
@@ -37,7 +37,7 @@ Current LangChain `create_agent` keeps its request system message outside graph 
 - Dynamic `@agent.instructions` functions are reevaluated for every run, including a run with `message_history`.
 - Pydantic AI `system_prompt` is the historical-prompt mechanism. With non-empty history, a new system prompt is not generated unless the chosen reinjection behavior does so.
 
-Do not mechanically replace every LangChain prompt with `instructions` or use Pydantic AI `system_prompt` merely because the source used the phrase “system prompt.” Choose from observed model-boundary behavior:
+Do not mechanically replace every LangChain prompt with `instructions` or use Pydantic AI `system_prompt` merely because the source used the phrase "system prompt." Choose from observed model-boundary behavior:
 
 | Required behavior | Pydantic AI choice |
 |---|---|

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/SEMANTIC-GAPS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/SEMANTIC-GAPS.md
@@ -1,0 +1,234 @@
+# Semantic Gaps and Parity Spikes
+
+Use this reference when the source path has stateful, operational, or version-sensitive behavior whose target semantics are uncertain. A migration is safe only when each observed source guarantee is preserved, intentionally changed, or assigned to an explicit external owner.
+
+## Contents
+
+- [Build a semantic-gap register](#build-a-semantic-gap-register)
+- [Prompts and message history](#prompts-and-message-history)
+- [Tools, context, and schemas](#tools-context-and-schemas)
+- [Structured output and run termination](#structured-output-and-run-termination)
+- [State, checkpoints, and approval](#state-checkpoints-and-approval)
+- [Middleware, retries, and limits](#middleware-retries-and-limits)
+- [Streaming and event contracts](#streaming-and-event-contracts)
+- [Concurrency and cancellation](#concurrency-and-cancellation)
+- [Spike protocol](#spike-protocol)
+- [Primary references](#primary-references)
+
+## Build a semantic-gap register
+
+For a checkpointed, side-effectful, approval-gated, or otherwise high-risk slice, write this before target code. A simple stateless port can record the few applicable residuals alongside its tests instead:
+
+| Source guarantee | Observed target behavior | Pydantic workaround | Outcome | Required probe | Residual / owner |
+|---|---|---|---|---|---|
+| checkpoint resumes after approval | deferred results start another agent run | deferred requests plus an authenticated durable pending-action record | `unverified` | crash before/after result persistence | selected workflow store / application workflow |
+
+Classify each observed contract with the evidence statuses in [Verification and Cutover](VERIFICATION-AND-CUTOVER.md): `verified-equivalent`, `verified-adapter`, `intentional-change`, `external-owner`, `not-applicable`, `unverified`, or `blocked`. A promising native API remains `unverified` until its parity probe passes. A source behavior may be non-equivalent internally while a tested adapter earns `verified-adapter` at the public boundary.
+
+Never use “native” to mean “the names look similar.” Do not leave `redesign` as the proposed solution: follow the affected row into [Validated Workaround Recipes](WORKAROUND-RECIPES.md), implement the smallest viable construction, and classify the resulting contract. Record installed versions and link each verified claim to an executable test; use traces, source lines, and official documentation as supporting evidence.
+
+## Prompts and message history
+
+### Current instructions versus historical prompts
+
+Current LangChain `create_agent` keeps its request system message outside graph state and prepends it at the model boundary; dynamic prompt middleware replaces that request field rather than checkpointing a `SystemMessage`. Custom or legacy graphs may instead store explicit system messages, so inspect the source and capture the actual model request. Pydantic AI distinguishes `instructions` from `system_prompt`:
+
+- Current Pydantic AI `instructions` are sent for the current agent. Instructions stored on historical `ModelRequest` objects are not model-visible instructions on the next run.
+- Dynamic `@agent.instructions` functions are reevaluated for every run, including a run with `message_history`.
+- Pydantic AI `system_prompt` is the historical-prompt mechanism. With non-empty history, a new system prompt is not generated unless the chosen reinjection behavior does so.
+
+Do not mechanically replace every LangChain prompt with `instructions` or use Pydantic AI `system_prompt` merely because the source used the phrase “system prompt.” Choose from observed model-boundary behavior:
+
+| Required behavior | Pydantic AI choice |
+|---|---|
+| only the current agent's policy applies | `instructions` |
+| historical prompts from earlier runs/agents remain authoritative | `system_prompt` plus tested history round-trip |
+| UI/database history may omit the system prompt | sanitize history, then consider `ReinjectSystemPrompt` |
+| per-request locale, tenant policy, or feature state | dynamic `instructions` from typed dependencies |
+
+Probe the actual model boundary with `FunctionModel` and `AgentInfo.instructions`; inspecting serialized history alone is misleading because old request objects can still contain their original `instructions` field.
+
+Multiple dynamic prompts also compose differently. LangChain `dynamic_prompt` middleware replaces the request's system message, and wrap middleware nests, so a later replacement can overwrite an earlier one. Pydantic AI composes registered instructions and orders stable static instructions before dynamic instructions. If the source has more than one prompt-mutating middleware, capture the exact final prompt and evaluation count; do not convert each entry to `@agent.instructions` and assume the concatenation is equivalent. When replacement is intentional, ordered `Hooks.on.before_model_request` processors can replace the latest request instructions; scrub those request-only instructions before persisting history if the source does not checkpoint them. Spike two dependency values and a continuation before adopting this adapter.
+
+### Message conversion is a protocol migration
+
+LangChain messages and Pydantic AI messages differ in tool-call IDs, tool-return pairing, reasoning/provider metadata, multimodal parts, timestamps, and serialization. Do not cast or rename them in place.
+
+Define and test a converter only when history must be retained. Include:
+
+- normal user/assistant turns;
+- multiple parallel tool calls and out-of-order returns;
+- interrupted or partially answered tool calls;
+- provider reasoning/signature metadata that must round-trip;
+- malformed or untrusted browser history;
+- branch/fork conversation identity.
+
+Pydantic AI can repair model history before a request, including dangling tool calls and orphaned tool results. LangGraph's `add_messages` instead merges messages by ID. Feed malformed and partially completed histories through both implementations and compare the actual fake-model input, not only stored JSON.
+
+Prefer an application-owned conversation DTO at public boundaries. Keep provider/framework messages inside adapters.
+
+## Tools, context, and schemas
+
+`ToolRuntime.context` and `RunContext.deps` both inject runtime values, but parity depends on what the model can choose. Keep authenticated identity, credentials, clients, idempotency services, and policy evaluators out of the tool schema.
+
+For every tool, diff the model-visible definitions from both implementations:
+
+- name and description;
+- parameter names, required fields, defaults, enums, nullability, and additional properties;
+- injected parameters excluded from JSON schema;
+- return content visible to the model versus application metadata;
+- validation error text and whether it is retried;
+- timeout, cancellation, idempotency, and side effects.
+
+Pydantic AI's LangChain wrappers are transitional: LangChain retains argument validation and framework dependencies. A wrapped tool is not proof of native parity.
+
+Audit source-only control flags before wrapping. For example, LangChain `return_direct=True` can end its agent immediately after the tool, while `tool_from_langchain` delegates the call without preserving that stop policy. If the model selects the call as a terminal action, make the callable a named output function with `ToolOutput`; a parity spike must prove the terminal value, one execution, and model-call count. This changes the callable from an ordinary optional tool into an output choice, so retain multiple output choices when the source has other terminal routes.
+
+Sync Pydantic AI tools may run in worker threads while async tools run on the event loop. Test context propagation, cancellation, thread safety, and resource lifetimes when source tools relied on thread-local callbacks or event-loop affinity.
+
+## Structured output and run termination
+
+The same schema type does not imply the same wire strategy:
+
+- LangChain may automatically choose `ProviderStrategy` when the selected model supports provider-native structured output, otherwise `ToolStrategy`.
+- Pydantic AI uses tool output for a plain structured `output_type` by default. Select `NativeOutput`, `ToolOutput`, `PromptedOutput`, or `TextOutput` deliberately when wire behavior matters.
+- LangChain returns structured output in agent state (commonly `structured_response`); Pydantic AI returns `result.output`. Preserve the application's public result DTO instead of exposing either shape.
+- Pydantic AI unions that include `str` permit plain text to end the run. Exclude it when structured output is mandatory.
+
+Characterize invalid schema retries, multiple output candidates, provider fallback, and a response that emits terminal output alongside function tools.
+
+### `run()` and `run_stream()` are not interchangeable
+
+Pydantic AI `run()` completes the agent graph. `run_stream()` commits the first matching streamed output immediately. When a response co-emits structured output and a function tool, this can change the final result even if the agent uses the same `end_strategy`.
+
+A verified probe should make the co-emitted function tool raise `ModelRetry`:
+
+- under `run()` with the default graceful strategy, the first output is rejected and the corrected later output wins;
+- under `run_stream()`, the first matching output is already committed, so retry-after-tool-failure cannot replace it.
+
+Use `run(event_stream_handler=...)`, `run_stream_events()`, or `iter()` when the application needs complete agent execution plus events. Test the chosen method; do not infer parity from `run()` tests.
+
+## State, checkpoints, and approval
+
+Split source state into four contracts:
+
+1. run dependencies: typed services and immutable request context;
+2. conversation: model messages;
+3. workflow state: counters, plans, joins, pending actions, and domain progress;
+4. long-term memory: cross-thread facts and retrieval indexes.
+
+A LangGraph checkpointer stores graph state at super-step boundaries and may retain task-level pending writes, next nodes, checkpoint ancestry, namespaces, and thread identity. It supports behaviors such as fault recovery, history, replay, and fork. Pydantic AI `message_history` supplies model context; it does not provide those workflow guarantees.
+
+### Interrupt and approval semantics differ
+
+LangGraph resume restarts the interrupted node from its beginning. Code before `interrupt()` runs again; multiple interrupts are matched by position. Keep pre-interrupt effects idempotent or move them after the interrupt/separate node.
+
+When an interrupt merely asks for missing user input, preserve it as conversational workflow state: persist the pending question and phase, then append the answer as user protocol content on resume. Do not introduce an approval protocol unless a protected effect actually needs authorization.
+
+For a protected-tool decision, Pydantic AI deferred approval ends or pauses at a tool-call boundary. An external resume supplies `DeferredToolResults` keyed by tool-call ID together with the original history. Pydantic AI does not automatically persist the history, dependencies, authenticated principal, or application resume token. Approval is not an authorization boundary: never trust a browser/client-provided `DeferredToolResults` merely because its ID is well formed. Authenticate the reviewer and correlate the result server-side to an issued pending call, authorized principal/tenant, tool name, and approved original arguments or an explicitly authorized override.
+
+Map these details explicitly:
+
+| LangChain/LangGraph behavior | Migration decision |
+|---|---|
+| ordered decisions for an interrupt batch | persist and map each decision to a stable Pydantic tool-call ID |
+| approve, edit, reject, or respond | map approve/override/deny; design a result path for human `respond` behavior |
+| node restarts on resume | decide which pre-interrupt hooks/effects must rerun or must not rerun |
+| checkpointer owns thread resume | choose application/durable-workflow storage and atomic correlation |
+| replay may re-execute later nodes | retain idempotency keys and reconcile unknown-after-crash outcomes |
+
+Prove denial executes the protected tool zero times. Prove approval executes it exactly once with the original authenticated dependencies, correlation, and either the original arguments or a separately authorized override. Add crash injection before persistence, after persistence, before the side effect, and after an unknown side-effect outcome.
+Also forge an approval for another thread/tenant and an unknown or already-consumed tool-call ID; the server-side boundary must reject both before the agent or tool executes.
+
+## Middleware, retries, and limits
+
+LangChain middleware order is behavioral: before hooks run in list order, after hooks in reverse, and wrappers nest with the first middleware outermost. Middleware can update graph state, jump, short-circuit, or transform model/tool calls. A flat list of Pydantic AI hooks does not prove the same nesting.
+
+Trace exact order on success, validation failure, tool failure, interrupt, resume, cancellation, and terminal output. Decide whether behavior belongs in a hook, capability, toolset wrapper, model wrapper, output validator, tool body, or application boundary.
+
+Keep retry domains separate:
+
+| Source policy | Why it is not 1:1 | Likely owner |
+|---|---|---|
+| LangGraph node `RetryPolicy` | reruns a node after selected exceptions/backoff | workflow or service retry |
+| LangChain tool retry middleware | may turn tool errors into model-visible feedback | tool wrapper or `ModelRetry` only for model-correctable failures |
+| provider/transport retry | repeats network requests without asking the model to change | model/provider transport |
+| Pydantic AI output/tool retry | per-domain validation/model-correction budget | agent/tool/output configuration |
+
+`ModelRetry` tells the model to try differently; do not use it as a generic transient-network retry. A repeated tool invocation may duplicate a side effect.
+
+In particular, LangChain `ToolRetryMiddleware` can retry the same tool handler locally with the same request before returning to the model. Pydantic AI `@agent.tool(retries=N)` limits validation/`ModelRetry` feedback cycles that involve another model request. A direct translation can change model-call count, arguments, latency, and cost. Use a `Hooks.on.tool_execute` wrapper or service-client retry when the source guarantee is same-handler local retry; reserve `ModelRetry` for model-correctable failures. Spike a fail-once tool and count both model and tool calls.
+
+Likewise, LangGraph `recursion_limit`, LangChain model-call middleware limits, Pydantic AI `request_limit`, and `tool_calls_limit` count different units and may fail differently. LangChain limit middleware can track a persisted thread total and may end with a synthetic assistant message; Pydantic AI run limits raise `UsageLimitExceeded` and reset unless the caller supplies accumulated usage. One verified Pydantic AI behavior is batch-atomic enforcement: if a parallel tool-call batch would exceed `tool_calls_limit`, none of that batch executes. Test boundary values, repeat across a persisted thread, and report the failure shape plus the unit each limit protects.
+
+## Streaming and event contracts
+
+LangGraph stream modes can expose full state, state updates, model messages/tokens, custom events, checkpoints, tasks, and debug data. Pydantic AI exposes model-part, tool, deferred, node, and final-result events through different APIs. Neither event grammar is a public-contract replacement for the other.
+
+Define a versioned application event envelope with correlation, sequence, event kind, payload, and terminal/error semantics. Then adapt both implementations to it during shadowing. In Pydantic AI event streams, emit the public terminal event from `AgentRunResultEvent`, which represents completed execution, rather than treating an earlier output-selection event as completion.
+
+Probe:
+
+- ordering of token, tool-start, tool-result, approval, state-update, and final events;
+- whether final means model output chosen or all side effects completed;
+- cancellation and cleanup when the consumer disconnects;
+- reconnect/resume cursor behavior and duplicate delivery;
+- bounded buffering/backpressure for slow consumers;
+- event-loop responsiveness before the first model chunk: use a native async retrieval/tool path or offload blocking synchronous work, and probe that unrelated async work can still advance;
+- durable execution limitations, since some workflow integrations cannot stream in real time.
+
+## Concurrency and cancellation
+
+LangGraph parallel nodes execute within super-steps and merge through channel reducers. `Send` creates dynamic branches. Pydantic AI function tools are concurrent by default when the model emits multiple calls; `sequential=True` makes a tool a barrier, and a run-level execution mode can serialize tools.
+
+LangGraph rejects conflicting same-step writes when a channel has no suitable reducer; annotated reducers define combination. Pydantic Graph parallel tasks can share mutable state, so a mechanical state-port can turn a deterministic reducer or conflict into a race and lost update. Prefer branch-local results and an explicit typed join/reducer; do not use shared dependencies as a mutable state channel. Carry a source index when visible order matters, sort at the join, and use `ReducerContext.cancel_sibling_tasks()` when the reducer's contract ends remaining branch work.
+
+Also test concurrent requests for the same persisted thread. An optimistic version check at final save can prevent a lost-state overwrite while both requests have already paid for model calls or executed tools. Preserve source serialization where promised, or claim/reserve the thread before dispatch and make effects idempotent. Report a final-save conflict as duplicate-work protection only when an executable probe proves that earlier work did not repeat.
+
+Do not replace graph fan-out with default tool concurrency. Preserve:
+
+- maximum concurrency and rate limits;
+- deterministic result order versus completion order;
+- reducer/merge rules and duplicate keys;
+- sibling cancellation when one branch fails;
+- partial-result policy and retry scope;
+- event order separately from execution order;
+- side-effect isolation and compensation.
+
+Spike a slow-first/fast-second pair. Prove overlap when allowed, barrier order when required, failure cancellation, and externally visible event ordering.
+
+## Spike protocol
+
+Use `TestModel` for schema/registration checks and `FunctionModel` for exact trajectories. Disable live model requests. Keep each spike small enough to explain one semantic claim.
+
+1. Pin and print LangChain, LangGraph, and Pydantic AI versions.
+2. Build the smallest source reproduction and run it before translating.
+3. Capture model-visible instructions, tool definitions, messages, events, state/checkpoints, calls, and side effects.
+4. Build the smallest target reproduction using the proposed primitive.
+5. Feed both the same fixture and compare an application-owned trace.
+6. Add failure injection and boundary values, not only the success path.
+7. Promote the probe to a parity test or record why it is version-specific and temporary.
+
+At minimum, spike these when present:
+
+- two dynamic-instruction dependency values and a history continuation;
+- invalid and multiple structured outputs;
+- two source dynamic-prompt middleware entries versus composed Pydantic AI instructions;
+- output co-emitted with a successful and retrying tool under the chosen stream API;
+- a fail-once tool under LangChain retry middleware versus Pydantic AI retry feedback;
+- oversized parallel tool-call batch;
+- concurrent tools plus a sequential barrier;
+- interrupt/deny/approve with crash and replay injection;
+- same-step graph writes with and without a reducer;
+- malformed history containing dangling calls, orphan results, and duplicate message IDs;
+- a transitional `return_direct` tool and model-call count;
+- per-run and persisted-thread limit exhaustion plus failure shape;
+- middleware order across failure and resume;
+- fan-out failure/cancellation and reducer order;
+- event sequence plus consumer cancellation.
+
+## Primary references
+
+- LangChain: [middleware execution order](https://docs.langchain.com/oss/python/langchain/middleware/custom#execution-order), [structured output](https://docs.langchain.com/oss/python/langchain/structured-output), and [human-in-the-loop](https://docs.langchain.com/oss/python/langchain/human-in-the-loop)
+- LangGraph: [checkpointers](https://docs.langchain.com/oss/python/langgraph/checkpointers), [interrupts](https://docs.langchain.com/oss/python/langgraph/interrupts), [fault tolerance](https://docs.langchain.com/oss/python/langgraph/fault-tolerance), and [streaming](https://docs.langchain.com/oss/python/langgraph/streaming)
+- Pydantic AI: [instructions](https://pydantic.dev/docs/ai/core-concepts/agent/#instructions), [message history](https://pydantic.dev/docs/ai/core-concepts/message-history/), [structured output](https://pydantic.dev/docs/ai/output/), [parallel tools](https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/#parallel-tool-calls--concurrency), [deferred tools](https://pydantic.dev/docs/ai/tools-toolsets/deferred-tools/), and [streaming](https://pydantic.dev/docs/ai/core-concepts/agent/#streaming)

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/VERIFICATION-AND-CUTOVER.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/VERIFICATION-AND-CUTOVER.md
@@ -1,0 +1,142 @@
+# Verification and Cutover
+
+Use this reference before editing a production agent or declaring a migration complete.
+
+## Contents
+
+- [Characterize the old system](#characterize-the-old-system)
+- [Classify every claim](#classify-every-claim)
+- [Build the test pyramid](#build-the-test-pyramid)
+- [Verify operational semantics](#verify-operational-semantics)
+- [Cut over safely](#cut-over-safely)
+- [Completion checklist](#completion-checklist)
+
+## Characterize the old system
+
+Capture the applicable behavior at stable boundaries; do not invent requirements for features the source path does not use:
+
+- accepted request and context schema;
+- final output and error schema;
+- tool names, descriptions, argument schemas, visibility, and side effects;
+- dynamic prompt/tool/model selection;
+- middleware/hook order;
+- state fields and reducer behavior;
+- message, checkpoint, store, thread, interrupt, and replay semantics;
+- stream modes and client-visible events;
+- usage, iteration, concurrency, timeout, and retry limits;
+- auth, tenant, filesystem, shell, network, and secret boundaries;
+- traces, metrics, and eval dimensions;
+- deployment, queue, scheduler, and webhook contracts.
+
+Record at least one success trace and representative failure traces for the risks the selected path actually has.
+
+## Classify every claim
+
+Apply a status to each observed contract, not to the migration as a whole:
+
+| Status | Required evidence |
+|---|---|
+| `verified-equivalent` | Source and target preserve the same externally observable contract in executable checks against the target project's versions and boundaries. |
+| `verified-adapter` | Internal semantics differ, but an adapter preserves the public contract in executable checks. |
+| `intentional-change` | The difference and impact were explained and explicitly accepted by the user or owner. |
+| `external-owner` | A named application or infrastructure component preserves the contract, with evidence at that boundary. |
+| `not-applicable` | The observed source path does not provide or consume this behavior. |
+| `unverified` | The behavior was not exercised, the evidence is incomplete, or only a candidate design exists. Do not call it equivalent. |
+| `blocked` | A required contract has no acceptable proved construction. Do not cut over that slice. |
+
+Trace similarity, successful imports, matching class names, a happy-path demo, and an author-side spike are not sufficient for `verified-equivalent`. Link each verified status to its test or boundary assertion and report every `unverified`, `intentional-change`, and `blocked` item to the user.
+
+## Build the test pyramid
+
+### Deterministic unit tests
+
+- Test tools as ordinary functions/services, including authorization and idempotency.
+- Use `TestModel` for schema/tool registration checks.
+- Use `FunctionModel` when exact requests, tool calls, retry, or failure behavior matters.
+- Assert `ModelRequestParameters` or captured run messages when tool schema and instructions are part of the contract.
+- Run the repository's static checker across the migrated slice. When output inference loses a real union, parameterize `Agent[DepsT, OutputT]` explicitly rather than weakening the owned boundary to `Any`.
+- Round-trip persisted model messages and typed workflow records through their production serializer, and prove malformed records fail validation.
+- For dynamic instructions, test at least two dependency values and prove the emitted instructions change while secrets and authenticated identity remain absent from model-visible content.
+- Test both approval decisions: denial must not execute the protected tool; an approved resume must execute it exactly once with the original authenticated dependencies and correlation ID.
+- Test graph/application transitions without a live model.
+
+### Integration tests
+
+- Exercise each real provider family used in production with a minimal recorded or low-cost case.
+- Test MCP/server lifecycle and transport failure.
+- Test database, vector store, sandbox, filesystem, shell, queue, and webhook adapters at their real boundary.
+- Test streaming consumers against the application-owned event schema.
+- Test persistence across a real process restart when restart survival is promised.
+
+### Evals
+
+Port representative LangSmith or custom datasets to `pydantic_evals` without changing prompts or graders at the same time. Compare:
+
+- task success and output validity;
+- tool choice and trajectory constraints;
+- citation/evidence quality;
+- latency and time to first event;
+- model requests, tokens, and cost;
+- retry, failure, and escalation rates;
+- unsafe or unauthorized attempts.
+
+Do not require identical prose unless wording is a public contract. Require identical structured fields, safety boundaries, and side effects where they are contracts.
+
+## Verify operational semantics
+
+### Persistence and recovery
+
+When the source promises them, prove separately:
+
+- conversation continuation;
+- workflow-state restoration;
+- approval correlation and resume;
+- replay/fork behavior;
+- pending-write or idempotency behavior;
+- crash recovery during a model call, tool call, and external write.
+
+Pydantic AI message history proves only conversation continuity. Use a durable execution integration or application workflow persistence when the old system promised graph state, pending writes, replay/fork, effect deduplication, or process-restart recovery.
+
+### Concurrency and limits
+
+When the slice fans out, accepts concurrent requests for one thread, or shares limits, test caps, cancellation, timeout, rate-limit backoff, partial child failure, deterministic result aggregation, and duplicate work before persistence conflicts. Verify that parent and child agents do not silently receive separate unlimited budgets.
+
+### Security
+
+Test the security boundaries the slice exposes. Examples include cross-tenant access, path traversal for filesystem tools, SSRF for URL-fetching tools, secret exposure, and approval bypass. For deferred approval, forge a foreign, unknown, or already-consumed tool-call ID and reject it at an authenticated server-side correlation boundary. Enforce failures below the model layer.
+
+### Streaming
+
+Check the event behavior promised by the public stream: event order, relevant correlation IDs, partial text, final-result emission, and any documented reconnect, backpressure, or cancellation behavior. Prove incremental delivery with a real client; model-level time to first chunk does not detect application buffering. If synchronous request construction, retrieval, or tools can block the event loop, preserve any source worker/thread boundary or use a native async path. When responsiveness before the first chunk is an observed contract, test that unrelated event-loop work still advances; do not move thread-affine clients across threads blindly. `run_stream` may treat the first valid final output as terminal; use `run(event_stream_handler=...)`, `run_stream_events`, or `iter` when all tool events must complete. Test early consumer exit, cleanup, and late producer errors.
+
+### Observability
+
+If the source uses another observability system, explain the retain, temporary dual-export, and switch-to-Logfire choices before editing it. Recommend Logfire for its first-party Pydantic AI integration, but preserve the existing system unless the user accepts the wider operational migration. A switch includes dashboards, alerts, evaluations, trace ingestion, privacy/retention controls, credentials, and documentation—not only the runtime SDK. When the user chooses Logfire, configure it at application startup and make content capture an explicit privacy decision. An installed SDK or outer request/graph span does not prove that a nested Pydantic AI model call, tokens, errors, usage, or tool calls remain observable. Probe the active success and failure lifecycle at the model boundary, including parent correlation and existing application metrics. Compare normalized source and target facts rather than raw telemetry schemas. Sampling, missing instrumentation, and disabled content limit what a trace can substantiate. Follow [Logfire-Assisted Migration Verification](LOGFIRE-VERIFICATION.md); traces complement rather than replace contract tests.
+
+## Cut over safely
+
+1. Add a framework-neutral adapter and route whole runs by a stable flag.
+2. Shadow read-only traffic first. Redact sensitive data in comparison logs.
+3. Compare outputs, trajectories, limits, and traces automatically.
+4. Canary low-risk write traffic with idempotency keys and rollback controls.
+5. Increase traffic only after predefined quality, latency, cost, and safety thresholds hold.
+6. Stop new LangChain feature work in the migrated slice.
+7. Remove `tool_from_langchain`, `LangChainToolset`, message converters, and dual observability after the rollback window.
+8. Remove LangChain/LangGraph dependencies only after the strict inventory has no errors, a repository-wide text search is clean or explained, dependency and entrypoint graphs show no runtime use, notebooks/config/plugin registries have been checked, and the original runtime tests still pass.
+
+Avoid dual-running side-effectful agents unless tools are in dry-run mode or every external write is deduplicated.
+
+## Completion checklist
+
+- [ ] Every observed contract has an evidence-backed status; a low-risk slice may use a concise residual-risk note instead of a ledger.
+- [ ] Public request, response, error, and event contracts pass.
+- [ ] Tool schemas, authorization, side effects, retries, and approval pass.
+- [ ] State, history, persistence, resume, and recovery promises pass.
+- [ ] Streaming and cancellation pass with real clients.
+- [ ] Unit, integration, and eval thresholds pass.
+- [ ] When Logfire is enabled, its privacy settings are deliberate and traces correlate the applicable app, agent, model, tool, and subagent boundaries without being treated as sole parity proof.
+- [ ] No hidden LangChain callbacks, globals, messages, or `RunnableConfig` assumptions remain.
+- [ ] Transitional bridges have been removed or have owners and removal dates.
+- [ ] Dependency files and operational documentation match the new runtime.
+
+Primary references: [Pydantic AI testing](https://pydantic.dev/docs/ai/guides/testing/), [Pydantic Evals](https://pydantic.dev/docs/ai/evals/evals/), [Logfire integration](https://pydantic.dev/docs/ai/integrations/logfire/), and [durable execution](https://pydantic.dev/docs/ai/integrations/durable_execution/overview/).

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/WORKAROUND-RECIPES.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/WORKAROUND-RECIPES.md
@@ -1,0 +1,222 @@
+# Validated Workaround Recipes
+
+Use this reference after finding a non-1:1 mapping. The job is not complete until the gap has a working Pydantic AI construction, a parity probe, and a named owner—or is an explicit blocker.
+
+## Contents
+
+- [Required outcomes](#required-outcomes)
+- [Choose the replacement mechanism](#choose-the-replacement-mechanism)
+- [Prompt replacement and history](#prompt-replacement-and-history)
+- [Middleware and local tool retry](#middleware-and-local-tool-retry)
+- [Structured output and return-direct tools](#structured-output-and-return-direct-tools)
+- [Conversational interrupts, approval, and durable resume](#conversational-interrupts-approval-and-durable-resume)
+- [Workflow state, fan-out, and reducers](#workflow-state-fan-out-and-reducers)
+- [Streaming and event contracts](#streaming-and-event-contracts)
+- [Limits and persisted budgets](#limits-and-persisted-budgets)
+- [Evidence rules](#evidence-rules)
+
+## Required outcomes
+
+Assign every semantic-gap row one outcome:
+
+| Outcome | Meaning |
+|---|---|
+| `verified-equivalent` | A Pydantic AI primitive preserves the required public behavior in executable source/target checks. |
+| `verified-adapter` | Small application or capability code closes the gap, and executable checks prove the public contract. |
+| `intentional-change` | The semantic difference and impact were explained and explicitly accepted. |
+| `external-owner` | A named application or infrastructure component preserves the contract, with evidence at that boundary. |
+| `not-applicable` | The observed source path does not provide or consume this behavior. |
+| `unverified` | A candidate construction exists, but the target project/version or operational boundary has not passed its own parity test. |
+| `blocked` | No acceptable construction has passed. Do not migrate that slice. |
+
+Do not leave a row at “redesign” or “not 1:1.” Select the most native mechanism that can preserve the behavior, write the smallest source/target reproduction, and measure both. Keep spike code outside the product and skill; promote only stable contract tests.
+
+## Choose the replacement mechanism
+
+| Source behavior | First Pydantic AI construction to spike | Fallback owner |
+|---|---|---|
+| current developer policy | `instructions` or one dynamic `@agent.instructions` function | model-request hook |
+| replace-not-compose prompt middleware | ordered `Hooks.on.before_model_request` replacements | request adapter |
+| missing/untrusted historical system prompt | `ReinjectSystemPrompt(replace_existing=True)` | server history adapter |
+| before/after/wrap middleware | `Hooks`; use `on.model_request`, `on.tool_execute`, or another wrapper hook for nesting | custom `AbstractCapability` |
+| same-handler transient tool retry | `Hooks.on.tool_execute` or service-client retry | application service |
+| model-correctable tool arguments | `ModelRetry` / tool retry budget | agent |
+| provider-native structured response | `NativeOutput` | provider-specific adapter |
+| tool-based structured response | `ToolOutput` | output adapter |
+| `return_direct=True` | named output function wrapped in `ToolOutput` | explicit application route |
+| HITL tool approval | deferred tools plus authenticated pending-action store | durable workflow |
+| checkpoint/replay | `DBOSAgent`, `TemporalAgent`, `PrefectAgent`, Restate, Kitaru, or another selected durable runtime | application workflow |
+| graph state and reducers | typed application state or `pydantic_graph`; branch-local results plus explicit reducer | orchestration layer |
+| complete execution with events | `run(event_stream_handler=...)`, `run_stream_events()`, or `iter()` | event adapter |
+| per-run request/tool limits | `UsageLimits` and shared `RunUsage` | application budget service |
+| persisted thread/graph-step limits | per-thread serialization or transactional reservation plus settlement/reconciliation | workflow store |
+
+## Prompt replacement and history
+
+If the desired policy is composition, put all policy fragments in `instructions`. If the source truly uses last-replacement-wins behavior, reproduce that rather than accidentally strengthening or weakening the prompt.
+
+The simplest validated route is to collapse a last-replacement-wins source chain into one effective dynamic instruction function, provided overwritten prompt functions are pure and do not own required side effects. If evaluating every replacement is itself behavioral, ordered `before_model_request` hooks can replace the latest request instructions.
+
+Do not rely on a success-only `after_run` hook to clean request instructions: failed or cancelled runs bypass it. If the source does not checkpoint request prompts, omit boundary-only instruction fields in the application message serializer, or use a reversible run wrapper whose `finally` path is proved under success, failure, and cancellation. Probe at least two dependency values plus a continued conversation and compare both actual model input and persisted application history.
+
+For UI or database history that omits system prompts, use:
+
+```python {noqa="F821"}
+# ruff: noqa: F821
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ReinjectSystemPrompt
+
+agent = Agent(
+    model,
+    system_prompt='Authoritative server policy',
+    capabilities=[ReinjectSystemPrompt(replace_existing=True)],
+)
+```
+
+`replace_existing=True` is important for untrusted history: it removes client-supplied system prompts before adding the server policy. This solves prompt authority, not general message conversion. Keep a fail-closed converter for the exact LangChain message subset the application retains; reject tool, reasoning, multimodal, or provider metadata until their round-trip is tested.
+
+## Middleware and local tool retry
+
+Pydantic AI `Hooks` wrapper hooks preserve nested control flow and can short-circuit by returning a response without calling the handler. Register separate capabilities in source order and trace their exact before/after sequence. Current decorator names omit `wrap_`: use `@hooks.on.model_request` and `@hooks.on.tool_execute`.
+
+Use a tool-execution wrapper when LangChain retries the same handler locally. A validated shape is:
+
+```python {noqa="F821"}
+# ruff: noqa: F821
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import Hooks
+
+retry_hooks = Hooks()
+
+@retry_hooks.on.tool_execute(tools=['lookup'])
+async def retry_lookup(
+    ctx: RunContext,
+    *,
+    call,
+    tool_def,
+    args: dict[str, Any],
+    handler,
+) -> Any:
+    for attempt in range(2):
+        try:
+            return await handler(args)
+        except TransientServiceError:
+            if attempt == 1:
+                raise
+    raise AssertionError('unreachable')
+```
+
+This can match LangChain at two handler executions but only the original tool-request model round plus finalization. `ModelRetry` is deliberately different: it asks the model to issue a corrected call and therefore adds a model request. Add exception filtering, backoff, timeout, observability, exhaustion behavior, and idempotency appropriate to the service; never blindly retry side effects.
+
+Use a custom capability rather than a pile of hooks when a source middleware unit owns tools, instructions, settings, and lifecycle behavior together. Use a model wrapper for provider failover/transport policy, and application code for routing or persisted workflow-state jumps.
+
+## Structured output and return-direct tools
+
+Match the source transport explicitly:
+
+```python {noqa="F821"}
+# ruff: noqa: F821
+from pydantic_ai import Agent, NativeOutput, ToolOutput
+
+native_agent = Agent(model, output_type=NativeOutput(Answer))
+tool_agent = Agent(model, output_type=ToolOutput(Answer, name='Answer'))
+```
+
+A parity probe must inspect the model request: native mode has an output object and no output tool; tool mode exposes the named output tool. Also compare invalid-output retries, co-emitted function tools, final DTO, and provider fallback.
+
+When a LangChain tool uses `return_direct=True`, and the model must choose it as a terminal action, migrate it as an output function rather than a normal function tool:
+
+```python {lint="skip"}
+# ruff: noqa: F821, I001
+from pydantic_ai import Agent, RunContext, ToolOutput
+
+def export_report(ctx: RunContext[Deps], report_id: str) -> str:
+    return ctx.deps.reports.export(ctx.deps.customer_id, report_id)
+
+agent = Agent(
+    model,
+    deps_type=Deps,
+    output_type=ToolOutput(export_report, name='export_report'),
+)
+```
+
+A disposable skill-development spike on Pydantic AI `2.10.1.dev24` observed one output-function execution and one model call. Treat that as a candidate construction, not validation for the target project: rerun the source/target probe before assigning `verified-equivalent`. It changes the model contract from “optional ordinary tool” to “terminal output choice,” so use a union/list of output choices when other terminal outcomes exist. Output functions can run on partial values under `run_stream()`; guard side effects with `ctx.partial_output` or use a complete-execution API.
+
+## Conversational interrupts, approval, and durable resume
+
+First distinguish two different source contracts:
+
+- A **conversational interrupt** pauses a workflow to ask the user for missing information, then resumes from that answer. It is not authorization for a protected effect.
+- A **tool approval** binds an authenticated decision to a particular tool call and arguments before a protected effect runs.
+
+For a conversational interrupt, keep the pending question, workflow phase, authenticated owner, thread ID, and any completed pre-interrupt work in application state. Resume by loading that state and adding the answer as user protocol content, unless the source deliberately treats it as a control signal; putting the answer only in transient instructions can make it disappear from later conversation history. Do not re-run pre-interrupt model calls merely to reconstruct context. Reuse or extend the repository's configured persistence interface instead of silently introducing a local-only store. Preserve existing anonymous/optional identity behavior unless the application owner accepts a stronger identity contract. Test a fresh process/agent instance against the same store, same-thread correlation, cross-user rejection when identity exists, and whether the source repeats the interrupted node. If the source promises checkpoint forks, pending writes, or replay, a linear application record is only a bounded adapter and must say so.
+
+For protected-tool approval, use `requires_approval=True` or raise `ApprovalRequired`, then persist the returned `DeferredToolRequests`. The application record should include:
+
+- application approval ID and Pydantic tool-call ID;
+- authenticated tenant, initiator, and permitted approver;
+- tool name and original validated arguments;
+- serializable dependencies or stable references to reconstruct them;
+- complete server-owned message history;
+- pending/consuming/completed/manual-reconciliation status, result, claim owner, lease expiry, attempt count, and fencing/consumption version;
+- business idempotency key plus an authoritative effect receipt or reconciliation reference when the external system provides one.
+
+On resume, authenticate first and atomically claim a pending or safely expired `consuming` row with a bounded lease and new fencing version. Return the cached result for `completed`; report an unexpired claim as in progress. Before reclaiming an expired lease, reconcile the protected effect by idempotency key or authoritative receipt: finalize a known result, retry only when the effect is known not to have happened or the external API guarantees safe replay, and move an unknowable outcome to manual reconciliation instead of blindly rerunning it. Reconstruct the original history/dependencies and pass server-created `DeferredToolResults`; only the current fenced claimant may persist completion. Unknown, foreign, modified, or stale claims must fail before the agent or tool executes.
+
+A disposable SQLite development spike exercised this adapter across a fresh service instance, including foreign-principal rejection and a simulated crash after the tool. The tool was attempted twice after recovery but its unique business idempotency key produced one durable effect. This is design evidence, not target-project validation or a claim that arbitrary external APIs are exactly once; keep the outcome `unverified` until the selected store passes the same probe.
+
+For long waits and process recovery, put the loop in a durable runtime. Pydantic AI supplies wrappers such as `DBOSAgent`, `TemporalAgent`, and `PrefectAgent`; Restate and Kitaru also provide integrations. A disposable two-process DBOS development spike with a stable agent name and workflow ID returned the persisted first result without repeating the model call. This narrows the candidate design but does not change the target outcome from `unverified`. For DBOS, decorate non-deterministic or I/O tool functions with `@DBOS.step`; they are not automatically durable merely because the agent is wrapped.
+
+Run real process-kill/restart tests against the selected production backend after claim, before the effect, after an unknown effect outcome, and before completion persistence. Prove expired-lease recovery, stale-worker fencing, cached-result replay, and the manual-reconciliation path. Keep stable agent/toolset IDs, serializable dependencies, and explicit workflow signals/events for approval. Do not generalize DBOS evidence to Temporal, Prefect, Restate, Kitaru, or a different database.
+
+## Workflow state, fan-out, and reducers
+
+Keep model messages out of workflow state. Persist plans, next step, joins, pending actions, counters, and domain progress in a typed workflow record or durable runtime. Pass only model protocol history through `message_history`.
+
+For a fixed fan-out, create branch-local tasks and reduce after they finish. Preserve source ordering deliberately, for example by keeping the input index and sorting before the reducer. Use `asyncio.TaskGroup` when sibling cancellation on failure is required; use `gather(..., return_exceptions=True)` only when partial results are part of the contract. Put concurrency limits in a semaphore.
+
+Use `pydantic_graph` when the state machine itself needs typed, inspectable nodes and joins. It is not a checkpoint replacement: current graph APIs do not supply LangGraph-style built-in persistence. Wrap the workflow in a durable runtime or persist transitions in application code.
+
+For model-emitted function tools, Pydantic AI runs tools concurrently by default. Set `sequential=True` on a barrier tool, or use `with agent.parallel_tool_call_execution_mode('sequential')` for a whole run. These settings control tool execution; they do not reproduce LangGraph reducers or `Send` branch state.
+
+## Streaming and event contracts
+
+Do not expose framework events as the public API. Normalize source and target into an application envelope with version, run ID, sequence, correlation/tool-call ID, event kind, payload, and terminal/error semantics.
+
+Use `run_stream()` only when committing the first matching output is the intended contract. When all function tools, retries, and side effects must complete, use `run(event_stream_handler=...)`, `run_stream_events()`, or `iter()`, then emit the application terminal event from the completed `AgentRunResult`.
+
+When adapting `run_stream_events()` or `iter()` to an existing token stream, handle both the initial text carried by `PartStartEvent` and later text in `PartDeltaEvent`. A consumer that forwards only deltas silently drops the first chunk. Forward events as they arrive rather than collecting them until the run finishes when the source promises live streaming; event order with buffered delivery does not preserve time to first event, backpressure, or cancellation. Keep live event forwarding separate from final-result collection so the application can emit its terminal message from the completed run.
+
+Probe token/tool/final ordering, co-emitted output and tools, consumer cancellation, cleanup, backpressure, reconnect cursor, and duplicate delivery. Durable runtimes have different streaming constraints: validate the selected wrapper rather than assuming core-agent streaming behavior survives unchanged.
+
+## Limits and persisted budgets
+
+Use `UsageLimits` for Pydantic AI units and reuse one `RunUsage` object when several runs or child agents share a budget:
+
+```python {noqa="F704,F821"}
+# ruff: noqa: F704, F821
+from pydantic_ai import RunUsage, UsageLimits
+
+usage = RunUsage()
+limits = UsageLimits(request_limit=12, tool_calls_limit=20)
+result = await agent.run(prompt, usage=usage, usage_limits=limits)
+```
+
+This does not implement LangGraph `recursion_limit` or LangChain's persisted per-thread model-call counter. Keep a workflow-step counter and thread budget in the application store. For a strict shared budget, either serialize all work for one thread or reserve capacity transactionally before dispatch with compare-and-swap/row locking, then settle measured usage and reconcile abandoned reservations after crashes. A check-before-call followed by an update-after-call is not safe under concurrency or process failure. Preserve the source failure shape if callers depend on a synthetic terminal message rather than an exception.
+
+Test boundary minus one, boundary, and boundary plus one. Pydantic AI checks a parallel tool-call batch atomically against `tool_calls_limit`; prove whether the source instead allows a prefix. Include child-agent usage, replayed steps, and resumed runs.
+
+## Evidence rules
+
+Keep workaround spikes disposable and deterministic:
+
+1. Print versions, module origins, and the Pydantic AI checkout SHA.
+2. Use real LangChain/LangGraph and Pydantic AI APIs with fake/function models; do not mock the behavior under comparison.
+3. Count model calls, tool calls, side effects, persisted records, and events.
+4. Add failure and restart injection where the workaround owns retries, durability, or approval.
+5. State the narrow guarantee proved and what remains unproved.
+6. Delete the spike after extracting the recipe; add a stable product test for the public contract.
+
+Treat each construction as a candidate pattern, not proof for the target project. Re-run the relevant behavioral check against its installed versions.

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/WORKAROUND-RECIPES.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/migrating-langchain-to-pydantic-ai/references/WORKAROUND-RECIPES.md
@@ -29,7 +29,7 @@ Assign every semantic-gap row one outcome:
 | `unverified` | A candidate construction exists, but the target project/version or operational boundary has not passed its own parity test. |
 | `blocked` | No acceptable construction has passed. Do not migrate that slice. |
 
-Do not leave a row at “redesign” or “not 1:1.” Select the most native mechanism that can preserve the behavior, write the smallest source/target reproduction, and measure both. Keep spike code outside the product and skill; promote only stable contract tests.
+Do not leave a row at "redesign" or "not 1:1." Select the most native mechanism that can preserve the behavior, write the smallest source/target reproduction, and measure both. Keep spike code outside the product and skill; promote only stable contract tests.
 
 ## Choose the replacement mechanism
 
@@ -142,7 +142,7 @@ agent = Agent(
 )
 ```
 
-A disposable skill-development spike on Pydantic AI `2.10.1.dev24` observed one output-function execution and one model call. Treat that as a candidate construction, not validation for the target project: rerun the source/target probe before assigning `verified-equivalent`. It changes the model contract from “optional ordinary tool” to “terminal output choice,” so use a union/list of output choices when other terminal outcomes exist. Output functions can run on partial values under `run_stream()`; guard side effects with `ctx.partial_output` or use a complete-execution API.
+A disposable skill-development spike on Pydantic AI `2.10.1.dev24` observed one output-function execution and one model call. Treat that as a candidate construction, not validation for the target project: rerun the source/target probe before assigning `verified-equivalent`. It changes the model contract from "optional ordinary tool" to "terminal output choice," so use a union/list of output choices when other terminal outcomes exist. Output functions can run on partial values under `run_stream()`; guard side effects with `ctx.partial_output` or use a complete-execution API.
 
 ## Conversational interrupts, approval, and durable resume
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Supersedes https://github.com/pydantic/skills/pull/34

Adds a `migrating-langchain-to-pydantic-ai` skill to help LangChain and LangGraph users migrate cleanly to Pydantic AI while preserving the behavior their applications rely on.

This repository will own the canonical skill. The `pydantic/skills` repository can sync it after this merges, so the skill is maintained in one place without duplicate source copies here.

Validation:

- `uv run pytest tests/test_skill_examples.py -q` — 57 passed
- skill structure validation passed
- `pydantic-ai-slim` wheel build includes the skill

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
