### PR TITLE
Drop the coverage HTML report and run coverage checks concurrently

### DIFF
--- a/.github/workflows/after-ci.yml
+++ b/.github/workflows/after-ci.yml
@@ -45,33 +45,3 @@ jobs:
           name: ci-duration-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
           path: ci-duration-record.json
           retention-days: 7
-
-  smokeshow:
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-
-    steps:
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          python-version: "3.12"
-
-      - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: ci.yml
-          name: "(diff-)?coverage-html.*"
-          name_is_regexp: true
-          commit: ${{ github.event.workflow_run.head_sha }}
-          allow_forks: true
-          workflow_conclusion: completed
-          if_no_artifact_found: warn
-
-      - run: uvx smokeshow upload coverage-html
-        if: hashFiles('coverage-html/*.html') != ''
-        env:
-          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Coverage {coverage-percentage}
-          SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 95
-          SMOKESHOW_GITHUB_CONTEXT: coverage
-          SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          SMOKESHOW_AUTH_KEY: ${{ secrets.SMOKESHOW_AUTH_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,7 @@ jobs:
       - run: uv run coverage combine
       - name: generate coverage reports
         # UV_NO_SYNC rather than `--no-sync` flags: strict-no-cover spawns its own nested
-        # `uv run`, and a sync there could modify the venv under the two concurrent readers.
+        # `uv run`, and a sync there could modify the venv under the concurrent reader.
         env:
           UV_NO_SYNC: '1'
         run: |
@@ -583,20 +583,11 @@ jobs:
           report_pid=$!
           COVERAGE_FILE=.coverage/.coverage uv run strict-no-cover &
           strict_pid=$!
-          uv run coverage html --show-contexts --title "Pydantic AI coverage for ${{ github.sha }}" &
-          html_pid=$!
 
           status=0
           wait "$report_pid" || status=1
           wait "$strict_pid" || status=1
-          wait "$html_pid" || status=1
           exit "$status"
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-html
-          path: htmlcov
-          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,13 +573,25 @@ jobs:
 
       - run: uv sync --group dev
       - run: uv run coverage combine
-      - run: uv run coverage report
-
-      - run: uv run strict-no-cover
+      - name: generate coverage reports
+        # UV_NO_SYNC rather than `--no-sync` flags: strict-no-cover spawns its own nested
+        # `uv run`, and a sync there could modify the venv under the two concurrent readers.
         env:
-          COVERAGE_FILE: .coverage/.coverage
+          UV_NO_SYNC: '1'
+        run: |
+          uv run coverage report &
+          report_pid=$!
+          COVERAGE_FILE=.coverage/.coverage uv run strict-no-cover &
+          strict_pid=$!
+          uv run coverage html --show-contexts --title "Pydantic AI coverage for ${{ github.sha }}" &
+          html_pid=$!
 
-      - run: uv run coverage html --show-contexts --title "Pydantic AI coverage for ${{ github.sha }}"
+          status=0
+          wait "$report_pid" || status=1
+          wait "$strict_pid" || status=1
+          wait "$html_pid" || status=1
+          exit "$status"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </div>
 <div align="center">
   <a href="https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push" alt="CI"></a>
-  <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai"><img src="https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg" alt="Coverage"></a>
+  <a href="https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage"></a>
   <a href="https://pypi.python.org/pypi/pydantic-ai"><img src="https://img.shields.io/pypi/v/pydantic-ai.svg" alt="PyPI"></a>
   <a href="https://github.com/pydantic/pydantic-ai"><img src="https://img.shields.io/pypi/pyversions/pydantic-ai.svg" alt="versions"></a>
   <a href="https://github.com/pydantic/pydantic-ai/blob/main/LICENSE"><img src="https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v" alt="license"></a>

--- a/clai/README.md
+++ b/clai/README.md
@@ -1,7 +1,7 @@
 # clai
 
 [![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
-[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
 [![PyPI](https://img.shields.io/pypi/v/clai.svg)](https://pypi.python.org/pypi/clai)
 [![versions](https://img.shields.io/pypi/pyversions/clai.svg)](https://github.com/pydantic/pydantic-ai)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@ description: "How Python does AI: agents, realtime voice, image generation, embe
   <a href="https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain">
     <img src="https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push" alt="CI" />
   </a>
-  <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai">
-    <img src="https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg" alt="Coverage" />
+  <a href="https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/badge/coverage-100%25-brightgreen" alt="Coverage" />
   </a>
   <a href="https://pypi.python.org/pypi/pydantic-ai">
     <img src="https://img.shields.io/pypi/v/pydantic-ai.svg" alt="PyPI" />

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Pydantic AI Examples
 
 [![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
-[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
 [![PyPI](https://img.shields.io/pypi/v/pydantic-ai.svg)](https://pypi.python.org/pypi/pydantic-ai)
 [![versions](https://img.shields.io/pypi/pyversions/pydantic-ai.svg)](https://github.com/pydantic/pydantic-ai)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)

--- a/pydantic_ai_slim/README.md
+++ b/pydantic_ai_slim/README.md
@@ -1,7 +1,7 @@
 # Pydantic AI Slim
 
 [![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
-[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
 [![PyPI](https://img.shields.io/pypi/v/pydantic-ai-slim.svg)](https://pypi.python.org/pypi/pydantic-ai-slim)
 [![versions](https://img.shields.io/pypi/pyversions/pydantic-ai-slim.svg)](https://github.com/pydantic/pydantic-ai)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)

--- a/pydantic_evals/README.md
+++ b/pydantic_evals/README.md
@@ -1,7 +1,7 @@
 # Pydantic Evals
 
 [![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
-[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
 [![PyPI](https://img.shields.io/pypi/v/pydantic-evals.svg)](https://pypi.python.org/pypi/pydantic-evals)
 [![python versions](https://img.shields.io/pypi/pyversions/pydantic-evals.svg)](https://github.com/pydantic/pydantic-ai)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)

--- a/pydantic_graph/README.md
+++ b/pydantic_graph/README.md
@@ -1,7 +1,7 @@
 # Pydantic Graph
 
 [![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
-[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
 [![PyPI](https://img.shields.io/pypi/v/pydantic-graph.svg)](https://pypi.python.org/pypi/pydantic-graph)
 [![python versions](https://img.shields.io/pypi/pyversions/pydantic-graph.svg)](https://github.com/pydantic/pydantic-ai)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)


### PR DESCRIPTION
Part of the CI performance series with #7731 and #7732; all three are independent.

### What changed

- Removed the coverage HTML report from CI, as suggested by @Kludex [in this comment](https://github.com/pydantic/pydantic-ai/pull/7733#issuecomment-5406068659): the `coverage html` step, its artifact upload, and the `smokeshow` job in `after-ci.yml` that published it.
- Replaced the coverage badges in the READMEs and docs with a static 100% badge.
- The two remaining commands, `coverage report` and `strict-no-cover`, now run concurrently after `coverage combine`; the step fails if either fails.

### Why

The published report was always empty: `fail_under = 100` means only fully-covered runs upload it, and `skip_covered = true` then hides every file ([example](https://smokeshow.helpmanual.io/306q213u184s5q4s4724/)). The badge was likewise a constant 100.00%, so a static badge says the same thing — CI enforces 100%.

The smokeshow job had to go with the HTML: its artifact download uses `if_no_artifact_found: warn`, so it would have kept running and silently publishing nothing. Logfire dropped its coverage HTML the same way (it uses Codecov for the human-facing view — the natural replacement here if we ever want per-PR line coverage back).

Speed: the coverage job's report steps ran serially at 25s + 32s + 25s ([current job](https://github.com/pydantic/pydantic-ai/actions/runs/32706412447/job/97371011669)). Dropping the HTML removes 25s plus the artifact upload; running the remaining two concurrently cuts 57s to ~32s. The step sets `UV_NO_SYNC=1` rather than `--no-sync` flags because `strict-no-cover` spawns a nested `uv run` that only the environment variable reaches.

The `SMOKESHOW_AUTH_KEY` repository secret becomes unused and can be deleted.

No linked issue: isolated CI maintenance.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the release changelog.
