### PR TITLE
Preserve explicit empty `Tool` description instead of falling back to the function docstring

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -421,7 +421,7 @@ class Tool(Generic[ToolAgentDepsT]):
         )
         self.takes_ctx = self.function_schema.takes_ctx
         self.max_retries = max_retries
-        self.description = description or self.function_schema.description
+        self.description = description if description is not None else self.function_schema.description
         self.prepare = prepare
         self.args_validator = args_validator
         self.docstring_format = docstring_format

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1383,6 +1383,25 @@ def test_sync_prepare_tools_agent_wide():
     assert result.output == snapshot('{"foobar":"0"}')
 
 
+def test_tool_explicit_empty_description_suppresses_docstring():
+    """https://github.com/pydantic/pydantic-ai/issues/7670"""
+
+    def my_tool(x: int) -> int:
+        """Docstring that should not be sent to the model."""
+        return x
+
+    assert Tool(my_tool).tool_def.description == 'Docstring that should not be sent to the model.'
+    assert Tool(my_tool, description=None).tool_def.description == 'Docstring that should not be sent to the model.'
+    assert Tool(my_tool, description='').tool_def.description == ''
+    assert Tool(my_tool, description=' ').tool_def.description == ' '
+
+    test_model = TestModel()
+    agent = Agent(test_model, tools=[Tool(my_tool, description='')])
+    agent.run_sync('hello')
+    assert test_model.last_model_request_parameters is not None
+    assert test_model.last_model_request_parameters.function_tools[0].description == ''
+
+
 def test_function_tool_consistent_with_schema():
     def function(*args: Any, **kwargs: Any) -> str:
         assert len(args) == 0


### PR DESCRIPTION
- Closes #7670

`Tool.__init__` documents `description=None` as the signal to infer the description from the function, but implemented it with a truthiness fallback (`description or self.function_schema.description`), so an explicit `description=""` was silently replaced by the function docstring — leaking docstrings a caller had deliberately suppressed into every model request.

This changes the fallback to an `is None` check, aligning `Tool(...)` with `Tool.from_schema(...)`, which already preserves an empty description.

- `description=None` (and the default) still infers from the function — no behavior change for existing callers not passing `""`.
- `description=""` is now preserved, as documented.
- No other ingestion path is affected: the `@agent.tool` decorator and `FunctionToolset.add_function` route through this same constructor, and the remaining `description or ...` occurrences in the codebase are wire-format `None` → `''` conversions at provider boundaries, not description inference.

The regression test covers the `None`/`""`/whitespace constructor contract and asserts via `TestModel.last_model_request_parameters` that the empty description is what actually reaches the model request.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

