### PR TITLE
Restore `pull-requests: write` for owner routing

### DIFF
--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import sys
+import urllib.error
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -650,7 +651,10 @@ def main() -> int:
         _summary(f'#{expected["number"]}: ' + ('assigned' if did_assign else 'already owned'))
         return 0
     except (KeyError, OSError, ValueError, RuntimeError) as exc:
-        print(f'owner routing failed: {type(exc).__name__}', file=sys.stderr)
+        error = type(exc).__name__
+        if isinstance(exc, urllib.error.HTTPError):
+            error += f' {exc.code}'
+        print(f'owner routing failed: {error}', file=sys.stderr)
         return 1
 
 

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import datetime as dt
 import json
 import sys
+import urllib.error
 import urllib.parse
 from collections.abc import Mapping
+from email.message import Message
 from pathlib import Path
 from typing import Any, cast
 
@@ -895,6 +897,26 @@ def test_cli_failure_is_redacted(monkeypatch: pytest.MonkeyPatch, capsys: pytest
     assert capsys.readouterr().err == 'owner routing failed: ValueError\n'
 
 
+def test_cli_http_failure_reports_status_without_response_details(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    def fail_client(_: str):
+        raise urllib.error.HTTPError(
+            'https://api.github.com/repos/pydantic/pydantic-ai/issues/7559/assignees?secret=value',
+            403,
+            'response details stay redacted',
+            Message(),
+            None,
+        )
+
+    monkeypatch.setattr(router.attention, 'GitHubClient', fail_client)
+    monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
+    monkeypatch.setenv('GITHUB_TOKEN', 'token')
+
+    assert router.main() == 1
+    assert capsys.readouterr().err == 'owner routing failed: HTTPError 403\n'
+
+
 def test_workflow_is_notification_first_and_least_privilege():
     workflow_path = Path(__file__).parents[1] / 'workflows' / 'pydantic-ai-owner-routing.yml'
     workflow = yaml.safe_load(workflow_path.read_text(encoding='utf-8'))
@@ -912,7 +934,7 @@ def test_workflow_is_notification_first_and_least_privilege():
     assert jobs['route']['permissions'] == {
         'contents': 'read',
         'issues': 'write',
-        'pull-requests': 'read',
+        'pull-requests': 'write',
     }
     prepare, notify, assign = jobs['route']['steps'][1:]
     select_step = jobs['select']['steps'][1]

--- a/.github/workflows/pydantic-ai-owner-routing.yml
+++ b/.github/workflows/pydantic-ai-owner-routing.yml
@@ -71,7 +71,8 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      # GitHub authorizes assignments by item type even though both use the Issues REST endpoint.
+      pull-requests: write
     steps:
       - name: Check out trusted routing policy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
The semantic owner router could select and notify for a pull request, but its final assignment failed because the route job only held `pull-requests: read`. The canonical failure was https://github.com/pydantic/pydantic-ai/actions/runs/32848775444.

This restores the pull-request mutation permission while retaining `issues: write` for issues. It also keeps failures redacted while including the numeric HTTP status, so future permission failures are diagnosable from the canonical run.

Regression coverage pins both the workflow permission contract and safe HTTP-status reporting.

Verification:

- `uv run pytest .github/scripts/test_semantic_owner_router.py` (91 passed)
- Ruff format and lint
- targeted Pyright on `semantic_owner_router.py`
- YAML validation and zizmor

- Closes N/A (operational workflow regression)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

