### PR TITLE
Stabilize timing- and concurrency-sensitive tests

### DIFF
--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -98,7 +98,10 @@ async def test_context_subtree_concurrent():
 
 @pytest.fixture
 def span_tree() -> SpanTree:
-    """Fixture that creates a span tree with a predefined structure and attributes."""
+    """Build deterministic input for pure tree queries, which have no provider request to record with VCR.
+
+    Live Logfire/OTel capture is exercised separately by the `context_subtree` tests above.
+    """
 
     def make_span(
         name: str,

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from pytest_mock import MockerFixture
@@ -12,7 +13,7 @@ with try_import() as imports_successful:
     from pydantic_evals.otel._context_subtree import (
         context_subtree,
     )
-    from pydantic_evals.otel.span_tree import SpanQuery, SpanTree
+    from pydantic_evals.otel.span_tree import AttributeValue, SpanNode, SpanQuery, SpanTree
 
 with try_import() as logfire_import_successful:
     import logfire
@@ -96,20 +97,39 @@ async def test_context_subtree_concurrent():
 
 
 @pytest.fixture
-async def span_tree() -> SpanTree:
+def span_tree() -> SpanTree:
     """Fixture that creates a span tree with a predefined structure and attributes."""
-    # Create spans with a tree structure and attributes
-    with context_subtree() as tree:
-        with logfire.span('root', level='0'):
-            with logfire.span('child1', level='1', type='important'):
-                with logfire.span('grandchild1', level='2', type='important'):
-                    pass
-                with logfire.span('grandchild2', level='2', type='normal'):
-                    pass
-            with logfire.span('child2', level='1', type='normal'):
-                with logfire.span('grandchild3', level='2', type='normal'):
-                    pass
-    assert isinstance(tree, SpanTree)
+
+    def make_span(
+        name: str,
+        span_id: int,
+        parent_span_id: int | None,
+        start: int,
+        duration: int,
+        **attributes: AttributeValue,
+    ) -> SpanNode:
+        start_timestamp = datetime.fromtimestamp(start, tz=timezone.utc)
+        return SpanNode(
+            name=name,
+            trace_id=1,
+            span_id=span_id,
+            parent_span_id=parent_span_id,
+            start_timestamp=start_timestamp,
+            end_timestamp=start_timestamp + timedelta(seconds=duration),
+            attributes=attributes,
+        )
+
+    tree = SpanTree()
+    tree.add_spans(
+        [
+            make_span('root', 1, None, 1, 11, level='0'),
+            make_span('child1', 3, 1, 2, 5, level='1', type='important'),
+            make_span('grandchild1', 5, 3, 3, 1, level='2', type='important'),
+            make_span('grandchild2', 7, 3, 5, 1, level='2', type='normal'),
+            make_span('child2', 9, 1, 8, 3, level='1', type='normal'),
+            make_span('grandchild3', 11, 9, 9, 1, level='2', type='normal'),
+        ]
+    )
     return tree
 
 

--- a/tests/providers/test_xai.py
+++ b/tests/providers/test_xai.py
@@ -41,7 +41,7 @@ async def test_xai_pass_xai_client() -> None:
     xai_client = AsyncClient(api_key='api-key')
     try:
         provider = XaiProvider(xai_client=xai_client)
-        assert provider.client == xai_client
+        assert provider.client is xai_client
     finally:
         await xai_client.close()
 

--- a/tests/providers/test_xai.py
+++ b/tests/providers/test_xai.py
@@ -35,10 +35,15 @@ def test_xai_provider_need_api_key(env: TestEnv) -> None:
         XaiProvider()
 
 
-def test_xai_pass_xai_client() -> None:
+@pytest.mark.anyio
+@pytest.mark.usefixtures('missing_event_loop')
+async def test_xai_pass_xai_client() -> None:
     xai_client = AsyncClient(api_key='api-key')
-    provider = XaiProvider(xai_client=xai_client)
-    assert provider.client == xai_client
+    try:
+        provider = XaiProvider(xai_client=xai_client)
+        assert provider.client == xai_client
+    finally:
+        await xai_client.close()
 
 
 @pytest.fixture

--- a/tests/providers/test_xai.py
+++ b/tests/providers/test_xai.py
@@ -36,7 +36,6 @@ def test_xai_provider_need_api_key(env: TestEnv) -> None:
 
 
 @pytest.mark.anyio
-@pytest.mark.usefixtures('missing_event_loop')
 async def test_xai_pass_xai_client() -> None:
     xai_client = AsyncClient(api_key='api-key')
     try:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -918,6 +918,27 @@ def test_sync_stream_bridge_init_interrupt_after_entry_exits_context():
     assert exited
 
 
+class _LoopTurnWatchdog:
+    """Stop a loop after deterministic progress, without making the test depend on wall-clock time."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, turns: int = 100) -> None:
+        self.loop = loop
+        self.remaining = turns
+        self.forced_stop = False
+        self.handle = loop.call_soon(self._tick)
+
+    def _tick(self) -> None:
+        self.remaining -= 1
+        if self.remaining == 0:  # pragma: no cover
+            self.forced_stop = True
+            self.loop.stop()
+        else:
+            self.handle = self.loop.call_soon(self._tick)
+
+    def cancel(self) -> None:
+        self.handle.cancel()
+
+
 @pytest.mark.parametrize('error_type', [KeyboardInterrupt, SystemExit])
 def test_sync_stream_bridge_init_propagates_base_exception(error_type: type[BaseException]):
     """A base exception from `__aenter__` escapes immediately instead of hanging the event loop.
@@ -928,7 +949,6 @@ def test_sync_stream_bridge_init_propagates_base_exception(error_type: type[Base
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     error = error_type('entry failed')
-    forced_stop = False
 
     class FailingContextManager:
         async def __aenter__(self) -> object:
@@ -942,21 +962,16 @@ def test_sync_stream_bridge_init_propagates_base_exception(error_type: type[Base
         ) -> None:
             pytest.fail('`__aexit__` must not be called when `__aenter__` fails')  # pragma: no cover
 
-    def force_stop() -> None:  # pragma: no cover
-        nonlocal forced_stop
-        forced_stop = True
-        loop.stop()
-
-    stop_handle = loop.call_later(1, force_stop)
+    watchdog = _LoopTurnWatchdog(loop)
     try:
         with pytest.raises(error_type) as exc_info:
             SyncStreamBridge(FailingContextManager(), async_alternative='`async_method`')
-        stop_handle.cancel()
+        watchdog.cancel()
         assert exc_info.value is error
-        assert not forced_stop
+        assert not watchdog.forced_stop
         assert loop.run_until_complete(asyncio.sleep(0)) is None
     finally:
-        stop_handle.cancel()
+        watchdog.cancel()
         loop.close()
         asyncio.set_event_loop(original_loop)
 
@@ -1312,7 +1327,6 @@ def test_sync_stream_bridge_pump_propagates_base_exception_without_hanging(error
     VCR cannot inject an in-process base exception into the iterator pump task.
     """
     error = error_type('pump failed')
-    forced_stop = False
 
     @asynccontextmanager
     async def stream_context() -> AsyncGenerator[object]:
@@ -1326,23 +1340,18 @@ def test_sync_stream_bridge_pump_propagates_base_exception_without_hanging(error
     loop = bridge._loop  # pyright: ignore[reportPrivateUsage]
     stream = bridge.stream_sync(source)
 
-    def force_stop() -> None:  # pragma: no cover
-        nonlocal forced_stop
-        forced_stop = True
-        loop.stop()
-
-    stop_handle = loop.call_later(1, force_stop)
+    watchdog = _LoopTurnWatchdog(loop)
     try:
         with pytest.raises(error_type) as exc_info:
             while True:
                 next(stream)
-        stop_handle.cancel()
+        watchdog.cancel()
         assert exc_info.value is error
-        assert not forced_stop
+        assert not watchdog.forced_stop
         assert bridge._owner_task.done()  # pyright: ignore[reportPrivateUsage]
         assert loop.run_until_complete(asyncio.sleep(0)) is None
     finally:
-        stop_handle.cancel()
+        watchdog.cancel()
 
 
 def test_run_stream_sync_preserves_capability_contextvars():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -951,6 +951,7 @@ def test_sync_stream_bridge_init_propagates_base_exception(error_type: type[Base
     try:
         with pytest.raises(error_type) as exc_info:
             SyncStreamBridge(FailingContextManager(), async_alternative='`async_method`')
+        stop_handle.cancel()
         assert exc_info.value is error
         assert not forced_stop
         assert loop.run_until_complete(asyncio.sleep(0)) is None

--- a/tests/test_sync_stream_loop_affinity.py
+++ b/tests/test_sync_stream_loop_affinity.py
@@ -113,9 +113,16 @@ def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]
 
     server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
     server.daemon_threads = True
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_started = threading.Event()
+
+    def serve_forever() -> None:
+        server_started.set()
+        server.serve_forever()
+
+    thread = threading.Thread(target=serve_forever, daemon=True)
     thread.start()
     try:
+        assert server_started.wait(timeout=10), 'keep-alive test server did not start'
         yield f'http://127.0.0.1:{server.server_port}', requests
     finally:
         server.shutdown()
@@ -157,14 +164,14 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         if api_surface == 'agent':
             agent = Agent(model)
             if stream_first:
-                with agent.run_stream_sync('first', model_settings={'timeout': 1}) as stream:
+                with agent.run_stream_sync('first', model_settings={'timeout': 10}) as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
-                run_output = agent.run_sync('second', model_settings={'timeout': 1}).output
+                run_output = agent.run_sync('second', model_settings={'timeout': 10}).output
             else:
-                first = agent.run_sync('first', model_settings={'timeout': 1})
+                first = agent.run_sync('first', model_settings={'timeout': 10})
                 history = first.all_messages() if use_history else None
                 run_output = first.output
-                with agent.run_stream_sync('second', message_history=history, model_settings={'timeout': 1}) as stream:
+                with agent.run_stream_sync('second', message_history=history, model_settings={'timeout': 10}) as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
 
             assert run_output == 'green'
@@ -172,12 +179,12 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         else:
             messages = [ModelRequest.user_text_prompt('test')]
             if stream_first:
-                with model_request_stream_sync(model, messages, model_settings={'timeout': 1}) as stream:
+                with model_request_stream_sync(model, messages, model_settings={'timeout': 10}) as stream:
                     stream_events = list(stream)
-                response = model_request_sync(model, messages, model_settings={'timeout': 1})
+                response = model_request_sync(model, messages, model_settings={'timeout': 10})
             else:
-                response = model_request_sync(model, messages, model_settings={'timeout': 1})
-                with model_request_stream_sync(model, messages, model_settings={'timeout': 1}) as stream:
+                response = model_request_sync(model, messages, model_settings={'timeout': 10})
+                with model_request_stream_sync(model, messages, model_settings={'timeout': 10}) as stream:
                     stream_events = list(stream)
 
             assert response.parts

--- a/tests/test_sync_stream_loop_affinity.py
+++ b/tests/test_sync_stream_loop_affinity.py
@@ -2,20 +2,19 @@ from __future__ import annotations
 
 import asyncio
 import json
-import threading
-from collections.abc import Iterator
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from collections.abc import AsyncIterator
 from typing import Literal
 
 import pytest
 
-from pydantic_ai import Agent, ModelRequest, ModelSettings
+from pydantic_ai import Agent, ModelRequest
 from pydantic_ai._utils import is_str_dict
 from pydantic_ai.direct import model_request_stream_sync, model_request_sync
 
 from .conftest import try_import
 
 with try_import() as imports_successful:
+    import httpx2
     from anthropic import AsyncAnthropic
 
     from pydantic_ai.models.anthropic import AnthropicModel
@@ -23,23 +22,24 @@ with try_import() as imports_successful:
 
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='anthropic not installed')
 
-# These tests assert event-loop and connection reuse, not one-second response latency under saturated CI workers.
-_LOCAL_REQUEST_SETTINGS = ModelSettings(timeout=10)
-
 
 @pytest.fixture
-def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]:
-    requests: list[tuple[bool, int]] = []
+def anthropic_loop_bound_transport() -> tuple[httpx2.AsyncClient, list[tuple[bool, asyncio.AbstractEventLoop]]]:
+    requests: list[tuple[bool, asyncio.AbstractEventLoop]] = []
 
-    class Handler(BaseHTTPRequestHandler):
-        protocol_version = 'HTTP/1.1'
+    class ResponseBody(httpx2.AsyncByteStream):
+        def __init__(self, content: bytes) -> None:
+            self.content = content
 
-        def do_POST(self) -> None:
-            size = int(self.headers.get('content-length', 0))
-            payload: object = json.loads(self.rfile.read(size))
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield self.content
+
+    class Transport(httpx2.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+            payload: object = json.loads(request.content)
             assert is_str_dict(payload)
             stream = payload.get('stream') is True
-            requests.append((stream, self.client_address[1]))
+            requests.append((stream, asyncio.get_running_loop()))
 
             if stream:
                 events: list[tuple[str, dict[str, object]]] = [
@@ -103,27 +103,15 @@ def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]
                 ).encode()
                 content_type = 'application/json'
 
-            self.send_response(200)
-            self.send_header('content-type', content_type)
-            self.send_header('content-length', str(len(body)))
-            self.send_header('connection', 'keep-alive')
-            self.end_headers()
-            self.wfile.write(body)
-            self.wfile.flush()
+            return httpx2.Response(
+                200,
+                headers={'content-type': content_type},
+                stream=ResponseBody(body),
+                request=request,
+            )
 
-        def log_message(self, format: str, *args: object) -> None:
-            pass
-
-    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
-    server.daemon_threads = True
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield f'http://127.0.0.1:{server.server_port}', requests
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join()
+    http_client = httpx2.AsyncClient(transport=Transport())
+    return http_client, requests
 
 
 @pytest.mark.parametrize(
@@ -139,19 +127,19 @@ def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]
 @pytest.mark.parametrize('client_owner', ['provider', 'user'])
 def test_sync_entry_points_keep_async_client_on_one_event_loop(
     allow_model_requests: None,
-    anthropic_keepalive_server: tuple[str, list[tuple[bool, int]]],
+    anthropic_loop_bound_transport: tuple[httpx2.AsyncClient, list[tuple[bool, asyncio.AbstractEventLoop]]],
     api_surface: Literal['agent', 'direct'],
     stream_first: bool,
     use_history: bool,
     client_owner: Literal['provider', 'user'],
 ) -> None:
-    """A real keep-alive connection is required because VCR does not retain asyncio transport state."""
-    base_url, requests = anthropic_keepalive_server
+    """A persistent transport exposes loop identity directly, which no HTTP recording can retain."""
+    http_client, requests = anthropic_loop_bound_transport
     if client_owner == 'provider':
-        provider = AnthropicProvider(api_key='test', base_url=base_url)
+        provider = AnthropicProvider(api_key='test', http_client=http_client)
         client = provider.client
     else:
-        client = AsyncAnthropic(api_key='test', base_url=base_url, max_retries=0)
+        client = AsyncAnthropic(api_key='test', http_client=http_client, max_retries=0)
         provider = AnthropicProvider(anthropic_client=client)
     client.max_retries = 0
     model = AnthropicModel('claude-test', provider=provider)
@@ -160,16 +148,14 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         if api_surface == 'agent':
             agent = Agent(model)
             if stream_first:
-                with agent.run_stream_sync('first', model_settings=_LOCAL_REQUEST_SETTINGS) as stream:
+                with agent.run_stream_sync('first') as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
-                run_output = agent.run_sync('second', model_settings=_LOCAL_REQUEST_SETTINGS).output
+                run_output = agent.run_sync('second').output
             else:
-                first = agent.run_sync('first', model_settings=_LOCAL_REQUEST_SETTINGS)
+                first = agent.run_sync('first')
                 history = first.all_messages() if use_history else None
                 run_output = first.output
-                with agent.run_stream_sync(
-                    'second', message_history=history, model_settings=_LOCAL_REQUEST_SETTINGS
-                ) as stream:
+                with agent.run_stream_sync('second', message_history=history) as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
 
             assert run_output == 'green'
@@ -177,19 +163,19 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         else:
             messages = [ModelRequest.user_text_prompt('test')]
             if stream_first:
-                with model_request_stream_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS) as stream:
+                with model_request_stream_sync(model, messages) as stream:
                     stream_events = list(stream)
-                response = model_request_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS)
+                response = model_request_sync(model, messages)
             else:
-                response = model_request_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS)
-                with model_request_stream_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS) as stream:
+                response = model_request_sync(model, messages)
+                with model_request_stream_sync(model, messages) as stream:
                     stream_events = list(stream)
 
             assert response.parts
             assert stream_events
         assert len(requests) == 2
         assert [stream for stream, _port in requests] == ([True, False] if stream_first else [False, True])
-        assert requests[0][1] == requests[1][1]
+        assert requests[0][1] is requests[1][1]
     finally:
         asyncio.get_event_loop().run_until_complete(client.close())
 
@@ -197,24 +183,23 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
 @pytest.mark.anyio
 async def test_async_run_and_stream_share_one_event_loop(
     allow_model_requests: None,
-    anthropic_keepalive_server: tuple[str, list[tuple[bool, int]]],
+    anthropic_loop_bound_transport: tuple[httpx2.AsyncClient, list[tuple[bool, asyncio.AbstractEventLoop]]],
 ) -> None:
-    """Fully async requests retain their keep-alive connection when both use one event loop."""
-    base_url, requests = anthropic_keepalive_server
-    client = AsyncAnthropic(api_key='test', base_url=base_url, max_retries=0)
+    """Fully async requests use one event loop as a control for the synchronous bridge tests."""
+    http_client, requests = anthropic_loop_bound_transport
+    client = AsyncAnthropic(api_key='test', http_client=http_client, max_retries=0)
     model = AnthropicModel('claude-test', provider=AnthropicProvider(anthropic_client=client))
     agent = Agent(model)
 
     try:
-        first = await agent.run('first', model_settings=_LOCAL_REQUEST_SETTINGS)
-        async with agent.run_stream(
-            'second', message_history=first.all_messages(), model_settings=_LOCAL_REQUEST_SETTINGS
-        ) as stream:
+        first = await agent.run('first')
+        async with agent.run_stream('second', message_history=first.all_messages()) as stream:
             streamed_output = ''.join([text async for text in stream.stream_text(debounce_by=None)])
 
         assert first.output == 'green'
         assert streamed_output == 'blue'
         assert len(requests) == 2
-        assert requests == [(False, requests[0][1]), (True, requests[0][1])]
+        assert [stream for stream, _loop in requests] == [False, True]
+        assert requests[0][1] is requests[1][1]
     finally:
         await client.close()

--- a/tests/test_sync_stream_loop_affinity.py
+++ b/tests/test_sync_stream_loop_affinity.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 import pytest
 
-from pydantic_ai import Agent, ModelRequest
+from pydantic_ai import Agent, ModelRequest, ModelSettings
 from pydantic_ai._utils import is_str_dict
 from pydantic_ai.direct import model_request_stream_sync, model_request_sync
 
@@ -22,6 +22,9 @@ with try_import() as imports_successful:
     from pydantic_ai.providers.anthropic import AnthropicProvider
 
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='anthropic not installed')
+
+# These tests assert event-loop and connection reuse, not one-second response latency under saturated CI workers.
+_LOCAL_REQUEST_SETTINGS = ModelSettings(timeout=10)
 
 
 @pytest.fixture
@@ -113,16 +116,9 @@ def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]
 
     server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
     server.daemon_threads = True
-    server_started = threading.Event()
-
-    def serve_forever() -> None:
-        server_started.set()
-        server.serve_forever()
-
-    thread = threading.Thread(target=serve_forever, daemon=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        assert server_started.wait(timeout=10), 'keep-alive test server did not start'
         yield f'http://127.0.0.1:{server.server_port}', requests
     finally:
         server.shutdown()
@@ -164,14 +160,16 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         if api_surface == 'agent':
             agent = Agent(model)
             if stream_first:
-                with agent.run_stream_sync('first', model_settings={'timeout': 10}) as stream:
+                with agent.run_stream_sync('first', model_settings=_LOCAL_REQUEST_SETTINGS) as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
-                run_output = agent.run_sync('second', model_settings={'timeout': 10}).output
+                run_output = agent.run_sync('second', model_settings=_LOCAL_REQUEST_SETTINGS).output
             else:
-                first = agent.run_sync('first', model_settings={'timeout': 10})
+                first = agent.run_sync('first', model_settings=_LOCAL_REQUEST_SETTINGS)
                 history = first.all_messages() if use_history else None
                 run_output = first.output
-                with agent.run_stream_sync('second', message_history=history, model_settings={'timeout': 10}) as stream:
+                with agent.run_stream_sync(
+                    'second', message_history=history, model_settings=_LOCAL_REQUEST_SETTINGS
+                ) as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
 
             assert run_output == 'green'
@@ -179,12 +177,12 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         else:
             messages = [ModelRequest.user_text_prompt('test')]
             if stream_first:
-                with model_request_stream_sync(model, messages, model_settings={'timeout': 10}) as stream:
+                with model_request_stream_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS) as stream:
                     stream_events = list(stream)
-                response = model_request_sync(model, messages, model_settings={'timeout': 10})
+                response = model_request_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS)
             else:
-                response = model_request_sync(model, messages, model_settings={'timeout': 10})
-                with model_request_stream_sync(model, messages, model_settings={'timeout': 10}) as stream:
+                response = model_request_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS)
+                with model_request_stream_sync(model, messages, model_settings=_LOCAL_REQUEST_SETTINGS) as stream:
                     stream_events = list(stream)
 
             assert response.parts
@@ -208,9 +206,9 @@ async def test_async_run_and_stream_share_one_event_loop(
     agent = Agent(model)
 
     try:
-        first = await agent.run('first', model_settings={'timeout': 1})
+        first = await agent.run('first', model_settings=_LOCAL_REQUEST_SETTINGS)
         async with agent.run_stream(
-            'second', message_history=first.all_messages(), model_settings={'timeout': 1}
+            'second', message_history=first.all_messages(), model_settings=_LOCAL_REQUEST_SETTINGS
         ) as stream:
             streamed_output = ''.join([text async for text in stream.stream_text(debounce_by=None)])
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -915,6 +915,82 @@ class BasicSpan:
     parent_id: int | None = field(repr=False, compare=False, default=None)
 
 
+def _parallel_tool_span_key(span: BasicSpan) -> tuple[int, str, int] | None:
+    """Return a canonical key for direct agent-run children created by parallel tool calls."""
+    import json
+
+    if span.content.startswith('running tool: '):
+        return 1, span.content.removeprefix('running tool: '), 0
+
+    spans = [span]
+    while spans:
+        current = spans.pop()
+        if current.content.startswith('{'):
+            try:
+                event: Any = json.loads(current.content)
+            except json.JSONDecodeError:
+                pass
+            else:
+                event_kind = event.get('event_kind')
+                part = event.get('part')
+                if event_kind in {'function_tool_call', 'function_tool_result'} and isinstance(part, dict):
+                    tool_name = cast(dict[str, Any], part).get('tool_name')
+                    if isinstance(tool_name, str):
+                        return (0, tool_name, 0) if event_kind == 'function_tool_call' else (1, tool_name, 1)
+        spans.extend(current.children)
+    return None
+
+
+def _normalize_parallel_tool_span_order(span: BasicSpan) -> None:
+    """Canonicalize exporter order between model turns without disturbing sequential spans."""
+    chat_positions = [index for index, child in enumerate(span.children) if child.content.startswith('chat ')]
+    for start, end in zip(chat_positions, [*chat_positions[1:], len(span.children)]):
+        keyed_children = [
+            (index, key, span.children[index])
+            for index in range(start + 1, end)
+            if (key := _parallel_tool_span_key(span.children[index])) is not None
+        ]
+        if len({key[1] for _, key, _ in keyed_children}) > 1:
+            ordered_children = [child for _, _, child in sorted(keyed_children, key=lambda item: item[1])]
+            for (index, _, _), child in zip(keyed_children, ordered_children):
+                span.children[index] = child
+
+    for child in span.children:
+        _normalize_parallel_tool_span_order(child)
+
+
+async def test_normalize_parallel_tool_span_order() -> None:
+    def event(tool_name: str, event_kind: str) -> BasicSpan:
+        return BasicSpan(content=f'{{"part": {{"tool_name": "{tool_name}"}}, "event_kind": "{event_kind}"}}')
+
+    run_span = BasicSpan(
+        content='agent run',
+        children=[
+            BasicSpan(content='chat model'),
+            event('product', 'function_tool_call'),
+            BasicSpan(content='running tool: product'),
+            event('country', 'function_tool_call'),
+            event('product', 'function_tool_result'),
+            BasicSpan(content='running tool: country'),
+            event('country', 'function_tool_result'),
+            BasicSpan(content='chat model'),
+        ],
+    )
+
+    _normalize_parallel_tool_span_order(run_span)
+
+    assert [child.content for child in run_span.children] == [
+        'chat model',
+        '{"part": {"tool_name": "country"}, "event_kind": "function_tool_call"}',
+        '{"part": {"tool_name": "product"}, "event_kind": "function_tool_call"}',
+        'running tool: country',
+        '{"part": {"tool_name": "country"}, "event_kind": "function_tool_result"}',
+        'running tool: product',
+        '{"part": {"tool_name": "product"}, "event_kind": "function_tool_result"}',
+        'chat model',
+    ]
+
+
 async def test_complex_agent_run_in_workflow(
     allow_model_requests: None, client_with_logfire: Client, capfire: CaptureLogfire
 ):
@@ -985,6 +1061,7 @@ async def test_complex_agent_run_in_workflow(
 
     assert root_span is not None
     _normalize_json_spans(root_span)
+    _normalize_parallel_tool_span_order(root_span)
 
     assert root_span == snapshot(
         BasicSpan(
@@ -8798,6 +8875,7 @@ async def test_durability_complex_agent_logfire_span_tree(
 
     assert root_span is not None
     _normalize_json_spans(root_span)
+    _normalize_parallel_tool_span_order(root_span)
 
     assert root_span == snapshot(
         BasicSpan(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import re
 import sys
@@ -252,7 +253,7 @@ with workflow.unsafe.imports_passed_through():
     from ._inline_snapshot import snapshot
 
     # Loads `vcr`, which Temporal doesn't like without passing through the import
-    from .conftest import IsDatetime, IsInt, IsStr, message, try_import
+    from .conftest import IsDatetime, IsInt, IsList, IsStr, message, try_import
 
 with try_import() as anthropic_imports_successful:
     import anthropic
@@ -914,81 +915,111 @@ class BasicSpan:
     children: list[BasicSpan] = field(default_factory=list['BasicSpan'])
     parent_id: int | None = field(repr=False, compare=False, default=None)
 
-
-def _parallel_tool_span_key(span: BasicSpan) -> tuple[int, str, int] | None:
-    """Return a canonical key for direct agent-run children created by parallel tool calls."""
-    import json
-
-    if span.content.startswith('running tool: '):
-        return 1, span.content.removeprefix('running tool: '), 0
-
-    spans = [span]
-    while spans:
-        current = spans.pop()
-        if current.content.startswith('{'):
-            try:
-                event: Any = json.loads(current.content)
-            except json.JSONDecodeError:
-                pass
-            else:
-                event_kind = event.get('event_kind')
-                part = event.get('part')
-                if event_kind in {'function_tool_call', 'function_tool_result'} and isinstance(part, dict):
-                    tool_name = cast(dict[str, Any], part).get('tool_name')
-                    if isinstance(tool_name, str):
-                        return (0, tool_name, 0) if event_kind == 'function_tool_call' else (1, tool_name, 1)
-        spans.extend(current.children)
-    return None
+    def walk(self) -> Iterator[BasicSpan]:
+        yield self
+        for child in self.children:
+            yield from child.walk()
 
 
-def _normalize_parallel_tool_span_order(span: BasicSpan) -> None:
-    """Canonicalize exporter order between model turns without disturbing sequential spans."""
-    chat_positions = [index for index, child in enumerate(span.children) if child.content.startswith('chat ')]
-    for start, end in zip(chat_positions, [*chat_positions[1:], len(span.children)]):
-        keyed_children = [
-            (index, key, span.children[index])
-            for index in range(start + 1, end)
-            if (key := _parallel_tool_span_key(span.children[index])) is not None
-        ]
-        if len({key[1] for _, key, _ in keyed_children}) > 1:
-            ordered_children = [child for _, _, child in sorted(keyed_children, key=lambda item: item[1])]
-            for (index, _, _), child in zip(keyed_children, ordered_children):
-                span.children[index] = child
+def _assert_agent_run_causality(root_span: BasicSpan, run_name: str) -> None:
+    """Pin sequential model turns and each tool's lifecycle while allowing cross-tool interleaving."""
+    run_span = next(span for span in root_span.walk() if span.content == run_name)
+    model_positions = [index for index, child in enumerate(run_span.children) if child.content.startswith('chat ')]
+    get_tools_positions = [
+        index for index, child in enumerate(run_span.children) if child.content.endswith('__get_tools')
+    ]
+    run_steps = [
+        next(span.content for span in child.walk() if span.content.startswith('ctx.run_step='))
+        for child in run_span.children
+        if child.content.startswith('chat ')
+    ]
+    assert run_steps == ['ctx.run_step=1', 'ctx.run_step=2', 'ctx.run_step=3']
+    assert len(get_tools_positions) == 1
+    assert get_tools_positions[0] < model_positions[0]
 
-    for child in span.children:
-        _normalize_parallel_tool_span_order(child)
+    lifecycle_by_tool: dict[str, list[str]] = {}
+    positions_by_tool: dict[str, list[int]] = {}
+    output_events: list[tuple[str, int]] = []
+    for index, child in enumerate(run_span.children):
+        output_event_span = next((span for span in child.walk() if '"event_kind": "output_tool_' in span.content), None)
+        if output_event_span is not None:
+            output_event = cast(dict[str, Any], json.loads(output_event_span.content))
+            output_events.append((cast(str, output_event['event_kind']), index))
+
+        if child.content.startswith('running tool: '):
+            tool_name = child.content.removeprefix('running tool: ')
+            phase = 'run'
+        else:
+            event_span = next((span for span in child.walk() if '"event_kind": "function_tool_' in span.content), None)
+            if event_span is None:
+                continue
+            event = cast(dict[str, Any], json.loads(event_span.content))
+            event_kind = cast(str, event['event_kind'])
+            tool_name = cast(str, cast(dict[str, Any], event['part'])['tool_name'])
+            phase = {'function_tool_call': 'call', 'function_tool_result': 'result'}[event_kind]
+        lifecycle_by_tool.setdefault(tool_name, []).append(phase)
+        positions_by_tool.setdefault(tool_name, []).append(index)
+
+    assert lifecycle_by_tool == {
+        'get_country': ['call', 'run', 'result'],
+        'get_product_name': ['call', 'run', 'result'],
+        'get_weather': ['call', 'run', 'result'],
+    }
+    assert all(
+        model_positions[0] < index < model_positions[1]
+        for tool in ('get_country', 'get_product_name')
+        for index in positions_by_tool[tool]
+    )
+    assert all(model_positions[1] < index < model_positions[2] for index in positions_by_tool['get_weather'])
+    assert [event_kind for event_kind, _ in output_events] == ['output_tool_call', 'output_tool_result']
+    assert all(model_positions[2] < index for _, index in output_events)
 
 
-async def test_normalize_parallel_tool_span_order() -> None:
+def test_agent_run_causality_rejects_invalid_order() -> None:
+    """A VCR request cannot exercise the test-only tree matcher used by the Temporal span snapshots."""
+
     def event(tool_name: str, event_kind: str) -> BasicSpan:
-        return BasicSpan(content=f'{{"part": {{"tool_name": "{tool_name}"}}, "event_kind": "{event_kind}"}}')
+        return BasicSpan(content=json.dumps({'part': {'tool_name': tool_name}, 'event_kind': event_kind}))
+
+    def chat(step: int) -> BasicSpan:
+        return BasicSpan(content='chat model', children=[BasicSpan(content=f'ctx.run_step={step}')])
 
     run_span = BasicSpan(
         content='agent run',
         children=[
-            BasicSpan(content='chat model'),
-            event('product', 'function_tool_call'),
-            BasicSpan(content='running tool: product'),
-            event('country', 'function_tool_call'),
-            event('product', 'function_tool_result'),
-            BasicSpan(content='running tool: country'),
-            event('country', 'function_tool_result'),
-            BasicSpan(content='chat model'),
+            BasicSpan(content='StartActivity:agent__test__mcp__get_tools'),
+            chat(1),
+            event('get_country', 'function_tool_call'),
+            BasicSpan(content='running tool: get_country'),
+            event('get_country', 'function_tool_result'),
+            event('get_product_name', 'function_tool_call'),
+            BasicSpan(content='running tool: get_product_name'),
+            event('get_product_name', 'function_tool_result'),
+            chat(2),
+            event('get_weather', 'function_tool_call'),
+            BasicSpan(content='running tool: get_weather'),
+            event('get_weather', 'function_tool_result'),
+            chat(3),
+            event('final_result', 'output_tool_call'),
+            event('final_result', 'output_tool_result'),
         ],
     )
+    root_span = BasicSpan(content='workflow', children=[run_span])
+    _assert_agent_run_causality(root_span, 'agent run')
 
-    _normalize_parallel_tool_span_order(run_span)
+    run_span.children[3], run_span.children[4] = run_span.children[4], run_span.children[3]
+    with pytest.raises(AssertionError):
+        _assert_agent_run_causality(root_span, 'agent run')
+    run_span.children[3], run_span.children[4] = run_span.children[4], run_span.children[3]
 
-    assert [child.content for child in run_span.children] == [
-        'chat model',
-        '{"part": {"tool_name": "country"}, "event_kind": "function_tool_call"}',
-        '{"part": {"tool_name": "product"}, "event_kind": "function_tool_call"}',
-        'running tool: country',
-        '{"part": {"tool_name": "country"}, "event_kind": "function_tool_result"}',
-        'running tool: product',
-        '{"part": {"tool_name": "product"}, "event_kind": "function_tool_result"}',
-        'chat model',
-    ]
+    run_span.children[7], run_span.children[8] = run_span.children[8], run_span.children[7]
+    with pytest.raises(AssertionError):
+        _assert_agent_run_causality(root_span, 'agent run')
+    run_span.children[7], run_span.children[8] = run_span.children[8], run_span.children[7]
+
+    run_span.children[-2], run_span.children[-1] = run_span.children[-1], run_span.children[-2]
+    with pytest.raises(AssertionError):
+        _assert_agent_run_causality(root_span, 'agent run')
 
 
 async def test_complex_agent_run_in_workflow(
@@ -1040,8 +1071,6 @@ async def test_complex_agent_run_in_workflow(
 
     def _normalize_json_spans(span: BasicSpan) -> None:
         """Normalize non-deterministic tool_call_ids in JSON event spans."""
-        import json
-
         for child in span.children:
             if child.content.startswith('{'):
                 try:
@@ -1061,7 +1090,7 @@ async def test_complex_agent_run_in_workflow(
 
     assert root_span is not None
     _normalize_json_spans(root_span)
-    _normalize_parallel_tool_span_order(root_span)
+    _assert_agent_run_causality(root_span, 'complex_agent run')
 
     assert root_span == snapshot(
         BasicSpan(
@@ -1070,7 +1099,7 @@ async def test_complex_agent_run_in_workflow(
                 BasicSpan(content='RunWorkflow:ComplexAgentWorkflow'),
                 BasicSpan(
                     content='complex_agent run',
-                    children=[
+                    children=IsList(
                         BasicSpan(
                             content='StartActivity:agent__complex_agent__mcp_server__mcp__get_tools',
                             children=[
@@ -1439,7 +1468,8 @@ async def test_complex_agent_run_in_workflow(
                                 )
                             ],
                         ),
-                    ],
+                        check_order=False,
+                    ),
                 ),
                 BasicSpan(content='CompleteWorkflow:ComplexAgentWorkflow'),
             ],
@@ -8854,8 +8884,6 @@ async def test_durability_complex_agent_logfire_span_tree(
 
     def _normalize_json_spans(span: BasicSpan) -> None:
         """Normalize non-deterministic tool_call_ids in JSON event spans."""
-        import json
-
         for child in span.children:
             if child.content.startswith('{'):
                 try:
@@ -8875,7 +8903,7 @@ async def test_durability_complex_agent_logfire_span_tree(
 
     assert root_span is not None
     _normalize_json_spans(root_span)
-    _normalize_parallel_tool_span_order(root_span)
+    _assert_agent_run_causality(root_span, 'durability_complex_agent_logfire run')
 
     assert root_span == snapshot(
         BasicSpan(
@@ -8884,7 +8912,7 @@ async def test_durability_complex_agent_logfire_span_tree(
                 BasicSpan(content='RunWorkflow:ComplexDurableAgentLogfireWorkflow'),
                 BasicSpan(
                     content='durability_complex_agent_logfire run',
-                    children=[
+                    children=IsList(
                         BasicSpan(
                             content='StartActivity:agent__durability_complex_agent_logfire__mcp_server__durability_complex_mcp__get_tools',
                             children=[
@@ -9265,7 +9293,8 @@ async def test_durability_complex_agent_logfire_span_tree(
                                 )
                             ],
                         ),
-                    ],
+                        check_order=False,
+                    ),
                 ),
                 BasicSpan(content='CompleteWorkflow:ComplexDurableAgentLogfireWorkflow'),
             ],


### PR DESCRIPTION
Five recent flakes came from tests asserting accidental timing, ambient state, or exporter order instead of their intended contract. This keeps the behavioral coverage while removing only those unrelated dependencies.

- Exercise both sync-stream BaseException paths with an event-loop-turn watchdog. A stalled worker cannot consume turns, so the anti-hang guard no longer depends on elapsed time.
- Build the predefined `SpanTree` query fixture from deterministic `SpanNode`s. The pure query tests no longer depend on live global OTel context; the capture-specific tests still exercise Logfire/OTel integration.
- Compare concurrent Temporal agent-run children structurally, then separately assert the real causal contract: tool discovery precedes model work, model turns remain sequential, each tool keeps call/run/result order within its turn, and the output call precedes its result. Negative tests prove invalid causal order is still rejected.
- Construct and close the xAI `AsyncClient` inside the test's running AnyIO loop; no ambient default-loop fixture is needed.
- Replace the local Anthropic server and response deadline with an in-process persistent transport that records the running loop for every request. The test now directly requires both sync entry points to use the exact same loop, with no socket, server thread, or timeout.

Failure evidence:

- Sync bridge watchdog: [run 32498362182](https://github.com/pydantic/pydantic-ai/actions/runs/32498362182/job/96822063593)
- Empty `SpanTree`: [run 32305486908](https://github.com/pydantic/pydantic-ai/actions/runs/32305486908/job/96237211517)
- Concurrent Temporal span order: [run 32468135964](https://github.com/pydantic/pydantic-ai/actions/runs/32468135964/job/96729058334)
- Local keep-alive timeout: [run 32701242939](https://github.com/pydantic/pydantic-ai/actions/runs/32701242939/job/97353021899)
- xAI ambient loop: [run 31712722673](https://github.com/pydantic/pydantic-ai/actions/runs/31712722673/job/94489565365)

Validation:

- 47 focused tests across all five modified files passed together.
- The no-timeout loop/bridge/xAI targets passed twenty repeated runs: 320 executions.
- A deliberate pre-fix loop-affinity reproduction fails immediately when the second sync operation reaches the transport on a different loop; the current bridge passes.
- A deliberate broken BaseException-forwarding reproduction reaches the loop-turn watchdog; the current bridge propagates immediately without reaching it.
- The Temporal targets passed five repeated runs (15 executions total).
- Focused branch coverage reports no uncovered lines or branches in the new deterministic helpers and negative tests.
- Ruff check/format and targeted Pyright passed for all five modified files.
- The full local pre-commit typecheck was skipped only because this focused environment lacks unrelated optional provider/harness packages; all other hooks passed, and the fully provisioned CI typecheck remains required.

Scope note: deterministic input fixes the pure `SpanTree` query-test flake, but this PR does not claim to solve every possible async OTel context-isolation failure. Temporal deadlock-detector false positives already mitigated by #7451, Prefect startup, coverage-fragment loss, `setup-uv` downloads, and interpreter crashes are also intentionally excluded because weakening tests would hide those harness/infra failures.

Refs #7725

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


