### PR TITLE
Carry Bedrock guardrail trace through to provider_details

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -899,6 +899,10 @@ class BedrockConverseModel(Model[BaseClient]):
         response_id = response.get('ResponseMetadata', {}).get('RequestId', None)
         raw_finish_reason = response['stopReason']
         provider_details = {'finish_reason': raw_finish_reason}
+        # Carry the guardrail assessment through when the guardrail config sets `trace: "enabled"`:
+        # it reports which policy fired, at what confidence, and the guardrail coverage.
+        if trace := response.get('trace'):
+            provider_details['trace'] = trace
         finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
 
         return ModelResponse(
@@ -1735,13 +1739,20 @@ class BedrockStreamedResponse(StreamedResponse):
                         continue
                     case {'messageStop': message_stop}:
                         raw_finish_reason = message_stop['stopReason']
-                        self.provider_details = {'finish_reason': raw_finish_reason}
+                        # Merge rather than replace: the `metadata` event (which carries the guardrail
+                        # `trace` when the guardrail config sets `trace: "enabled"`) may have arrived
+                        # before `messageStop`, and vice versa.
+                        self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}
                         self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
                     case {'metadata': metadata}:
                         if 'usage' in metadata:  # pragma: no branch
                             self._usage += _map_usage(
                                 metadata['usage'], self._provider_name, self._provider_url, self._model_name
                             )
+                        # Guardrail assessment (which policy fired, at what confidence) arrives on the
+                        # metadata event; merge it into whatever `messageStop` already recorded.
+                        if 'trace' in metadata:
+                            self.provider_details = {**(self.provider_details or {}), 'trace': metadata['trace']}
                     case {'contentBlockStart': content_block_start}:
                         index = content_block_start['contentBlockIndex']
                         start = content_block_start['start']

--- a/tests/models/bedrock/test_guardrail_trace.py
+++ b/tests/models/bedrock/test_guardrail_trace.py
@@ -1,0 +1,167 @@
+"""Tests for carrying the Bedrock guardrail `trace` through to `provider_details`.
+
+Regression test for #7561: when the guardrail config sets `trace: "enabled"`,
+Bedrock returns the per-policy assessment (which filter fired, at what
+confidence, and the guardrail coverage) on the response's `trace` field —
+both in the non-streaming response body and on the streaming `metadata`
+event. It was previously discarded, so callers could tell *that* a guardrail
+intervened but not *why*.
+"""
+
+from __future__ import annotations as _annotations
+
+import pytest
+from dirty_equals import IsPartialDict
+from pytest_mock import MockerFixture
+
+from pydantic_ai import Agent, TextPart
+
+from ...conftest import try_import
+
+with try_import() as imports_successful:
+    from pydantic_ai.models.bedrock import BedrockConverseModel
+    from pydantic_ai.providers.bedrock import BedrockProvider
+
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(not imports_successful(), reason='bedrock not installed'),
+]
+
+
+GUARDRAIL_TRACE = {
+    'guardrail': {
+        'inputAssessment': {
+            'guardrail-id-1': {
+                'contentPolicy': {
+                    'filters': [
+                        {'type': 'PROMPT_ATTACK', 'confidence': 'HIGH', 'action': 'BLOCKED'},
+                    ]
+                },
+            },
+        },
+    },
+}
+
+
+async def test_non_streaming_trace_in_provider_details(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    mocker: MockerFixture,
+):
+    """The guardrail assessment from the response body lands in `provider_details['trace']`."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 5, 'outputTokens': 10},
+        'trace': GUARDRAIL_TRACE,
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    result = await agent.run('hi')
+
+    response = result.all_messages()[-1]
+    assert response.provider_details == IsPartialDict(trace=GUARDRAIL_TRACE)
+    assert response.provider_details['finish_reason'] == 'end_turn'
+    assert TextPart(content='hello') in response.parts
+
+
+async def test_non_streaming_no_trace_keeps_details_unchanged(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    mocker: MockerFixture,
+):
+    """Without a `trace` on the response, `provider_details` keeps its previous shape."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 5, 'outputTokens': 10},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    result = await agent.run('hi')
+
+    response = result.all_messages()[-1]
+    assert response.provider_details == {'finish_reason': 'end_turn'}
+
+
+async def test_streaming_trace_in_provider_details(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    mocker: MockerFixture,
+):
+    """The guardrail assessment on the streaming `metadata` event lands in `provider_details['trace']`.
+
+    Uses the metadata-after-messageStop order (the one Bedrock actually emits) but the merge
+    logic must also survive the opposite order.
+    """
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model)
+
+    def fake_event_stream():
+        yield {'messageStart': {'role': 'assistant'}}
+        yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hello'}}}
+        yield {'contentBlockStop': {'contentBlockIndex': 0}}
+        yield {'messageStop': {'stopReason': 'guardrail_intervened'}}
+        yield {
+            'metadata': {
+                'usage': {'inputTokens': 5, 'outputTokens': 10},
+                'trace': GUARDRAIL_TRACE,
+            }
+        }
+
+    mock_converse_stream = mocker.patch.object(model.client, 'converse_stream')
+    mock_converse_stream.return_value = {'stream': fake_event_stream()}
+
+    async with agent.run_stream('hi') as result:
+        chunks = [c async for c in result.stream_text(delta=True)]
+
+    assert chunks == ['hello']
+    response = result.all_messages()[-1]
+    assert response.provider_details == IsPartialDict(
+        finish_reason='guardrail_intervened',
+        trace=GUARDRAIL_TRACE,
+    )
+
+
+async def test_streaming_trace_before_message_stop_preserved(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    mocker: MockerFixture,
+):
+    """A `metadata` event arriving *before* `messageStop` must not lose the trace when
+    `messageStop` writes the finish reason."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model)
+
+    def fake_event_stream():
+        yield {'messageStart': {'role': 'assistant'}}
+        yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hi'}}}
+        yield {'contentBlockStop': {'contentBlockIndex': 0}}
+        yield {
+            'metadata': {
+                'usage': {'inputTokens': 5, 'outputTokens': 10},
+                'trace': GUARDRAIL_TRACE,
+            }
+        }
+        yield {'messageStop': {'stopReason': 'guardrail_intervened'}}
+
+    mock_converse_stream = mocker.patch.object(model.client, 'converse_stream')
+    mock_converse_stream.return_value = {'stream': fake_event_stream()}
+
+    async with agent.run_stream('hi') as result:
+        _ = [c async for c in result.stream_text(delta=True)]
+
+    response = result.all_messages()[-1]
+    assert response.provider_details == IsPartialDict(
+        finish_reason='guardrail_intervened',
+        trace=GUARDRAIL_TRACE,
+    )


### PR DESCRIPTION
## Issue Number

Fixes #7561

## Summary

When a Bedrock guardrail is configured with `trace: "enabled"` (via `guardrailConfig.trace`), Bedrock returns the per-policy guardrail assessment — which filter fired, at what confidence, and the action taken — on the response's `trace` field. Both code paths dropped it:

- **Non-streaming** (`converse`): the top-level `response['trace']` was never read.
- **Streaming** (`converse_stream`): the `metadata` event carries the trace alongside `usage`, but only `usage` was consumed.

So callers could tell *that* a guardrail intervened (`finish_reason: 'guardrail_intervened'`) but not *why* — e.g. which content filter matched, or whether it was a promptattack detection. This makes guardrail behavior effectively unobservable for debugging or audit logging.

## Implementation

Both paths now copy the trace into `provider_details['trace']`, consistent with how `finish_reason` is already surfaced:

```python
# non-streaming
if trace := response.get('trace'):
    provider_details['trace'] = trace

# streaming metadata event
if 'trace' in metadata:
    self.provider_details = {**(self.provider_details or {}), 'trace': metadata['trace']}
```

The streaming write is a merge (`{**existing, ...}`) rather than an assignment, because `messageStop` and `metadata` event order is not guaranteed: when `metadata` arrives first (as in some Bedrock SDK clients) and `messageStop` later writes `finish_reason`, a plain assignment would clobber the trace collected earlier. This mirrors the same merge pattern already used in the `messageStop` handler.

## How to Test

New regression tests in `tests/models/bedrock/test_guardrail_trace.py` (4 tests, all mocked, no AWS credentials needed):

1. `test_non_streaming_trace_in_provider_details` — trace from the response body lands in `provider_details['trace']`.
2. `test_non_streaming_no_trace_keeps_details_unchanged` — no trace, `provider_details` keeps its previous shape.
3. `test_streaming_trace_in_provider_details` — metadata-after-messageStop order (what Bedrock emits): both `finish_reason` and `trace` present.
4. `test_streaming_trace_before_message_stop_preserved` — metadata-before-messageStop order: the earlier trace survives the later finish-reason write.

Before the fix, tests 1–3 fail (`provider_details` missing `trace`); after the fix all 4 pass:

```
pytest tests/models/bedrock/test_guardrail_trace.py
# 4 passed
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

