### PR TITLE
Avoid asyncio's deprecated get_event_loop() warning in synchronous runs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,6 +8,7 @@ import re
 import sys
 import time
 import uuid
+import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
@@ -1037,9 +1038,17 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
     except RuntimeError:
-        event_loop = None
+        # No running loop: fall back to the thread's current (or newly created) loop. `get_event_loop()`
+        # itself emits a `DeprecationWarning` for this exact case since Python 3.10, even though creating
+        # a loop on demand is precisely the fallback we want here, so we silence just that warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            try:
+                event_loop = asyncio.get_event_loop()
+            except RuntimeError:
+                event_loop = None
 
     if event_loop is None or event_loop.is_closed():
         event_loop = asyncio.new_event_loop()

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -64,9 +64,17 @@ def _implements_run_until_complete(loop: asyncio.AbstractEventLoop) -> bool:
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
     except RuntimeError:
-        event_loop = None
+        # No running loop: fall back to the thread's current (or newly created) loop. `get_event_loop()`
+        # itself emits a `DeprecationWarning` for this exact case since Python 3.10, even though creating
+        # a loop on demand is precisely the fallback we want here, so we silence just that warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            try:
+                event_loop = asyncio.get_event_loop()
+            except RuntimeError:
+                event_loop = None
 
     if event_loop is not None and not _implements_run_until_complete(event_loop):
         # A loop that only its own runtime can drive -- like Temporal's workflow loop -- typically leaves

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import contextvars
 import functools
 import importlib
 import os
+import subprocess
 import sys
 import threading
 from collections.abc import AsyncIterator
@@ -364,6 +365,51 @@ def test_run_sync_on_undrivable_event_loop():
     assert str(exc_info.value) == snapshot(
         'The current event loop (UndrivableEventLoop) does not implement `run_until_complete()`, which synchronous methods need in order to run their asynchronous implementation. This is the case inside a Temporal workflow, whose event loop can only be driven by Temporal itself. Use the asynchronous method instead, e.g. `await agent.run()` rather than `agent.run_sync()`.'
     )
+
+
+def test_run_sync_no_event_loop_deprecation_warning():
+    """`run_sync()` must not trigger `asyncio`'s "There is no current event loop" `DeprecationWarning`.
+
+    That warning only fires the first time the main thread asks for an event loop without one already
+    set, so it has to be reproduced in a fresh interpreter rather than inside the suite's own process,
+    where anyio/pytest-asyncio have long since set one. See https://github.com/pydantic/pydantic-ai/issues/1196.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-W',
+            'error',
+            '-c',
+            "from pydantic_ai import Agent\nfrom pydantic_ai.models.test import TestModel\nAgent(TestModel()).run_sync('hi')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ''
+
+
+def test_run_stream_sync_no_event_loop_deprecation_warning():
+    """`run_stream_sync()` must not trigger the same event-loop `DeprecationWarning` as `run_sync()`.
+
+    It goes through `pydantic_ai._utils.get_event_loop()` directly rather than through
+    `pydantic_graph`'s copy, so it needs its own fresh-interpreter regression test.
+    See https://github.com/pydantic/pydantic-ai/issues/1196.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-W',
+            'error',
+            '-c',
+            'from pydantic_ai import Agent\nfrom pydantic_ai.models.test import TestModel\n'
+            "with Agent(TestModel()).run_stream_sync('hi') as stream:\n    stream.get_output()",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ''
 
 
 def test_run_sync_propagates_not_implemented_error_from_tool():


### PR DESCRIPTION
Closes #1196

`agent.run_sync()` calls into `pydantic_graph`'s `get_event_loop()`, which calls `asyncio.get_event_loop()` directly. Since Python 3.10, that emits `DeprecationWarning: There is no current event loop` the first time the main thread asks for a loop with none set, which is exactly what happens when `run_sync()` is the first async call in a program.

The existing `try/except RuntimeError` around that call doesn't help. The deprecated call doesn't raise here, it warns and then creates a loop anyway, so nothing catches it.

`pydantic_ai`'s own `get_event_loop()`, used by `run_stream_sync()`, has the identical logic and the same bug, so I fixed both.

## Changes

- Both `get_event_loop()` implementations now try `asyncio.get_running_loop()` first. That's the non-deprecated equivalent for the "already inside a running loop" case, with no behavior change.
- When nothing is running, the normal `run_sync()`/`run_stream_sync()` case, fall back to the original `asyncio.get_event_loop()` call with just its `DeprecationWarning` suppressed. The fallback still creates or reuses a loop the same way as before; only the warning is gone.

## Tests

Added two tests to `tests/test_utils.py`, one for `run_sync()` and one for `run_stream_sync()`. Both spawn a fresh interpreter subprocess (`sys.executable -W error -c ...`) because the warning only fires the first time a process's main thread asks for a loop with none set. By the time any test runs inside the suite's own process, anyio/pytest-asyncio have already set one, so this can't be reproduced against an already-running suite.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

