### PR TITLE
Forward Cohere `ChatResponse.id` as `provider_response_id` on `ModelResponse`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -283,6 +283,7 @@ class CohereModel(Model[AsyncClientV2]):
             parts=parts,
             usage=_map_usage(response, self._provider.name, provider_url, self._model_name),
             model_name=self._model_name,
+            provider_response_id=response.id,
             provider_name=self._provider.name,
             provider_url=provider_url,
             finish_reason=finish_reason,

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -173,6 +173,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 provider_name='cohere',
                 provider_url='https://api.cohere.com',
                 provider_details={'finish_reason': 'COMPLETE'},
+                provider_response_id='123',
                 finish_reason='stop',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -191,12 +192,36 @@ async def test_request_simple_success(allow_model_requests: None):
                 provider_name='cohere',
                 provider_url='https://api.cohere.com',
                 provider_details={'finish_reason': 'COMPLETE'},
+                provider_response_id='123',
                 finish_reason='stop',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
         ]
     )
+
+
+async def test_provider_response_id_forwarded(allow_model_requests: None):
+    """The Cohere adapter must forward `ChatResponse.id` as `ModelResponse.provider_response_id`.
+
+    Unit-style mock: the mock's `completion_message` sets `id='resp-abc'`, and the adapter must pass
+    it through rather than silently dropping it — a regression a VCR test cannot reliably pin because
+    the cassette matcher ignores response-id drift.
+    """
+    c = ChatResponse(
+        id='resp-abc',
+        finish_reason='COMPLETE',
+        message=AssistantMessageResponse(
+            content=[TextAssistantMessageResponseContentItem(text='hello')],
+        ),
+    )
+    mock_client = MockAsyncClientV2.create_mock(c)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('hi')
+    response = next(m for m in result.all_messages() if isinstance(m, ModelResponse))
+    assert response.provider_response_id == 'resp-abc'
 
 
 async def test_request_simple_usage(allow_model_requests: None):
@@ -364,6 +389,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 provider_name='cohere',
                 provider_url='https://api.cohere.com',
                 provider_details={'finish_reason': 'COMPLETE'},
+                provider_response_id='123',
                 finish_reason='stop',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -463,6 +489,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 provider_name='cohere',
                 provider_url='https://api.cohere.com',
                 provider_details={'finish_reason': 'COMPLETE'},
+                provider_response_id='123',
                 finish_reason='stop',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -499,6 +526,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 provider_name='cohere',
                 provider_url='https://api.cohere.com',
                 provider_details={'finish_reason': 'COMPLETE'},
+                provider_response_id='123',
                 finish_reason='stop',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -524,6 +552,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 provider_name='cohere',
                 provider_url='https://api.cohere.com',
                 provider_details={'finish_reason': 'COMPLETE'},
+                provider_response_id='123',
                 finish_reason='stop',
                 run_id=IsStr(),
                 conversation_id=IsStr(),


### PR DESCRIPTION
## Summary

- Pass `response.id` from the Cohere `ChatResponse` through to `ModelResponse.provider_response_id` in `CohereModel._process_response`
- Add a focused regression test (`test_provider_response_id_forwarded`) that pins the forwarding behavior
- Update existing inline snapshots to reflect the now-populated field

Closes #7744

## Test plan

- [x] New unit test asserts `provider_response_id` matches `ChatResponse.id`
- [x] All existing non-VCR cohere tests pass with updated snapshots
- [x] Pyright clean on `models/cohere.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

