### PR TITLE
Remove unreachable `ToolSearchToolset.max_retries`

### DIFF
--- a/docs/capabilities/tool-search.md
+++ b/docs/capabilities/tool-search.md
@@ -11,6 +11,6 @@ from pydantic_ai.capabilities import ToolSearch
 agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[ToolSearch(strategy='keywords')])
 ```
 
-When the local `search_tools` function tool is used, its retry budget follows the agent's tool budget — so `Agent(retries={'tools': N})` gives the model `N` attempts to correct a malformed `queries` argument, on the same [precedence ladder](../tools-advanced.md#which-retry-limit-wins) as any other tool. A search that finds no matches returns normally and never spends a retry.
+When the local `search_tools` function tool is used, its retry budget follows the agent's tool budget — so `Agent(retries={'tools': N})` gives the model `N` attempts to correct a malformed `queries` argument. A search that finds no matches returns normally and never spends a retry.
 
 See [Tool Search](../tools-advanced.md#tool-search) for when to reach for it, the full strategy table, and provider support details.

--- a/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
@@ -311,18 +311,6 @@ class ToolSearchToolset(WrapperToolset[AgentDepsT]):
     keyword algorithm; and on providers that DO support it, only the native tool reaches
     the wire (no redundant `search_tools` slot that could confuse the model)."""
 
-    max_retries: int | None = None
-    """Maximum number of retries for the local `search_tools` function tool, *after* the
-    first attempt.
-
-    When `None`, the agent's tool retry budget applies (`Agent(retries={'tools': N})`),
-    following the same `tool.max_retries` -> `toolset.max_retries` -> `ctx.max_retries`
-    precedence as [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset]. The budget is
-    consumed by malformed arguments (e.g. a bare string where a list is expected) and by
-    blank queries; a search that simply finds no matches returns normally and never spends
-    a retry.
-    """
-
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         all_tools = await self.wrapped.get_tools(ctx)
 
@@ -415,7 +403,7 @@ class ToolSearchToolset(WrapperToolset[AgentDepsT]):
         return _SearchTool(
             toolset=self,
             tool_def=search_tool_def,
-            max_retries=self.max_retries if self.max_retries is not None else ctx.max_retries,
+            max_retries=ctx.max_retries,
             args_validator=args_validator,
             corpus=corpus,
             revealed_tool_names=set(ctx.discovered_tool_names),

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -553,7 +553,6 @@ def _build_run_context(
     messages: list[ModelMessage] | None = None,
     capabilities: dict[str, AbstractCapability[T]] | None = None,
     discovered_tool_names: set[str] | None = None,
-    max_retries: int = 0,
 ) -> RunContext[T]:
     """Build a `RunContext` for unit tests using `TestModel`."""
     return RunContext(
@@ -565,7 +564,6 @@ def _build_run_context(
         run_step=run_step,
         capabilities=capabilities or {},
         discovered_tool_names=discovered_tool_names or set(),
-        max_retries=max_retries,
     )
 
 
@@ -677,23 +675,6 @@ async def test_search_tools_inherits_agent_tool_retries(tool_retries: int):
         await agent.run('find me a weather tool')
 
     assert calls == tool_retries + 1
-
-
-async def test_tool_search_toolset_max_retries_overrides_agent_budget():
-    """An explicit `max_retries` on the toolset wins over the agent's tool retry budget.
-
-    Asserted at `get_tools` rather than through an agent run: the capability that owns tool
-    search is auto-injected, so a hand-constructed `ToolSearchToolset` can't be handed to an
-    `Agent` without the outer wrapper tripping the reserved-`search_tools` guard.
-    """
-    toolset = _create_function_toolset()
-    ctx = _build_run_context(None, max_retries=5)
-
-    inheriting = await ToolSearchToolset(wrapped=toolset).get_tools(ctx)
-    overriding = await ToolSearchToolset(wrapped=toolset, max_retries=2).get_tools(ctx)
-
-    assert inheriting[_SEARCH_TOOLS_NAME].max_retries == 5
-    assert overriding[_SEARCH_TOOLS_NAME].max_retries == 2
 
 
 async def test_tool_search_toolset_search_returns_matching_tools():


### PR DESCRIPTION
`ToolSearchToolset.max_retries` was introduced in #6740, but it cannot be configured through any supported public API: public `ToolSearch` neither exposes nor forwards it, and `ToolSearchToolset` is a private implementation detail.

The original review identified this and the maintainers agreed to remove the field and use `ctx.max_retries` directly: https://github.com/pydantic/pydantic-ai/pull/6740#discussion_r3687830609. That decision landed seconds before the PR was merged, so the cleanup was missed.

This PR:

- removes the unreachable private override
- passes `ctx.max_retries` directly to the managed `search_tools` tool
- removes the private-only override test
- retains the public `Agent(retries={"tools": N})` regression test as the behavioral invariant
- removes the misleading per-tool precedence wording from the docs

### Tests

- `uv run pytest tests/test_tool_search.py::test_search_tools_inherits_agent_tool_retries -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py tests/test_tool_search.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

