### PR TITLE
Suppress Gemini token subcounts from OTel `details.*` attributes to prevent double-counting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -25,6 +25,27 @@ conceptual quantity under two attributes that consumers like Langfuse then sum, 
 and cost. Adapters that stash these keys in `details` (e.g. Anthropic's streaming carry-forward, Cohere's
 billed units) keep them accessible on `RequestUsage.details`; only the ambiguous OTel emission is dropped."""
 
+_GEMINI_TOKEN_SUBCOUNT_KEYS = frozenset({
+    'cached_content_tokens',
+    'thoughts_tokens',
+    'tool_use_prompt_tokens',
+})
+"""Gemini-specific `details` keys that are subsets of first-class token totals (`input_tokens`,
+`output_tokens`, `cache_read_tokens`). The Google adapter also emits per-modality breakdowns
+(`text_prompt_tokens`, `audio_candidates_tokens`, …) that follow the `{modality}_{prefix}_tokens`
+pattern — those are caught by `_GEMINI_TOKEN_SUBCOUNT_SUFFIXES` below."""
+
+_GEMINI_TOKEN_SUBCOUNT_SUFFIXES = (
+    '_prompt_tokens',
+    '_cache_tokens',
+    '_candidates_tokens',
+    '_output_tokens',
+    '_tool_use_prompt_tokens',
+)
+"""Suffixes of Gemini per-modality token breakdown keys.  Every key matching one of these is a
+subset of a first-class total and must be suppressed from OTel for the same reason as
+`_FIRST_CLASS_TOKEN_DETAIL_KEYS`."""
+
 _LEGACY_USAGE_KEYS = frozenset({'requests', 'request_tokens', 'response_tokens', 'total_tokens'})
 """Keys accepted in stored usage data for backwards compatibility but not preserved as arbitrary fields."""
 
@@ -241,10 +262,13 @@ class UsageBase:
         if details:
             prefix = 'gen_ai.usage.details.'
             for key, value in details.items():
-                # Never emit a `details` entry whose name collides with a first-class token attribute: the
-                # value is already reported as `gen_ai.usage.{input,output}_tokens`, and emitting it again
-                # under `gen_ai.usage.details.*` makes consumers like Langfuse sum the two and double-count.
-                if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
+                # Never emit a `details` entry that duplicates or is a subset of a first-class token
+                # attribute: the value is already included in `gen_ai.usage.{input,output}_tokens` (or
+                # the cache/audio typed fields), and emitting it again under `gen_ai.usage.details.*`
+                # makes consumers like Langfuse sum the two and double-count.
+                if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS or key in _GEMINI_TOKEN_SUBCOUNT_KEYS:
+                    continue
+                if key.endswith(_GEMINI_TOKEN_SUBCOUNT_SUFFIXES):
                     continue
                 # Zero is a meaningful value, but a `None` would be an invalid OTel attribute value.
                 # Provider data can contain None despite the annotation.

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -399,6 +399,43 @@ def test_opentelemetry_attributes_excludes_first_class_token_details():
     }
 
 
+def test_opentelemetry_attributes_excludes_gemini_token_subcounts():
+    """Gemini-specific token subcount keys must not leak into OTel `details.*` attributes.
+
+    The Google adapter stores per-modality breakdowns (`text_prompt_tokens`, `text_candidates_tokens`,
+    …) and aggregate subcounts (`thoughts_tokens`, `cached_content_tokens`, `tool_use_prompt_tokens`)
+    in `details`. These are all subsets of the first-class `input_tokens`/`output_tokens` totals, so
+    emitting them under `gen_ai.usage.details.*` lets consumers like Langfuse sum them with the
+    first-class attributes and double-count. They stay accessible on `RequestUsage.details`; only the
+    OTel emission is suppressed.
+    """
+    usage = RequestUsage(
+        input_tokens=500,
+        output_tokens=200,
+        details={
+            'thoughts_tokens': 35,
+            'cached_content_tokens': 100,
+            'tool_use_prompt_tokens': 50,
+            'text_prompt_tokens': 350,
+            'text_candidates_tokens': 165,
+            'audio_prompt_tokens': 150,
+            'text_cache_tokens': 80,
+            'text_tool_use_prompt_tokens': 50,
+            'reasoning_tokens': 10,
+        },
+    )
+    assert usage.opentelemetry_attributes() == {
+        'gen_ai.usage.input_tokens': 500,
+        'gen_ai.usage.output_tokens': 200,
+        # reasoning_tokens is the only detail that survives — it's a standard OTel concept,
+        # not a Gemini-specific modality breakdown.
+        'gen_ai.usage.details.reasoning_tokens': 10,
+    }
+    # The details dict itself is untouched — programmatic access is preserved.
+    assert usage.details['text_prompt_tokens'] == 350
+    assert usage.details['thoughts_tokens'] == 35
+
+
 async def test_multi_agent_usage_sync():
     """As in `test_multi_agent_usage_async`, with a sync tool."""
     controller_agent = Agent(TestModel())


### PR DESCRIPTION
## Summary

- Add `_GEMINI_TOKEN_SUBCOUNT_KEYS` and `_GEMINI_TOKEN_SUBCOUNT_SUFFIXES` to `usage.py` to suppress Gemini-specific token subcount keys from OTel `gen_ai.usage.details.*` attributes
- Static keys: `cached_content_tokens`, `thoughts_tokens`, `tool_use_prompt_tokens`
- Dynamic per-modality keys matching `{modality}_{prefix}_tokens` (e.g. `text_prompt_tokens`, `audio_candidates_tokens`) caught by suffix check
- Keys remain accessible on `RequestUsage.details` for programmatic use — only the OTel emission is suppressed
- Existing `reasoning_tokens` (OpenAI/xAI) continues to be emitted as before

Closes #7742

## Test plan

- [x] New `test_opentelemetry_attributes_excludes_gemini_token_subcounts` covers static keys, modality breakdown keys, and verifies `reasoning_tokens` still passes through
- [x] Existing `test_opentelemetry_attributes_excludes_first_class_token_details` still passes
- [x] Pyright clean on `usage.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

