### PR TITLE
Add `visit_and_replace` to `AbstractCapability`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -236,6 +236,31 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         """
         visitor(self)
 
+    def visit_and_replace(
+        self, visitor: Callable[[AbstractCapability[AgentDepsT]], AbstractCapability[AgentDepsT] | None]
+    ) -> AbstractCapability[AgentDepsT] | None:
+        """Run a visitor function on the same capabilities as `apply`, and replace them in this tree with its result.
+
+        Analogous to
+        [`AbstractToolset.visit_and_replace`][pydantic_ai.toolsets.AbstractToolset.visit_and_replace],
+        except that returning `None` removes the visited capability instead of replacing it.
+
+        Rewrites in place: containers and wrappers rebuild only the branches that changed, so what
+        survives keeps its position in the hierarchy and a wrapper goes on wrapping whatever is left
+        of its subtree. Rebuilding a tree from the flat list `apply` produces does neither: it loses
+        the nesting, and re-adds a container's children next to the wrapper that already contributes
+        them.
+
+        Returns `self` when nothing changed, and `None` when the visitor removed everything.
+
+        For a single capability, returns the visitor's result for itself. Overridden by
+        [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] and
+        [`WrapperCapability`][pydantic_ai.capabilities.WrapperCapability] to rebuild their children;
+        a custom capability that overrides `apply` because it holds children of its own should
+        override this alongside it, or those children are invisible to callers rewriting the tree.
+        """
+        return visitor(self)
+
     @property
     @deprecated(
         '`has_wrap_node_run` is deprecated: `wrap_node_run` now runs under every way of driving a run, '

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -82,6 +82,27 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         for cap in self.capabilities:
             cap.apply(visitor)
 
+    def visit_and_replace(
+        self, visitor: Callable[[AbstractCapability[AgentDepsT]], AbstractCapability[AgentDepsT] | None]
+    ) -> AbstractCapability[AgentDepsT] | None:
+        new_caps: list[AbstractCapability[AgentDepsT]] = []
+        unchanged = True
+        for cap in self.capabilities:
+            new_cap = cap.visit_and_replace(visitor)
+            if new_cap is not cap:
+                unchanged = False
+            if new_cap is not None:
+                new_caps.append(new_cap)
+        if unchanged:
+            return self
+        if not new_caps:
+            # A container that lost every child contributes nothing, and reporting it as removed is
+            # what lets an enclosing wrapper or container drop it in turn.
+            return None
+        new_self = replace_no_init(self, capabilities=new_caps)
+        new_self.__normalize_capabilities()
+        return new_self
+
     @property
     def _has_wrap_node_run(self) -> bool:
         return any(c._has_wrap_node_run for c in self.capabilities)

--- a/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
@@ -81,14 +81,40 @@ class WrapperCapability(AbstractCapability[AgentDepsT]):
 
     def apply(self, visitor: Callable[[AbstractCapability[AgentDepsT]], None]) -> None:
         visitor(self)
-        # A wrapper over a leaf capability is the registered proxy for that leaf. A wrapper
-        # over a container still needs the container's leaves registered for child-owned hooks
-        # and toolsets to resolve their capability ids.
+        if self._registers_wrapped_children:
+            self.wrapped.apply(visitor)
+
+    @property
+    def _registers_wrapped_children(self) -> bool:
+        """Whether the wrapped subtree contributes capabilities of its own beyond this wrapper.
+
+        A wrapper over a leaf capability is the registered proxy for that leaf. A wrapper
+        over a container still needs the container's leaves registered for child-owned hooks
+        and toolsets to resolve their capability ids.
+        """
         wrapped_capabilities: list[AbstractCapability[AgentDepsT]] = []
         self.wrapped.apply(wrapped_capabilities.append)
-        if len(wrapped_capabilities) != 1 or wrapped_capabilities[0] is not self.wrapped:
-            for capability in wrapped_capabilities:
-                visitor(capability)
+        return len(wrapped_capabilities) != 1 or wrapped_capabilities[0] is not self.wrapped
+
+    def visit_and_replace(
+        self, visitor: Callable[[AbstractCapability[AgentDepsT]], AbstractCapability[AgentDepsT] | None]
+    ) -> AbstractCapability[AgentDepsT] | None:
+        replacement = visitor(self)
+        if replacement is not self:
+            # The wrapper is what's registered for the subtree, so replacing or removing it takes
+            # the subtree with it — visiting children the caller just discarded would be pointless.
+            return replacement
+        if not self._registers_wrapped_children:
+            return self
+        new_wrapped = self.wrapped.visit_and_replace(visitor)
+        if new_wrapped is None:
+            # `wrapped` is required, and a wrapper whose subtree is gone has nothing left to modify.
+            return None
+        if new_wrapped is self.wrapped:
+            return self
+        new_self = replace_no_init(self, wrapped=new_wrapped)
+        new_self.__adopt_wrapped_identity()
+        return new_self
 
     @classmethod
     def get_serialization_name(cls) -> str | None:

--- a/tests/test_capability_visit_and_replace.py
+++ b/tests/test_capability_visit_and_replace.py
@@ -96,6 +96,24 @@ def test_visit_and_replace_removes_every_combined_child():
     assert combined.visit_and_replace(lambda _: None) is None
 
 
+def test_visit_and_replace_splats_a_combined_replacement():
+    """A container handed back by the visitor is splatted into the parent, as on construction."""
+    web_search = WebSearch(local='duckduckgo')
+    combined = CombinedCapability[Any]([Thinking(id='thinking'), web_search])
+
+    rewritten = combined.visit_and_replace(
+        lambda cap: (
+            CombinedCapability[Any]([Capability(tools=[], id='a'), Capability(tools=[], id='b')])
+            if isinstance(cap, Thinking)
+            else cap
+        )
+    )
+
+    assert isinstance(rewritten, CombinedCapability)
+    assert [type(cap).__name__ for cap in rewritten.capabilities] == snapshot(['Capability', 'Capability', 'WebSearch'])
+    assert _visited(rewritten) == snapshot([('Capability', 'a'), ('Capability', 'b'), ('WebSearch', None)])
+
+
 def test_visit_and_replace_wrapper_over_capability():
     """A wrapper over a leaf is offered instead of the leaf, and takes the leaf with it."""
     thinking = Thinking()

--- a/tests/test_capability_visit_and_replace.py
+++ b/tests/test_capability_visit_and_replace.py
@@ -1,0 +1,258 @@
+"""Rewriting a capability tree with `AbstractCapability.visit_and_replace`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_ai import Agent
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.capabilities import (
+    Capability,
+    DynamicCapability,
+    PrefixTools,
+    Thinking,
+    Toolset,
+    WebSearch,
+    WrapperCapability,
+)
+from pydantic_ai.capabilities._dynamic import ResolvedDynamicCapability
+from pydantic_ai.capabilities.abstract import AbstractCapability
+from pydantic_ai.capabilities.combined import CombinedCapability
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.usage import RunUsage
+
+pytestmark = [
+    pytest.mark.anyio,
+]
+
+
+def _visited(capability: AbstractCapability[Any]) -> list[tuple[str, str | None]]:
+    """The type name and `id` of every capability `apply` visits, in order."""
+    visited: list[AbstractCapability[Any]] = []
+    capability.apply(visited.append)
+    return [(type(cap).__name__, cap.id) for cap in visited]
+
+
+def test_visit_and_replace_single_capability():
+    """AbstractCapability.visit_and_replace() offers just the capability itself."""
+    thinking = Thinking(effort='low')
+    replacement = Thinking(effort='high')
+
+    assert thinking.visit_and_replace(lambda _: replacement) is replacement
+    assert thinking.visit_and_replace(lambda _: None) is None
+    assert thinking.visit_and_replace(lambda cap: cap) is thinking
+
+
+def test_visit_and_replace_combined_capability():
+    """CombinedCapability.visit_and_replace() replaces children in place."""
+    web_search = WebSearch(local='duckduckgo')
+    combined = CombinedCapability[Any]([Thinking(effort='low', id='thinking'), web_search])
+
+    rewritten = combined.visit_and_replace(
+        lambda cap: Thinking(effort='high', id='thinking') if isinstance(cap, Thinking) else cap
+    )
+
+    assert isinstance(rewritten, CombinedCapability)
+    assert _visited(rewritten) == snapshot([('Thinking', 'thinking'), ('WebSearch', None)])
+    assert rewritten.capabilities[1] is web_search
+    # The original is left alone: rewriting builds a new tree.
+    assert _visited(combined)[0] == ('Thinking', 'thinking')
+    assert combined.capabilities[0] is not rewritten.capabilities[0]
+
+
+def test_visit_and_replace_combined_capability_unchanged():
+    """A visitor that changes nothing hands back the very same tree."""
+    combined = CombinedCapability[Any]([Thinking(), WebSearch(local='duckduckgo')])
+    assert combined.visit_and_replace(lambda cap: cap) is combined
+
+
+def test_visit_and_replace_empty_combined():
+    """An already-empty container has nothing to remove, so it survives untouched."""
+    combined = CombinedCapability[Any]([])
+    assert combined.visit_and_replace(lambda _: None) is combined
+
+
+def test_visit_and_replace_removes_combined_child():
+    """Removing one child keeps the container and its remaining children."""
+    web_search = WebSearch(local='duckduckgo')
+    combined = CombinedCapability[Any]([Thinking(id='thinking'), web_search])
+
+    rewritten = combined.visit_and_replace(lambda cap: None if isinstance(cap, Thinking) else cap)
+
+    assert isinstance(rewritten, CombinedCapability)
+    assert _visited(rewritten) == snapshot([('WebSearch', None)])
+    assert rewritten.capabilities[0] is web_search
+
+
+def test_visit_and_replace_removes_every_combined_child():
+    """A container emptied by removals reports itself as removed."""
+    combined = CombinedCapability[Any]([Thinking(), WebSearch(local='duckduckgo')])
+    assert combined.visit_and_replace(lambda _: None) is None
+
+
+def test_visit_and_replace_wrapper_over_capability():
+    """A wrapper over a leaf is offered instead of the leaf, and takes the leaf with it."""
+    thinking = Thinking()
+    wrapper = WrapperCapability(wrapped=thinking)
+
+    offered: list[AbstractCapability[Any]] = []
+
+    def visit(cap: AbstractCapability[Any]) -> AbstractCapability[Any]:
+        offered.append(cap)
+        return cap
+
+    assert wrapper.visit_and_replace(visit) is wrapper
+    assert offered == [wrapper]
+    assert wrapper.visit_and_replace(lambda _: None) is None
+
+
+def test_visit_and_replace_wrapper_over_combined_capability():
+    """A capability nested in a wrapper is removed from the wrapper's delegate, not around it.
+
+    Regression test for the flatten-and-rebuild alternative: because
+    [`WrapperCapability.apply`][pydantic_ai.capabilities.WrapperCapability.apply] visits the wrapper
+    *and* the leaves of the container it wraps, rebuilding a tree from that flat list keeps the
+    wrapper delegating to the dropped capability and re-adds the container's other children next to
+    it. Rewriting in place does neither.
+    """
+    stale = Thinking(effort='low', id='thinking')
+    kept = Capability(tools=[], id='bundle')
+    wrapper = WrapperCapability(wrapped=CombinedCapability[Any]([stale, kept]))
+
+    assert _visited(wrapper) == snapshot(
+        [('WrapperCapability', None), ('Thinking', 'thinking'), ('Capability', 'bundle')]
+    )
+
+    rewritten = wrapper.visit_and_replace(lambda cap: None if cap is stale else cap)
+
+    assert isinstance(rewritten, WrapperCapability)
+    assert _visited(rewritten) == snapshot([('WrapperCapability', None), ('Capability', 'bundle')])
+    assert isinstance(rewritten.wrapped, CombinedCapability)
+    assert rewritten.wrapped.capabilities == [kept]
+
+
+def test_visit_and_replace_wrapper_over_combined_capability_unchanged():
+    """A visitor that changes nothing inside a wrapped container hands back the same wrapper."""
+    wrapper = WrapperCapability(wrapped=CombinedCapability[Any]([Thinking(), WebSearch(local='duckduckgo')]))
+    assert wrapper.visit_and_replace(lambda cap: cap) is wrapper
+
+
+def test_visit_and_replace_wrapper_over_emptied_combined_capability():
+    """A wrapper whose whole subtree was removed is removed too: it has nothing left to modify."""
+    wrapper = WrapperCapability(wrapped=CombinedCapability[Any]([Thinking(), WebSearch(local='duckduckgo')]))
+    assert wrapper.visit_and_replace(lambda cap: cap if isinstance(cap, WrapperCapability) else None) is None
+
+
+def test_visit_and_replace_replaces_wrapper_wholesale():
+    """Replacing a wrapper takes its subtree with it, so its children are never offered."""
+    inner = Thinking(id='thinking')
+    wrapper = WrapperCapability(wrapped=CombinedCapability[Any]([inner]))
+    replacement = WebSearch(local='duckduckgo')
+
+    offered: list[AbstractCapability[Any]] = []
+
+    def visit(cap: AbstractCapability[Any]) -> AbstractCapability[Any]:
+        offered.append(cap)
+        return replacement if isinstance(cap, WrapperCapability) else cap
+
+    assert wrapper.visit_and_replace(visit) is replacement
+    assert offered == [wrapper]
+
+
+def test_visit_and_replace_keeps_wrapper_subclass_state():
+    """Rebuilding a wrapper preserves subclass fields and re-adopts the new wrapped identity."""
+    prefixed = PrefixTools(
+        wrapped=CombinedCapability[Any]([Thinking(id='thinking'), Capability(tools=[], id='bundle')]),
+        prefix='ns',
+    )
+
+    rewritten = prefixed.visit_and_replace(lambda cap: None if isinstance(cap, Thinking) else cap)
+
+    assert isinstance(rewritten, PrefixTools)
+    assert rewritten.prefix == 'ns'
+    assert _visited(rewritten) == snapshot([('PrefixTools', None), ('Capability', 'bundle')])
+
+
+async def test_visit_and_replace_resolved_dynamic_capability():
+    """A `DynamicCapability` resolved for a run rewrites like any other wrapper."""
+
+    def factory(ctx: RunContext[Any]) -> AbstractCapability[Any]:
+        return CombinedCapability([Thinking(id='thinking'), Capability(tools=[], id='bundle')])
+
+    ctx = RunContext[Any](deps=None, model=TestModel(), usage=RunUsage(), run_step=0)
+    ctx.agent = Agent(TestModel())
+    resolved = await DynamicCapability[Any](factory).for_run(ctx)
+    assert isinstance(resolved, ResolvedDynamicCapability)
+
+    rewritten = resolved.visit_and_replace(lambda cap: None if isinstance(cap, Thinking) else cap)
+
+    assert isinstance(rewritten, ResolvedDynamicCapability)
+    assert rewritten.dynamic_toolset is resolved.dynamic_toolset
+    assert _visited(rewritten) == snapshot([('ResolvedDynamicCapability', None), ('Capability', 'bundle')])
+
+
+async def test_visit_and_replace_supersedes_nested_capability_in_a_run(allow_model_requests: None):
+    """Last-wins supersession across layers keeps the surviving structure intact.
+
+    A run-level capability reusing an agent-level `id` replaces it. Dropping the superseded
+    occurrence in place leaves the wrapper prefixing what remains of its container, while rebuilding
+    from the flat `apply()` list would keep the wrapper delegating to the dropped capability and
+    duplicate the container's other child.
+    """
+    stale = FunctionToolset(id='stale')
+
+    @stale.tool_plain
+    def stale_tool() -> str:
+        return 'stale'  # pragma: no cover
+
+    kept = FunctionToolset(id='kept')
+
+    @kept.tool_plain
+    def kept_tool() -> str:
+        return 'kept'  # pragma: no cover
+
+    fresh = FunctionToolset(id='fresh')
+
+    @fresh.tool_plain
+    def fresh_tool() -> str:
+        return 'fresh'  # pragma: no cover
+
+    agent_layer = PrefixTools(
+        wrapped=CombinedCapability[Any]([Toolset(stale, id='shared'), Toolset(kept, id='bundle')]),
+        prefix='ns',
+    )
+    composed = CombinedCapability[Any]([agent_layer, Toolset(fresh, id='shared')])
+
+    occurrences: dict[str, int] = {}
+    for _, cap_id in _visited(composed):
+        if cap_id is not None:
+            occurrences[cap_id] = occurrences.get(cap_id, 0) + 1
+    seen: dict[str, int] = {}
+
+    def supersede(cap: AbstractCapability[Any]) -> AbstractCapability[Any] | None:
+        if cap.id is None:
+            return cap
+        seen[cap.id] = seen.get(cap.id, 0) + 1
+        return cap if seen[cap.id] == occurrences[cap.id] else None
+
+    rewritten = composed.visit_and_replace(supersede)
+    assert rewritten is not None
+    assert _visited(rewritten) == snapshot([('PrefixTools', None), ('Toolset', 'bundle'), ('Toolset', 'shared')])
+
+    seen_tools: list[tuple[str, str | None]] = []
+
+    def respond(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen_tools.extend(sorted((tool.name, tool.capability_id) for tool in info.function_tools))
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(respond), capabilities=[rewritten])
+    result = await agent.run('list tools')
+
+    assert result.output == 'done'
+    assert seen_tools == snapshot([('fresh_tool', 'shared'), ('ns_kept_tool', 'bundle')])


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Draft, opened to get the design reviewed before [#7248](https://github.com/pydantic/pydantic-ai/pull/7248) adopts it. No issue — it came out of a bug found while working on that PR.

`AbstractCapability.visit_and_replace(visitor)` rewrites a capability tree in place, mirroring [`AbstractToolset.visit_and_replace`](https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py) with one deliberate divergence: the visitor may return `None` to **remove** a node.

The load-bearing invariant is that it visits **exactly the nodes `apply` visits, in the same order**. That is what makes "collect with `apply`, decide, remove with `visit_and_replace`" coherent.

## The bug it exists to fix

Reproduced on `main`, not theoretical. `WrapperCapability.apply` visits `self` **and**, when it wraps a container, that container's leaves. A flat `leaf_capabilities()` list is therefore not a partition of the tree, and rebuilding from it double-counts:

```
layer = PrefixTools(CombinedCapability([Thinking(low), Capability(id='bundle')]))
run   = Thinking(high)

rebuilt from the flat list:
    PrefixTools  id=None
    Thinking     id=thinking   <- superseded, still reachable through the wrapper
    Capability   id=bundle
    Capability   id=bundle     <- duplicated
    Thinking     id=thinking   <- run-level
```

Only `Wrapper(Container)` breaks. `Wrapper(single leaf)` is fine — `apply` yields just the wrapper, which adopted the wrapped leaf's `id`.

Rewriting in place instead gives the target shape, `Combined([PrefixTools(Combined([bundle])), Thinking(high)])`.

## What changed

| type | behavior |
|---|---|
| `AbstractCapability` | `return visitor(self)` — the leaf default |
| `CombinedCapability` | recurse children, drop `None`s, `replace_no_init` + re-run `__normalize_capabilities`; `self` if unchanged; `None` if removals emptied it (an already-empty container returns `self`) |
| `WrapperCapability` | offer `self` first — a different result, including `None`, takes the whole subtree; otherwise recurse into `wrapped` only when it registers children; rebuild via `replace_no_init` + `__adopt_wrapped_identity` |
| `PrefixTools`, `ResolvedDynamicCapability` | inherit from `WrapperCapability`; subclass state is carried by `replace_no_init` |
| `DynamicCapability` | leaf — holds no child capability, so the base implementation is correct |

`def apply` is defined in exactly those three places under `capabilities/`, so the enumeration is complete.

This also extracts `WrapperCapability._registers_wrapped_children`, so `apply` and `visit_and_replace` share one predicate instead of drifting. `apply` becomes `visitor(self); if self._registers_wrapped_children: self.wrapped.apply(visitor)` — behavior-identical.

## Known limitation

`Wrapper(leaf)` never offers the leaf to the visitor. That is the existing `apply` contract, not a new gap: the wrapper is the registered proxy that adopted the leaf's `id`, so dropping it must drop the leaf. A reachability boundary, not a structure-preservation failure.

## Adoption in #7248

Not ported here — `_compose_run_layers` only exists on that branch. The adoption replaces its flatten-and-rebuild with an occurrence-counting last-wins visitor over the composed tree.

**The counter must be per-`id` occurrence, not flat `apply` index.** #7248 keys supersession on `(group_index, leaf_index)`, correct against its flat per-group lists, but that does not translate to a tree walk: flat position there removes the wrong nodes and can return `None` for the whole tree.

## Rejected alternatives

1. **A public `CapabilityVisitor` type alias** — inlined the `Callable` instead, mirroring `AbstractToolset.visit_and_replace` exactly. Avoids a new public symbol on a draft.
2. **A visitor that cannot return `None`** (strict toolset parity) — removal is the motivating operation, and `None` already has precedent in `CapabilityFunc` and `DynamicToolset.toolset_func`.
3. **An emptied container returning `CombinedCapability([])`** — leaves a dead node and stops an enclosing wrapper from collapsing.
4. **Offering the wrapped leaf of `Wrapper(leaf)`** — would diverge from `apply`; see the limitation above.

## Tests and docs

`tests/test_capability_visit_and_replace.py`, 15 tests. Its own feature-central file rather than an addition to `tests/test_capabilities.py`, which sits ~6 KB under the `check-added-large-files` pre-commit ceiling. The three modified source files are at 100% line and branch coverage.

Docstring only for docs: `docs/api/capabilities.md` renders the module, and toolsets' `visit_and_replace` carries no prose docs either.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

