### PR TITLE
Fix typo in xai.py comment: re-emmiting -> re-emitting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -1095,7 +1095,7 @@ class XaiStreamedResponse(StreamedResponse):
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         with _map_api_errors(self._model_name):
-            # Local state to avoid re-emmiting duplicate events.
+            # Local state to avoid re-emitting duplicate events.
             prev_reasoning_content = ''
             prev_encrypted_content = ''
             seen_tool_call_ids: set[str] = set()


### PR DESCRIPTION
Trivial typo fix in a code comment in `pydantic_ai_slim/pydantic_ai/models/xai.py` — "re-emmiting" should be "re-emitting". No behavior change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

