### PR TITLE
Ignore Temporal sibling span export order in snapshots

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -252,7 +252,7 @@ with workflow.unsafe.imports_passed_through():
     from ._inline_snapshot import snapshot
 
     # Loads `vcr`, which Temporal doesn't like without passing through the import
-    from .conftest import IsDatetime, IsInt, IsStr, message, try_import
+    from .conftest import IsDatetime, IsInt, IsList, IsStr, message, try_import
 
 with try_import() as anthropic_imports_successful:
     import anthropic
@@ -8806,7 +8806,7 @@ async def test_durability_complex_agent_logfire_span_tree(
                 BasicSpan(content='RunWorkflow:ComplexDurableAgentLogfireWorkflow'),
                 BasicSpan(
                     content='durability_complex_agent_logfire run',
-                    children=[
+                    children=IsList(
                         BasicSpan(
                             content='StartActivity:agent__durability_complex_agent_logfire__mcp_server__durability_complex_mcp__get_tools',
                             children=[
@@ -9187,7 +9187,8 @@ async def test_durability_complex_agent_logfire_span_tree(
                                 )
                             ],
                         ),
-                    ],
+                        check_order=False,
+                    ),
                 ),
                 BasicSpan(content='CompleteWorkflow:ComplexDurableAgentLogfireWorkflow'),
             ],


### PR DESCRIPTION
Split from #7726. This PR is independently mergeable.

Refs #7725.

`test_durability_complex_agent_logfire_span_tree` builds its tree by appending completed spans in exporter arrival order. The country and product tools run concurrently, so their direct child spans can reach the exporter in more than one valid order. The snapshot accidentally treated that incidental order as part of the span-tree contract.

This changes only the direct children of the concurrent agent-run span to an unordered `IsList`. The snapshot still requires the exact same spans, attributes, duplicates, and parent-child structure; it only stops asserting sibling export order.

Failure evidence: [run 32468135964](https://github.com/pydantic/pydantic-ai/actions/runs/32468135964/job/96729058334)

Validation:

- `uv run pytest tests/test_temporal.py::test_durability_complex_agent_logfire_span_tree`
- `uv run ruff check tests/test_temporal.py`
- `uv run ruff format --check tests/test_temporal.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/test_temporal.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).