### PR TITLE
Fix grammar in Pydantic model example

### DIFF
--- a/docs/examples/pydantic-model.md
+++ b/docs/examples/pydantic-model.md
@@ -14,7 +14,7 @@ With [dependencies installed and environment variables set](./setup.md#usage), r
 python/uv-run -m pydantic_ai_examples.pydantic_model
 ```
 
-This examples uses `openai:gpt-5` by default, but it works well with other models, e.g. you can run it
+This example uses `openai:gpt-5` by default, but it works well with other models, e.g. you can run it
 with Gemini using:
 
 ```bash


### PR DESCRIPTION
Correct the grammar in the Pydantic model example documentation.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

