### PR TITLE
Fix: CohereModel silently drops zero-argument tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -265,7 +265,7 @@ class CohereModel(Model[AsyncClientV2]):
                 elif content.type == 'thinking':  # pragma: no branch
                     parts.append(ThinkingPart(content=content.thinking))
         for c in response.message.tool_calls or []:
-            if c.function and c.function.name and c.function.arguments:  # pragma: no branch
+            if c.function and c.function.name:
                 parts.append(
                     ToolCallPart(
                         tool_name=c.function.name,

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -860,3 +860,93 @@ async def test_cohere_empty_response_skipped_in_history(allow_model_requests: No
     second_call_messages = cast(MockAsyncClientV2, mock_client).chat_kwargs[1]['messages']
     assert not any(message.role == 'assistant' for message in second_call_messages)
     assert [message.role for message in second_call_messages] == snapshot(['user', 'user'])
+
+
+def test_cohere_process_response_tool_call_with_none_arguments():
+    """A zero-argument tool call comes back from Cohere with `arguments=None` (see
+    `ToolCallV2Function.arguments: typing.Optional[str] = None` in the Cohere SDK). It must
+    still produce a `ToolCallPart` instead of being silently dropped.
+    """
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    response = completion_message(
+        AssistantMessageResponse(
+            content=None,
+            role='assistant',
+            tool_calls=[
+                ToolCallV2(
+                    id='1',
+                    function=ToolCallV2Function(arguments=None, name='get_current_time'),
+                    type='function',
+                )
+            ],
+        )
+    )
+
+    result = m._process_response(response)  # pyright: ignore[reportPrivateUsage]
+
+    assert result.parts == snapshot([ToolCallPart(tool_name='get_current_time', args=None, tool_call_id='1')])
+
+
+def test_cohere_process_response_tool_call_with_empty_string_arguments():
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    response = completion_message(
+        AssistantMessageResponse(
+            content=None,
+            role='assistant',
+            tool_calls=[
+                ToolCallV2(
+                    id='2',
+                    function=ToolCallV2Function(arguments='', name='get_current_time'),
+                    type='function',
+                )
+            ],
+        )
+    )
+
+    result = m._process_response(response)  # pyright: ignore[reportPrivateUsage]
+
+    assert result.parts == snapshot([ToolCallPart(tool_name='get_current_time', args='', tool_call_id='2')])
+
+
+def test_cohere_process_response_tool_call_with_real_arguments_unchanged():
+    """Regression: a normal tool call with real arguments must be processed exactly as before."""
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    response = completion_message(
+        AssistantMessageResponse(
+            content=None,
+            role='assistant',
+            tool_calls=[
+                ToolCallV2(
+                    id='3',
+                    function=ToolCallV2Function(arguments='{"loc_name": "San Fransisco"}', name='get_location'),
+                    type='function',
+                )
+            ],
+        )
+    )
+
+    result = m._process_response(response)  # pyright: ignore[reportPrivateUsage]
+
+    assert result.parts == snapshot(
+        [ToolCallPart(tool_name='get_location', args='{"loc_name": "San Fransisco"}', tool_call_id='3')]
+    )
+
+
+def test_cohere_process_response_malformed_tool_call_without_function_skipped():
+    """Regression: a malformed tool call with no `function` at all must still be skipped
+    without raising.
+    """
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    response = completion_message(
+        AssistantMessageResponse(
+            content=None,
+            role='assistant',
+            tool_calls=[
+                ToolCallV2(id='4', function=None, type='function'),
+            ],
+        )
+    )
+
+    result = m._process_response(response)  # pyright: ignore[reportPrivateUsage]
+
+    assert result.parts == snapshot([])


### PR DESCRIPTION
Fixes #7718

## Summary

Written in conjunction with my pair programmer Claude.

`CohereModel._process_response` is the only place Cohere's tool calls get turned into `ToolCallPart`s (Cohere has no `request_stream` yet, so every non-streamed call goes through this one function). The four other provider adapters build the part unconditionally:

- `openai.py:1258` — `ToolCallPart(c.function.name, c.function.arguments, tool_call_id=c.id)`
- `mistral.py:487` — `ToolCallPart(func_call.name, func_call.arguments, tool_call_id)`
- `anthropic.py` and `google.py` — same shape

`cohere.py:268` is the one adapter that gates construction on `arguments` being truthy:

```python
if c.function and c.function.name and c.function.arguments:  # pragma: no branch
    parts.append(ToolCallPart(tool_name=c.function.name, args=c.function.arguments, ...))
```

Cohere's own SDK declares this field as optional and `None`-by-default:

```python
class ToolCallV2Function(UncheckedBaseModel):
    name: typing.Optional[str] = None
    arguments: typing.Optional[str] = None
```

So a call to a zero-argument tool comes back with `arguments=None` (I also saw `arguments=""` from a different code path), the `and c.function.arguments` check is false, and the entire `ToolCallPart` is dropped — not the args, the whole tool call. `parts` ends up empty, the agent graph treats that as an invalid model response and retries, and it eventually blows up with:

```
UnexpectedModelBehavior: Exceeded maximum output retries (1)
```

which gives no hint that a tool call was ever made. I reproduced this locally with a mock Cohere client returning `ToolCallV2Function(name='get_current_time', arguments=None)`.

The `# pragma: no branch` on that line is part of the bug, not incidental — it tells the coverage tool this condition never goes the other way, which is exactly what let this ship without a red test. `c.function` and `c.function.name` are both legitimately `Optional` too, so I kept those two checks (a malformed call with no `function` should still be skipped) but dropped `and c.function.arguments` and removed the pragma, since the remaining condition really can go either way.

## Is `args=None` safe?

Checked `BaseToolCallPart` in `messages.py`:

```python
args: str | dict[str, Any] | None = None
```

`None` is the field's own default, and `args_as_dict()` already special-cases it (`if not self.args: return {}`), so a `ToolCallPart` with `args=None` behaves the same way it already does for every other provider that hands us a genuinely argument-less call. No coercion needed.

## Testing

Added four tests to `tests/models/test_cohere.py`, calling `CohereModel._process_response` directly (same pattern already used in `test_google.py` / `test_openrouter.py`):

- `arguments=None` produces a `ToolCallPart` (was silently dropped before the fix)
- `arguments=''` likewise
- a normal tool call with real JSON arguments is unchanged (regression)
- a malformed call with `function=None` is still skipped without raising (regression)

Ran with the fix reverted first to confirm the two new bug tests fail red, then restored the fix and confirmed all green. What I ran:

```
uv run pytest tests/models/test_cohere.py -v
```

24 passed, 1 deselected. The one deselected test, `test_cohere_model_thinking_part`, fails in this sandbox on an unmodified checkout too (a `blockbuster`/`pytest-recording` VCR-cassette read gets flagged as a blocking call) — unrelated to this change, so I left it out of the run rather than paper over it.

Also ran `ruff check`, `ruff format --diff`, and `pyright` against both changed files — clean.

I did not run the full test suite or the pre-commit hooks end to end; scoped this to the Cohere model tests plus lint/typecheck on the touched files.

## Related, not a duplicate

#6100 (open, Cohere streaming) adds `request_stream` and writes the correct guard for its *new* streaming tool-call path, but that PR doesn't touch `_process_response`, so this existing non-streaming bug is still there regardless of whether #6100 lands.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



