### PR TITLE
Use a shallow checkout for coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,8 +555,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # needed for diff-cover
-          fetch-depth: 0
           persist-credentials: false
 
       - name: get coverage files


### PR DESCRIPTION
Part of the CI performance series: #7731, #7732, and #7733 are independent and can merge in any order. Draft #7734 → #7735 carry the separate Torch cache proposal.

### What changed

Let `actions/checkout` use its default shallow checkout in the coverage job.

### Why

The full-history override is accompanied by a stale “needed for diff-cover” comment, but the coverage job no longer invokes `diff-cover` or any Git history consumer. In [a current coverage job](https://github.com/pydantic/pydantic-ai/actions/runs/32706412447/job/97371011669), checkout occupied 14 seconds before coverage work began.

`actions/checkout` documents that the default fetches only the triggering commit; `fetch-depth: 0` fetches all branches and tags ([official checkout documentation](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches)).

### Verification and scope

- Inspected every remaining coverage-job command for Git history use.
- YAML and zizmor checks passed.
- Full pre-commit passed.

This does not change coverage collection, reporting, branch protection, tests, or the matrix. It is separate from coverage-process scheduling so either change can be evaluated or reverted alone.

No linked issue: isolated CI maintenance.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the release changelog.

