### PR TITLE
Assert sync client event-loop affinity directly

### DIFF
--- a/tests/test_sync_stream_loop_affinity.py
+++ b/tests/test_sync_stream_loop_affinity.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import AsyncIterator
 from typing import Literal, TypeAlias
 
+import httpx2
 import pytest
 
 from pydantic_ai import Agent, ModelRequest
@@ -14,7 +15,6 @@ from pydantic_ai.direct import model_request_stream_sync, model_request_sync
 from .conftest import try_import
 
 with try_import() as imports_successful:
-    import httpx2
     from anthropic import AsyncAnthropic
 
     from pydantic_ai.models.anthropic import AnthropicModel

--- a/tests/test_sync_stream_loop_affinity.py
+++ b/tests/test_sync_stream_loop_affinity.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import threading
-from collections.abc import Iterator
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Literal
+from collections.abc import AsyncIterator
+from typing import Literal, TypeAlias
 
 import pytest
 
@@ -16,27 +14,34 @@ from pydantic_ai.direct import model_request_stream_sync, model_request_sync
 from .conftest import try_import
 
 with try_import() as imports_successful:
+    import httpx2
     from anthropic import AsyncAnthropic
 
     from pydantic_ai.models.anthropic import AnthropicModel
     from pydantic_ai.providers.anthropic import AnthropicProvider
 
+    _LoopBoundTransport: TypeAlias = tuple[httpx2.AsyncClient, list[tuple[bool, asyncio.AbstractEventLoop]]]
+
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='anthropic not installed')
 
 
 @pytest.fixture
-def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]:
-    requests: list[tuple[bool, int]] = []
+def anthropic_loop_bound_transport() -> _LoopBoundTransport:
+    requests: list[tuple[bool, asyncio.AbstractEventLoop]] = []
 
-    class Handler(BaseHTTPRequestHandler):
-        protocol_version = 'HTTP/1.1'
+    class ResponseBody(httpx2.AsyncByteStream):
+        def __init__(self, content: bytes) -> None:
+            self.content = content
 
-        def do_POST(self) -> None:
-            size = int(self.headers.get('content-length', 0))
-            payload: object = json.loads(self.rfile.read(size))
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield self.content
+
+    class Transport(httpx2.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+            payload: object = json.loads(request.content)
             assert is_str_dict(payload)
             stream = payload.get('stream') is True
-            requests.append((stream, self.client_address[1]))
+            requests.append((stream, asyncio.get_running_loop()))
 
             if stream:
                 events: list[tuple[str, dict[str, object]]] = [
@@ -100,27 +105,15 @@ def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]
                 ).encode()
                 content_type = 'application/json'
 
-            self.send_response(200)
-            self.send_header('content-type', content_type)
-            self.send_header('content-length', str(len(body)))
-            self.send_header('connection', 'keep-alive')
-            self.end_headers()
-            self.wfile.write(body)
-            self.wfile.flush()
+            return httpx2.Response(
+                200,
+                headers={'content-type': content_type},
+                stream=ResponseBody(body),
+                request=request,
+            )
 
-        def log_message(self, format: str, *args: object) -> None:
-            pass
-
-    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
-    server.daemon_threads = True
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield f'http://127.0.0.1:{server.server_port}', requests
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join()
+    http_client = httpx2.AsyncClient(transport=Transport())
+    return http_client, requests
 
 
 @pytest.mark.parametrize(
@@ -136,19 +129,19 @@ def anthropic_keepalive_server() -> Iterator[tuple[str, list[tuple[bool, int]]]]
 @pytest.mark.parametrize('client_owner', ['provider', 'user'])
 def test_sync_entry_points_keep_async_client_on_one_event_loop(
     allow_model_requests: None,
-    anthropic_keepalive_server: tuple[str, list[tuple[bool, int]]],
+    anthropic_loop_bound_transport: _LoopBoundTransport,
     api_surface: Literal['agent', 'direct'],
     stream_first: bool,
     use_history: bool,
     client_owner: Literal['provider', 'user'],
 ) -> None:
-    """A real keep-alive connection is required because VCR does not retain asyncio transport state."""
-    base_url, requests = anthropic_keepalive_server
+    """A persistent transport exposes loop identity directly, which no HTTP recording can retain."""
+    http_client, requests = anthropic_loop_bound_transport
     if client_owner == 'provider':
-        provider = AnthropicProvider(api_key='test', base_url=base_url)
+        provider = AnthropicProvider(api_key='test', http_client=http_client)
         client = provider.client
     else:
-        client = AsyncAnthropic(api_key='test', base_url=base_url, max_retries=0)
+        client = AsyncAnthropic(api_key='test', http_client=http_client, max_retries=0)
         provider = AnthropicProvider(anthropic_client=client)
     client.max_retries = 0
     model = AnthropicModel('claude-test', provider=provider)
@@ -157,14 +150,14 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         if api_surface == 'agent':
             agent = Agent(model)
             if stream_first:
-                with agent.run_stream_sync('first', model_settings={'timeout': 1}) as stream:
+                with agent.run_stream_sync('first') as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
-                run_output = agent.run_sync('second', model_settings={'timeout': 1}).output
+                run_output = agent.run_sync('second').output
             else:
-                first = agent.run_sync('first', model_settings={'timeout': 1})
+                first = agent.run_sync('first')
                 history = first.all_messages() if use_history else None
                 run_output = first.output
-                with agent.run_stream_sync('second', message_history=history, model_settings={'timeout': 1}) as stream:
+                with agent.run_stream_sync('second', message_history=history) as stream:
                     streamed_output = ''.join(stream.stream_text(debounce_by=None))
 
             assert run_output == 'green'
@@ -172,19 +165,19 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
         else:
             messages = [ModelRequest.user_text_prompt('test')]
             if stream_first:
-                with model_request_stream_sync(model, messages, model_settings={'timeout': 1}) as stream:
+                with model_request_stream_sync(model, messages) as stream:
                     stream_events = list(stream)
-                response = model_request_sync(model, messages, model_settings={'timeout': 1})
+                response = model_request_sync(model, messages)
             else:
-                response = model_request_sync(model, messages, model_settings={'timeout': 1})
-                with model_request_stream_sync(model, messages, model_settings={'timeout': 1}) as stream:
+                response = model_request_sync(model, messages)
+                with model_request_stream_sync(model, messages) as stream:
                     stream_events = list(stream)
 
             assert response.parts
             assert stream_events
         assert len(requests) == 2
-        assert [stream for stream, _port in requests] == ([True, False] if stream_first else [False, True])
-        assert requests[0][1] == requests[1][1]
+        assert [stream for stream, _loop in requests] == ([True, False] if stream_first else [False, True])
+        assert requests[0][1] is requests[1][1]
     finally:
         asyncio.get_event_loop().run_until_complete(client.close())
 
@@ -192,24 +185,23 @@ def test_sync_entry_points_keep_async_client_on_one_event_loop(
 @pytest.mark.anyio
 async def test_async_run_and_stream_share_one_event_loop(
     allow_model_requests: None,
-    anthropic_keepalive_server: tuple[str, list[tuple[bool, int]]],
+    anthropic_loop_bound_transport: _LoopBoundTransport,
 ) -> None:
-    """Fully async requests retain their keep-alive connection when both use one event loop."""
-    base_url, requests = anthropic_keepalive_server
-    client = AsyncAnthropic(api_key='test', base_url=base_url, max_retries=0)
+    """Fully async requests use one event loop as a control for the synchronous bridge tests."""
+    http_client, requests = anthropic_loop_bound_transport
+    client = AsyncAnthropic(api_key='test', http_client=http_client, max_retries=0)
     model = AnthropicModel('claude-test', provider=AnthropicProvider(anthropic_client=client))
     agent = Agent(model)
 
     try:
-        first = await agent.run('first', model_settings={'timeout': 1})
-        async with agent.run_stream(
-            'second', message_history=first.all_messages(), model_settings={'timeout': 1}
-        ) as stream:
+        first = await agent.run('first')
+        async with agent.run_stream('second', message_history=first.all_messages()) as stream:
             streamed_output = ''.join([text async for text in stream.stream_text(debounce_by=None)])
 
         assert first.output == 'green'
         assert streamed_output == 'blue'
         assert len(requests) == 2
-        assert requests == [(False, requests[0][1]), (True, requests[0][1])]
+        assert [stream for stream, _loop in requests] == [False, True]
+        assert requests[0][1] is requests[1][1]
     finally:
         await client.close()


### PR DESCRIPTION
Split from #7726. This PR is independently mergeable.

Refs #7725.

The loop-affinity regression test inferred client-loop reuse through a local HTTP server, keep-alive source ports, and a one-second deadline. It now injects a persistent in-process HTTPX transport that records the running loop for each request. The test directly requires both sync entry points to reach the same loop, with no socket, server thread, or timeout.

Failure evidence: [run 32701242939](https://github.com/pydantic/pydantic-ai/actions/runs/32701242939/job/97353021899)

Validation:

- All 11 loop-affinity cases passed on current `main`.
- The pre-fix bridge fails immediately on different loop identity.
- Ruff and targeted Pyright passed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

