### PR TITLE
Create xAI `AsyncClient` inside a running event loop

### DIFF
--- a/tests/providers/test_xai.py
+++ b/tests/providers/test_xai.py
@@ -35,10 +35,14 @@ def test_xai_provider_need_api_key(env: TestEnv) -> None:
         XaiProvider()
 
 
-def test_xai_pass_xai_client() -> None:
+@pytest.mark.anyio
+async def test_xai_pass_xai_client() -> None:
     xai_client = AsyncClient(api_key='api-key')
-    provider = XaiProvider(xai_client=xai_client)
-    assert provider.client == xai_client
+    try:
+        provider = XaiProvider(xai_client=xai_client)
+        assert provider.client is xai_client
+    finally:
+        await xai_client.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
Split from #7726. This PR is independently mergeable.

Refs #7725.

The xAI client-injection test constructed an asyncio-bound SDK client from a synchronous test and depended on a default loop left in the thread. It now creates and closes the client inside the running AnyIO loop and asserts identity rather than equality.

Failure evidence: [run 31712722673](https://github.com/pydantic/pydantic-ai/actions/runs/31712722673/job/94489565365)

Validation:

- The focused xAI test passed on current `main`.
- Ruff and targeted Pyright passed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

