### PR TITLE
Fix InstructionPart message round-tripping

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2470,6 +2470,7 @@ def _model_request_part_discriminator(v: Any) -> str | None:
 ModelRequestPart = Annotated[
     Annotated[SystemPromptPart, pydantic.Tag('system-prompt')]
     | Annotated[UserPromptPart, pydantic.Tag('user-prompt')]
+    | Annotated[InstructionPart, pydantic.Tag('instruction')]
     | Annotated[SpeechPart, pydantic.Tag('speech')]
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
     | Annotated[LoadCapabilityReturnPart, pydantic.Tag('capability-load-return')]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2094,6 +2094,16 @@ class TestInstructionParts:
         msg = message(deserialized, ModelRequest)
         assert msg.instructions == 'static part\n\ndynamic part'
 
+    def test_instruction_part_serialization_round_trip(self):
+        """InstructionPart survives the canonical message adapter round trip."""
+        original = ModelRequest(parts=[InstructionPart(content='cached instructions', dynamic=True)])
+
+        serialized = ModelMessagesTypeAdapter.dump_json([original])
+        deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+
+        msg = message(deserialized, ModelRequest)
+        assert msg.parts == [InstructionPart(content='cached instructions', dynamic=True)]
+
     def test_repr(self):
         """InstructionPart repr omits default values."""
         part = InstructionPart(content='hello')


### PR DESCRIPTION
Closes #7701

Summary:
- Include InstructionPart in ModelRequestPart validation.
- Add a JSON round-trip regression test.

Tests:
- Python syntax compilation passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

