### PR TITLE
Redirect observed legacy Pydantic AI docs routes

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -134,6 +134,8 @@ navigation:
       - page: "OpenAI"
         path: "models/openai.md"
         slug: "models/openai"
+        aliases:
+          - "providers/openai"
       - page: "Anthropic"
         path: "models/anthropic.md"
         slug: "models/anthropic"
@@ -566,6 +568,8 @@ navigation:
         path: "multi-agent-applications.md"
         slug: "guides/multi-agent-applications"
         aliases:
+          - "core-concepts/multi-agent-systems"
+          - "multi-agent"
           - "multi-agent-applications"
       - page: "Web Chat UI"
         path: "web.md"
@@ -688,6 +692,7 @@ navigation:
           - "api/pydantic_graph/persistence"
           - "api/pydantic_graph/mermaid"
           - "api/pydantic_graph/state"
+          - "guides/graph"
       - section: "Graph Builder"
         slug: ""
         contents:
@@ -722,6 +727,8 @@ navigation:
           - page: "Overview"
             path: "ui/overview.md"
             slug: "integrations/ui/overview"
+            aliases:
+              - "integrations/ui"
           - page: "AG-UI"
             path: "ui/ag-ui.md"
             slug: "integrations/ui/ag-ui"


### PR DESCRIPTION
## Summary

Add repository-owned aliases for five legacy Pydantic AI documentation routes observed returning 404s:

- `providers/openai` → `models/openai`
- `core-concepts/multi-agent-systems` → `guides/multi-agent-applications`
- `multi-agent` → `guides/multi-agent-applications`
- `guides/graph` → `graph/graph`
- `integrations/ui` → `integrations/ui/overview`

Keeping these aliases beside their canonical pages lets unified-docs generate permanent redirects without adding another central redirect list.

## Validation

- `pre-commit run --files docs/navigation.yml`
- Compiled the manifest with unified-docs on Node 24 and verified all five sources emit the expected `301` targets
- `git diff --check`

## Scope

Only high-confidence legacy routes with clear canonical successors are included. Ambiguous 404s such as `streaming`, `multimodal`, `streamlit`, and `fastapi` are intentionally left unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

