### PR TITLE
Support Cohere image content blocks in user prompts and tool returns

### DIFF
--- a/docs/models/cohere.md
+++ b/docs/models/cohere.md
@@ -74,6 +74,29 @@ agent = Agent(model)
 ...
 ```
 
+## Image inputs
+
+Cohere's [vision models](https://docs.cohere.com/docs/image-inputs) accept images in user messages,
+so an [`ImageUrl`][pydantic_ai.messages.ImageUrl] or an image
+[`BinaryContent`][pydantic_ai.messages.BinaryContent] is sent as an `image_url` content block:
+
+```python
+from pydantic_ai import Agent, ImageUrl
+from pydantic_ai.models.cohere import CohereModel
+
+model = CohereModel('command-a-vision-07-2025')
+agent = Agent(model)
+prompt = ['What breed is this dog?', ImageUrl(url='https://iili.io/3Hs4FMg.png')]
+...
+```
+
+On a model without vision support, an image raises a
+[`UserError`][pydantic_ai.exceptions.UserError].
+
+Cohere tool results are text-only, so an image a tool returns is referenced by identifier in the tool
+result and sent in full in a following user message. Other content kinds (documents, audio, video)
+are not supported in either position.
+
 ## Model settings
 
 You can customize model behavior using [`CohereModelSettings`][pydantic_ai.models.cohere.CohereModelSettings]:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -7,7 +7,7 @@ from typing import Literal, cast
 
 from typing_extensions import assert_never
 
-from pydantic_ai.exceptions import ModelAPIError
+from pydantic_ai.exceptions import ModelAPIError, UserError
 
 from .. import ModelHTTPError, usage
 from .._utils import (
@@ -16,10 +16,12 @@ from .._utils import (
     is_str_dict as _is_str_dict,
 )
 from ..messages import (
+    BinaryContent,
     CachePoint,
     CompactionPart,
     FilePart,
     FinishReason,
+    ImageUrl,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -35,6 +37,7 @@ from ..messages import (
     ToolAvailabilityDeltaPart,
     ToolCallPart,
     ToolReturnPart,
+    UserContent,
     UserPromptPart,
 )
 from ..profiles import ModelProfileSpec
@@ -57,6 +60,8 @@ try:
         ChatFinishReason,
         ChatMessageV2,
         Content as CohereContent,
+        ImageUrl as CohereImageUrl,
+        ImageUrlContent as CohereImageUrlContent,
         SystemChatMessageV2,
         TextAssistantMessageV2ContentOneItem,
         TextContent as CohereTextContent,
@@ -367,29 +372,20 @@ class CohereModel(Model[AsyncClientV2]):
             ),
         )
 
-    @classmethod
-    def _map_user_message(cls, message: ModelRequest) -> Iterable[ChatMessageV2]:
+    def _map_user_message(self, message: ModelRequest) -> Iterable[ChatMessageV2]:
+        file_content: list[UserContent] = []
         for part in message.parts:
             if isinstance(part, SystemPromptPart):
                 yield SystemChatMessageV2(role='system', content=part.content)
             elif isinstance(part, UserPromptPart):
-                if isinstance(part.content, str):
-                    yield UserChatMessageV2(role='user', content=part.content)
-                else:
-                    cohere_content: list[CohereContent] = []
-                    for c in part.content:
-                        if isinstance(c, str | TextContent):
-                            cohere_content.append(CohereTextContent(text=c if isinstance(c, str) else c.content))
-                        elif isinstance(c, CachePoint):
-                            continue
-                        else:
-                            raise RuntimeError('Cohere does not yet support multi-modal inputs.')
-                    yield UserChatMessageV2(role='user', content=cohere_content)
+                yield self._map_user_prompt(part)
             elif isinstance(part, ToolReturnPart):
+                tool_text, tool_file_content = part.model_response_str_and_user_content()
+                file_content.extend(tool_file_content)
                 yield ToolChatMessageV2(
                     role='tool',
                     tool_call_id=_guard_tool_call_id(t=part),
-                    content=part.model_response_str(),
+                    content=tool_text,
                 )
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
@@ -407,6 +403,34 @@ class CohereModel(Model[AsyncClientV2]):
                 raise _unconverted_speech_part_error()
             else:
                 assert_never(part)
+
+        if file_content:
+            # Cohere tool results are text-only, so media a tool returned rides in a trailing user
+            # message, the same fallback OpenAI Chat, Groq, Hugging Face and xAI use.
+            yield self._map_user_prompt(UserPromptPart(content=file_content))
+
+    def _map_user_prompt(self, part: UserPromptPart) -> UserChatMessageV2:
+        if isinstance(part.content, str):
+            return UserChatMessageV2(role='user', content=part.content)
+
+        cohere_content: list[CohereContent] = []
+        for item in part.content:
+            if isinstance(item, str | TextContent):
+                cohere_content.append(CohereTextContent(text=item if isinstance(item, str) else item.content))
+            elif isinstance(item, ImageUrl):
+                cohere_content.append(self._map_image_url(item.url))
+            elif isinstance(item, BinaryContent) and item.is_image:
+                cohere_content.append(self._map_image_url(item.data_uri))
+            elif isinstance(item, CachePoint):
+                continue
+            else:
+                raise RuntimeError('Cohere does not yet support multi-modal inputs.')
+        return UserChatMessageV2(role='user', content=cohere_content)
+
+    def _map_image_url(self, url: str) -> CohereImageUrlContent:
+        if not self.profile.get('cohere_supports_image_content'):
+            raise UserError(f'Image inputs are not supported by the Cohere model {self._model_name!r}.')
+        return CohereImageUrlContent(type='image_url', image_url=CohereImageUrl(url=url))
 
 
 def _map_usage(response: V2ChatResponse, provider: str, provider_url: str, model: str) -> usage.RequestUsage:

--- a/pydantic_ai_slim/pydantic_ai/profiles/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/cohere.py
@@ -3,9 +3,28 @@ from __future__ import annotations as _annotations
 from . import ModelProfile
 
 
+class CohereModelProfile(ModelProfile, total=False):
+    """Profile for Cohere models.
+
+    ALL FIELDS MUST BE `cohere_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
+    """
+
+    cohere_supports_image_content: bool
+    """Whether the model accepts `image_url` content blocks in user messages. Default: `False`.
+
+    Only Cohere's vision models take images; the others reject the block.
+    See [Cohere's image inputs docs](https://docs.cohere.com/docs/image-inputs).
+    """
+
+
 def cohere_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a Cohere model."""
-    is_reasoning = 'reasoning' in model_name
-    if is_reasoning:
-        return ModelProfile(supports_thinking=True, thinking_always_enabled=True)
-    return None
+    profile = CohereModelProfile()
+    if 'reasoning' in model_name:
+        profile['supports_thinking'] = True
+        profile['thinking_always_enabled'] = True
+    if 'vision' in model_name:
+        # Cohere's vision models carry `vision` in the name, e.g. `command-a-vision-07-2025`.
+        profile['cohere_supports_image_content'] = True
+    # Only the keys a model actually needs, so a plain `command` resolves to the same profile as before.
+    return profile or None

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -12,10 +12,13 @@ import pytest
 
 from pydantic_ai import (
     Agent,
+    BinaryImage,
     CachePoint,
+    DocumentUrl,
     ImageUrl,
     ModelAPIError,
     ModelHTTPError,
+    ModelMessage,
     ModelRequest,
     ModelResponse,
     ModelRetry,
@@ -41,13 +44,17 @@ from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, raise_if_exception,
 with try_import() as imports_successful:
     import cohere
     from cohere import (
+        AssistantChatMessageV2,
         AssistantMessageResponse,
         AsyncClientV2,
         ChatResponse,
+        ImageUrl as CohereImageUrl,
+        ImageUrlContent as CohereImageUrlContent,
         TextAssistantMessageResponseContentItem,
         TextContent as CohereTextContent,
         ToolCallV2,
         ToolCallV2Function,
+        ToolChatMessageV2,
         UserChatMessageV2,
     )
     from cohere.core.api_error import ApiError
@@ -570,7 +577,8 @@ def test_text_content_in_request(allow_model_requests: None):
             )
         ]
     )
-    assert list(CohereModel._map_user_message(req)) == snapshot(  # pyright: ignore[reportPrivateUsage]
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    assert list(m._map_user_message(req)) == snapshot(  # pyright: ignore[reportPrivateUsage]
         [
             UserChatMessageV2(
                 content=[
@@ -586,7 +594,8 @@ def test_text_content_in_request(allow_model_requests: None):
 
 def test_cache_point_silently_skipped_user_prompt_part(allow_model_requests: None):
     req = ModelRequest(parts=[UserPromptPart(content=['Hello there!', CachePoint()])])
-    assert list(CohereModel._map_user_message(req)) == snapshot(  # pyright: ignore[reportPrivateUsage]
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    assert list(m._map_user_message(req)) == snapshot(  # pyright: ignore[reportPrivateUsage]
         [
             UserChatMessageV2(
                 content=[
@@ -604,14 +613,80 @@ async def test_multimodal(allow_model_requests: None):
     agent = Agent(m)
 
     with pytest.raises(RuntimeError, match=re.escape('Cohere does not yet support multi-modal inputs.')):
-        await agent.run(
-            [
-                'hello',
-                ImageUrl(
-                    url='https://t3.ftcdn.net/jpg/00/85/79/92/360_F_85799278_0BBGV9OAdQDTLnKwAPBCcg1J7QtiieJY.jpg'
-                ),
-            ]
-        )
+        await agent.run(['hello', DocumentUrl(url='https://example.com/document.pdf')])
+
+
+async def test_image_input_requires_a_vision_model(allow_model_requests: None):
+    c = completion_message(AssistantMessageResponse(content=[TextAssistantMessageResponseContentItem(text='world')]))
+    mock_client = MockAsyncClientV2.create_mock(c)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    with pytest.raises(
+        UserError, match=re.escape("Image inputs are not supported by the Cohere model 'command-r7b-12-2024'.")
+    ):
+        await agent.run(['hello', ImageUrl(url='https://example.com/image.png')])
+
+
+def test_image_input_on_a_vision_model(allow_model_requests: None):
+    m = CohereModel('command-a-vision-07-2025', provider=CohereProvider(api_key='foobar'))
+    req = ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=[
+                    'hello',
+                    ImageUrl(url='https://example.com/image.png'),
+                    BinaryImage(data=b'fake', media_type='image/png'),
+                ]
+            )
+        ]
+    )
+    assert list(m._map_user_message(req)) == snapshot(  # pyright: ignore[reportPrivateUsage]
+        [
+            UserChatMessageV2(
+                content=[
+                    CohereTextContent(text='hello'),
+                    CohereImageUrlContent(image_url=CohereImageUrl(url='https://example.com/image.png')),
+                    CohereImageUrlContent(image_url=CohereImageUrl(url='data:image/png;base64,ZmFrZQ==')),
+                ]
+            )
+        ]
+    )
+
+
+def test_tool_returned_image_spills_into_a_user_message(allow_model_requests: None):
+    """A Cohere tool result is text-only, so a tool-returned image rides in a trailing user message.
+
+    Before, the image was dropped and the tool result was sent as an empty string.
+    """
+    m = CohereModel('command-a-vision-07-2025', provider=CohereProvider(api_key='foobar'))
+    image = BinaryImage(data=b'fake', media_type='image/png')
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='show me the chart')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='get_chart', args={}, tool_call_id='call_1')]),
+        ModelRequest(
+            parts=[ToolReturnPart(tool_name='get_chart', content=image, tool_call_id='call_1')],
+        ),
+    ]
+    assert m._map_messages(messages, ModelRequestParameters()) == snapshot(  # pyright: ignore[reportPrivateUsage]
+        [
+            UserChatMessageV2(content='show me the chart'),
+            AssistantChatMessageV2(
+                tool_calls=[
+                    ToolCallV2(
+                        id='call_1', type='function', function=ToolCallV2Function(name='get_chart', arguments='{}')
+                    )
+                ]
+            ),
+            ToolChatMessageV2(tool_call_id='call_1', content=f'See file {image.identifier}.'),
+            UserChatMessageV2(
+                content=[
+                    CohereTextContent(text=f'This is file {image.identifier}:'),
+                    CohereImageUrlContent(image_url=CohereImageUrl(url='data:image/png;base64,ZmFrZQ==')),
+                ]
+            ),
+        ]
+    )
 
 
 def test_model_status_error(allow_model_requests: None) -> None:


### PR DESCRIPTION
- Closes #7646

Cohere v2 accepts `image_url` content blocks on its vision models, but `CohereModel` rejected all non-text user content, so `_map_user_message` could not use the tool-return spill that OpenAI Chat, Groq, Hugging Face and xAI use.

One correction to the issue, found while reproducing at `61f0da5f7`: the tool-return path does not raise, it silently drops. `_map_user_message` sent `part.model_response_str()`, which renders a `BinaryImage` as `''`, so a tool returning an image put `ToolChatMessageV2(content='')` on the wire with no error anywhere. The user-prompt path is the one that raises.

What this does, following the four steps in the issue:

- `CohereModelProfile.cohere_supports_image_content`, set by `cohere_model_profile` for the models carrying `vision` in the name, following the `google_supported_mime_types_in_tool_returns` and `bedrock_supported_media_kinds_in_tool_returns` precedent.
- `ImageUrl` and image `BinaryContent` map to `ImageUrlContent` in `_map_user_prompt`.
- `_map_user_message` spills tool-returned media into a trailing user message through `model_response_str_and_user_content()`.
- An image on a model without vision support raises `UserError` instead of being dropped.

`cohere_model_profile` sets only the keys a model actually needs and returns `None` when there are none, so a plain `command` resolves to exactly the profile it did before and no `test_resolution_matrix` snapshot moves.

> [!WARNING]
> **Compatibility impact:** on a Cohere model *without* vision support, a tool that returns an image used to send an empty tool result and let the run continue. It now raises `UserError`.
>
> **Why this can ship in a minor release:** the previous behavior dropped the tool's return value silently, so any run relying on it was already getting a result the tool did not produce.
>
> **Migration:** switch to a vision model, or stop returning media from tools on that model.

Happy to change this if you would rather the non-vision path keep degrading quietly, or degrade with a warning instead of an error. It is the one part of the change that moves behavior for people who are not hitting the reported problem, so I did not want to decide it.

Three things I deliberately left out, each of which widens the diff past the issue:

1. Cohere keeps its existing blanket `RuntimeError('Cohere does not yet support multi-modal inputs.')` for documents, audio and video, which the spill now also routes into. Every sibling provider raises `NotImplementedError` naming the kind, and `tests/models/test_multimodal_tool_returns.py` expects that shape, so adding `cohere` to that matrix wants this settled first. Should I change it here?
2. `ImageUrl.vendor_metadata['detail']` is not forwarded, though Cohere's `ImageUrl` accepts `detail` and Groq and OpenAI Chat both forward it.
3. `LatestCohereModelNames` lists no vision model, so `command-a-vision-07-2025` gets no autocomplete.

### Verification

- `tests/models/test_cohere.py`: 27 passed. New cases cover both sides of the profile flag (an image on `command-a-vision-07-2025` maps, an image on `command-r7b-12-2024` raises) and the tool-return spill.
- `-k "cohere or profile"`: 604 passed, 5 skipped.
- `tests/test_examples.py -k cohere`: 10 passed, none skipped.
- `make lint`, `ruff format --check` and `pyright` clean on the changed files; pre-commit ran the full typecheck.
- Not done: a live `command-a-vision-07-2025` cassette, and the `cohere` row in `test_multimodal_tool_returns.py` that depends on it. I can record it once the issue is assigned.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

