### PR TITLE
Handle asctime-form `Retry-After` dates in `wait_retry_after()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -575,6 +575,9 @@ def wait_retry_after(
                     try:
                         retry_time = parsedate_to_datetime(retry_after)
                         assert isinstance(retry_time, datetime)
+                        # asctime-date format (RFC 9110 §5.6.7) carries no timezone; treat as UTC.
+                        if retry_time.tzinfo is None:
+                            retry_time = retry_time.replace(tzinfo=timezone.utc)
                         now = datetime.now(timezone.utc)
                         wait_seconds = (retry_time - now).total_seconds()
 

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -615,6 +615,24 @@ class TestWaitRetryAfter:
         assert 25 <= result <= 35
         fallback.assert_not_called()
 
+    def test_retry_after_asctime_date_format(self):
+        """Asctime HTTP dates are timezone-naive but represent UTC per RFC 9110."""
+        fallback = Mock(return_value=1.0)
+        wait_func = wait_retry_after(fallback_strategy=fallback, max_wait=300)
+        retry_time = datetime.now(timezone.utc).timestamp() + 30
+        retry_after = datetime.fromtimestamp(retry_time, timezone.utc).strftime('%a %b %d %H:%M:%S %Y')
+
+        request = httpx.Request('GET', 'https://example.com')
+        response = Mock(spec=httpx.Response)
+        response.headers = {'retry-after': retry_after}
+        http_error = httpx.HTTPStatusError('Rate limited', request=request, response=response)
+        retry_state = Mock(spec=RetryCallState)
+        retry_state.outcome = Mock()
+        retry_state.outcome.exception.return_value = http_error
+
+        assert 25 <= wait_func(retry_state) <= 35
+        fallback.assert_not_called()
+
     def test_retry_after_http_date_past_time_uses_fallback(self):
         """Test that past dates in Retry-After fall back to fallback strategy."""
         fallback = Mock(return_value=1.0)

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -616,25 +616,26 @@ class TestWaitRetryAfter:
         fallback.assert_not_called()
 
     def test_retry_after_asctime_date_format(self):
-        """Asctime HTTP dates are timezone-naive but represent UTC per RFC 9110.
-
-        This tests deterministic local header parsing; no provider request is involved.
-        """
-        fallback = Mock(return_value=1.0)
-        wait_func = wait_retry_after(fallback_strategy=fallback, max_wait=300)
-        retry_time = datetime.now(timezone.utc).timestamp() + 30
-        retry_after = datetime.fromtimestamp(retry_time, timezone.utc).strftime('%a %b %d %H:%M:%S %Y')
-
+        """Asctime `Retry-After` dates are parsed locally without a provider request."""
+        retry_time = datetime(2095, 11, 6, 8, 49, 37, tzinfo=timezone.utc)
         request = httpx2.Request('GET', 'https://example.com')
-        response = httpx2.Response(429, headers={'retry-after': retry_after}, request=request)
-        with pytest.raises(httpx2.HTTPStatusError) as exc_info:
-            response.raise_for_status()
+        response = httpx2.Response(
+            429,
+            headers={'retry-after': retry_time.ctime()},
+            request=request,
+        )
+        http_error = httpx2.HTTPStatusError('Rate limited', request=request, response=response)
         retry_state = Mock(spec=RetryCallState)
         retry_state.outcome = Mock()
-        retry_state.outcome.exception.return_value = exc_info.value
+        retry_state.outcome.exception.return_value = http_error
 
-        assert 25 <= wait_func(retry_state) <= 35
-        fallback.assert_not_called()
+        wait_func = wait_retry_after(fallback_strategy=wait_fixed(1), max_wait=float('inf'))
+
+        before = datetime.now(timezone.utc)
+        wait_seconds = wait_func(retry_state)
+        after = datetime.now(timezone.utc)
+
+        assert (retry_time - after).total_seconds() <= wait_seconds <= (retry_time - before).total_seconds()
 
     def test_retry_after_http_date_past_time_uses_fallback(self):
         """Test that past dates in Retry-After fall back to fallback strategy."""

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -616,19 +616,22 @@ class TestWaitRetryAfter:
         fallback.assert_not_called()
 
     def test_retry_after_asctime_date_format(self):
-        """Asctime HTTP dates are timezone-naive but represent UTC per RFC 9110."""
+        """Asctime HTTP dates are timezone-naive but represent UTC per RFC 9110.
+
+        This tests deterministic local header parsing; no provider request is involved.
+        """
         fallback = Mock(return_value=1.0)
         wait_func = wait_retry_after(fallback_strategy=fallback, max_wait=300)
         retry_time = datetime.now(timezone.utc).timestamp() + 30
         retry_after = datetime.fromtimestamp(retry_time, timezone.utc).strftime('%a %b %d %H:%M:%S %Y')
 
-        request = httpx.Request('GET', 'https://example.com')
-        response = Mock(spec=httpx.Response)
-        response.headers = {'retry-after': retry_after}
-        http_error = httpx.HTTPStatusError('Rate limited', request=request, response=response)
+        request = httpx2.Request('GET', 'https://example.com')
+        response = httpx2.Response(429, headers={'retry-after': retry_after}, request=request)
+        with pytest.raises(httpx2.HTTPStatusError) as exc_info:
+            response.raise_for_status()
         retry_state = Mock(spec=RetryCallState)
         retry_state.outcome = Mock()
-        retry_state.outcome.exception.return_value = http_error
+        retry_state.outcome.exception.return_value = exc_info.value
 
         assert 25 <= wait_func(retry_state) <= 35
         fallback.assert_not_called()


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://pydantic.dev/docs/ai/project/contributing/ -->

This makes `wait_retry_after()` honor valid asctime-form HTTP dates. `parsedate_to_datetime()` returns those dates without timezone information, so the retry helper now treats them as UTC before calculating the delay, matching `ModelHTTPError.retry_after`.

A focused regression test covers the asctime form and verifies that the configured fallback isn't used.

- Closes #7677

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

