### PR TITLE
Marshal sync RunContext.enqueue() calls onto the run loop

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -672,14 +672,11 @@ loop all deliver enqueued messages.
       system-prompt callback that re-enqueues on each reinjection), the run will
       loop indefinitely. Set [`UsageLimits`][pydantic_ai.usage.UsageLimits] on the
       run as a safety net.
-    - `enqueue` is designed to be called from the same event loop that drives the
-      agent run. Inside the run that's automatic: async tools, sync tools (which
-      Pydantic AI auto-wraps in a thread executor), and capability hooks all
-      enqueue safely because the drain only iterates between graph nodes, never
-      concurrently with a tool body. If you're forwarding events from a *different*
-      thread or loop (e.g. a webhook handler), marshal the call onto the agent's
-      loop first — e.g. `loop.call_soon_threadsafe(agent_run.enqueue, msg)`. The
-      drain isn't atomic against concurrent cross-thread appends.
+    - `RunContext.enqueue` is safe in async tools, capability hooks, and sync callbacks
+      dispatched through Pydantic AI's thread executor. Sync callbacks are marshalled
+      back to the run's event loop automatically. If you're forwarding events from a
+      different thread or loop (e.g. a webhook handler), marshal `AgentRun.enqueue`
+      onto the agent's loop first — e.g. `loop.call_soon_threadsafe(agent_run.enqueue, msg)`.
 
 ## Processing Message History
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
@@ -127,3 +127,5 @@ A `priority` controls delivery:
 - `'when_idle'`: delivered only when the agent would otherwise terminate, after any `'asap'` messages — a follow-up task that shouldn't interrupt in-flight work.
 
 Both priorities drain however you drive the run — `agent.run()`, explicit `AgentRun.next()`, and a bare `async for node in agent_run:` loop all deliver enqueued messages. See [message history docs](https://pydantic.dev/docs/ai/core-concepts/message-history/#injecting-messages-mid-run) for details.
+
+`RunContext.enqueue()` is safe in sync tools dispatched through Pydantic AI's thread executor. In a standard run, the queue update is marshalled back to the run's event loop. Calls to `AgentRun.enqueue()` from unrelated threads must be marshalled onto that loop by the caller.

--- a/pydantic_ai_slim/pydantic_ai/_enqueue.py
+++ b/pydantic_ai_slim/pydantic_ai/_enqueue.py
@@ -6,8 +6,13 @@ state for the pending message queue, not part of the wire-serializable message h
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import asyncio
+from collections.abc import Generator, Sequence
+from concurrent.futures import CancelledError as FutureCancelledError, Future, InvalidStateError
+from contextlib import contextmanager, suppress
+from contextvars import ContextVar
 from dataclasses import dataclass, field
+from threading import Event, Lock
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from ._uuid import uuid7
@@ -64,6 +69,8 @@ interleaved exchange (e.g. a synthetic tool call + result — a `ModelResponse` 
 `ModelRequest`). The assembled sequence must end in a `ModelRequest` so the agent has something to
 respond to.
 """
+
+_RUN_ENDED_MESSAGE = '`enqueue` is not available because the agent run is no longer accepting messages.'
 
 
 def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessage]:
@@ -164,3 +171,91 @@ class PendingMessage:
                 'items that form one), so the agent has a request to respond to.'
             )
         return cls(messages=messages, priority=priority)
+
+
+class _PendingMessageBridge:
+    def __init__(self, queue: list[PendingMessage]) -> None:
+        self.queue = queue
+        self._loop = asyncio.get_running_loop()
+        self._closed = Event()
+        self._waiting: set[Future[None]] = set()
+        self._lock = Lock()
+
+    def append(self, pending: PendingMessage) -> None:
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            if running_loop is not self._loop:
+                raise UserError('`enqueue` cannot be called from a different event loop than the agent run.')
+            self._append(pending)
+            return
+
+        result: Future[None] = Future()
+        with self._lock:
+            if self._closed.is_set():
+                raise UserError(_RUN_ENDED_MESSAGE)
+            self._waiting.add(result)
+
+        def append() -> None:
+            try:
+                self._append(pending)
+            except BaseException as e:
+                with suppress(InvalidStateError):
+                    result.set_exception(e)
+            else:
+                with suppress(InvalidStateError):
+                    result.set_result(None)
+
+        try:
+            self._loop.call_soon_threadsafe(append)
+            result.result()
+        except FutureCancelledError as e:
+            raise UserError(_RUN_ENDED_MESSAGE) from e
+        finally:
+            with self._lock:
+                self._waiting.discard(result)
+
+    def _append(self, pending: PendingMessage) -> None:
+        if self._closed.is_set():
+            raise UserError(_RUN_ENDED_MESSAGE)
+        self.queue.append(pending)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed.set()
+            waiting = tuple(self._waiting)
+        for result in waiting:
+            result.cancel()
+
+
+_pending_message_bridge: ContextVar[_PendingMessageBridge | None] = ContextVar('_pending_message_bridge', default=None)
+
+
+@contextmanager
+def bind_pending_message_queue(queue: list[PendingMessage]) -> Generator[None]:
+    """Bind `queue` to its run loop for the lifetime of an agent run."""
+    bridge = _PendingMessageBridge(queue)
+    token = _pending_message_bridge.set(bridge)
+    try:
+        yield
+    finally:
+        bridge.close()
+        _pending_message_bridge.reset(token)
+
+
+def append_pending_message(queue: list[PendingMessage], pending: PendingMessage) -> None:
+    """Append on the run loop when called from a sync callback owned by that run."""
+    bridge = _pending_message_bridge.get()
+    if bridge is None or bridge.queue is not queue:
+        queue.append(pending)
+    else:
+        bridge.append(pending)
+
+
+def close_pending_message_queue(queue: list[PendingMessage]) -> None:
+    """Stop sync callbacks from appending after the run's final drain."""
+    bridge = _pending_message_bridge.get()
+    if bridge is not None and bridge.queue is queue:
+        bridge.close()

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -14,7 +14,7 @@ from typing_extensions import TypeVar
 from pydantic_ai._instrumentation import DEFAULT_INSTRUMENTATION_VERSION
 
 from . import _utils, messages as _messages
-from ._enqueue import EnqueueContent, PendingMessage, PendingMessagePriority
+from ._enqueue import EnqueueContent, PendingMessage, PendingMessagePriority, append_pending_message
 from .exceptions import UserError
 
 if TYPE_CHECKING:
@@ -417,12 +417,9 @@ class RunContext(Generic[RunContextAgentDepsT]):
     ) -> str | None:
         """Enqueue content to be injected into the conversation.
 
-        Safe to call from anywhere a `RunContext` is available — async tools,
-        sync tools (auto-wrapped in a thread executor by Pydantic AI), and
-        capability hooks. The drain only iterates the queue between graph nodes
-        (in `before_model_request` and `after_node_run`), never concurrently
-        with the tool body, so `list.append` from a worker thread doesn't race
-        the drain.
+        Safe to call from async tools, capability hooks, and sync callbacks dispatched
+        through Pydantic AI's thread executor. During a standard agent run, calls from
+        those sync callbacks are marshalled onto the event loop that owns the run.
 
         Args:
             *content: One or more [`EnqueueContent`][pydantic_ai.run.EnqueueContent] items.
@@ -451,7 +448,8 @@ class RunContext(Generic[RunContextAgentDepsT]):
         Raises:
             UserError: If this `RunContext` isn't backed by a running agent's queue (e.g. the
                 synthetic context from `Agent.system_prompt_parts`), since there'd be nowhere
-                to deliver the message.
+                to deliver the message; if a sync callback outlives its run; or if called from
+                a different event loop than the run.
         """
         if self.pending_messages is None:
             raise UserError(
@@ -461,7 +459,7 @@ class RunContext(Generic[RunContextAgentDepsT]):
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
-        self.pending_messages.append(pending)
+        append_pending_message(self.pending_messages, pending)
         return pending.enqueue_id
 
     def cancel(self) -> None:

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -31,6 +31,7 @@ from pydantic_ai.capabilities._deferred_capability_loader import DeferredCapabil
 
 from .. import (
     _agent_graph,
+    _enqueue,
     _instructions,
     _output,
     _system_prompt,
@@ -1798,6 +1799,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         async with AsyncExitStack() as stack:
             # Enter first so cancellation is classified only after every other context has torn down.
             await stack.enter_async_context(_translate_cancellation())
+            stack.enter_context(_enqueue.bind_pending_message_queue(state.pending_messages))
 
             # Bind the run's cancellation controller to this task and register the token BEFORE any
             # potentially-blocking setup (the concurrency limiter, model entry): a run queued behind

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_pending_messages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from pydantic_ai._agent_graph import ModelRequestNode
-from pydantic_ai._enqueue import PendingMessage, PendingMessagePriority
+from pydantic_ai._enqueue import PendingMessage, PendingMessagePriority, close_pending_message_queue
 from pydantic_ai._utils import fill_run_metadata
 from pydantic_ai.capabilities.abstract import AbstractCapability, CapabilityOrdering
 from pydantic_ai.exceptions import UserError
@@ -144,6 +144,7 @@ class PendingMessageDrainCapability(AbstractCapability[Any]):
         leftover_asap = _drain_by_priority(ctx.pending_messages, 'asap')
         when_idle = _drain_by_priority(ctx.pending_messages, 'when_idle')
         if not leftover_asap and not when_idle:
+            close_pending_message_queue(ctx.pending_messages)
             return result
 
         drained = [*leftover_asap, *when_idle]

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -22,7 +22,7 @@ import pytest
 from opentelemetry.trace import NoOpTracer
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from pydantic_ai import Capability as TopLevelCapability, _agent_graph
+from pydantic_ai import Capability as TopLevelCapability, _agent_graph, _enqueue, _utils
 from pydantic_ai._enqueue import PendingMessage
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._spec import CapabilitySpec, NamedSpec
@@ -17548,6 +17548,109 @@ async def test_pending_messages_accessible_on_run_context():
             ),
         ]
     )
+
+
+async def test_enqueue_from_sync_callback_mutates_queue_on_agent_loop():
+    """A sync callback never mutates the pending-message queue from its worker thread."""
+    agent_thread = threading.get_ident()
+
+    class LoopOwnedQueue(list[PendingMessage]):
+        def append(self, pending: PendingMessage) -> None:
+            assert threading.get_ident() == agent_thread
+            super().append(pending)
+
+    queue = LoopOwnedQueue()
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=queue)
+
+    def enqueue_from_nested_loop() -> None:
+        async def enqueue() -> None:
+            with pytest.raises(UserError, match='different event loop'):
+                ctx.enqueue('from nested loop')
+
+        asyncio.run(enqueue())
+
+    with _enqueue.bind_pending_message_queue(queue):
+        await _utils.run_in_executor(ctx.enqueue, 'from worker')
+        await _utils.run_in_executor(enqueue_from_nested_loop)
+
+    assert len(queue) == 1
+
+
+async def test_enqueue_from_inline_sync_callback_does_not_deadlock():
+    queue: list[PendingMessage] = []
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=queue)
+
+    with _enqueue.bind_pending_message_queue(queue), _utils.disable_threads():
+        await _utils.run_in_executor(ctx.enqueue, 'inline')
+
+    _enqueue.close_pending_message_queue(queue)
+    assert len(queue) == 1
+
+
+async def test_enqueue_from_abandoned_sync_callback_is_rejected_after_run():
+    started = threading.Event()
+    release = threading.Event()
+    returned = threading.Event()
+    errors: list[UserError] = []
+    queue: list[PendingMessage] = []
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=queue)
+
+    def enqueue_late() -> None:
+        started.set()
+        release.wait()
+        try:
+            ctx.enqueue('too late')
+        except UserError as e:
+            errors.append(e)
+        finally:
+            returned.set()
+
+    with _enqueue.bind_pending_message_queue(queue), _utils.abandon_threads_on_cancel():
+        task = asyncio.create_task(_utils.run_in_executor(enqueue_late))
+        assert await asyncio.to_thread(started.wait, 1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    release.set()
+    assert await asyncio.to_thread(returned.wait, 1)
+    assert queue == []
+    assert len(errors) == 1
+    assert 'no longer accepting messages' in str(errors[0])
+
+
+async def test_enqueue_run_teardown_releases_sync_callback_waiting_on_loop(monkeypatch: pytest.MonkeyPatch):
+    scheduled: list[Callable[[], None]] = []
+    returned = threading.Event()
+    errors: list[UserError] = []
+    queue: list[PendingMessage] = []
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=queue)
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, 'call_soon_threadsafe', scheduled.append)
+
+    def enqueue() -> None:
+        try:
+            ctx.enqueue('waiting')
+        except UserError as e:
+            errors.append(e)
+        finally:
+            returned.set()
+
+    with _enqueue.bind_pending_message_queue(queue):
+        callback_context = contextvars.copy_context()
+        thread = threading.Thread(target=callback_context.run, args=(enqueue,))
+        thread.start()
+        while not scheduled:
+            await asyncio.sleep(0)
+
+    while not returned.is_set():
+        await asyncio.sleep(0)
+    thread.join()
+    scheduled[0]()
+
+    assert queue == []
+    assert len(errors) == 1
+    assert 'no longer accepting messages' in str(errors[0])
 
 
 async def test_enqueue_with_no_args_is_a_noop():


### PR DESCRIPTION
Closes #7634.

`RunContext.enqueue()` can run inside a synchronous tool on a worker thread. A capability may allow that tool to overlap later graph nodes, so the worker must not mutate the run-owned pending-message list while the event loop drains it.

This keeps the queue as a plain list and marshals Core-dispatched sync callback submissions onto the event loop that owns the run. `enqueue()` waits for that small queue update, preserving its immediate return contract. The bridge closes at the final empty drain and during run teardown, so late submissions are rejected and a worker already waiting on the loop is released.

`AgentRun.enqueue()` remains loop-affine. Callers forwarding events from unrelated threads still need to marshal that call onto the run loop. Serialized graph state and realtime queue behavior are unchanged.

### Verification

- `make lint`
- `make typecheck`
- `BLOCKBUSTER_ENABLED=false make testcov` (`12013 passed`, `576 skipped`, `3 xfailed`; the local aggregate coverage report remains below 100% because optional integration paths are not exercised, while all changed production modules have complete coverage)
- Harness `BackgroundTools` acceptance probe with a synchronous background tool calling `ctx.enqueue()`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

