### PR TITLE
Retain uv wheels for dependency-heavy CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-suffix: ${{ matrix.install.name }}
+          # Retain wheels only for all-extras; keep smaller matrix caches pruned.
+          prune-cache: ${{ matrix.install.name != 'all-extras' }}
 
       - run: mkdir .coverage
 


### PR DESCRIPTION
Stacked on #7734 (`codex/ci-linux-cpu-torch`) and must not merge before it. Draft: to be promoted only if warm CI runs after #7734 lands show all-extras jobs still spending meaningful time re-downloading wheels.

### What changed

Make setup-uv retain built wheels only for the dependency-heavy `all-extras` test lane. Other matrix caches, including `lowest-versions`, remain pruned to limit pressure on the 10GB repository cache quota.

### Why

The pinned setup-uv v8.2.0 defaults `prune-cache` to true. setup-uv documents that pruning removes pre-built wheels, causing them to be downloaded again on subsequent runs ([official caching documentation](https://github.com/astral-sh/setup-uv/blob/main/docs/caching.md#enable-cache-pruning)). Current all-extras jobs demonstrate this directly: a ~546KiB exact cache hit is followed by the same Torch/dependency downloads in [main](https://github.com/pydantic/pydantic-ai/actions/runs/32706412447/job/97368356980) and [an external PR](https://github.com/pydantic/pydantic-ai/actions/runs/32713769565/job/97390593387).

This PR is stacked after CPU-only Linux Torch because retaining the old 2.529GiB CUDA graph per cache key would be unsafe. At audit time the repository held **9,625,949,139 bytes across 298 cache entries**, close to GitHub's documented [10GB repository cache limit](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy).

### Safety and measurement plan

- The all-extras caches keep their existing per-lane suffix; no other lane's cache grows.
- Small lint/docs/standard/slim/evals caches keep the current pruning behavior.
- YAML and zizmor checks passed.
- Full pre-commit passed.

This PR should be evaluated with cold then warm CI runs and cache-size telemetry. It can be dropped independently if retention does not improve warm runs or causes quota churn.

No linked issue: isolated CI cache-policy maintenance.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the release changelog.

