### PR TITLE
Make pending-message enqueues thread-safe

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -3,6 +3,7 @@ from __future__ import annotations as _annotations
 import asyncio
 import dataclasses
 import inspect
+import threading
 import time
 from asyncio import Task
 from collections import deque
@@ -427,6 +428,9 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     instrumentation_settings: InstrumentationSettings | None
 
     agent: Agent[DepsT, Any] | None = None
+
+    pending_messages_lock: threading.Lock = dataclasses.field(default_factory=threading.Lock, repr=False)
+    """Per-run lock serializing pending-message enqueues with drain transactions."""
 
     cancellation: RunCancellation = dataclasses.field(default_factory=RunCancellation, repr=False)
     """The run's first-party cancellation controller. Runtime-only: holds a live task reference."""
@@ -2362,6 +2366,7 @@ def build_run_context(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT
         loaded_capability_ids=ctx.deps.loaded_capability_ids,
         discovered_tool_names=ctx.deps.discovered_tool_names,
         pending_messages=ctx.state.pending_messages,
+        _pending_messages_lock=ctx.deps.pending_messages_lock,
         _cancellation=ctx.deps.cancellation,
         _event_stream_buffer=ctx.state.event_stream_buffer,
         _mcp_tool_defs_cache=ctx.state.mcp_tool_defs_cache,

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import sys
+import threading
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -152,6 +153,12 @@ class RunContext(Generic[RunContextAgentDepsT]):
     [`enqueue`][pydantic_ai.tools.RunContext.enqueue] would have nowhere to drain to and so raises.
     Managed by the framework: read it if useful, but use [`enqueue`][pydantic_ai.tools.RunContext.enqueue]
     to add messages rather than mutating it directly.
+    """
+
+    _pending_messages_lock: threading.Lock | None = field(default=None, repr=False)
+    """Private per-run lock shared by enqueue entry points and pending-message drains.
+
+    Runtime-only: `None` in synthetic contexts and across durable-execution boundaries.
     """
 
     _cancellation: RunCancellation | None = field(default=None, repr=False)
@@ -419,10 +426,8 @@ class RunContext(Generic[RunContextAgentDepsT]):
 
         Safe to call from anywhere a `RunContext` is available — async tools,
         sync tools (auto-wrapped in a thread executor by Pydantic AI), and
-        capability hooks. The drain only iterates the queue between graph nodes
-        (in `before_model_request` and `after_node_run`), never concurrently
-        with the tool body, so `list.append` from a worker thread doesn't race
-        the drain.
+        capability hooks. Enqueues and drains share a per-run lock, so a capability can let the graph continue
+        while a sync tool is still running without racing the drain's list iteration and replacement.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -461,7 +466,11 @@ class RunContext(Generic[RunContextAgentDepsT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self.pending_messages.append(pending)
+        if self._pending_messages_lock is None:
+            self.pending_messages.append(pending)
+        else:
+            with self._pending_messages_lock:
+                self.pending_messages.append(pending)
         return pending.enqueue_id
 
     def cancel(self) -> None:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
@@ -100,7 +100,10 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
         messages exactly as delivered here.
         """
         assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
-        drained = _drain_by_priority(ctx.pending_messages, 'asap')
+        lock = ctx._pending_messages_lock  # pyright: ignore[reportPrivateUsage]
+        assert lock is not None, 'drain runs during an agent run, which always has a queue lock'
+        with lock:
+            drained = _drain_by_priority(ctx.pending_messages, 'asap')
         for pending in drained:
             messages = _stamped_messages(
                 pending, fallback_run_id=ctx.run_id, fallback_conversation_id=ctx.conversation_id
@@ -137,12 +140,15 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
             return result
 
         assert ctx.pending_messages is not None, 'drain runs during an agent run, which always has a queue'
+        lock = ctx._pending_messages_lock  # pyright: ignore[reportPrivateUsage]
+        assert lock is not None, 'drain runs during an agent run, which always has a queue lock'
         # Pi-mono parity: drain `'asap'` first so anything that arrived during the
         # final step (e.g. a background task completing while the model produced
         # its final response) gets delivered before `'when_idle'` messages, and the
         # agent gets another turn rather than terminating with the message lost.
-        leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
-        when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
+        with lock:
+            leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
+            when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
         if not leftover_asap and not when_idle:
             return result
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_run_context.py
@@ -46,7 +46,14 @@ _REHYDRATORS: tuple[tuple[str, type[Any], TypeAdapter[Any]], ...] = (
 # the property override below), or falls back to `discovered_tool_names` without one.
 # `realtime_session` is a live session object that cannot cross the boundary, and its contract
 # already makes `None` mean "not available here".
-_NONE_UNLESS_ATTACHED = ('agent', 'root_capability', 'pending_messages', 'tool_manager', 'realtime_session')
+_NONE_UNLESS_ATTACHED = (
+    'agent',
+    'root_capability',
+    'pending_messages',
+    '_pending_messages_lock',
+    'tool_manager',
+    'realtime_session',
+)
 
 # Defaulted rather than guarded when a payload doesn't carry it. Unlike the guarded fields, the
 # dataclass default can't be mistaken for real run state here: empty means "no anchored evidence",

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -518,12 +518,8 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
     ) -> str | None:
         """Enqueue content to be injected into the conversation.
 
-        Designed to be called from the same event loop driving `agent.iter()`. If
-        you're forwarding events from a different thread (e.g. a webhook handler
-        running on its own loop or thread), marshal the call back onto the agent's
-        loop first (e.g. `loop.call_soon_threadsafe(agent_run.enqueue, msg)`).
-        The drain's `queue[:] = remaining` pattern in `_drain_by_priority` isn't
-        atomic against concurrent appends from a different thread.
+        Safe to call from the event loop driving `agent.iter()` or from another thread. Enqueues and drains share
+        a per-run lock so the drain's list iteration and replacement cannot overwrite a concurrent append.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -549,7 +545,8 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self._graph_run.state.pending_messages.append(pending)
+        with self._graph_run.deps.pending_messages_lock:
+            self._graph_run.state.pending_messages.append(pending)
         return pending.enqueue_id
 
     def cancel(self) -> None:

--- a/tests/test_pending_message_thread_safety.py
+++ b/tests/test_pending_message_thread_safety.py
@@ -1,0 +1,108 @@
+"""Thread-safety regression tests for the pending-message queue."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Literal
+
+import pytest
+
+from pydantic_ai import Agent, _agent_graph
+from pydantic_ai._enqueue import PendingMessage
+from pydantic_ai.capabilities._pending_messages import PendingMessageDrainCapability
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.test import TestModel
+
+pytestmark = pytest.mark.anyio
+
+
+class _LockCheckingPendingMessages(list[PendingMessage]):
+    """Assert that every drain slice-write happens under the run's queue lock."""
+
+    def __init__(self, lock: threading.Lock):
+        super().__init__()
+        self.lock = lock
+        self.slice_writes = 0
+
+    def __setitem__(self, key: Any, value: Any, /) -> None:
+        if isinstance(key, slice):
+            assert self.lock.locked(), 'pending-message drain replaced the queue without holding its lock'
+            self.slice_writes += 1
+        super().__setitem__(key, value)  # pyright: ignore[reportUnknownArgumentType]
+
+
+@pytest.mark.parametrize('enqueue_from', ['run_context', 'agent_run'])
+async def test_enqueue_waits_for_pending_message_lock(
+    enqueue_from: Literal['run_context', 'agent_run'],
+) -> None:
+    """Both public enqueue entry points use the same per-run lock as drains."""
+    agent = Agent(TestModel())
+    async with agent.iter('hello') as agent_run:
+        run_context = _agent_graph.build_run_context(agent_run.ctx)
+        lock = agent_run._graph_run.deps.pending_messages_lock  # pyright: ignore[reportPrivateUsage]
+        assert run_context._pending_messages_lock is lock  # pyright: ignore[reportPrivateUsage]
+
+        enqueue_started = threading.Event()
+        enqueue_done = threading.Event()
+        enqueue_errors: list[BaseException] = []
+
+        def enqueue() -> None:
+            enqueue_started.set()
+            try:
+                if enqueue_from == 'run_context':
+                    run_context.enqueue('late')
+                else:
+                    agent_run.enqueue('late')
+            except BaseException as exc:  # pragma: no cover - asserted below
+                enqueue_errors.append(exc)
+            finally:
+                enqueue_done.set()
+
+        enqueue_thread = threading.Thread(target=enqueue)
+        with lock:
+            enqueue_thread.start()
+            assert enqueue_started.wait(timeout=5)
+            completed_while_locked = enqueue_done.wait(timeout=0.1)
+
+        enqueue_thread.join(timeout=5)
+        assert not enqueue_thread.is_alive()
+        assert not completed_while_locked, 'enqueue did not wait for the pending-message lock'
+        assert enqueue_errors == []
+
+        queue = agent_run._graph_run.state.pending_messages  # pyright: ignore[reportPrivateUsage]
+        assert len(queue) == 1
+        late = queue[0].messages[0]
+        assert isinstance(late, ModelRequest)
+        assert isinstance(late.parts[0], UserPromptPart)
+        assert late.parts[0].content == 'late'
+        queue.clear()
+
+
+async def test_pending_message_drain_holds_lock_through_queue_replacement() -> None:
+    """The drain holds the run lock through iteration and slice replacement."""
+    agent = Agent(TestModel())
+    async with agent.iter('hello') as agent_run:
+        lock = agent_run._graph_run.deps.pending_messages_lock  # pyright: ignore[reportPrivateUsage]
+        queue = _LockCheckingPendingMessages(lock)
+        initial = PendingMessage.from_content('initial')
+        assert initial is not None
+        queue.append(initial)
+        agent_run._graph_run.state.pending_messages = queue  # pyright: ignore[reportPrivateUsage]
+        run_context = _agent_graph.build_run_context(agent_run.ctx)
+
+        request_context = ModelRequestContext(
+            model=TestModel(),
+            messages=[],
+            model_settings=None,
+            model_request_parameters=ModelRequestParameters(),
+        )
+        await PendingMessageDrainCapability().before_model_request(run_context, request_context)
+
+        assert queue.slice_writes == 1
+        assert queue == []
+        assert len(request_context.messages) == 1
+        drained = request_context.messages[0]
+        assert isinstance(drained, ModelRequest)
+        assert isinstance(drained.parts[0], UserPromptPart)
+        assert drained.parts[0].content == 'initial'

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1950,6 +1950,7 @@ def test_cache_key_run_context_projection_is_exhaustive():
         'capabilities',  # live capability objects, not hashable run state
         'root_capability',  # live capability tree (static config); run-varying loaded state is projected via loaded_capability_ids/discovered_tool_names
         'pending_messages',  # live run queue, not hashable run state
+        '_pending_messages_lock',  # runtime-only lock protecting the live pending-message queue
         'trace_include_content',  # tracing config, fixed for the agent rather than varying per run
         'instrumentation_version',  # tracing config, fixed for the agent rather than varying per run
         'partial_output',  # only set for output validators, which run in flow code, never inside a task

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4517,6 +4517,7 @@ def test_temporal_run_context_serialization_is_exhaustive():
         'capabilities',  # live capability objects (toolsets/hooks/callables), not serializable
         'root_capability',  # live capability chain, not serializable; reattached from the bound agent by deserialize_run_context
         'pending_messages',  # live run queue, meaningless outside the running agent; replaced by an EnqueueGuard
+        '_pending_messages_lock',  # runtime-only lock protecting the live pending-message queue
         'messages',  # full history would be duplicated into every activity payload, against Temporal's 2MB limit
         'prompt',  # multi-modal BinaryContent would ride in every payload, against Temporal's 2MB limit; text-only subclasses can opt in
         'validation_context',  # arbitrary user object with no serialization contract


### PR DESCRIPTION
Concurrent background tools can enqueue a message from a worker thread while the agent graph drains and replaces the pending-message list. That interleaving can overwrite the new append and lose the message.

This adds one runtime-only lock per agent run and shares it across `RunContext.enqueue()`, `AgentRun.enqueue()`, and each complete drain transaction. The durable graph state remains a plain serializable list, and Temporal/Prefect projections explicitly exclude the live lock.

Regression coverage verifies that both public enqueue entry points use the same lock as the drain and that queue replacement happens while the lock is held.

Tests:

- `pytest tests/test_pending_message_thread_safety.py -q`
- `pytest tests/test_capabilities.py -k "enqueue or pending_message" -q`
- `pytest tests/test_temporal.py::test_temporal_run_context_enqueue_raises_inside_activity tests/test_temporal.py::test_temporal_run_context_serialization_is_exhaustive tests/test_prefect.py::test_cache_key_run_context_projection_is_exhaustive -q`
- `ruff check` and `ruff format` on all changed files
- `pyright` on the changed implementation and regression test

- Closes #7634

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

