### PR TITLE
Do not treat leading whitespace as a final `run_stream` result before tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -53,9 +53,18 @@ class OpenAIProvider(_OpenAICompatibleProvider):
         # The flag stays here rather than moving into `openai_model_profile`, which is shared with
         # OpenAI-compatible endpoints (Azure, OpenRouter, vLLM, ...) that speak the Responses API without
         # necessarily implementing this item — the same reasoning `openai_supports_phase` documents.
+        #
+        # First-party Chat Completions models must keep `ignore_streamed_leading_whitespace` off:
+        # applying it globally dropped leading whitespace tokens from official OpenAI streams.
+        # Unrecognized names used with this provider are almost always OpenAI-compatible custom
+        # endpoints (oMLX, vLLM, LM Studio) that emit a whitespace-only text part ahead of tool
+        # calls; ignoring that whitespace lets `run_stream` continue into the tool-call follow-up.
+        name = model_name.lower()
+        first_party = name.startswith(('gpt-', 'o1', 'o3', 'o4', 'chatgpt-', 'ft:gpt-', 'ft:o1', 'ft:o3', 'ft:o4'))
         return merge_profile(
             openai_model_profile(model_name),
             OpenAIModelProfile(tool_addition_mode='with_definitions', tool_deferral_mode='with_tool_search'),
+            None if first_party else ModelProfile(ignore_streamed_leading_whitespace=True),
         )
 
     @staticmethod

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -958,6 +958,70 @@ async def test_stream_text_empty_think_tag_and_text_before_tool_call(allow_model
     assert await result.get_output() == snapshot({'first': 'One', 'second': 'Two'})
 
 
+async def test_stream_whitespace_text_before_tool_call_on_custom_openai_endpoint(
+    allow_model_requests: None,
+):
+    """Custom OpenAI-compatible endpoints can emit thinking + whitespace + tool calls.
+
+    That whitespace must not be treated as the final `run_stream` result when `str` is a
+    valid output type, or the agent never sends the tool result back to the model.
+    """
+    first_stream = [
+        chunk([ChoiceDelta.model_construct(role='assistant', reasoning_content='Need the current time.')]),
+        text_chunk('\n\n\n'),
+        struc_chunk('get_datetime', '{}'),
+        chunk([], finish_reason='tool_calls'),
+    ]
+    second_stream = [
+        text_chunk('It is 3pm in Korea.'),
+        chunk([], finish_reason='stop'),
+    ]
+    mock_client = MockOpenAI.create_mock_stream([first_stream, second_stream])
+    m = OpenAIChatModel(
+        'Ornith-1.5-35B-A3B-MLX-4bit',
+        provider=OpenAIProvider(openai_client=mock_client),
+    )
+    agent = Agent(m)
+
+    @agent.tool_plain
+    def get_datetime() -> str:
+        return '2026-08-22T16:00:00+09:00'
+
+    async with agent.run_stream('What time is it in Korea?') as result:
+        chunks = [c async for c in result.stream_text(debounce_by=None)]
+        assert chunks[-1] == 'It is 3pm in Korea.'
+
+    assert await result.get_output() == 'It is 3pm in Korea.'
+    assert len(get_mock_chat_completion_kwargs(mock_client)) == 2
+
+
+async def test_stream_non_empty_text_before_tool_call_still_final_on_custom_endpoint(
+    allow_model_requests: None,
+):
+    """Non-empty leading text is still a final `run_stream` result, even on custom endpoints."""
+    stream = [
+        text_chunk('Here is the time.'),
+        struc_chunk('get_datetime', '{}'),
+        chunk([], finish_reason='tool_calls'),
+    ]
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel(
+        'Ornith-1.5-35B-A3B-MLX-4bit',
+        provider=OpenAIProvider(openai_client=mock_client),
+    )
+    agent = Agent(m)
+
+    @agent.tool_plain
+    def get_datetime() -> str:
+        return '2026-08-22T16:00:00+09:00'
+
+    async with agent.run_stream('What time is it?') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['Here is the time.'])
+
+    assert await result.get_output() == 'Here is the time.'
+    assert len(get_mock_chat_completion_kwargs(mock_client)) == 1
+
+
 async def test_no_delta(allow_model_requests: None):
     stream = [
         chunk([]),

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -51,3 +51,29 @@ def test_init_of_openai_with_base_url_env_var_and_without_api_key(env: TestEnv):
     env.set('OPENAI_BASE_URL', 'https://example.com/v1')
     provider = OpenAIProvider()
     assert provider.client.api_key == 'api-key-not-set'
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    ['gpt-4o', 'gpt-5.4', 'o3-mini', 'o4-mini', 'chatgpt-4o-latest', 'ft:gpt-4o-2024-08-06:org:name:id'],
+)
+def test_first_party_openai_models_keep_leading_whitespace_flag_off(model_name: str):
+    """Official Chat Completions names must not ignore leading streamed whitespace.
+
+    Applying the flag to first-party models dropped leading whitespace tokens from
+    official OpenAI streams.
+    """
+    profile = OpenAIProvider.model_profile(model_name)
+    assert profile is not None
+    assert profile.get('ignore_streamed_leading_whitespace', False) is False
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    ['Ornith-1.5-35B-A3B-MLX-4bit', 'qwen3', 'my-local-model', 'foobar'],
+)
+def test_unrecognized_openai_compatible_names_ignore_leading_whitespace(model_name: str):
+    """Unrecognized names used with OpenAIProvider are custom-endpoint configurations."""
+    profile = OpenAIProvider.model_profile(model_name)
+    assert profile is not None
+    assert profile.get('ignore_streamed_leading_whitespace') is True


### PR DESCRIPTION
- Closes #7688

I commented on the issue offering to take this and am happy to adjust if maintainers want a different approach.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

`run_stream()` treats any `TextPart` as a final result when `str` is a valid output type. OpenAI-compatible custom endpoints (oMLX, vLLM, LM Studio) often emit a whitespace-only `TextPart` ahead of `ToolCallPart`s, so the agent executes the tool and then stops without a follow-up model request. `run()` is unaffected.

This enables the existing `ignore_streamed_leading_whitespace` profile flag in `OpenAIProvider.model_profile` for unrecognized model names (the custom-endpoint case). First-party Chat Completions names (`gpt-*`, `o1`/`o3`/`o4`, `chatgpt-*`, matching `ft:` prefixes) keep the flag off, so official OpenAI streams still surface leading whitespace tokens.

Non-empty text before tool calls is still treated as final.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

