### PR TITLE
Support `CancellationToken` in UI adapter run methods

### DIFF
--- a/docs/ui/vercel-ai.md
+++ b/docs/ui/vercel-ai.md
@@ -55,6 +55,9 @@ When a run ends in [first-party cancellation](../agent.md#cancelling-a-run) — 
 !!! note "Client disconnects are external cancellation"
     Calling `stop()` on the client aborts the browser's request, which the server sees as a *disconnect*, not a first-party cancellation. That tears the run down as an external `asyncio.CancelledError` (see [the two kinds of cancellation](../agent.md#cancelling-a-run)), so no `abort` chunk is emitted and `on_cancel` does not fire — and the client has disconnected anyway. To get the `abort` chunk and run `on_cancel` on a stop gesture, keep the stream connected and cancel the run *first-party*: give the run a [`CancellationToken`][pydantic_ai.CancellationToken] and expose a separate endpoint (e.g. `POST /chat/{id}/cancel`) that calls `token.cancel()`.
 
+!!! note
+    The in-memory token registry below requires a single server process or sticky routing. In a multi-worker deployment, route the cancel request to the worker that owns the run using shared coordination such as a message broker.
+
 ```py {title="run_stream.py"}
 import json
 from collections.abc import AsyncIterator
@@ -105,7 +108,8 @@ async def chat(chat_id: str, request: Request) -> Response:
             async for event in adapter.encode_stream(event_stream):
                 yield event
         finally:
-            cancellation_tokens.pop(chat_id, None)
+            if cancellation_tokens.get(chat_id) is cancellation_token:
+                cancellation_tokens.pop(chat_id, None)
 
     return StreamingResponse(encode_stream(), media_type=accept)
 

--- a/docs/ui/vercel-ai.md
+++ b/docs/ui/vercel-ai.md
@@ -57,6 +57,7 @@ When a run ends in [first-party cancellation](../agent.md#cancelling-a-run) — 
 
 ```py {title="run_stream.py"}
 import json
+from collections.abc import AsyncIterator
 from http import HTTPStatus
 
 from fastapi import FastAPI
@@ -64,7 +65,7 @@ from fastapi.requests import Request
 from fastapi.responses import Response, StreamingResponse
 from pydantic import ValidationError
 
-from pydantic_ai import Agent, RunCancelled
+from pydantic_ai import Agent, CancellationToken, RunCancelled
 from pydantic_ai.ui import SSE_CONTENT_TYPE
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 
@@ -72,14 +73,16 @@ agent = Agent('openai:gpt-5.2')
 
 app = FastAPI()
 
+cancellation_tokens: dict[str, CancellationToken] = {}
+
 
 async def on_cancel(cancelled: RunCancelled) -> None:
     messages = cancelled.all_messages()  # (1)!
     print(f'cancelled after {len(messages)} messages')
 
 
-@app.post('/chat')
-async def chat(request: Request) -> Response:
+@app.post('/chat/{chat_id}')
+async def chat(chat_id: str, request: Request) -> Response:
     accept = request.headers.get('accept', SSE_CONTENT_TYPE)
     try:
         run_input = VercelAIAdapter.build_run_input(await request.body())
@@ -91,10 +94,26 @@ async def chat(request: Request) -> Response:
         )
 
     adapter = VercelAIAdapter(agent=agent, run_input=run_input, accept=accept)
-    event_stream = adapter.run_stream(on_cancel=on_cancel)
+    cancellation_token = CancellationToken()
+    cancellation_tokens[chat_id] = cancellation_token
+    event_stream = adapter.run_stream(
+        cancellation_token=cancellation_token, on_cancel=on_cancel
+    )
 
-    sse_event_stream = adapter.encode_stream(event_stream)
-    return StreamingResponse(sse_event_stream, media_type=accept)
+    async def encode_stream() -> AsyncIterator[str]:
+        try:
+            async for event in adapter.encode_stream(event_stream):
+                yield event
+        finally:
+            cancellation_tokens.pop(chat_id, None)
+
+    return StreamingResponse(encode_stream(), media_type=accept)
+
+
+@app.post('/chat/{chat_id}/cancel', status_code=HTTPStatus.NO_CONTENT)
+async def cancel_chat(chat_id: str) -> None:
+    if token := cancellation_tokens.get(chat_id):
+        token.cancel()
 ```
 
 1. The resumable history to persist -- pass it as `message_history` to a later run to resume the conversation.

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -478,12 +478,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         deferred_tool_results: DeferredToolResults | None = None,
         conversation_id: str | None = None,
         run_id: str | None = None,
-        cancellation_token: CancellationToken | None = None,
         model: Model | KnownModelName | str | None = None,
         instructions: _instructions.AgentInstructions[AgentDepsT] = None,
         deps: AgentDepsT = None,
         model_settings: ModelSettings | None = None,
         usage_limits: UsageLimits | None = None,
+        cancellation_token: CancellationToken | None = None,
         usage: RunUsage | None = None,
         metadata: AgentMetadata[AgentDepsT] | None = None,
         infer_name: bool = True,
@@ -499,12 +499,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             deferred_tool_results: Optional results for deferred tool calls in the message history.
             conversation_id: ID of the conversation this run belongs to. Pass `'new'` to start a fresh conversation, ignoring any `conversation_id` already on `message_history`. If omitted, falls back to the most recent `conversation_id` on `message_history` or a freshly generated UUID7.
             run_id: Optional ID for this agent run. Unlike `conversation_id`, never inherited from `message_history`. Passing an empty string, or a value that already appears on `message_history`, raises `UserError` because both break `new_messages()`; use `conversation_id` to correlate across turns or deferred-tool resume. If omitted, a fresh UUID7 is generated.
-            cancellation_token: Optional token for cancelling this run from another task.
             model: Optional model to use for this run, required if `model` was not set when creating the agent.
             instructions: Optional additional instructions to use for this run.
             deps: Optional dependencies to use for this run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
+            cancellation_token: Optional token for cancelling this run from another task.
             usage: Optional usage to start with, useful for resuming a conversation or agents used in tools.
             metadata: Optional metadata to attach to this run. Accepts a dictionary or a callable taking
                 [`RunContext`][pydantic_ai.tools.RunContext]; merged with the agent's configured metadata.
@@ -583,12 +583,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         deferred_tool_results: DeferredToolResults | None = None,
         conversation_id: str | None = None,
         run_id: str | None = None,
-        cancellation_token: CancellationToken | None = None,
         model: Model | KnownModelName | str | None = None,
         instructions: _instructions.AgentInstructions[AgentDepsT] = None,
         deps: AgentDepsT = None,
         model_settings: ModelSettings | None = None,
         usage_limits: UsageLimits | None = None,
+        cancellation_token: CancellationToken | None = None,
         usage: RunUsage | None = None,
         metadata: AgentMetadata[AgentDepsT] | None = None,
         infer_name: bool = True,
@@ -606,12 +606,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             deferred_tool_results: Optional results for deferred tool calls in the message history.
             conversation_id: ID of the conversation this run belongs to. Pass `'new'` to start a fresh conversation, ignoring any `conversation_id` already on `message_history`. If omitted, falls back to the most recent `conversation_id` on `message_history` or a freshly generated UUID7.
             run_id: Optional ID for this agent run. Unlike `conversation_id`, never inherited from `message_history`. Passing an empty string, or a value that already appears on `message_history`, raises `UserError` because both break `new_messages()`; use `conversation_id` to correlate across turns or deferred-tool resume. If omitted, a fresh UUID7 is generated.
-            cancellation_token: Optional token for cancelling this run from another task.
             model: Optional model to use for this run, required if `model` was not set when creating the agent.
             instructions: Optional additional instructions to use for this run.
             deps: Optional dependencies to use for this run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
+            cancellation_token: Optional token for cancelling this run from another task.
             usage: Optional usage to start with, useful for resuming a conversation or agents used in tools.
             metadata: Optional metadata to attach to this run. Accepts a dictionary or a callable taking
                 [`RunContext`][pydantic_ai.tools.RunContext]; merged with the agent's configured metadata.
@@ -657,13 +657,13 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         deferred_tool_results: DeferredToolResults | None = None,
         conversation_id: str | None = None,
         run_id: str | None = None,
-        cancellation_token: CancellationToken | None = None,
         model: Model | KnownModelName | str | None = None,
         instructions: _instructions.AgentInstructions[DispatchDepsT] = None,
         deps: DispatchDepsT = None,
         output_type: OutputSpec[Any] | None = None,
         model_settings: ModelSettings | None = None,
         usage_limits: UsageLimits | None = None,
+        cancellation_token: CancellationToken | None = None,
         usage: RunUsage | None = None,
         metadata: AgentMetadata[DispatchDepsT] | None = None,
         infer_name: bool = True,
@@ -691,12 +691,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             deferred_tool_results: Optional results for deferred tool calls in the message history.
             conversation_id: ID of the conversation this run belongs to. Pass `'new'` to start a fresh conversation, ignoring any `conversation_id` already on `message_history`. If omitted, falls back to the most recent `conversation_id` on `message_history` or a freshly generated UUID7.
             run_id: Optional ID for this agent run. Unlike `conversation_id`, never inherited from `message_history`. Passing an empty string, or a value that already appears on `message_history`, raises `UserError` because both break `new_messages()`; use `conversation_id` to correlate across turns or deferred-tool resume. If omitted, a fresh UUID7 is generated.
-            cancellation_token: Optional token for cancelling this run from another task.
             model: Optional model to use for this run, required if `model` was not set when creating the agent.
             instructions: Optional additional instructions to use for this run.
             deps: Optional dependencies to use for this run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
+            cancellation_token: Optional token for cancelling this run from another task.
             usage: Optional usage to start with, useful for resuming a conversation or agents used in tools.
             metadata: Optional metadata to attach to this run. Accepts a dictionary or a callable taking
                 [`RunContext`][pydantic_ai.tools.RunContext]; merged with the agent's configured metadata.

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -21,7 +21,7 @@ from typing import (
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from typing_extensions import Self, TypeVar
 
-from pydantic_ai import DeferredToolRequests, DeferredToolResults, _instructions
+from pydantic_ai import CancellationToken, DeferredToolRequests, DeferredToolResults, _instructions
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.agent import AbstractAgent
 from pydantic_ai.agent.abstract import AgentMetadata
@@ -478,6 +478,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         deferred_tool_results: DeferredToolResults | None = None,
         conversation_id: str | None = None,
         run_id: str | None = None,
+        cancellation_token: CancellationToken | None = None,
         model: Model | KnownModelName | str | None = None,
         instructions: _instructions.AgentInstructions[AgentDepsT] = None,
         deps: AgentDepsT = None,
@@ -498,6 +499,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             deferred_tool_results: Optional results for deferred tool calls in the message history.
             conversation_id: ID of the conversation this run belongs to. Pass `'new'` to start a fresh conversation, ignoring any `conversation_id` already on `message_history`. If omitted, falls back to the most recent `conversation_id` on `message_history` or a freshly generated UUID7.
             run_id: Optional ID for this agent run. Unlike `conversation_id`, never inherited from `message_history`. Passing an empty string, or a value that already appears on `message_history`, raises `UserError` because both break `new_messages()`; use `conversation_id` to correlate across turns or deferred-tool resume. If omitted, a fresh UUID7 is generated.
+            cancellation_token: Optional token for cancelling this run from another task.
             model: Optional model to use for this run, required if `model` was not set when creating the agent.
             instructions: Optional additional instructions to use for this run.
             deps: Optional dependencies to use for this run.
@@ -556,6 +558,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 deferred_tool_results=deferred_tool_results,
                 conversation_id=conversation_id,
                 run_id=run_id,
+                cancellation_token=cancellation_token,
                 model=model,
                 deps=deps,
                 model_settings=model_settings,
@@ -580,6 +583,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         deferred_tool_results: DeferredToolResults | None = None,
         conversation_id: str | None = None,
         run_id: str | None = None,
+        cancellation_token: CancellationToken | None = None,
         model: Model | KnownModelName | str | None = None,
         instructions: _instructions.AgentInstructions[AgentDepsT] = None,
         deps: AgentDepsT = None,
@@ -602,6 +606,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             deferred_tool_results: Optional results for deferred tool calls in the message history.
             conversation_id: ID of the conversation this run belongs to. Pass `'new'` to start a fresh conversation, ignoring any `conversation_id` already on `message_history`. If omitted, falls back to the most recent `conversation_id` on `message_history` or a freshly generated UUID7.
             run_id: Optional ID for this agent run. Unlike `conversation_id`, never inherited from `message_history`. Passing an empty string, or a value that already appears on `message_history`, raises `UserError` because both break `new_messages()`; use `conversation_id` to correlate across turns or deferred-tool resume. If omitted, a fresh UUID7 is generated.
+            cancellation_token: Optional token for cancelling this run from another task.
             model: Optional model to use for this run, required if `model` was not set when creating the agent.
             instructions: Optional additional instructions to use for this run.
             deps: Optional dependencies to use for this run.
@@ -626,6 +631,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 deferred_tool_results=deferred_tool_results,
                 conversation_id=conversation_id,
                 run_id=run_id,
+                cancellation_token=cancellation_token,
                 model=model,
                 instructions=instructions,
                 deps=deps,
@@ -651,6 +657,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         deferred_tool_results: DeferredToolResults | None = None,
         conversation_id: str | None = None,
         run_id: str | None = None,
+        cancellation_token: CancellationToken | None = None,
         model: Model | KnownModelName | str | None = None,
         instructions: _instructions.AgentInstructions[DispatchDepsT] = None,
         deps: DispatchDepsT = None,
@@ -684,6 +691,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             deferred_tool_results: Optional results for deferred tool calls in the message history.
             conversation_id: ID of the conversation this run belongs to. Pass `'new'` to start a fresh conversation, ignoring any `conversation_id` already on `message_history`. If omitted, falls back to the most recent `conversation_id` on `message_history` or a freshly generated UUID7.
             run_id: Optional ID for this agent run. Unlike `conversation_id`, never inherited from `message_history`. Passing an empty string, or a value that already appears on `message_history`, raises `UserError` because both break `new_messages()`; use `conversation_id` to correlate across turns or deferred-tool resume. If omitted, a fresh UUID7 is generated.
+            cancellation_token: Optional token for cancelling this run from another task.
             model: Optional model to use for this run, required if `model` was not set when creating the agent.
             instructions: Optional additional instructions to use for this run.
             deps: Optional dependencies to use for this run.
@@ -756,6 +764,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 deferred_tool_results=deferred_tool_results,
                 conversation_id=conversation_id,
                 run_id=run_id,
+                cancellation_token=cancellation_token,
                 deps=deps,
                 output_type=output_type,
                 model=model,

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3295,6 +3295,7 @@ async def test_run_stream_cancellation_token():
     assert events == [
         {'type': 'start'},
         {'type': 'abort', 'reason': 'The agent run was cancelled.'},
+        {'type': 'finish-step'},
         '[DONE]',
     ]
     assert len(cancelled) == 1
@@ -4181,6 +4182,7 @@ async def test_adapter_dispatch_request_cancellation_token():
     assert chunks == [
         {'type': 'start'},
         {'type': 'abort', 'reason': 'The agent run was cancelled.'},
+        {'type': 'finish-step'},
         '[DONE]',
     ]
     assert len(cancelled) == 1

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3256,6 +3256,7 @@ async def test_run_stream_cancelled():
     )
     assert not any(isinstance(event, dict) and event['type'] in {'error', 'finish'} for event in events)
 
+
 async def test_run_stream_native_cancellation_token():
     token = CancellationToken()
     token.cancel()
@@ -4137,6 +4138,7 @@ async def test_adapter_dispatch_request():
             '[DONE]',
         ]
     )
+
 
 async def test_adapter_dispatch_request_cancellation_token():
     token = CancellationToken()

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, cast
 import pytest
 from pydantic import ValidationError
 
-from pydantic_ai import Agent, capture_run_messages
+from pydantic_ai import Agent, CancellationToken, RunCancelled, capture_run_messages
 from pydantic_ai._deferred_capabilities import (
     parse_loaded_capabilities,
 )
@@ -3257,6 +3257,51 @@ async def test_run_stream_cancelled():
     assert not any(isinstance(event, dict) and event['type'] in {'error', 'finish'} for event in events)
 
 
+
+async def test_run_stream_native_cancellation_token():
+    token = CancellationToken()
+    token.cancel()
+    adapter = VercelAIAdapter(
+        Agent(model=TestModel()),
+        SubmitMessage(
+            id='foo',
+            messages=[UIMessage(id='bar', role='user', parts=[TextUIPart(text='Hello')])],
+        ),
+    )
+
+    with pytest.raises(RunCancelled):
+        async for _ in adapter.run_stream_native(cancellation_token=token):
+            pass
+
+
+async def test_run_stream_cancellation_token():
+    token = CancellationToken()
+    token.cancel()
+    adapter = VercelAIAdapter(
+        Agent(model=TestModel()),
+        SubmitMessage(
+            id='foo',
+            messages=[UIMessage(id='bar', role='user', parts=[TextUIPart(text='Hello')])],
+        ),
+    )
+    cancelled: list[RunCancelled] = []
+
+    events = [
+        '[DONE]' if '[DONE]' in event else json.loads(event.removeprefix('data: '))
+        async for event in adapter.encode_stream(
+            adapter.run_stream(cancellation_token=token, on_cancel=cancelled.append)
+        )
+    ]
+
+    assert events == [
+        {'type': 'start'},
+        {'type': 'abort', 'reason': 'The agent run was cancelled.'},
+        '[DONE]',
+    ]
+    assert len(cancelled) == 1
+    assert cancelled[0].all_messages() == []
+
+
 async def test_adapter_uses_request_id_as_conversation_id():
     """The Vercel AI top-level `id` (chat ID) is wired through to `gen_ai.conversation.id`."""
     agent = Agent(model=TestModel())
@@ -4094,6 +4139,54 @@ async def test_adapter_dispatch_request():
             '[DONE]',
         ]
     )
+
+
+
+async def test_adapter_dispatch_request_cancellation_token():
+    token = CancellationToken()
+    token.cancel()
+    run_input = SubmitMessage(
+        id='foo',
+        messages=[UIMessage(id='bar', role='user', parts=[TextUIPart(text='Hello')])],
+    )
+
+    async def receive() -> dict[str, Any]:
+        return {'type': 'http.request', 'body': run_input.model_dump_json().encode('utf-8')}
+
+    request = Request(
+        scope={
+            'type': 'http',
+            'method': 'POST',
+            'headers': [(b'content-type', b'application/json')],
+        },
+        receive=receive,
+    )
+    cancelled: list[RunCancelled] = []
+
+    response = await VercelAIAdapter.dispatch_request(
+        request,
+        agent=Agent(model=TestModel()),
+        cancellation_token=token,
+        on_cancel=cancelled.append,
+    )
+    assert isinstance(response, StreamingResponse)
+
+    chunks: list[str | dict[str, Any]] = []
+
+    async def send(data: MutableMapping[str, Any]) -> None:
+        body = cast(bytes, data.get('body', b'')).decode('utf-8').strip().removeprefix('data: ')
+        if body:
+            chunks.append('[DONE]' if body == '[DONE]' else json.loads(body))
+
+    await response.stream_response(send)
+
+    assert chunks == [
+        {'type': 'start'},
+        {'type': 'abort', 'reason': 'The agent run was cancelled.'},
+        '[DONE]',
+    ]
+    assert len(cancelled) == 1
+    assert cancelled[0].all_messages() == []
 
 
 async def test_adapter_dispatch_request_explicit_run_id():

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3256,8 +3256,6 @@ async def test_run_stream_cancelled():
     )
     assert not any(isinstance(event, dict) and event['type'] in {'error', 'finish'} for event in events)
 
-
-
 async def test_run_stream_native_cancellation_token():
     token = CancellationToken()
     token.cancel()
@@ -4139,8 +4137,6 @@ async def test_adapter_dispatch_request():
             '[DONE]',
         ]
     )
-
-
 
 async def test_adapter_dispatch_request_cancellation_token():
     token = CancellationToken()

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3299,7 +3299,9 @@ async def test_run_stream_cancellation_token():
         '[DONE]',
     ]
     assert len(cancelled) == 1
-    assert cancelled[0].all_messages() == []
+    assert cancelled[0].all_messages() == snapshot(
+        [ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())])]
+    )
 
 
 async def test_adapter_uses_request_id_as_conversation_id():
@@ -4186,7 +4188,9 @@ async def test_adapter_dispatch_request_cancellation_token():
         '[DONE]',
     ]
     assert len(cancelled) == 1
-    assert cancelled[0].all_messages() == []
+    assert cancelled[0].all_messages() == snapshot(
+        [ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())])]
+    )
 
 
 async def test_adapter_dispatch_request_explicit_run_id():

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3292,13 +3292,18 @@ async def test_run_stream_cancellation_token():
         )
     ]
 
-    assert events == [
-        {'type': 'start'},
-        {'type': 'abort', 'reason': 'The agent run was cancelled.'},
-        '[DONE]',
-    ]
+    assert events == snapshot(
+        [
+            {'type': 'start'},
+            {'type': 'abort', 'reason': 'The agent run was cancelled.'},
+            {'type': 'finish-step'},
+            '[DONE]',
+        ]
+    )
     assert len(cancelled) == 1
-    assert cancelled[0].all_messages() == []
+    assert cancelled[0].all_messages() == snapshot(
+        [ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())])]
+    )
 
 
 async def test_adapter_uses_request_id_as_conversation_id():
@@ -4178,13 +4183,18 @@ async def test_adapter_dispatch_request_cancellation_token():
 
     await response.stream_response(send)
 
-    assert chunks == [
-        {'type': 'start'},
-        {'type': 'abort', 'reason': 'The agent run was cancelled.'},
-        '[DONE]',
-    ]
+    assert chunks == snapshot(
+        [
+            {'type': 'start'},
+            {'type': 'abort', 'reason': 'The agent run was cancelled.'},
+            {'type': 'finish-step'},
+            '[DONE]',
+        ]
+    )
     assert len(cancelled) == 1
-    assert cancelled[0].all_messages() == []
+    assert cancelled[0].all_messages() == snapshot(
+        [ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())])]
+    )
 
 
 async def test_adapter_dispatch_request_explicit_run_id():


### PR DESCRIPTION
## Why we make these changes

The Vercel AI adapter documentation promises first-party cancellation, but `UIAdapter.run_stream_native()`, `run_stream()`, and `dispatch_request()` rejected `cancellation_token=` instead of forwarding it to the agent run. This closes #7722.

## New public surface

- Optional `cancellation_token: CancellationToken | None` keyword arguments on `UIAdapter.run_stream_native()`, `UIAdapter.run_stream()`, and `UIAdapter.dispatch_request()`.

## User-visible behavior

```diff
 VercelAIAdapter.run_stream(cancellation_token=token)
-└─ TypeError: unexpected keyword argument 'cancellation_token'
+└─ UIAdapter.run_stream_native(cancellation_token=token)
+   └─ AbstractAgent.run_stream_events(cancellation_token=token)
+      └─ first-party cancellation emits the protocol abort stream
```

## Verification

- Regression coverage exercises native streaming, encoded Vercel AI streaming, and request dispatch with a pre-cancelled token.
- The documentation example now includes token registration, a cancellation endpoint, race-safe cleanup, and multi-worker deployment guidance.

## What changes for existing users

Nothing unless they opt into first-party cancellation by passing `cancellation_token=`.

- Closes #7722

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
