### PR TITLE
Fix realtime event guidance in `building-pydantic-ai-agents`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -221,8 +221,9 @@ the tool loop for you. Stream input with `send_audio`/`send`, and iterate the
 session to consume the **same part/event vocabulary as a streamed run** — `PartStartEvent` /
 `PartDeltaEvent` / `PartEndEvent` carrying `SpeechPart`s and `ToolCallPart`s, plus
 `FunctionToolCallEvent` / `FunctionToolResultEvent`, plus realtime control events (`RealtimeInputSpeechStartEvent`,
-`RealtimeInputSpeechEndEvent`, `RealtimeResponseInterruptedEvent`, ...). Stop on `RealtimeTurnCompleteEvent`: the exchange is
-over, the model has said everything it is going to say, and it is the user's turn again.
+`RealtimeInputSpeechEndEvent`, `RealtimeResponseInterruptedEvent`, ...). Use `RealtimeTurnCompleteEvent` as the exchange
+boundary, when generation and tool work are complete. This is not always the end of audible speech:
+on WebRTC sidebands, track playback with `RealtimeOutputSpeechStartEvent` and `RealtimeOutputSpeechEndEvent`.
 
 ```python {test="skip"}
 from pydantic_ai import Agent
@@ -232,25 +233,36 @@ from pydantic_ai.messages import (
     SpeechPart,
     SpeechPartDelta,
 )
+from pydantic_ai.realtime import RealtimeSessionErrorEvent, RealtimeTurnCompleteEvent
 from pydantic_ai.realtime.openai import OpenAIRealtimeModelSettings
 
 agent = Agent(instructions='You are a helpful voice assistant.')
 
 
 async def main(microphone_chunk: bytes):
-    settings = OpenAIRealtimeModelSettings(
-        openai_voice='alloy', turn_detection={'sensitivity': 'high'}
-    )
+    settings = OpenAIRealtimeModelSettings(openai_voice='alloy', turn_detection=False)
     async with agent.realtime(
         'openai:gpt-realtime', model_settings=settings
     ).session() as session:
         await session.send_audio(microphone_chunk)  # PCM16 bytes
+        await session.commit_audio()
+        await session.create_response()
+        # Input transcription can finish after the model's response.
+        turn_complete = user_turn_complete = False
         async for event in session:
             match event:
                 case PartDeltaEvent(delta=SpeechPartDelta(audio_chunk=chunk)) if chunk:
                     ...  # play audio out
                 case PartEndEvent(part=SpeechPart(speaker='user', transcript=t)):
-                    print('user said:', t)
+                    if t is not None:
+                        print('user said:', t)
+                    user_turn_complete = True
+                case RealtimeTurnCompleteEvent():
+                    turn_complete = True
+                case RealtimeSessionErrorEvent(message=message):
+                    raise RuntimeError(message)
+            if turn_complete and user_turn_complete:
+                break
 
     # A session builds ordinary ModelMessage history: hand it off to a text agent.
     notes = Agent('openai:gpt-5.2', instructions='Summarize.')

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -116,7 +116,9 @@ Pick a run method based on the interaction pattern:
 - `run_stream_events()` when the caller needs the typed event stream directly
 - `iter()` when the caller needs step-by-step control over the agent loop
 
-Use `event_stream_handler=` with `run()` or `run_stream()` when the user wants progress updates without manually consuming the event stream. The stream includes model deltas, tool call/result events, and framework events such as `EnqueuedMessagesEvent` when queued messages enter run history. During realtime sessions it also includes realtime-only `RealtimeEvent` members:
+Use `event_stream_handler=` with `run()` or `run_stream()` when the user wants progress updates without manually consuming the event stream. The stream includes model deltas, tool call/result events, and framework events such as `EnqueuedMessagesEvent` when queued messages enter run history.
+
+Realtime sessions do not use `event_stream_handler`; iterate the session to consume realtime-only `RealtimeEvent` members.
 
 ```python
 from collections.abc import AsyncIterable

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -4108,10 +4108,11 @@ class DeferredToolResultsEvent:
 
 @dataclass(repr=False)
 class RealtimeTurnCompleteEvent:
-    """The exchange is over: the model has finished replying and nothing is outstanding.
+    """The model exchange is over: generation and tool work are complete.
 
-    This is the event to stop consuming on. It is synthesized by the session once no tool calls are
-    still running and no further response is in flight.
+    It is synthesized by the session once no tool calls are still running and no further response is
+    in flight. Input transcription can finish after this event. On WebRTC sidebands, provider playback
+    can also continue until [`RealtimeOutputSpeechEndEvent`][pydantic_ai.realtime.RealtimeOutputSpeechEndEvent].
     """
 
     _: KW_ONLY


### PR DESCRIPTION
Fixes the realtime findings from [pydantic/skills#50](https://github.com/pydantic/skills/pull/50):

- make the one-shot audio example use explicit manual turn control and exit safely
- wait for late input transcription before handing off history
- distinguish model exchange completion from WebRTC playback completion
- clarify that `event_stream_handler` does not apply to realtime sessions
- align the canonical `RealtimeTurnCompleteEvent` documentation

### Validation

- `63` targeted skill and realtime tests passed
- recorded WebRTC event-order test passed
- targeted Pyright check for `messages.py` passed
- pre-commit formatting, lint, codespell, and file checks passed
- repository-wide typecheck was unavailable in the isolated worktree because optional harness, UI, and Temporal dependencies are not installed

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

