### PR TITLE
fix: materialize pruned SpanQuery iterators so later conditions still see descendants

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -351,7 +351,9 @@ class SpanNode:
         def pruned_descendants():
             stop_recursing_when = query.get('stop_recursing_when')
             return (
-                self._filter_descendants(lambda _: True, stop_recursing_when) if stop_recursing_when else descendants()
+                list(self._filter_descendants(lambda _: True, stop_recursing_when))
+                if stop_recursing_when
+                else descendants()
             )
 
         if (min_descendant_count := query.get('min_descendant_count')) and len(descendants()) < min_descendant_count:
@@ -382,7 +384,11 @@ class SpanNode:
         @cache
         def pruned_ancestors():
             stop_recursing_when = query.get('stop_recursing_when')
-            return self._filter_ancestors(lambda _: True, stop_recursing_when) if stop_recursing_when else ancestors()
+            return (
+                list(self._filter_ancestors(lambda _: True, stop_recursing_when))
+                if stop_recursing_when
+                else ancestors()
+            )
 
         if (min_depth := query.get('min_depth')) and len(ancestors()) < min_depth:
             return False

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -496,6 +496,23 @@ async def test_span_tree_ancestors_methods():
         {'no_ancestor_has': {'name_matches_regex': 'root'}, 'stop_recursing_when': {'name_equals': 'level1'}}
     )
 
+    # A `stop_recursing_when` that never matches must not change the verdict when multiple conditions
+    # iterate the pruned ancestors; the pruned list used to be a cached generator that the first
+    # condition exhausted, making `no_ancestor_has` pass vacuously:
+    assert not leaf_node.matches(
+        {
+            'all_ancestors_have': {'name_matches_regex': 'level|root'},
+            'no_ancestor_has': {'name_equals': 'root'},
+        }
+    )
+    assert not leaf_node.matches(
+        {
+            'all_ancestors_have': {'name_matches_regex': 'level|root'},
+            'no_ancestor_has': {'name_equals': 'root'},
+            'stop_recursing_when': {'name_equals': 'never-matches'},
+        }
+    )
+
 
 async def test_span_tree_descendants_methods():
     """Test the descendant traversal methods in SpanNode."""
@@ -581,6 +598,23 @@ async def test_span_tree_descendants_methods():
     )
     assert root_node.matches(
         {'no_descendant_has': {'name_equals': 'leaf'}, 'stop_recursing_when': {'name_equals': 'level3'}}
+    )
+
+    # A `stop_recursing_when` that never matches must not change the verdict when multiple conditions
+    # iterate the pruned descendants; the pruned list used to be a cached generator that the first
+    # condition exhausted, making `no_descendant_has` pass vacuously:
+    assert not root_node.matches(
+        {
+            'some_descendant_has': {'name_equals': 'leaf'},
+            'no_descendant_has': {'name_equals': 'leaf'},
+        }
+    )
+    assert not root_node.matches(
+        {
+            'some_descendant_has': {'name_equals': 'leaf'},
+            'no_descendant_has': {'name_equals': 'leaf'},
+            'stop_recursing_when': {'name_equals': 'never-matches'},
+        }
     )
 
 


### PR DESCRIPTION
Closes #7484.

I reproduced this on current `main` (`086a65a5`) with a hand-built `SpanNode` tree (no LLM, no Logfire):

```
plain = {
    'all_ancestors_have': {'name_matches_regex': '.*'},
    'no_ancestor_has': {'name_equals': 'root'},
}
with_stop = {**plain, 'stop_recursing_when': {'name_equals': 'this-never-matches'}}
leaf.matches(plain)      # False  (correct: root is an ancestor)
leaf.matches(with_stop)  # True   (wrong: inert prune flips the verdict)
```

## Why

`SpanNode._matches_query` caches `pruned_descendants()` / `pruned_ancestors()` with `@cache`. When `stop_recursing_when` is set they returned the generators from `_filter_descendants` / `_filter_ancestors`. The second and third consumers (`some_*` / `all_*` / `no_*`) then iterated an already-exhausted iterator, so later conditions ran against an empty sequence:

- `no_descendant_has` / `no_ancestor_has` pass vacuously (the dangerous false negative)
- `all_*_have` pass vacuously
- `some_*_has` fail vacuously

Without the prune the helpers already return lists, which is why existing tests (one prune + one condition) stayed green. Other callers of `_filter_*` at L191/L197/L224/L230 already materialize via `list(...)` / `next(...)`.

## Fix

`list()` the two pruning branches. No public API change. Traversal order and prune behavior are unchanged.

## Tests

- Ancestor: `all_ancestors_have` + `no_ancestor_has` + inert `stop_recursing_when` stays False.
- Descendant: `some_descendant_has 'leaf'` + `no_descendant_has 'leaf'` + inert prune stays False.

`uv run --package pydantic-evals pytest tests/evals/test_otel.py -q` → 29 passed.

## Notes

#7494 / #7498 / #7499 already had this same two-line materialization and were auto-closed because #7484 was unassigned. This is a fresh patch against current `main`, not a rebase of those. I am not racing prior contributors; if a maintainer prefers to assign @mikemikimike and reopen #7499, that is the lower-friction path and I will close this.

I have not asked to be assigned. If the auto-close bot parks this until a maintainer wants an outside PR, that is understood.

AI-assisted implementation (Claude Code). I reproduced the failure on this tree, reviewed the diff, and reran the evals OTel tests before opening this.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

