### PR TITLE
Recognize Bedrock’s `r1` alias in `deepseek_model_profile()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
@@ -5,7 +5,7 @@ from . import ModelProfile
 
 def deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model."""
-    is_r1 = model_name.startswith('deepseek-r1') or model_name == 'deepseek-reasoner'
+    is_r1 = model_name == 'r1' or model_name.startswith('deepseek-r1') or model_name == 'deepseek-reasoner'
     # V4 models (deepseek-v4-flash, deepseek-v4-pro, …) support thinking via reasoning_effort
     # but do not always enable it — thinking_always_enabled stays False.
     is_v4 = model_name.startswith('deepseek-v4-')

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -750,7 +750,7 @@ def test_bedrock_meta_llama3():
 @pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
 def test_bedrock_deepseek_r1():
     """`bedrock_send_back_thinking_parts=True` applied for `r1` models via separate function."""
-    profile = BedrockProvider.model_profile('deepseek.deepseek-r1-v1:0')
+    profile = BedrockProvider.model_profile('us.deepseek.r1-v1:0')
     assert _normalize(profile) == snapshot(
         {
             'supports_thinking': True,

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -235,8 +235,8 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
     assert cohere_profile is not None
     assert cohere_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
-    deepseek_profile = provider.model_profile('deepseek.deepseek-r1')
-    deepseek_model_profile_mock.assert_called_with('deepseek-r1')
+    deepseek_profile = provider.model_profile('deepseek.r1-v1:0')
+    deepseek_model_profile_mock.assert_called_with('r1')
     assert deepseek_profile is not None
     assert deepseek_profile.get('ignore_streamed_leading_whitespace', False) is True
     assert deepseek_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()


### PR DESCRIPTION
`split_bedrock_model_id()` normalizes the real Bedrock R1 identifier to `r1`. Teach the shared DeepSeek family profile that exact alias instead of reconstructing a synthetic `deepseek-r1` name in the Bedrock adapter.

The regression tests now use the real regional and non-regional AWS identifiers. They pin both the `r1` handoff and the complete resolved R1 profile.

- Closes #6831

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

