### PR TITLE
Render tool parts as text when mapping history to MCP sampling messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/_mcp.py
@@ -113,6 +113,25 @@ def map_from_pai_messages(pai_messages: list[messages.ModelMessage]) -> tuple[st
                             # TODO(Marcelo): Add support for audio content.
                             else:
                                 raise NotImplementedError(f'Unsupported content type: {type(chunk)}')
+                elif isinstance(part, messages.ToolReturnPart):
+                    # The MCP sampling protocol has no tool-result content either, so a tool
+                    # exchange from a prior (non-sampling) turn is rendered as text instead of
+                    # being silently dropped. Mirrors the realtime seeding fallback.
+                    add_msg(
+                        'user',
+                        mcp_types.TextContent(
+                            type='text',
+                            text=f'[Tool {part.tool_call_id}: {part.tool_name} returned: {part.model_response_str()}]',
+                        ),
+                    )
+                elif isinstance(part, messages.RetryPromptPart):
+                    output = part.model_response()
+                    text = (
+                        output
+                        if part.tool_name is None
+                        else f'[Tool {part.tool_call_id}: {part.tool_name} error: {output}]'
+                    )
+                    add_msg('user', mcp_types.TextContent(type='text', text=text))
         else:
             add_msg('assistant', map_from_model_response(pai_message))
     return ''.join(system_prompt), sampling_msgs
@@ -125,6 +144,13 @@ def map_from_model_response(model_response: messages.ModelResponse) -> mcp_types
         if isinstance(part, messages.TextPart):
             text_parts.append(part.content)
         elif isinstance(part, messages.ThinkingPart):
+            continue
+        elif isinstance(part, messages.ToolCallPart):
+            # The MCP sampling protocol has no tool-call content, so render the call as text the
+            # sampling server can still reason over. Mirrors the realtime seeding fallback.
+            text_parts.append(f'[Tool {part.tool_call_id}: {part.tool_name}({part.args_as_json_str()})]')
+        elif isinstance(part, messages.NativeToolCallPart):
+            # Provider-session-bound native tool calls can't round-trip into sampling.
             continue
         else:
             raise exceptions.UnexpectedModelBehavior(f'Unexpected part type: {type(part).__name__}, expected TextPart')

--- a/pydantic_ai_slim/pydantic_ai/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/_mcp.py
@@ -149,7 +149,7 @@ def map_from_model_response(model_response: messages.ModelResponse) -> mcp_types
             # The MCP sampling protocol has no tool-call content, so render the call as text the
             # sampling server can still reason over. Mirrors the realtime seeding fallback.
             text_parts.append(f'[Tool {part.tool_call_id}: {part.tool_name}({part.args_as_json_str()})]')
-        elif isinstance(part, messages.NativeToolCallPart):
+        elif isinstance(part, (messages.NativeToolCallPart, messages.NativeToolReturnPart)):
             # Provider-session-bound native tool calls can't round-trip into sampling.
             continue
         else:

--- a/tests/models/test_mcp_sampling.py
+++ b/tests/models/test_mcp_sampling.py
@@ -11,10 +11,12 @@ from pydantic_ai import (
     ModelResponse,
     SystemPromptPart,
     TextPart,
+    ToolReturnPart,
     UserPromptPart,
 )
 from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import RetryPromptPart, ToolCallPart
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsNow, IsStr, try_import
@@ -180,4 +182,75 @@ def test_assistant_text_history_complex():
     assert any(
         isinstance(message.content, TextContent) and message.content.text == '<system>system content</system>'
         for message in sampling_messages
+    )
+
+
+def test_tool_history_rendered_as_text():
+    """A history containing a tool call/return is rendered as text instead of raising.
+
+    The MCP sampling protocol only carries text/image/audio content, so a conversation that used
+    tools on another model can't round-trip natively — but it should map to readable text rather
+    than crash with `UnexpectedModelBehavior` (or silently drop the tool result).
+    """
+    result = CreateMessageResult(
+        role='assistant', content=TextContent(type='text', text='text content'), model='test-model'
+    )
+    create_message = AsyncMock(return_value=result)
+    agent = Agent(model=MCPSamplingModel(fake_session(create_message)))
+
+    tool_call_id = 'pyd_ai_test_12345'
+    history = [
+        ModelRequest(parts=[UserPromptPart(content='what time is it')]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name='get_time', args={'tz': 'UTC'}, tool_call_id=tool_call_id)],
+            model_name='test-model',
+        ),
+        ModelRequest(parts=[ToolReturnPart(tool_name='get_time', content='12:00', tool_call_id=tool_call_id)]),
+    ]
+
+    result = agent.run_sync('thanks', message_history=history)
+    assert result.output == snapshot('text content')
+
+    sampling_messages = create_message.call_args.args[0]
+    assert [(m.role, m.content.text) for m in sampling_messages] == snapshot(
+        [
+            ('user', 'what time is it'),
+            ('assistant', '[Tool pyd_ai_test_12345: get_time({"tz":"UTC"})]'),
+            ('user', '[Tool pyd_ai_test_12345: get_time returned: 12:00]'),
+            ('user', 'thanks'),
+        ]
+    )
+
+
+def test_retry_prompt_history_rendered_as_text():
+    """A `RetryPromptPart` from a prior turn is rendered as text instead of being dropped."""
+    result = CreateMessageResult(
+        role='assistant', content=TextContent(type='text', text='text content'), model='test-model'
+    )
+    create_message = AsyncMock(return_value=result)
+    agent = Agent(model=MCPSamplingModel(fake_session(create_message)))
+
+    tool_call_id = 'pyd_ai_test_67890'
+    history = [
+        ModelRequest(parts=[UserPromptPart(content='what time is it')]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name='get_time', args={}, tool_call_id=tool_call_id)],
+            model_name='test-model',
+        ),
+        ModelRequest(
+            parts=[RetryPromptPart(content='wrong arguments', tool_name='get_time', tool_call_id=tool_call_id)]
+        ),
+    ]
+
+    result = agent.run_sync('try again', message_history=history)
+    assert result.output == snapshot('text content')
+
+    sampling_messages = create_message.call_args.args[0]
+    assert [(m.role, m.content.text) for m in sampling_messages] == snapshot(
+        [
+            ('user', 'what time is it'),
+            ('assistant', '[Tool pyd_ai_test_67890: get_time({})]'),
+            ('user', '[Tool pyd_ai_test_67890: get_time error: wrong arguments\n\nFix the errors and try again.]'),
+            ('user', 'try again'),
+        ]
     )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1681,6 +1681,8 @@ class TestSamplingMessageMapping:
             BinaryContent,
             FilePart,
             ModelResponse,
+            NativeToolCallPart,
+            NativeToolReturnPart,
             TextPart,
             ThinkingPart,
             ToolCallPart,
@@ -1698,6 +1700,19 @@ class TestSamplingMessageMapping:
             ModelResponse(parts=[ToolCallPart(tool_name='foo', args='{}', tool_call_id='pyd_ai_test_1')])
         )
         assert result.text == '[Tool pyd_ai_test_1: foo({})]'
+
+        # Native tool call/return exchanges are provider-session-bound and can't round-trip
+        # into sampling, so both sides of the exchange are silently skipped.
+        result = _mcp_helpers.map_from_model_response(
+            ModelResponse(
+                parts=[
+                    NativeToolCallPart(tool_name='native_search', args='{}', tool_call_id='pyd_ai_test_2'),
+                    NativeToolReturnPart(tool_name='native_search', content='found', tool_call_id='pyd_ai_test_2'),
+                    TextPart(content='kept'),
+                ]
+            )
+        )
+        assert result.text == 'kept'
 
         # Unsupported parts still raise a clear error.
         with pytest.raises(UnexpectedModelBehavior):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1677,7 +1677,14 @@ class TestSamplingMessageMapping:
     async def test_map_from_model_response_skips_thinking_and_rejects_unknown(self):
         from pydantic_ai import _mcp as _mcp_helpers
         from pydantic_ai.exceptions import UnexpectedModelBehavior
-        from pydantic_ai.messages import ModelResponse, TextPart, ThinkingPart, ToolCallPart
+        from pydantic_ai.messages import (
+            BinaryContent,
+            FilePart,
+            ModelResponse,
+            TextPart,
+            ThinkingPart,
+            ToolCallPart,
+        )
 
         # `ThinkingPart` is silently skipped, leaving the text content.
         result = _mcp_helpers.map_from_model_response(
@@ -1685,9 +1692,18 @@ class TestSamplingMessageMapping:
         )
         assert result.text == 'visible'
 
-        # Unsupported parts (e.g. tool calls) raise a clear error.
+        # Tool calls have no sampling representation, so they're rendered as text the sampling
+        # server can still reason over (matching the realtime seeding fallback).
+        result = _mcp_helpers.map_from_model_response(
+            ModelResponse(parts=[ToolCallPart(tool_name='foo', args='{}', tool_call_id='pyd_ai_test_1')])
+        )
+        assert result.text == '[Tool pyd_ai_test_1: foo({})]'
+
+        # Unsupported parts still raise a clear error.
         with pytest.raises(UnexpectedModelBehavior):
-            _mcp_helpers.map_from_model_response(ModelResponse(parts=[ToolCallPart(tool_name='foo', args='{}')]))
+            _mcp_helpers.map_from_model_response(
+                ModelResponse(parts=[FilePart(content=BinaryContent(data=b'x', media_type='application/octet-stream'))])
+            )
 
 
 class TestResourceMethodErrorPaths:


### PR DESCRIPTION
Fixes #7707.

## Problem

`map_from_pai_messages()` / `map_from_model_response()` in `pydantic_ai/_mcp.py` can't map a `message_history` containing tool parts, which breaks the cross-model history flow for `MCPSamplingModel`:

- a `ToolCallPart` in a prior `ModelResponse` raises `UnexpectedModelBehavior: Unexpected part type: ToolCallPart, expected TextPart`
- `ToolReturnPart` / `RetryPromptPart` in a prior `ModelRequest` are silently dropped, so the sampling server never sees the tool results

Repro is in the linked issue.

## Change

The MCP sampling protocol only carries text/image/audio content, so tool parts can't round-trip natively. Following the existing realtime seeding fallback (`realtime/google.py` `_seed_request_parts` / `_seed_response_parts`), tool parts are now rendered as text:

- `ToolCallPart` → assistant text `[Tool {tool_call_id}: {tool_name}({args})]`
- `ToolReturnPart` → user text `[Tool {tool_call_id}: {tool_name} returned: {output}]`
- `RetryPromptPart` → user text `[Tool {tool_call_id}: {tool_name} error: {output}]` (plain output when `tool_name` is `None`)
- `NativeToolCallPart` → skipped, as provider-session-bound (also matching realtime)

Unknown part types (e.g. `FilePart`) still raise `UnexpectedModelBehavior` as before.

## Behavior change note

This deliberately changes behavior pinned by `test_map_from_model_response_skips_thinking_and_rejects_unknown` ("Unsupported parts (e.g. tool calls) raise a clear error"). I've updated that test to assert the new rendering, keeping the raise for genuinely unknown parts. Opened the issue first per the contributing guide — happy to adjust if maintainers prefer a different treatment (e.g. strict raise kept, but agent-level history filtering, or a `ModelRetry` instead).

## Tests

- `test_tool_history_rendered_as_text` — full tool exchange renders as readable text and no longer crashes
- `test_retry_prompt_history_rendered_as_text` — retry feedback is delivered instead of dropped
- updated pinned test: tool calls render, unknown parts still raise

`pytest tests/test_mcp.py tests/models/test_mcp_sampling.py` → 149 passed, 2 skipped (with fastmcp full install).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

