### PR TITLE
Add `pydantic_ai.history_repair.*` instrumentation attributes

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -257,6 +257,12 @@ After the invalid parts are handled, consecutive compatible messages are **merge
 
 The repair is deterministic and idempotent: repairing the same history always produces the same output, running a repaired history through another run leaves it untouched, and synthesized parts contain no wall-clock data, so reuse doesn't invalidate provider prompt caches.
 
+When [OpenTelemetry instrumentation](logfire.md) is active, the model request span records how much repair happened on that request, so you can see at a glance whether a history was already clean or needed intervention. Non-zero counters are reported under the `pydantic_ai.history_repair.*` span attributes:
+
+- `pydantic_ai.history_repair.synthesized_tool_returns` - how many dangling [`ToolCallPart`][pydantic_ai.messages.ToolCallPart]s were closed with a synthesized [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart].
+- `pydantic_ai.history_repair.dropped_orphaned_results` - how many orphaned tool-result parts were removed.
+- `pydantic_ai.history_repair.merged_messages` - how many merge operations combined consecutive compatible messages.
+
 Tool calls that can still receive a real result are left alone: when the history ends on a `ModelResponse` with tool calls, running without a new `user_prompt` executes them, and [deferred tool calls](deferred-tools.md) are matched to their `deferred_tool_results` — including when a 'complete' `ModelRequest` with the already-executed results follows the response. Repair of that live frontier only happens when the interruption is evident: a final response with [`state='interrupted'`][pydantic_ai.messages.ModelResponse.state] or a trailing request with [`state='interrupted'`][pydantic_ai.messages.ModelRequest.state] (e.g. from a [cancelled stream](output.md#cancelling-streams) or a crash during tool execution) whose tool calls will never be executed.
 
 This pipeline handles regular, locally-executed tool calls only. Provider-native tool parts — produced and resolved by the provider inline — are left untouched and repaired by each model's own serializer instead. Some other provider-invalid histories are also out of scope and may be rejected: duplicate tool results for one call, and provider-specific ordering rules beyond call/result pairing — where one of those rules is known and verified, the model's own serializer normalizes the request for it instead.

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -97,12 +97,12 @@ __all__ = (
 
 @asynccontextmanager
 async def _history_repair_stats_scope(stats: HistoryRepairStats) -> AsyncGenerator[None]:
-    """Bind history-repair counters to the current request and reset them on exit."""
-    history_repair_stats_ctx.set(stats)
+    """Bind history-repair counters to the current request and restore the previous value on exit."""
+    token = history_repair_stats_ctx.set(stats)
     try:
         yield
     finally:
-        history_repair_stats_ctx.set(None)
+        history_repair_stats_ctx.reset(token)
 
 
 T = TypeVar('T')

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -19,8 +19,10 @@ from typing_extensions import TypeVar, assert_never
 from pydantic_ai._history_processor import HistoryProcessor
 from pydantic_ai._instrumentation import (
     DEFAULT_INSTRUMENTATION_VERSION,
+    HistoryRepairStats,
     capture_current_context,
     get_instructions as _get_history_instructions,
+    history_repair_stats_ctx,
     time_to_first_chunk_ctx,
 )
 from pydantic_ai._tool_execution import process_tool_calls
@@ -91,6 +93,16 @@ __all__ = (
     'process_tool_calls',
     'resolve_run_id',
 )
+
+
+@asynccontextmanager
+async def _history_repair_stats_scope(stats: HistoryRepairStats) -> AsyncGenerator[None]:
+    """Bind history-repair counters to the current request and reset them on exit."""
+    history_repair_stats_ctx.set(stats)
+    try:
+        yield
+    finally:
+        history_repair_stats_ctx.set(None)
 
 
 T = TypeVar('T')
@@ -535,7 +547,8 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                 ctx_messages.used = True
 
         # Replace the `capture_run_messages` list with the message history
-        messages[:] = _clean_message_history(ctx.state.message_history)
+        cleaned_messages, _ = _clean_message_history(ctx.state.message_history)
+        messages[:] = cleaned_messages
         # Use the `capture_run_messages` list as the message history so that new messages are added to it
         ctx.state.message_history = messages
         ctx.deps.new_message_index = len(messages)
@@ -553,7 +566,7 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
             # synthesized returns. A 'complete' trailing request (e.g. from a run that ended in
             # `DeferredToolRequests`) is left alone: its response's open calls may still receive
             # `deferred_tool_results`.
-            messages[:] = _repair_dangling_tool_calls(messages, repair_last_response=True)
+            messages[:] = _repair_dangling_tool_calls(messages, repair_last_response=True)[0]
 
         next_message: _messages.ModelRequest | None = None
         is_resuming_without_prompt = False
@@ -629,7 +642,7 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                         # The response was cut off (e.g. a cancelled stream), so its tool calls
                         # will never be executed; close them out with synthesized returns instead
                         # of refusing the new prompt.
-                        messages[:] = _repair_dangling_tool_calls(messages, repair_last_response=True)
+                        messages[:] = _repair_dangling_tool_calls(messages, repair_last_response=True)[0]
                     else:
                         raise exceptions.UserError(
                             'Cannot provide a new user prompt when the message history contains unprocessed tool calls.'
@@ -1145,9 +1158,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         assert not self._did_stream, 'stream() should only be called once per node'
 
         try:
-            model, model_settings, model_request_parameters, message_history, run_context = await self._prepare_request(
-                ctx, streaming=True
-            )
+            (
+                model,
+                model_settings,
+                model_request_parameters,
+                message_history,
+                run_context,
+                repair_stats,
+            ) = await self._prepare_request(ctx, streaming=True)
         except exceptions.SkipModelRequest as e:
             # SkipModelRequest in stream path: yield an empty stream and finish handling
             # new_message_index wasn't updated in _prepare_request, fix it here
@@ -1171,187 +1189,190 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             assert self._result is not None
             return
 
-        # Cooperative hand-off between this coroutine and the wrap_model_request task:
-        # 1. The task runs capability middleware, then calls _streaming_handler which opens the stream.
-        # 2. _streaming_handler sets stream_ready once the stream is open, then waits on stream_done.
-        # 3. This coroutine waits for stream_ready (or early task completion), yields the stream
-        #    to the caller, and sets stream_done when the caller is finished consuming it.
-        # 4. The handler resumes, the stream context manager closes, and the task completes.
-        stream_ready = asyncio.Event()
-        stream_done = asyncio.Event()
-        agent_stream_holder: list[result.AgentStream[DepsT, T]] = []
+        async with _history_repair_stats_scope(repair_stats):
+            # Cooperative hand-off between this coroutine and the wrap_model_request task:
+            # 1. The task runs capability middleware, then calls _streaming_handler which opens the stream.
+            # 2. _streaming_handler sets stream_ready once the stream is open, then waits on stream_done.
+            # 3. This coroutine waits for stream_ready (or early task completion), yields the stream
+            #    to the caller, and sets stream_done when the caller is finished consuming it.
+            # 4. The handler resumes, the stream context manager closes, and the task completes.
+            stream_ready = asyncio.Event()
+            stream_done = asyncio.Event()
+            agent_stream_holder: list[result.AgentStream[DepsT, T]] = []
 
-        _handler_response: _messages.ModelResponse | None = None
+            _handler_response: _messages.ModelResponse | None = None
 
-        async def _streaming_handler(
-            req_ctx: ModelRequestContext,
-        ) -> _messages.ModelResponse:
-            nonlocal _handler_response
-            _ensure_model_supports_streaming(req_ctx.model)
-            # Stamp the request-issue instant so the instrumentation capability can record
-            # `gen_ai.client.operation.time_to_first_chunk` (TTFT). `StreamedResponse` records
-            # the first-chunk instant; the delta is the client-side time to first token.
-            request_start = time.perf_counter()
-            # `model_request_stream` stitches the (possibly suspended → complete) segments
-            # into one continuous stream, so the whole chain is presented as a single
-            # `AgentStream` and the model-request hooks wrap it once.
-            # `ctx.state.usage.requests` is bumped once here: continuations aren't
-            # separate request steps.
-            async with model_request_stream(req_ctx.model, request_context=req_ctx, run_context=run_context) as sr:
+            async def _streaming_handler(
+                req_ctx: ModelRequestContext,
+            ) -> _messages.ModelResponse:
+                nonlocal _handler_response
+                _ensure_model_supports_streaming(req_ctx.model)
+                # Stamp the request-issue instant so the instrumentation capability can record
+                # `gen_ai.client.operation.time_to_first_chunk` (TTFT). `StreamedResponse` records
+                # the first-chunk instant; the delta is the client-side time to first token.
+                request_start = time.perf_counter()
+                # `model_request_stream` stitches the (possibly suspended → complete) segments
+                # into one continuous stream, so the whole chain is presented as a single
+                # `AgentStream` and the model-request hooks wrap it once.
+                # `ctx.state.usage.requests` is bumped once here: continuations aren't
+                # separate request steps.
+                async with model_request_stream(req_ctx.model, request_context=req_ctx, run_context=run_context) as sr:
+                    self._did_stream = True
+                    ctx.state.usage.requests += 1
+                    agent_stream = self._build_agent_stream(ctx, sr, req_ctx.model_request_parameters)
+                    agent_stream_holder.append(agent_stream)
+                    stream_ready.set()
+                    try:
+                        await stream_done.wait()
+                    finally:
+                        # Report TTFT in a `finally` so it also lands when the consumer raises
+                        # mid-iteration and `_cancel_task(wrap_task)` injects CancelledError at
+                        # the `wait()` above, mirroring `InstrumentedModel.request_stream`. On
+                        # that cancelled path `finish` is never reached today (no metrics of any
+                        # kind are recorded), so this is symmetry rather than an observable fix.
+                        time_to_first_chunk_ctx.set(sr.time_to_first_chunk(request_start))
+                response = sr.get()
+                _handler_response = response
+                return response
+
+            wrap_request_context = ModelRequestContext(
+                model=model,
+                messages=message_history,
+                model_settings=model_settings,
+                model_request_parameters=model_request_parameters,
+            )
+            wrap_request_context.model_id = ctx.deps.model_id
+            # Signal to hooks that the agent loop expects a real event stream.
+            wrap_request_context.streaming = True
+            wrap_task = asyncio.create_task(
+                ctx.deps.root_capability.wrap_model_request(
+                    run_context,
+                    request_context=wrap_request_context,
+                    handler=_streaming_handler,
+                )
+            )
+
+            # Wait for handler to start or wrap to complete (short-circuit).
+            # If outer cancellation arrives during this wait, drain both tasks before re-raising
+            # so the user's `wrap_model_request` cleanup runs instead of orphaning.
+            ready_waiter = asyncio.create_task(stream_ready.wait())
+            try:
+                await asyncio.wait({ready_waiter, wrap_task}, return_when=asyncio.FIRST_COMPLETED)
+            except BaseException:
+                # `BaseException` to also catch `CancelledError`. Handoff hasn't completed,
+                # so both tasks are still ours; drain them so cleanup runs before we re-raise.
+                #
+                # Unblock `_streaming_handler` before draining: if wrap_task's model
+                # absorbed the CancelledError (e.g. Temporal's cooperative cancellation),
+                # the handler is parked on `stream_done.wait()`. Setting stream_done lets
+                # it exit so cancel_and_drain's gather can complete. Harmless no-op when
+                # the task was actually cancelled — it's already unwinding. See https://github.com/pydantic/pydantic-ai/issues/6422.
+                stream_done.set()
+                await cancel_and_drain(ready_waiter, wrap_task)
+                raise
+            else:
+                # Handoff succeeded: `wrap_task` is owned by the rest of the streaming
+                # lifecycle below. Only the throwaway readiness waiter is ours to clean up.
+                await cancel_and_drain(ready_waiter)
+
+            if wrap_task.done() and not stream_ready.is_set():
+                # wrap_model_request completed without calling handler — short-circuited or raised SkipModelRequest
+                try:
+                    result_or_exc: _messages.ModelResponse | Exception
+                    try:
+                        result_or_exc = wrap_task.result()
+                    except Exception as e:
+                        result_or_exc = e
+                    model_response = await self._resolve_wrap_result(
+                        ctx, run_context, wrap_request_context, result_or_exc
+                    )
+                except exceptions.ModelRetry as e:
+                    self._did_stream = True
+                    # Don't increment usage.requests — handler was never called (short-circuit)
+                    run_context = build_run_context(ctx)
+                    await self._build_retry_node(ctx, e)
+                    # Must still yield from @asynccontextmanager — yield an empty stream
+                    dummy_sr = CompletedStreamedResponse(
+                        _messages.ModelResponse(parts=[]), model_request_parameters=model_request_parameters
+                    )
+                    agent_stream = self._build_agent_stream(ctx, dummy_sr, model_request_parameters)
+                    try:
+                        yield agent_stream
+                    finally:
+                        await agent_stream.aclose_events()
+                    return
                 self._did_stream = True
                 ctx.state.usage.requests += 1
-                agent_stream = self._build_agent_stream(ctx, sr, req_ctx.model_request_parameters)
-                agent_stream_holder.append(agent_stream)
-                stream_ready.set()
-                try:
-                    await stream_done.wait()
-                finally:
-                    # Report TTFT in a `finally` so it also lands when the consumer raises
-                    # mid-iteration and `_cancel_task(wrap_task)` injects CancelledError at
-                    # the `wait()` above, mirroring `InstrumentedModel.request_stream`. On
-                    # that cancelled path `finish` is never reached today (no metrics of any
-                    # kind are recorded), so this is symmetry rather than an observable fix.
-                    time_to_first_chunk_ctx.set(sr.time_to_first_chunk(request_start))
-            response = sr.get()
-            _handler_response = response
-            return response
-
-        wrap_request_context = ModelRequestContext(
-            model=model,
-            messages=message_history,
-            model_settings=model_settings,
-            model_request_parameters=model_request_parameters,
-        )
-        wrap_request_context.model_id = ctx.deps.model_id
-        # Signal to hooks that the agent loop expects a real event stream.
-        wrap_request_context.streaming = True
-        wrap_task = asyncio.create_task(
-            ctx.deps.root_capability.wrap_model_request(
-                run_context,
-                request_context=wrap_request_context,
-                handler=_streaming_handler,
-            )
-        )
-
-        # Wait for handler to start or wrap to complete (short-circuit).
-        # If outer cancellation arrives during this wait, drain both tasks before re-raising
-        # so the user's `wrap_model_request` cleanup runs instead of orphaning.
-        ready_waiter = asyncio.create_task(stream_ready.wait())
-        try:
-            await asyncio.wait({ready_waiter, wrap_task}, return_when=asyncio.FIRST_COMPLETED)
-        except BaseException:
-            # `BaseException` to also catch `CancelledError`. Handoff hasn't completed,
-            # so both tasks are still ours; drain them so cleanup runs before we re-raise.
-            #
-            # Unblock `_streaming_handler` before draining: if wrap_task's model
-            # absorbed the CancelledError (e.g. Temporal's cooperative cancellation),
-            # the handler is parked on `stream_done.wait()`. Setting stream_done lets
-            # it exit so cancel_and_drain's gather can complete. Harmless no-op when
-            # the task was actually cancelled — it's already unwinding. See https://github.com/pydantic/pydantic-ai/issues/6422.
-            stream_done.set()
-            await cancel_and_drain(ready_waiter, wrap_task)
-            raise
-        else:
-            # Handoff succeeded: `wrap_task` is owned by the rest of the streaming
-            # lifecycle below. Only the throwaway readiness waiter is ours to clean up.
-            await cancel_and_drain(ready_waiter)
-
-        if wrap_task.done() and not stream_ready.is_set():
-            # wrap_model_request completed without calling handler — short-circuited or raised SkipModelRequest
-            try:
-                result_or_exc: _messages.ModelResponse | Exception
-                try:
-                    result_or_exc = wrap_task.result()
-                except Exception as e:
-                    result_or_exc = e
-                model_response = await self._resolve_wrap_result(ctx, run_context, wrap_request_context, result_or_exc)
-            except exceptions.ModelRetry as e:
-                self._did_stream = True
-                # Don't increment usage.requests — handler was never called (short-circuit)
-                run_context = build_run_context(ctx)
-                await self._build_retry_node(ctx, e)
-                # Must still yield from @asynccontextmanager — yield an empty stream
-                dummy_sr = CompletedStreamedResponse(
-                    _messages.ModelResponse(parts=[]), model_request_parameters=model_request_parameters
+                replay_sr = CompletedStreamedResponse(
+                    model_response,
+                    model_request_parameters=model_request_parameters,
+                    replay_events=True,
                 )
-                agent_stream = self._build_agent_stream(ctx, dummy_sr, model_request_parameters)
+                agent_stream = self._build_agent_stream(ctx, replay_sr, model_request_parameters)
                 try:
                     yield agent_stream
                 finally:
+                    # The event iterator is memoized on the stream, so a consumer that broke out early
+                    # leaves the capability chain suspended. Close it now that the node is done with it.
                     await agent_stream.aclose_events()
+                self.last_request_context = wrap_request_context
+                await self._finish_handling(ctx, model_response)
+                assert self._result is not None
                 return
-            self._did_stream = True
-            ctx.state.usage.requests += 1
-            replay_sr = CompletedStreamedResponse(
-                model_response,
-                model_request_parameters=model_request_parameters,
-                replay_events=True,
-            )
-            agent_stream = self._build_agent_stream(ctx, replay_sr, model_request_parameters)
-            try:
-                yield agent_stream
-            finally:
-                # The event iterator is memoized on the stream, so a consumer that broke out early
-                # leaves the capability chain suspended. Close it now that the node is done with it.
-                await agent_stream.aclose_events()
-            self.last_request_context = wrap_request_context
-            await self._finish_handling(ctx, model_response)
-            assert self._result is not None
-            return
 
-        # Normal path: handler was called, stream is ready
-        stream_error: BaseException | None = None
-        try:
-            yield agent_stream_holder[0]
-        except BaseException as exc:
-            stream_error = exc
-            raise
-        finally:
-            stream_done.set()
+            # Normal path: handler was called, stream is ready
+            stream_error: BaseException | None = None
             try:
-                if stream_error is not None:
-                    await _cancel_task(wrap_task)
-                    # Capture the partial response so `capture_run_messages` and `all_messages()`
-                    # include what was streamed before the interruption.
-                    # We append directly rather than via `_append_response` to skip the usage-limit
-                    # check; raising `UsageLimitExceeded` here would mask `stream_error`.
-                    if agent_stream_holder:  # pragma: no branch
-                        partial = agent_stream_holder[0].response
-                        recorded_state = await _resolve_interrupted_stream_state(model, stream_error, partial)
-                        partial_response = replace(
-                            partial,
-                            state=recorded_state,
-                            run_id=ctx.state.run_id,
-                            conversation_id=ctx.state.conversation_id,
-                        )
-                        fill_response_cost(partial_response)
-                        ctx.state.usage.incr(partial_response.usage)
-                        ctx.state.message_history.append(partial_response)
-                else:
-                    try:
-                        try:
-                            model_response = await wrap_task
-                        except exceptions.ModelRetry:
-                            raise  # Propagate to outer handler
-                        except Exception as e:
-                            model_response = await ctx.deps.root_capability.on_model_request_error(
-                                run_context, request_context=wrap_request_context, error=e
-                            )
-                    except exceptions.ModelRetry as e:
-                        # Don't increment usage.requests — _streaming_handler already did
-                        # In the normal streaming path the handler was always called (that's
-                        # how the stream was created), so _handler_response is always set.
-                        assert _handler_response is not None
-                        self._append_response(ctx, _handler_response)
-                        await self._build_retry_node(ctx, e)
-                    else:
-                        self.last_request_context = wrap_request_context
-                        await self._finish_handling(ctx, model_response)
-                        assert self._result is not None
+                yield agent_stream_holder[0]
+            except BaseException as exc:
+                stream_error = exc
+                raise
             finally:
-                # The event iterator is memoized on the stream, so a consumer that broke out early
-                # leaves the capability chain suspended. Close it now that the node is done with it.
-                await agent_stream_holder[0].aclose_events()
+                stream_done.set()
+                try:
+                    if stream_error is not None:
+                        await _cancel_task(wrap_task)
+                        # Capture the partial response so `capture_run_messages` and `all_messages()`
+                        # include what was streamed before the interruption.
+                        # We append directly rather than via `_append_response` to skip the usage-limit
+                        # check; raising `UsageLimitExceeded` here would mask `stream_error`.
+                        if agent_stream_holder:  # pragma: no branch
+                            partial = agent_stream_holder[0].response
+                            recorded_state = await _resolve_interrupted_stream_state(model, stream_error, partial)
+                            partial_response = replace(
+                                partial,
+                                state=recorded_state,
+                                run_id=ctx.state.run_id,
+                                conversation_id=ctx.state.conversation_id,
+                            )
+                            fill_response_cost(partial_response)
+                            ctx.state.usage.incr(partial_response.usage)
+                            ctx.state.message_history.append(partial_response)
+                    else:
+                        try:
+                            try:
+                                model_response = await wrap_task
+                            except exceptions.ModelRetry:
+                                raise  # Propagate to outer handler
+                            except Exception as e:
+                                model_response = await ctx.deps.root_capability.on_model_request_error(
+                                    run_context, request_context=wrap_request_context, error=e
+                                )
+                        except exceptions.ModelRetry as e:
+                            # Don't increment usage.requests — _streaming_handler already did
+                            # In the normal streaming path the handler was always called (that's
+                            # how the stream was created), so _handler_response is always set.
+                            assert _handler_response is not None
+                            self._append_response(ctx, _handler_response)
+                            await self._build_retry_node(ctx, e)
+                        else:
+                            self.last_request_context = wrap_request_context
+                            await self._finish_handling(ctx, model_response)
+                            assert self._result is not None
+                finally:
+                    # The event iterator is memoized on the stream, so a consumer that broke out early
+                    # leaves the capability chain suspended. Close it now that the node is done with it.
+                    await agent_stream_holder[0].aclose_events()
 
     @staticmethod
     def _build_agent_stream(
@@ -1380,9 +1401,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             return self._result  # pragma: no cover
 
         try:
-            model, model_settings, model_request_parameters, message_history, run_context = await self._prepare_request(
-                ctx, streaming=False
-            )
+            (
+                model,
+                model_settings,
+                model_request_parameters,
+                message_history,
+                run_context,
+                repair_stats,
+            ) = await self._prepare_request(ctx, streaming=False)
         except exceptions.SkipModelRequest as e:
             # new_message_index wasn't updated in _prepare_request, fix it here
             ctx.deps.new_message_index = _first_new_message_index(
@@ -1394,59 +1420,60 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             ctx.state.usage.requests += 1
             return await self._finish_handling(ctx, e.response)
 
-        _handler_response: _messages.ModelResponse | None = None
+        async with _history_repair_stats_scope(repair_stats):
+            _handler_response: _messages.ModelResponse | None = None
 
-        async def model_handler(req_ctx: ModelRequestContext) -> _messages.ModelResponse:
-            nonlocal _handler_response
-
-            # `model_request` resolves any suspended → complete continuation chain (Anthropic
-            # `pause_turn`, OpenAI background mode) and returns the final merged response, so
-            # `wrap_model_request` spans the whole chain and `after_model_request` sees just
-            # the final response. Continuations are not separate request steps, so usage is
-            # committed exactly once by `_finish_handling` → `_append_response`.
-            def on_progress(response: _messages.ModelResponse) -> None:
+            async def model_handler(req_ctx: ModelRequestContext) -> _messages.ModelResponse:
                 nonlocal _handler_response
+
+                # `model_request` resolves any suspended → complete continuation chain (Anthropic
+                # `pause_turn`, OpenAI background mode) and returns the final merged response, so
+                # `wrap_model_request` spans the whole chain and `after_model_request` sees just
+                # the final response. Continuations are not separate request steps, so usage is
+                # committed exactly once by `_finish_handling` → `_append_response`.
+                def on_progress(response: _messages.ModelResponse) -> None:
+                    nonlocal _handler_response
+                    _handler_response = response
+
+                response = await model_request(
+                    req_ctx.model, request_context=req_ctx, run_context=run_context, on_progress=on_progress
+                )
                 _handler_response = response
+                return response
 
-            response = await model_request(
-                req_ctx.model, request_context=req_ctx, run_context=run_context, on_progress=on_progress
+            request_context = ModelRequestContext(
+                model=model,
+                messages=message_history,
+                model_settings=model_settings,
+                model_request_parameters=model_request_parameters,
             )
-            _handler_response = response
-            return response
-
-        request_context = ModelRequestContext(
-            model=model,
-            messages=message_history,
-            model_settings=model_settings,
-            model_request_parameters=model_request_parameters,
-        )
-        request_context.model_id = ctx.deps.model_id
-        try:
+            request_context.model_id = ctx.deps.model_id
             try:
-                model_response = await ctx.deps.root_capability.wrap_model_request(
-                    run_context,
-                    request_context=request_context,
-                    handler=model_handler,
-                )
-            except exceptions.SkipModelRequest as e:
-                model_response = e.response
-            except exceptions.ModelRetry:
-                raise  # Propagate to outer handler
-            except Exception as e:
-                model_response = await ctx.deps.root_capability.on_model_request_error(
-                    run_context, request_context=request_context, error=e
-                )
-        except exceptions.ModelRetry as e:
-            # ModelRetry from wrap_model_request or on_model_request_error — retry the model request.
-            # If the handler was called, preserve the response in history for context.
-            if _handler_response is not None:
-                ctx.state.usage.requests += 1
-                self._append_response(ctx, _handler_response)
-            return await self._build_retry_node(ctx, e)
-        self.last_request_context = request_context
-        ctx.state.usage.requests += 1
+                try:
+                    model_response = await ctx.deps.root_capability.wrap_model_request(
+                        run_context,
+                        request_context=request_context,
+                        handler=model_handler,
+                    )
+                except exceptions.SkipModelRequest as e:
+                    model_response = e.response
+                except exceptions.ModelRetry:
+                    raise  # Propagate to outer handler
+                except Exception as e:
+                    model_response = await ctx.deps.root_capability.on_model_request_error(
+                        run_context, request_context=request_context, error=e
+                    )
+            except exceptions.ModelRetry as e:
+                # ModelRetry from wrap_model_request or on_model_request_error — retry the model request.
+                # If the handler was called, preserve the response in history for context.
+                if _handler_response is not None:
+                    ctx.state.usage.requests += 1
+                    self._append_response(ctx, _handler_response)
+                return await self._build_retry_node(ctx, e)
+            self.last_request_context = request_context
+            ctx.state.usage.requests += 1
 
-        return await self._finish_handling(ctx, model_response)
+            return await self._finish_handling(ctx, model_response)
 
     async def _prepare_request(
         self,
@@ -1459,6 +1486,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         models.ModelRequestParameters,
         list[_messages.ModelMessage],
         RunContext[DepsT],
+        HistoryRepairStats,
     ]:
         if self._resume_suspended is not None:
             return await self._prepare_resume_request(ctx, streaming=streaming)
@@ -1565,7 +1593,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         # Run a first pass so `prepare_messages` sees a normalized history.
         # The history is definitively being sent to the model at this point, so even the last
         # response's dangling tool calls (e.g. left by a history processor) can be repaired.
-        messages = _clean_message_history(messages, repair_last_response=True)
+        messages, repair_stats = _clean_message_history(messages, repair_last_response=True)
 
         # Reveal state is a property of the history actually sent to the model. A history
         # processor may remove or replace availability deltas, so the per-request parameters
@@ -1593,9 +1621,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         # messages are merged. The default `prepare_messages` returns the input list
         # unchanged, so the identity check skips the redundant second pass.
         if prepared is not messages:
-            messages = _clean_message_history(prepared, repair_last_response=True)
-        else:
-            messages = prepared
+            messages, second_pass_stats = _clean_message_history(prepared, repair_last_response=True)
+            repair_stats = HistoryRepairStats(
+                dropped_orphaned_results=repair_stats.dropped_orphaned_results
+                + second_pass_stats.dropped_orphaned_results,
+                synthesized_tool_returns=repair_stats.synthesized_tool_returns
+                + second_pass_stats.synthesized_tool_returns,
+                merged_messages=repair_stats.merged_messages + second_pass_stats.merged_messages,
+            )
 
         ctx.state.last_max_tokens = model_settings.get('max_tokens') if model_settings else None
         ctx.state.last_model_request_parameters = model_request_parameters
@@ -1620,7 +1653,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         ctx.deps.usage_limits.check_before_request(usage)
 
-        return model, model_settings or None, model_request_parameters, messages, run_context
+        return model, model_settings or None, model_request_parameters, messages, run_context, repair_stats
 
     async def _prepare_resume_request(
         self,
@@ -1633,6 +1666,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         models.ModelRequestParameters,
         list[_messages.ModelMessage],
         RunContext[DepsT],
+        HistoryRepairStats,
     ]:
         """Prepare a request that resumes a turn the provider paused mid-flight.
 
@@ -1722,7 +1756,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         ctx.state.last_model_request_parameters = model_request_parameters
         ctx.deps.usage_limits.check_before_request(ctx.state.usage)
 
-        return model, model_settings or None, model_request_parameters, messages, run_context
+        return model, model_settings or None, model_request_parameters, messages, run_context, HistoryRepairStats()
 
     async def _finish_handling(
         self,
@@ -2768,7 +2802,9 @@ def _is_tool_result_part(
     )
 
 
-def _drop_orphaned_tool_results(messages: list[_messages.ModelMessage]) -> list[_messages.ModelMessage]:
+def _drop_orphaned_tool_results(
+    messages: list[_messages.ModelMessage],
+) -> tuple[list[_messages.ModelMessage], int]:
     """REMOVE regular tool results whose call is missing.
 
     A `ToolReturnPart` or tool-bound `RetryPromptPart` (in a `ModelRequest`) whose `tool_call_id`
@@ -2790,10 +2826,13 @@ def _drop_orphaned_tool_results(messages: list[_messages.ModelMessage]) -> list[
     `_repair_dangling_tool_calls`). If dropping empties an interior `ModelRequest` the request is
     dropped; if it empties the last message an empty `ModelRequest` is kept so the history still ends
     on a request. Returns the input unchanged when there are no orphans.
+
+    The returned integer is the number of orphaned tool-result parts that were dropped.
     """
     seen_call_ids: set[str] = set()
     repaired: list[_messages.ModelMessage] = []
     changed = False
+    dropped_count = 0
     for index, message in enumerate(messages):
         for part in message.parts:
             if isinstance(part, _messages.ToolCallPart):
@@ -2805,17 +2844,18 @@ def _drop_orphaned_tool_results(messages: list[_messages.ModelMessage]) -> list[
         ]
         if len(kept_parts) == len(message.parts):
             repaired.append(message)
-            continue
-        changed = True
-        if kept_parts or (isinstance(message, _messages.ModelRequest) and index == len(messages) - 1):
-            repaired.append(replace(message, parts=kept_parts))
-        # else: interior emptied `ModelRequest` — drop the message
-    return repaired if changed else messages
+        else:
+            changed = True
+            dropped_count += len(message.parts) - len(kept_parts)
+            if kept_parts or index == len(messages) - 1:
+                repaired.append(replace(message, parts=kept_parts))
+            # else: interior emptied `ModelRequest` — drop the message
+    return (repaired if changed else messages, dropped_count)
 
 
 def _repair_dangling_tool_calls(
     messages: list[_messages.ModelMessage], *, repair_last_response: bool = False
-) -> list[_messages.ModelMessage]:
+) -> tuple[list[_messages.ModelMessage], int]:
     """Repair tool calls that are missing a matching result ("dangling" tool calls).
 
     A run that was cancelled or crashed mid-tool-execution — or a hand-built history — can contain
@@ -2847,6 +2887,8 @@ def _repair_dangling_tool_calls(
     If there is nothing to repair, the input list is returned unchanged. Repair is silent — like
     the other pipeline passes — with the `SYNTHESIZED_TOOL_RETURN_METADATA_KEY` marker as the
     mechanism for inspecting what was synthesized.
+
+    The returned integer is the number of synthesized `ToolReturnPart`s created.
     """
     dangling_by_response = _dangling_tool_calls_by_response(messages)
     if not repair_last_response:
@@ -2861,10 +2903,11 @@ def _repair_dangling_tool_calls(
         if last_response_index is not None:
             dangling_by_response.pop(last_response_index, None)
     if not dangling_by_response:
-        return messages
+        return messages, 0
 
     repaired: list[_messages.ModelMessage] = []
     synthesized: list[_messages.ToolReturnPart] = []
+    synthesized_count = 0
     for index, message in enumerate(messages):
         if isinstance(message, _messages.ModelResponse):
             if synthesized:
@@ -2885,6 +2928,7 @@ def _repair_dangling_tool_calls(
                             outcome='interrupted',
                         )
                     )
+                    synthesized_count += 1
             repaired.append(message)
         elif isinstance(message, _messages.ModelRequest):  # pragma: no branch
             if synthesized:
@@ -2895,10 +2939,12 @@ def _repair_dangling_tool_calls(
     if synthesized:
         repaired.append(_messages.ModelRequest(parts=synthesized))
 
-    return repaired
+    return repaired, synthesized_count
 
 
-def _merge_consecutive_messages(messages: list[_messages.ModelMessage]) -> list[_messages.ModelMessage]:
+def _merge_consecutive_messages(
+    messages: list[_messages.ModelMessage],
+) -> tuple[list[_messages.ModelMessage], int]:
     """Normalize the history's shape by merging consecutive same-role messages into one.
 
     Neither adds nor removes content — it only combines adjacent `ModelRequest`s (or adjacent
@@ -2906,8 +2952,11 @@ def _merge_consecutive_messages(messages: list[_messages.ModelMessage]) -> list[
     hoists tool results ahead of user-facing parts (where providers require them). Runs last, after
     the repair passes have settled call/result pairing, so it operates on a valid history and never
     separates a result from the call it answers.
+
+    The returned integer is the number of merge operations performed.
     """
     clean_messages: list[_messages.ModelMessage] = []
+    merged_count = 0
     for message in messages:
         last_message = clean_messages[-1] if len(clean_messages) > 0 else None
 
@@ -2936,6 +2985,7 @@ def _merge_consecutive_messages(messages: list[_messages.ModelMessage]) -> list[
                     timestamp=message.timestamp or last_message.timestamp,
                 )
                 clean_messages[-1] = merged_message
+                merged_count += 1
             else:
                 clean_messages.append(message)
         elif isinstance(message, _messages.ModelResponse):  # pragma: no branch
@@ -2952,14 +3002,15 @@ def _merge_consecutive_messages(messages: list[_messages.ModelMessage]) -> list[
             ):
                 merged_message = replace(last_message, parts=[*last_message.parts, *message.parts])
                 clean_messages[-1] = merged_message
+                merged_count += 1
             else:
                 clean_messages.append(message)
-    return clean_messages
+    return clean_messages, merged_count
 
 
 def _clean_message_history(
     messages: list[_messages.ModelMessage], *, repair_last_response: bool = False
-) -> list[_messages.ModelMessage]:
+) -> tuple[list[_messages.ModelMessage], HistoryRepairStats]:
     """Make the message history provider-valid and normalize its shape, out of the box.
 
     An ordered pipeline of pure `list[ModelMessage] -> list[ModelMessage]` passes over regular,
@@ -2979,8 +3030,16 @@ def _clean_message_history(
        the last response's still-answerable calls are left alone.
     3. `_merge_consecutive_messages` (normalize) — last, once call/result pairing is valid, so it
        never separates a result from its call.
+
+    Returns the cleaned message list alongside a `HistoryRepairStats` object reporting how many
+    silent changes the pipeline made. The stats are read by `open_model_request_span` and exposed
+    as OTel attributes on the model-request span.
     """
-    messages = _drop_orphaned_tool_results(messages)
-    messages = _repair_dangling_tool_calls(messages, repair_last_response=repair_last_response)
-    messages = _merge_consecutive_messages(messages)
-    return messages
+    messages, dropped = _drop_orphaned_tool_results(messages)
+    messages, synthesized = _repair_dangling_tool_calls(messages, repair_last_response=repair_last_response)
+    messages, merged = _merge_consecutive_messages(messages)
+    return messages, HistoryRepairStats(
+        dropped_orphaned_results=dropped,
+        synthesized_tool_returns=synthesized,
+        merged_messages=merged,
+    )

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -87,6 +87,22 @@ public and holds only the *inputs* to `Model.request[_stream]`.
 """
 
 
+@dataclass(frozen=True, slots=True)
+class HistoryRepairStats:
+    """Counters for the silent message-history repair pass run before each model request."""
+
+    dropped_orphaned_results: int = 0
+    synthesized_tool_returns: int = 0
+    merged_messages: int = 0
+
+
+history_repair_stats_ctx: ContextVar[HistoryRepairStats | None] = ContextVar('history_repair_stats', default=None)
+"""Carries history-repair counters from `_clean_message_history` in the agent graph to
+`open_model_request_span`, where they're recorded as attributes on the model-request span.
+Read and cleared when the span opens so stale values don't leak across requests.
+"""
+
+
 @dataclass(slots=True)
 class CachedMessageJson:
     """A `MessageJsonCache` entry: one input message's serialized OTel JSON fragment."""
@@ -343,6 +359,20 @@ def model_settings_attributes(model_settings: ModelSettings | None) -> dict[str,
     return attributes
 
 
+def _add_history_repair_attributes(attributes: dict[str, AttributeValue]) -> None:
+    """Read and clear `history_repair_stats_ctx`, adding non-zero counters to `attributes`."""
+    repair_stats = history_repair_stats_ctx.get()
+    if repair_stats is None:
+        return
+    if repair_stats.synthesized_tool_returns:
+        attributes['pydantic_ai.history_repair.synthesized_tool_returns'] = repair_stats.synthesized_tool_returns
+    if repair_stats.dropped_orphaned_results:
+        attributes['pydantic_ai.history_repair.dropped_orphaned_results'] = repair_stats.dropped_orphaned_results
+    if repair_stats.merged_messages:
+        attributes['pydantic_ai.history_repair.merged_messages'] = repair_stats.merged_messages
+    history_repair_stats_ctx.set(None)
+
+
 def annotate_tool_call_otel_metadata(response: ModelResponse, parameters: ModelRequestParameters) -> None:
     """Copy OTel-relevant metadata from tool definitions onto matching tool call parts.
 
@@ -489,6 +519,8 @@ def open_model_request_span(
         attributes['gen_ai.tool.definitions'] = safe_to_json(tool_definitions).decode()
 
     attributes.update(model_settings_attributes(prepared_settings))
+
+    _add_history_repair_attributes(attributes)
 
     record_metrics: Callable[[], None] | None = None
     try:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -455,7 +455,8 @@ class TemporalModel(WrapperModel):
         prepared = model_for_request.prepare_messages(params.messages, params.model_request_parameters)
         if prepared is params.messages:
             return prepared
-        return _clean_message_history(prepared, repair_last_response=True)
+        cleaned_messages, _ = _clean_message_history(prepared, repair_last_response=True)
+        return cleaned_messages
 
     def _resolve_model_id(self, model_id: str | None, run_context: RunContext[Any] | None = None) -> Model:
         """Resolve a model ID to a Model instance.

--- a/tests/evals/conftest.py
+++ b/tests/evals/conftest.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
+from opentelemetry import context as otel_ctx
 
 
 @pytest.fixture(autouse=True)
@@ -17,3 +19,22 @@ async def _cleanup_background_evaluations() -> AsyncIterator[None]:
     except ImportError:  # pragma: no cover
         return
     await wait_for_evaluations()
+
+
+# The sync `fresh_logfire` fixture resets the main-thread OTel context, but async
+# test bodies run in anyio's runner task whose context is copied before that fixture
+# runs. A leaked non-sampled span in that task causes parent-based sampling to drop
+# descendant spans, which surfaces as an empty `context_subtree()` tree. We keep a
+# per-worker setup token so each async eval test can detach the clean context from
+# the previous test and attach its own.
+_setup_token: Any = None
+
+
+@pytest.fixture(autouse=True)
+async def _reset_async_otel_context() -> AsyncIterator[None]:
+    """Reset the anyio runner task's OTel context around each async eval test."""
+    global _setup_token
+    if _setup_token is not None:
+        otel_ctx.detach(_setup_token)
+    _setup_token = otel_ctx.attach(otel_ctx.Context())
+    yield

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -36,7 +36,12 @@ from pydantic_ai import (
     UserPromptPart,
     VideoUrl,
 )
-from pydantic_ai._instrumentation import MessageJsonCache, has_stale_message_json
+from pydantic_ai._instrumentation import (
+    HistoryRepairStats,
+    MessageJsonCache,
+    has_stale_message_json,
+    history_repair_stats_ctx,
+)
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
@@ -362,6 +367,36 @@ async def test_instrumented_model_wrapped_model_server_attributes(capfire: Captu
     assert {k: v for k, v in span['attributes'].items() if k.startswith('server.')} == snapshot(
         {'server.address': 'example.com', 'server.port': 8000}
     )
+
+
+async def test_history_repair_stats_recorded_on_model_request_span(capfire: CaptureLogfire):
+    """`history_repair_stats_ctx` counters are emitted as span attributes on the model request span."""
+    history_repair_stats_ctx.set(
+        HistoryRepairStats(dropped_orphaned_results=1, synthesized_tool_returns=2, merged_messages=3)
+    )
+    try:
+        model = InstrumentedModel(MyModel(), InstrumentationSettings())
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart('hello')])],
+            model_settings=None,
+            model_request_parameters=ModelRequestParameters(
+                function_tools=[],
+                allow_text_output=True,
+                output_tools=[],
+                output_mode='text',
+                output_object=None,
+            ),
+        )
+    finally:
+        history_repair_stats_ctx.set(None)
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat_spans = [s for s in spans if s['attributes'].get('gen_ai.operation.name') == 'chat']
+    assert len(chat_spans) == 1
+    attrs = chat_spans[0]['attributes']
+    assert attrs['pydantic_ai.history_repair.dropped_orphaned_results'] == 1
+    assert attrs['pydantic_ai.history_repair.synthesized_tool_returns'] == 2
+    assert attrs['pydantic_ai.history_repair.merged_messages'] == 3
 
 
 def test_input_messages_json_matches_whole_history_with_and_without_cache():

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -385,9 +385,7 @@ async def test_history_repair_stats_recorded_on_model_request_span():
         tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
         model = InstrumentedModel(
             MyModel(),
-            InstrumentationSettings(
-                tracer_provider=tracer_provider, meter_provider=NoOpMeterProvider()
-            ),
+            InstrumentationSettings(tracer_provider=tracer_provider, meter_provider=NoOpMeterProvider()),
         )
         await model.request(
             [ModelRequest(parts=[UserPromptPart('hello')])],

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -369,13 +369,26 @@ async def test_instrumented_model_wrapped_model_server_attributes(capfire: Captu
     )
 
 
-async def test_history_repair_stats_recorded_on_model_request_span(capfire: CaptureLogfire):
+async def test_history_repair_stats_recorded_on_model_request_span():
     """`history_repair_stats_ctx` counters are emitted as span attributes on the model request span."""
-    history_repair_stats_ctx.set(
+    from opentelemetry.metrics import NoOpMeterProvider
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    token = history_repair_stats_ctx.set(
         HistoryRepairStats(dropped_orphaned_results=1, synthesized_tool_returns=2, merged_messages=3)
     )
     try:
-        model = InstrumentedModel(MyModel(), InstrumentationSettings())
+        exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+        model = InstrumentedModel(
+            MyModel(),
+            InstrumentationSettings(
+                tracer_provider=tracer_provider, meter_provider=NoOpMeterProvider()
+            ),
+        )
         await model.request(
             [ModelRequest(parts=[UserPromptPart('hello')])],
             model_settings=None,
@@ -388,12 +401,14 @@ async def test_history_repair_stats_recorded_on_model_request_span(capfire: Capt
             ),
         )
     finally:
-        history_repair_stats_ctx.set(None)
+        history_repair_stats_ctx.reset(token)
 
-    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
-    chat_spans = [s for s in spans if s['attributes'].get('gen_ai.operation.name') == 'chat']
+    chat_spans = [
+        s for s in exporter.get_finished_spans() if (s.attributes or {}).get('gen_ai.operation.name') == 'chat'
+    ]
     assert len(chat_spans) == 1
-    attrs = chat_spans[0]['attributes']
+    attrs = chat_spans[0].attributes
+    assert attrs is not None
     assert attrs['pydantic_ai.history_repair.dropped_orphaned_results'] == 1
     assert attrs['pydantic_ai.history_repair.synthesized_tool_returns'] == 2
     assert attrs['pydantic_ai.history_repair.merged_messages'] == 3

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -6172,7 +6172,7 @@ def test_prepare_messages_then_clean_history_merges_consecutive_requests() -> No
     after_synthesis = synthesize_local_tool_search_messages(history)
     assert [type(m).__name__ for m in after_synthesis] == ['ModelResponse', 'ModelRequest', 'ModelRequest']
 
-    cleaned = _clean_message_history(after_synthesis)
+    cleaned, _ = _clean_message_history(after_synthesis)
     assert [type(m).__name__ for m in cleaned] == ['ModelResponse', 'ModelRequest']
 
     # The merged request carries both the synthetic search return and the original user prompt,

--- a/tests/test_transcript_repair.py
+++ b/tests/test_transcript_repair.py
@@ -503,7 +503,7 @@ async def test_orphaned_result_emptying_last_request_keeps_placeholder():
         ModelRequest(parts=[ToolReturnPart('ghost_tool', 'x', tool_call_id='ghost', timestamp=TS)], timestamp=TS),
     ]
 
-    cleaned = _clean_message_history(message_history)
+    cleaned, _ = _clean_message_history(message_history)
 
     # The orphaned result is dropped, but its now-empty trailing request is retained as a placeholder
     # so the history still ends on a `ModelRequest`.
@@ -563,7 +563,7 @@ async def test_native_tool_calls_left_untouched():
     ]
     original = ModelMessagesTypeAdapter.dump_json(message_history)
 
-    cleaned = _clean_message_history(message_history, repair_last_response=True)
+    cleaned, _ = _clean_message_history(message_history, repair_last_response=True)
 
     assert cleaned == message_history
     assert ModelMessagesTypeAdapter.dump_json(cleaned) == original


### PR DESCRIPTION
Closes #6495

Exposes the silent history-repair work from `_clean_message_history` as OpenTelemetry span attributes on the model request span.

- `pydantic_ai.history_repair.synthesized_tool_returns` - synthesized tool returns for dangling calls.
- `pydantic_ai.history_repair.dropped_orphaned_results` - orphaned tool results dropped.
- `pydantic_ai.history_repair.merged_messages` - consecutive compatible messages merged.

Also fixes a context leak in `_history_repair_stats_scope` where a non-sampled parent span would reset the global `_context_subtree()` map, breaking unrelated eval tests depending on order. The eval test suite now resets the async OTel context between tests for isolation.

Counters are collected in `_clean_message_history` and passed to `open_model_request_span` via a new context var, then emitted only when non-zero. Existing call sites and tests are updated to unpack the new return value.

### Checklist
- [x] No breaking changes in accordance with the version policy.
- [x] PR title is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

