### PR TITLE
Make `SpanTree` query fixtures deterministic

### DIFF
--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from pytest_mock import MockerFixture
@@ -12,7 +13,7 @@ with try_import() as imports_successful:
     from pydantic_evals.otel._context_subtree import (
         context_subtree,
     )
-    from pydantic_evals.otel.span_tree import SpanQuery, SpanTree
+    from pydantic_evals.otel.span_tree import AttributeValue, SpanNode, SpanQuery, SpanTree
 
 with try_import() as logfire_import_successful:
     import logfire
@@ -96,20 +97,42 @@ async def test_context_subtree_concurrent():
 
 
 @pytest.fixture
-async def span_tree() -> SpanTree:
-    """Fixture that creates a span tree with a predefined structure and attributes."""
-    # Create spans with a tree structure and attributes
-    with context_subtree() as tree:
-        with logfire.span('root', level='0'):
-            with logfire.span('child1', level='1', type='important'):
-                with logfire.span('grandchild1', level='2', type='important'):
-                    pass
-                with logfire.span('grandchild2', level='2', type='normal'):
-                    pass
-            with logfire.span('child2', level='1', type='normal'):
-                with logfire.span('grandchild3', level='2', type='normal'):
-                    pass
-    assert isinstance(tree, SpanTree)
+def span_tree() -> SpanTree:
+    """Build deterministic input for pure tree queries, which have no provider request to record with VCR.
+
+    Live Logfire/OTel capture is exercised separately by the `context_subtree` tests above.
+    """
+
+    def make_span(
+        name: str,
+        span_id: int,
+        parent_span_id: int | None,
+        start: int,
+        duration: int,
+        **attributes: AttributeValue,
+    ) -> SpanNode:
+        start_timestamp = datetime.fromtimestamp(start, tz=timezone.utc)
+        return SpanNode(
+            name=name,
+            trace_id=1,
+            span_id=span_id,
+            parent_span_id=parent_span_id,
+            start_timestamp=start_timestamp,
+            end_timestamp=start_timestamp + timedelta(seconds=duration),
+            attributes=attributes,
+        )
+
+    tree = SpanTree()
+    tree.add_spans(
+        [
+            make_span('root', 1, None, 1, 11, level='0'),
+            make_span('child1', 3, 1, 2, 5, level='1', type='important'),
+            make_span('grandchild1', 5, 3, 3, 1, level='2', type='important'),
+            make_span('grandchild2', 7, 3, 5, 1, level='2', type='normal'),
+            make_span('child2', 9, 1, 8, 3, level='1', type='normal'),
+            make_span('grandchild3', 11, 9, 9, 1, level='2', type='normal'),
+        ]
+    )
     return tree
 
 


### PR DESCRIPTION
Split from #7726. This PR is independently mergeable.

Refs #7725.

The pure `SpanTree` query tests built their predefined input through live global Logfire/OTel capture and occasionally received an empty tree. This constructs the same topology directly from `SpanNode` objects. Dedicated `context_subtree` tests continue to cover live capture.

Failure evidence: [run 32305486908](https://github.com/pydantic/pydantic-ai/actions/runs/32305486908/job/96237211517)

Validation:

- All 29 tests in `tests/evals/test_otel.py` passed on current `main`.
- Ruff and targeted Pyright passed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

