### PR TITLE
Improve semantic owner routing recovery, author precedence, and Slack notices

### DIFF
--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -37,6 +37,7 @@ query RoutingItem($owner: String!, $name: String!, $number: Int!) {
       }
       ... on PullRequest {
         number state isDraft changedFiles
+        author { login }
         labels(first: 50) { nodes { name } pageInfo { hasNextPage } }
         assignees(first: 10) { nodes { login } pageInfo { hasNextPage } }
         files(first: 100) { nodes { path } pageInfo { hasNextPage } }
@@ -371,6 +372,28 @@ def _pull_request_draft_status(item: Mapping[str, Any]) -> str | None:
     return 'draft' if value else None
 
 
+def _pull_request_precedence(
+    client: attention.GitHubClient,
+    repo: str,
+    number: int,
+    item: Mapping[str, Any],
+) -> Selection | None:
+    if draft_status := _pull_request_draft_status(item):
+        return Selection(number=number, decision=None, status=draft_status)
+    author = item.get('author')
+    author_login = cast(Mapping[str, object], author).get('login') if isinstance(author, Mapping) else None
+    if isinstance(author_login, str):
+        key = author_login.casefold()
+        owner = next((candidate for candidate in _OWNERS if candidate.casefold() == key), None)
+        if owner is not None and client.maintainer_login(repo, owner, refresh=True) is not None:
+            return Selection(
+                number=number,
+                decision=Decision(number=number, owner=owner, evidence=f'author:{owner}'),
+                status='route',
+            )
+    return None
+
+
 def decision_for(
     client: attention.GitHubClient,
     repo: str,
@@ -399,8 +422,8 @@ def decision_for(
     if len(normalized['assignees']) >= _ASSIGNEE_LIMIT:
         return Selection(number=number, decision=None, status='assignee-capacity')
     is_pull_request = item.get('__typename') == 'PullRequest'
-    if is_pull_request and (draft_status := _pull_request_draft_status(item)) is not None:
-        return Selection(number=number, decision=None, status=draft_status)
+    if is_pull_request and (precedence := _pull_request_precedence(client, repo, number, item)) is not None:
+        return precedence
     participant = _participant_decision(client, repo, number, participant_login)
     if participant is not None:
         return Selection(number=number, decision=participant, status='route')
@@ -592,11 +615,35 @@ def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> boo
     return True
 
 
-def _slack_payload(repo: str, decision: Decision, mentions_value: str) -> str:
+def _routing_reason(decision: Decision, mention: str) -> str:
+    evidence = decision['evidence']
+    owner = decision['owner']
+    if evidence == f'participant:{owner}':
+        return f'{mention} was the most recent qualified maintainer to participate.'
+    if evidence == f'author:{owner}':
+        return f'{mention} authored this pull request.'
+    source, separator, detail = evidence.partition(':')
+    if separator and detail and source in {'label', 'path'}:
+        return f'Matched ownership {source} `{detail}`.'
+    if evidence.startswith('manual:'):
+        return 'Automatic routing could not determine an available semantic owner, so this needs manual triage.'
+    raise ValueError('routing evidence cannot be explained')
+
+
+def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value: str) -> str:
     """Build one canonical Slack assignment notice."""
     repo = _repository(repo)
     mentions = attention.slack_mentions(mentions_value, decision['owner'])
-    text = f'Routing intent: {repo}#{decision["number"]} → {mentions[decision["owner"]]}\nWhy: {decision["evidence"]}'
+    mention = mentions[decision['owner']]
+    if item_type == 'Issue':
+        kind, path = 'Issue', 'issues'
+    elif item_type == 'PullRequest':
+        kind, path = 'Pull request', 'pull'
+    else:
+        raise ValueError('item type is not canonical')
+    number = decision['number']
+    item = f'<https://github.com/{repo}/{path}/{number}|{repo}#{number}>'
+    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(decision, mention)}'
     return json.dumps({'text': text}, separators=(',', ':'))
 
 
@@ -607,6 +654,12 @@ def prepare_current(
     mentions_value: str,
 ) -> str | None:
     """Build a notice only while the selected route still matches GitHub."""
+    item = _fetch_item(client, repo, expected['number'])
+    if item is None:
+        return None
+    item_type = item.get('__typename')
+    if not isinstance(item_type, str):
+        raise RuntimeError('GitHub returned invalid routing metadata')
     current = decision_for(
         client,
         repo,
@@ -615,7 +668,7 @@ def prepare_current(
     )
     if current['decision'] != expected:
         return None
-    return _slack_payload(repo, expected, mentions_value)
+    return _slack_payload(repo, item_type, expected, mentions_value)
 
 
 def _output(values: Mapping[str, object]) -> None:

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -519,7 +519,8 @@ def _recovery_numbers(
     negatives = ' '.join(f'-assignee:{owner}' for owner in qualified)
     created = f'created:<{_RECOVERY_EPOCH}' if legacy else f'created:>={_RECOVERY_EPOCH}'
     order = 'updated-desc' if legacy else 'created-asc'
-    query = f'repo:{repo} is:open {created} -draft:true {negatives} sort:{order}'
+    assignees = 'no:assignee' if legacy else negatives
+    query = f'repo:{repo} is:open {created} -draft:true {assignees} sort:{order}'
     return _search_numbers(client, query)
 
 
@@ -547,11 +548,9 @@ def select_batch(
     pull_request_number: str | None,
     participant_login: str | None = None,
     *,
-    legacy_limit: int = 0,
+    legacy_recovery: bool = False,
 ) -> list[Selection]:
     """Select an event item, one recent recovery, or a bounded legacy batch."""
-    if not 0 <= legacy_limit <= _LEGACY_BATCH_LIMIT:
-        raise ValueError(f'legacy recovery limit must be between 0 and {_LEGACY_BATCH_LIMIT}')
     repo = _repository(repo)
     if number := event_number(issue_number, pull_request_number):
         if participant_login:
@@ -561,13 +560,13 @@ def select_batch(
         return [decision_for(client, repo, number, participant_login=participant_login)]
     qualified = _qualified_owners(client, repo)
     recent = _select_numbers(client, repo, _recovery_numbers(client, repo, qualified), limit=1)
-    if recent or legacy_limit == 0:
+    if recent or not legacy_recovery:
         return recent
     return _select_numbers(
         client,
         repo,
         _recovery_numbers(client, repo, qualified, legacy=True),
-        limit=legacy_limit,
+        limit=_LEGACY_BATCH_LIMIT,
     )
 
 
@@ -693,26 +692,22 @@ def main() -> int:
             _summary(f'#{args.number}: ' + ('prepared routing intent' if payload else 'route changed'))
             return 0
         if args.mode == 'select':
-            legacy_limit_value = os.environ.get('ROUTING_LEGACY_LIMIT', '0')
-            if legacy_limit_value not in {'0', str(_LEGACY_BATCH_LIMIT)}:
-                raise ValueError('ROUTING_LEGACY_LIMIT must be 0 or 6')
+            legacy_recovery_value = os.environ.get('ROUTING_LEGACY_RECOVERY', 'false')
+            if legacy_recovery_value not in {'false', 'true'}:
+                raise ValueError('ROUTING_LEGACY_RECOVERY must be false or true')
             selected = select_batch(
                 client,
                 repo,
                 os.environ.get('ROUTING_ISSUE_NUMBER'),
                 os.environ.get('ROUTING_PULL_REQUEST_NUMBER'),
                 os.environ.get('ROUTING_PARTICIPANT_LOGIN'),
-                legacy_limit=int(legacy_limit_value),
+                legacy_recovery=legacy_recovery_value == 'true',
             )
             decisions = [selection['decision'] for selection in selected if selection['decision'] is not None]
             first = selected[0] if selected else Selection(number=0, decision=None, status='nothing-to-route')
-            decision = first['decision']
             _output(
                 {
                     'should_assign': str(bool(decisions)).lower(),
-                    'number': first['number'],
-                    'owner': decision['owner'] if decision else '',
-                    'evidence': decision['evidence'] if decision else '',
                     'routes': json.dumps(decisions, separators=(',', ':')),
                 }
             )

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -305,20 +305,6 @@ def _participant_owner(login: str) -> str | None:
     return next((owner for owner in _PARTICIPATION_OWNERS if owner.casefold() == key), None)
 
 
-def _pull_request_author_owner(
-    client: attention.GitHubClient,
-    repo: str,
-    item: Mapping[str, Any],
-) -> str | None:
-    author = item.get('author')
-    login = cast(Mapping[str, object], author).get('login') if isinstance(author, Mapping) else None
-    if not isinstance(login, str):
-        return None
-    key = login.casefold()
-    owner = next((candidate for candidate in _OWNERS if candidate.casefold() == key), None)
-    return owner if owner is not None and client.maintainer_login(repo, owner, refresh=True) is not None else None
-
-
 def _latest_participant(
     client: attention.GitHubClient,
     repo: str,
@@ -394,12 +380,17 @@ def _pull_request_precedence(
 ) -> Selection | None:
     if draft_status := _pull_request_draft_status(item):
         return Selection(number=number, decision=None, status=draft_status)
-    if author := _pull_request_author_owner(client, repo, item):
-        return Selection(
-            number=number,
-            decision=Decision(number=number, owner=author, evidence=f'author:{author}'),
-            status='route',
-        )
+    author = item.get('author')
+    login = cast(Mapping[str, object], author).get('login') if isinstance(author, Mapping) else None
+    if isinstance(login, str):
+        key = login.casefold()
+        owner = next((candidate for candidate in _OWNERS if candidate.casefold() == key), None)
+        if owner is not None and client.maintainer_login(repo, owner, refresh=True) is not None:
+            return Selection(
+                number=number,
+                decision=Decision(number=number, owner=owner, evidence=f'author:{owner}'),
+                status='route',
+            )
     return None
 
 
@@ -634,18 +625,8 @@ def _routing_reason(decision: Decision, mention: str) -> str:
     source, separator, detail = evidence.partition(':')
     if separator and detail and source in {'label', 'path'}:
         return f'Matched ownership {source} `{detail}`.'
-    manual_reasons = {
-        'manual:conflict-or-unknown': 'No single semantic owner matched, so this needs manual triage.',
-        'manual:incomplete-file-list': 'The changed-file list could not be completely verified, so this needs manual triage.',
-        'manual:incomplete-labels': 'The label list could not be completely verified, so this needs manual triage.',
-        'manual:invalid-file-list': 'The changed-file list was invalid, so this needs manual triage.',
-        'manual:unowned-production-path': 'A changed production path has no semantic owner, so this needs manual triage.',
-    }
-    if owner == _MANUAL_OWNER and evidence in manual_reasons:
-        return manual_reasons[evidence]
-    unavailable = evidence.removeprefix('manual:unavailable-owner:')
-    if owner == _MANUAL_OWNER and unavailable != evidence and unavailable in _OWNERS:
-        return 'The matched semantic owner is unavailable, so this needs manual triage.'
+    if evidence.startswith('manual:'):
+        return 'Automatic routing could not determine an available semantic owner, so this needs manual triage.'
     raise ValueError('routing evidence cannot be explained')
 
 
@@ -732,16 +713,13 @@ def main() -> int:
             _summary(f'#{args.number}: ' + ('prepared routing intent' if payload else 'route changed'))
             return 0
         if args.mode == 'select':
-            legacy_recovery_value = os.environ.get('ROUTING_LEGACY_RECOVERY', 'false')
-            if legacy_recovery_value not in {'false', 'true'}:
-                raise ValueError('ROUTING_LEGACY_RECOVERY must be false or true')
             selected = select_batch(
                 client,
                 repo,
                 os.environ.get('ROUTING_ISSUE_NUMBER'),
                 os.environ.get('ROUTING_PULL_REQUEST_NUMBER'),
                 os.environ.get('ROUTING_PARTICIPANT_LOGIN'),
-                legacy_recovery=legacy_recovery_value == 'true',
+                legacy_recovery=os.environ.get('ROUTING_LEGACY_RECOVERY') == 'true',
             )
             decisions = [selection['decision'] for selection in selected if selection['decision'] is not None]
             first = selected[0] if selected else Selection(number=0, decision=None, status='nothing-to-route')

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deterministically assign one open item to its semantic maintainer owner."""
+"""Deterministically assign open items to their semantic maintainer owners."""
 
 from __future__ import annotations
 
@@ -19,10 +19,8 @@ import issue_pr_attention_monitor as attention
 _REPOSITORIES = attention.REPOSITORIES
 _OWNERS = frozenset(attention.MAINTAINER_OWNERS)
 _MANUAL_OWNER = 'adtyavrdhn'
-# Everything before this rollout watermark was handled by the one-time manual
-# audit. Keeping it fixed makes later outages recoverable without draining years
-# of historical backlog into the triage channel.
 _RECOVERY_EPOCH = attention.ROUTING_RECOVERY_EPOCH
+_LEGACY_BATCH_LIMIT = 6
 _FILE_LIMIT = 100
 _ASSIGNEE_LIMIT = 10
 _PARTICIPATION_TIMELINE_PAGES = 2
@@ -479,10 +477,66 @@ def _qualified_owners(client: attention.GitHubClient, repo: str) -> tuple[str, .
     )
 
 
-def _recovery_numbers(client: attention.GitHubClient, repo: str, qualified: Sequence[str]) -> list[int]:
+def _recovery_numbers(
+    client: attention.GitHubClient,
+    repo: str,
+    qualified: Sequence[str],
+    *,
+    legacy: bool = False,
+) -> list[int]:
     negatives = ' '.join(f'-assignee:{owner}' for owner in qualified)
-    query = f'repo:{repo} is:open created:>={_RECOVERY_EPOCH} -draft:true {negatives} sort:created-asc'
+    created = f'created:<{_RECOVERY_EPOCH}' if legacy else f'created:>={_RECOVERY_EPOCH}'
+    order = 'updated-desc' if legacy else 'created-asc'
+    query = f'repo:{repo} is:open {created} -draft:true {negatives} sort:{order}'
     return _search_numbers(client, query)
+
+
+def _select_numbers(
+    client: attention.GitHubClient,
+    repo: str,
+    numbers: Sequence[int],
+    *,
+    limit: int,
+) -> list[Selection]:
+    selected: list[Selection] = []
+    for number in numbers:
+        selection = decision_for(client, repo, number)
+        if selection['decision'] is not None:
+            selected.append(selection)
+            if len(selected) == limit:
+                break
+    return selected
+
+
+def select_batch(
+    client: attention.GitHubClient,
+    repo: str,
+    issue_number: str | None,
+    pull_request_number: str | None,
+    participant_login: str | None = None,
+    *,
+    legacy_limit: int = 0,
+) -> list[Selection]:
+    """Select an event item, one recent recovery, or a bounded legacy batch."""
+    if not 0 <= legacy_limit <= _LEGACY_BATCH_LIMIT:
+        raise ValueError(f'legacy recovery limit must be between 0 and {_LEGACY_BATCH_LIMIT}')
+    repo = _repository(repo)
+    if number := event_number(issue_number, pull_request_number):
+        if participant_login:
+            owner = _participant_owner(participant_login)
+            if owner is None or client.maintainer_login(repo, owner, refresh=True) is None:
+                return [Selection(number=number, decision=None, status='non-maintainer-response')]
+        return [decision_for(client, repo, number, participant_login=participant_login)]
+    qualified = _qualified_owners(client, repo)
+    recent = _select_numbers(client, repo, _recovery_numbers(client, repo, qualified), limit=1)
+    if recent or legacy_limit == 0:
+        return recent
+    return _select_numbers(
+        client,
+        repo,
+        _recovery_numbers(client, repo, qualified, legacy=True),
+        limit=legacy_limit,
+    )
 
 
 def select(
@@ -492,20 +546,9 @@ def select(
     pull_request_number: str | None,
     participant_login: str | None = None,
 ) -> Selection:
-    """Select exactly the event item or one recovery candidate."""
-    repo = _repository(repo)
-    if number := event_number(issue_number, pull_request_number):
-        if participant_login:
-            owner = _participant_owner(participant_login)
-            if owner is None or client.maintainer_login(repo, owner, refresh=True) is None:
-                return Selection(number=number, decision=None, status='non-maintainer-response')
-        return decision_for(client, repo, number, participant_login=participant_login)
-    qualified = _qualified_owners(client, repo)
-    for number in _recovery_numbers(client, repo, qualified):
-        selection = decision_for(client, repo, number)
-        if selection['decision'] is not None:
-            return selection
-    return Selection(number=0, decision=None, status='nothing-to-route')
+    """Select exactly the event item or one recent recovery candidate."""
+    selected = select_batch(client, repo, issue_number, pull_request_number, participant_login)
+    return selected[0] if selected else Selection(number=0, decision=None, status='nothing-to-route')
 
 
 def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> bool:
@@ -618,23 +661,33 @@ def main() -> int:
             _summary(f'#{args.number}: ' + ('prepared routing intent' if payload else 'route changed'))
             return 0
         if args.mode == 'select':
-            selected = select(
+            legacy_limit_value = os.environ.get('ROUTING_LEGACY_LIMIT', '0')
+            if legacy_limit_value not in {'0', str(_LEGACY_BATCH_LIMIT)}:
+                raise ValueError('ROUTING_LEGACY_LIMIT must be 0 or 6')
+            selected = select_batch(
                 client,
                 repo,
                 os.environ.get('ROUTING_ISSUE_NUMBER'),
                 os.environ.get('ROUTING_PULL_REQUEST_NUMBER'),
                 os.environ.get('ROUTING_PARTICIPANT_LOGIN'),
+                legacy_limit=int(legacy_limit_value),
             )
-            decision = selected['decision']
+            decisions = [selection['decision'] for selection in selected if selection['decision'] is not None]
+            first = selected[0] if selected else Selection(number=0, decision=None, status='nothing-to-route')
+            decision = first['decision']
             _output(
                 {
-                    'should_assign': str(decision is not None).lower(),
-                    'number': selected['number'],
+                    'should_assign': str(bool(decisions)).lower(),
+                    'number': first['number'],
                     'owner': decision['owner'] if decision else '',
                     'evidence': decision['evidence'] if decision else '',
+                    'routes': json.dumps(decisions, separators=(',', ':')),
                 }
             )
-            _summary(f'#{selected["number"]}: {selected["status"]}' if selected['number'] else selected['status'])
+            if decisions:
+                _summary(', '.join(f'#{route["number"]}' for route in decisions) + ': route')
+            else:
+                _summary(f'#{first["number"]}: {first["status"]}' if first['number'] else first['status'])
             return 0
         if args.number is None or args.owner is None or args.evidence is None:
             parser.error('assign requires --number, --owner, and --evidence')

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -624,20 +624,16 @@ def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> boo
     return True
 
 
-def _routing_reason(repo: str, decision: Decision, mention: str) -> str:
+def _routing_reason(decision: Decision, mention: str) -> str:
     evidence = decision['evidence']
     owner = decision['owner']
     if evidence == f'participant:{owner}':
         return f'{mention} was the most recent qualified maintainer to participate.'
     if evidence == f'author:{owner}':
         return f'{mention} authored this pull request.'
-    for rule in _RULES[repo]:
-        for label in rule.labels:
-            if evidence == f'label:{label}' and owner == rule.owner:
-                return f'Matched ownership label `{label}`.'
-        for path in rule.paths:
-            if evidence == f'path:{path}' and owner == rule.owner:
-                return f'Matched ownership path `{path}`.'
+    source, separator, detail = evidence.partition(':')
+    if separator and detail and source in {'label', 'path'}:
+        return f'Matched ownership {source} `{detail}`.'
     manual_reasons = {
         'manual:conflict-or-unknown': 'No single semantic owner matched, so this needs manual triage.',
         'manual:incomplete-file-list': 'The changed-file list could not be completely verified, so this needs manual triage.',
@@ -650,7 +646,7 @@ def _routing_reason(repo: str, decision: Decision, mention: str) -> str:
     unavailable = evidence.removeprefix('manual:unavailable-owner:')
     if owner == _MANUAL_OWNER and unavailable != evidence and unavailable in _OWNERS:
         return 'The matched semantic owner is unavailable, so this needs manual triage.'
-    raise ValueError('routing evidence is not canonical')
+    raise ValueError('routing evidence cannot be explained')
 
 
 def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value: str) -> str:
@@ -666,7 +662,7 @@ def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value
         raise ValueError('item type is not canonical')
     number = decision['number']
     item = f'<https://github.com/{repo}/{path}/{number}|{repo}#{number}>'
-    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(repo, decision, mention)}'
+    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(decision, mention)}'
     return json.dumps({'text': text}, separators=(',', ':'))
 
 

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -37,7 +37,6 @@ query RoutingItem($owner: String!, $name: String!, $number: Int!) {
       }
       ... on PullRequest {
         number state isDraft changedFiles
-        author { login }
         labels(first: 50) { nodes { name } pageInfo { hasNextPage } }
         assignees(first: 10) { nodes { login } pageInfo { hasNextPage } }
         files(first: 100) { nodes { path } pageInfo { hasNextPage } }
@@ -372,28 +371,6 @@ def _pull_request_draft_status(item: Mapping[str, Any]) -> str | None:
     return 'draft' if value else None
 
 
-def _pull_request_precedence(
-    client: attention.GitHubClient,
-    repo: str,
-    number: int,
-    item: Mapping[str, Any],
-) -> Selection | None:
-    if draft_status := _pull_request_draft_status(item):
-        return Selection(number=number, decision=None, status=draft_status)
-    author = item.get('author')
-    login = cast(Mapping[str, object], author).get('login') if isinstance(author, Mapping) else None
-    if isinstance(login, str):
-        key = login.casefold()
-        owner = next((candidate for candidate in _OWNERS if candidate.casefold() == key), None)
-        if owner is not None and client.maintainer_login(repo, owner, refresh=True) is not None:
-            return Selection(
-                number=number,
-                decision=Decision(number=number, owner=owner, evidence=f'author:{owner}'),
-                status='route',
-            )
-    return None
-
-
 def decision_for(
     client: attention.GitHubClient,
     repo: str,
@@ -422,8 +399,8 @@ def decision_for(
     if len(normalized['assignees']) >= _ASSIGNEE_LIMIT:
         return Selection(number=number, decision=None, status='assignee-capacity')
     is_pull_request = item.get('__typename') == 'PullRequest'
-    if is_pull_request and (precedence := _pull_request_precedence(client, repo, number, item)) is not None:
-        return precedence
+    if is_pull_request and (draft_status := _pull_request_draft_status(item)) is not None:
+        return Selection(number=number, decision=None, status=draft_status)
     participant = _participant_decision(client, repo, number, participant_login)
     if participant is not None:
         return Selection(number=number, decision=participant, status='route')
@@ -615,35 +592,11 @@ def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> boo
     return True
 
 
-def _routing_reason(decision: Decision, mention: str) -> str:
-    evidence = decision['evidence']
-    owner = decision['owner']
-    if evidence == f'participant:{owner}':
-        return f'{mention} was the most recent qualified maintainer to participate.'
-    if evidence == f'author:{owner}':
-        return f'{mention} authored this pull request.'
-    source, separator, detail = evidence.partition(':')
-    if separator and detail and source in {'label', 'path'}:
-        return f'Matched ownership {source} `{detail}`.'
-    if evidence.startswith('manual:'):
-        return 'Automatic routing could not determine an available semantic owner, so this needs manual triage.'
-    raise ValueError('routing evidence cannot be explained')
-
-
-def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value: str) -> str:
+def _slack_payload(repo: str, decision: Decision, mentions_value: str) -> str:
     """Build one canonical Slack assignment notice."""
     repo = _repository(repo)
     mentions = attention.slack_mentions(mentions_value, decision['owner'])
-    mention = mentions[decision['owner']]
-    if item_type == 'Issue':
-        kind, path = 'Issue', 'issues'
-    elif item_type == 'PullRequest':
-        kind, path = 'Pull request', 'pull'
-    else:
-        raise ValueError('item type is not canonical')
-    number = decision['number']
-    item = f'<https://github.com/{repo}/{path}/{number}|{repo}#{number}>'
-    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(decision, mention)}'
+    text = f'Routing intent: {repo}#{decision["number"]} → {mentions[decision["owner"]]}\nWhy: {decision["evidence"]}'
     return json.dumps({'text': text}, separators=(',', ':'))
 
 
@@ -654,12 +607,6 @@ def prepare_current(
     mentions_value: str,
 ) -> str | None:
     """Build a notice only while the selected route still matches GitHub."""
-    item = _fetch_item(client, repo, expected['number'])
-    if item is None:
-        return None
-    item_type = item.get('__typename')
-    if not isinstance(item_type, str):
-        raise RuntimeError('GitHub returned invalid routing metadata')
     current = decision_for(
         client,
         repo,
@@ -668,7 +615,7 @@ def prepare_current(
     )
     if current['decision'] != expected:
         return None
-    return _slack_payload(repo, item_type, expected, mentions_value)
+    return _slack_payload(repo, expected, mentions_value)
 
 
 def _output(values: Mapping[str, object]) -> None:

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -624,11 +624,49 @@ def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> boo
     return True
 
 
-def _slack_payload(repo: str, decision: Decision, mentions_value: str) -> str:
+def _routing_reason(repo: str, decision: Decision, mention: str) -> str:
+    evidence = decision['evidence']
+    owner = decision['owner']
+    if evidence == f'participant:{owner}':
+        return f'{mention} was the most recent qualified maintainer to participate.'
+    if evidence == f'author:{owner}':
+        return f'{mention} authored this pull request.'
+    for rule in _RULES[repo]:
+        for label in rule.labels:
+            if evidence == f'label:{label}' and owner == rule.owner:
+                return f'Matched ownership label `{label}`.'
+        for path in rule.paths:
+            if evidence == f'path:{path}' and owner == rule.owner:
+                return f'Matched ownership path `{path}`.'
+    manual_reasons = {
+        'manual:conflict-or-unknown': 'No single semantic owner matched, so this needs manual triage.',
+        'manual:incomplete-file-list': 'The changed-file list could not be completely verified, so this needs manual triage.',
+        'manual:incomplete-labels': 'The label list could not be completely verified, so this needs manual triage.',
+        'manual:invalid-file-list': 'The changed-file list was invalid, so this needs manual triage.',
+        'manual:unowned-production-path': 'A changed production path has no semantic owner, so this needs manual triage.',
+    }
+    if owner == _MANUAL_OWNER and evidence in manual_reasons:
+        return manual_reasons[evidence]
+    unavailable = evidence.removeprefix('manual:unavailable-owner:')
+    if owner == _MANUAL_OWNER and unavailable != evidence and unavailable in _OWNERS:
+        return 'The matched semantic owner is unavailable, so this needs manual triage.'
+    raise ValueError('routing evidence is not canonical')
+
+
+def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value: str) -> str:
     """Build one canonical Slack assignment notice."""
     repo = _repository(repo)
     mentions = attention.slack_mentions(mentions_value, decision['owner'])
-    text = f'Routing intent: {repo}#{decision["number"]} → {mentions[decision["owner"]]}\nWhy: {decision["evidence"]}'
+    mention = mentions[decision['owner']]
+    if item_type == 'Issue':
+        kind, path = 'Issue', 'issues'
+    elif item_type == 'PullRequest':
+        kind, path = 'Pull request', 'pull'
+    else:
+        raise ValueError('item type is not canonical')
+    number = decision['number']
+    item = f'<https://github.com/{repo}/{path}/{number}|{repo}#{number}>'
+    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(repo, decision, mention)}'
     return json.dumps({'text': text}, separators=(',', ':'))
 
 
@@ -639,6 +677,12 @@ def prepare_current(
     mentions_value: str,
 ) -> str | None:
     """Build a notice only while the selected route still matches GitHub."""
+    item = _fetch_item(client, repo, expected['number'])
+    if item is None:
+        return None
+    item_type = item.get('__typename')
+    if not isinstance(item_type, str):
+        raise RuntimeError('GitHub returned invalid routing metadata')
     current = decision_for(
         client,
         repo,
@@ -647,7 +691,7 @@ def prepare_current(
     )
     if current['decision'] != expected:
         return None
-    return _slack_payload(repo, expected, mentions_value)
+    return _slack_payload(repo, item_type, expected, mentions_value)
 
 
 def _output(values: Mapping[str, object]) -> None:

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -37,6 +37,7 @@ query RoutingItem($owner: String!, $name: String!, $number: Int!) {
       }
       ... on PullRequest {
         number state isDraft changedFiles
+        author { login }
         labels(first: 50) { nodes { name } pageInfo { hasNextPage } }
         assignees(first: 10) { nodes { login } pageInfo { hasNextPage } }
         files(first: 100) { nodes { path } pageInfo { hasNextPage } }
@@ -304,6 +305,20 @@ def _participant_owner(login: str) -> str | None:
     return next((owner for owner in _PARTICIPATION_OWNERS if owner.casefold() == key), None)
 
 
+def _pull_request_author_owner(
+    client: attention.GitHubClient,
+    repo: str,
+    item: Mapping[str, Any],
+) -> str | None:
+    author = item.get('author')
+    login = cast(Mapping[str, object], author).get('login') if isinstance(author, Mapping) else None
+    if not isinstance(login, str):
+        return None
+    key = login.casefold()
+    owner = next((candidate for candidate in _OWNERS if candidate.casefold() == key), None)
+    return owner if owner is not None and client.maintainer_login(repo, owner, refresh=True) is not None else None
+
+
 def _latest_participant(
     client: attention.GitHubClient,
     repo: str,
@@ -371,6 +386,23 @@ def _pull_request_draft_status(item: Mapping[str, Any]) -> str | None:
     return 'draft' if value else None
 
 
+def _pull_request_precedence(
+    client: attention.GitHubClient,
+    repo: str,
+    number: int,
+    item: Mapping[str, Any],
+) -> Selection | None:
+    if draft_status := _pull_request_draft_status(item):
+        return Selection(number=number, decision=None, status=draft_status)
+    if author := _pull_request_author_owner(client, repo, item):
+        return Selection(
+            number=number,
+            decision=Decision(number=number, owner=author, evidence=f'author:{author}'),
+            status='route',
+        )
+    return None
+
+
 def decision_for(
     client: attention.GitHubClient,
     repo: str,
@@ -399,8 +431,8 @@ def decision_for(
     if len(normalized['assignees']) >= _ASSIGNEE_LIMIT:
         return Selection(number=number, decision=None, status='assignee-capacity')
     is_pull_request = item.get('__typename') == 'PullRequest'
-    if is_pull_request and (draft_status := _pull_request_draft_status(item)) is not None:
-        return Selection(number=number, decision=None, status=draft_status)
+    if is_pull_request and (precedence := _pull_request_precedence(client, repo, number, item)) is not None:
+        return precedence
     participant = _participant_decision(client, repo, number, participant_login)
     if participant is not None:
         return Selection(number=number, decision=participant, status='route')

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -627,7 +627,7 @@ def _routing_reason(decision: Decision, mention: str) -> str:
         return f'Matched ownership {source} `{detail}`.'
     if evidence.startswith('manual:'):
         return 'Automatic routing could not determine an available semantic owner, so this needs manual triage.'
-    raise ValueError('routing evidence cannot be explained')
+    return 'Matched the semantic ownership policy.'
 
 
 def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value: str) -> str:

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -12,7 +12,7 @@ import urllib.error
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, TypedDict, cast  # noqa: TID251
+from typing import Any, Literal, TypedDict, cast  # noqa: TID251
 
 import issue_pr_attention_monitor as attention
 
@@ -630,17 +630,20 @@ def _routing_reason(decision: Decision, mention: str) -> str:
     return 'Matched the semantic ownership policy.'
 
 
-def _slack_payload(repo: str, item_type: str, decision: Decision, mentions_value: str) -> str:
+def _slack_payload(
+    repo: str,
+    item_type: Literal['Issue', 'PullRequest'],
+    decision: Decision,
+    mentions_value: str,
+) -> str:
     """Build one canonical Slack assignment notice."""
     repo = _repository(repo)
     mentions = attention.slack_mentions(mentions_value, decision['owner'])
     mention = mentions[decision['owner']]
     if item_type == 'Issue':
         kind, path = 'Issue', 'issues'
-    elif item_type == 'PullRequest':
-        kind, path = 'Pull request', 'pull'
     else:
-        raise ValueError('item type is not canonical')
+        kind, path = 'Pull request', 'pull'
     number = decision['number']
     item = f'<https://github.com/{repo}/{path}/{number}|{repo}#{number}>'
     text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(decision, mention)}'
@@ -654,11 +657,12 @@ def prepare_current(
     mentions_value: str,
 ) -> str | None:
     """Build a notice only while the selected route still matches GitHub."""
+    repo = _repository(repo)
     item = _fetch_item(client, repo, expected['number'])
     if item is None:
         return None
     item_type = item.get('__typename')
-    if not isinstance(item_type, str):
+    if item_type not in ('Issue', 'PullRequest'):
         raise RuntimeError('GitHub returned invalid routing metadata')
     current = decision_for(
         client,

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -34,6 +34,7 @@ def item(
     labels: list[str] | None = None,
     assignees: list[str] | None = None,
     pull_request: bool = False,
+    author: str = 'contributor',
     state: str = 'open',
 ) -> dict[str, Any]:
     value: dict[str, Any] = {
@@ -47,6 +48,7 @@ def item(
     }
     if pull_request:
         value['pull_request'] = {'url': f'https://api.github.com/pulls/{number}'}
+        value['author'] = {'login': author}
     return value
 
 
@@ -105,6 +107,7 @@ class FakeClient(router.attention.GitHubClient):
                     value.update(
                         {
                             'isDraft': number in self.drafts,
+                            'author': source['author'],
                             'changedFiles': self.changed_counts.get(number, len(filenames)),
                             'files': {
                                 'nodes': [{'path': filename} for filename in filenames],
@@ -148,12 +151,29 @@ def test_repository_allowlist_is_exact():
         router.select(client, 'attacker/repository', None, None)
 
 
-def test_graphql_projection_never_requests_title_body_or_author():
+def test_graphql_projection_never_requests_title_or_body():
     compact = ''.join(router._ITEM_QUERY.split()).casefold()
 
     assert 'title' not in compact
     assert 'body' not in compact
-    assert 'author' not in compact
+
+
+@pytest.mark.parametrize(
+    ('permission', 'expected'),
+    [
+        ('write', ('adtyavrdhn', 'author:adtyavrdhn')),
+        ('read', ('dsfaccini', 'path:pydantic_ai_slim/pydantic_ai/models/')),
+    ],
+)
+def test_pr_author_precedence_requires_current_maintainer_permission(permission: str, expected: tuple[str, str]):
+    client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
+    client.permissions['adtyavrdhn'] = permission
+    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision is not None
+    assert (decision['owner'], decision['evidence']) == expected
 
 
 @pytest.mark.parametrize(
@@ -808,21 +828,44 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
     with pytest.raises(ValueError, match='selected owner'):
         router._slack_payload(  # pyright: ignore[reportPrivateUsage]
             CORE,
+            'Issue',
             router.Decision(number=7, owner='DouweM', evidence='label:durable exec'),
             value,
         )
 
 
-def test_notification_payload_contains_only_canonical_fields():
+@pytest.mark.parametrize(
+    ('item_type', 'decision', 'expected'),
+    [
+        (
+            'Issue',
+            router.Decision(number=7177, owner='dsfaccini', evidence='participant:dsfaccini'),
+            'Routing intent: Issue <https://github.com/pydantic/pydantic-ai/issues/7177|pydantic/pydantic-ai#7177> '
+            '→ <@UDAVID>\nWhy: <@UDAVID> was the most recent qualified maintainer to participate.',
+        ),
+        (
+            'PullRequest',
+            router.Decision(number=7, owner='adtyavrdhn', evidence='author:adtyavrdhn'),
+            'Routing intent: Pull request <https://github.com/pydantic/pydantic-ai/pull/7|pydantic/pydantic-ai#7> '
+            '→ <@UADITYA>\nWhy: <@UADITYA> authored this pull request.',
+        ),
+        (
+            'PullRequest',
+            router.Decision(number=7, owner='dsfaccini', evidence='path:pydantic_ai_slim/pydantic_ai/models/'),
+            'Routing intent: Pull request <https://github.com/pydantic/pydantic-ai/pull/7|pydantic/pydantic-ai#7> '
+            '→ <@UDAVID>\nWhy: Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
+        ),
+    ],
+)
+def test_notification_is_linked_typed_and_explained(item_type: str, decision: router.Decision, expected: str):
     payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
-        HARNESS,
-        router.Decision(number=620, owner='dsfaccini', evidence='label:cap:compaction'),
+        CORE,
+        item_type,
+        decision,
         MENTIONS,
     )
 
-    assert json.loads(payload) == {
-        'text': 'Routing intent: pydantic/pydantic-ai-harness#620 → <@UDAVID>\nWhy: label:cap:compaction'
-    }
+    assert json.loads(payload)['text'] == expected
 
 
 def test_no_attacker_text_is_used_in_output_or_notification():
@@ -834,7 +877,7 @@ def test_no_attacker_text_is_used_in_output_or_notification():
     assert decision is not None
     serialized = json.dumps(decision)
     assert attacker not in serialized
-    assert attacker not in router._slack_payload(CORE, decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
+    assert attacker not in router._slack_payload(CORE, 'Issue', decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_stale_route_is_not_prepared():

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -824,7 +824,7 @@ def test_daily_recovery_routes_six_recently_active_legacy_items():
         legacy=list(range(1, 8)),
     )
 
-    selected = router.select_batch(client, CORE, None, None, legacy_limit=6)
+    selected = router.select_batch(client, CORE, None, None, legacy_recovery=True)
 
     assert [selection['number'] for selection in selected] == [1, 2, 3, 4, 5, 6]
     queries = [
@@ -840,9 +840,7 @@ def test_daily_recovery_routes_six_recently_active_legacy_items():
         'repo:pydantic/pydantic-ai is:open created:>=2026-08-18 -draft:true '
         '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger '
         'sort:created-asc',
-        'repo:pydantic/pydantic-ai is:open created:<2026-08-18 -draft:true '
-        '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger '
-        'sort:updated-desc',
+        'repo:pydantic/pydantic-ai is:open created:<2026-08-18 -draft:true no:assignee sort:updated-desc',
     ]
 
 
@@ -853,7 +851,7 @@ def test_daily_recovery_keeps_post_rollout_item_ahead_of_legacy_batch():
         legacy=[8],
     )
 
-    selected = router.select_batch(client, CORE, None, None, legacy_limit=6)
+    selected = router.select_batch(client, CORE, None, None, legacy_recovery=True)
 
     assert [selection['number'] for selection in selected] == [7]
     assert not any(
@@ -983,9 +981,6 @@ def test_cli_modes_write_the_workflow_contract(tmp_path: Path, monkeypatch: pyte
     selected = dict(line.split('=', 1) for line in output.read_text().splitlines())
     assert selected == {
         'should_assign': 'true',
-        'number': '7',
-        'owner': 'adtyavrdhn',
-        'evidence': 'label:streaming',
         'routes': '[{"number":7,"owner":"adtyavrdhn","evidence":"label:streaming"}]',
     }
 
@@ -1020,7 +1015,7 @@ def test_cli_daily_recovery_outputs_six_matrix_routes(tmp_path: Path, monkeypatc
     monkeypatch.setenv('GITHUB_TOKEN', 'token')
     monkeypatch.setenv('GITHUB_REPOSITORY', CORE)
     monkeypatch.setenv('GITHUB_OUTPUT', str(output))
-    monkeypatch.setenv('ROUTING_LEGACY_LIMIT', '6')
+    monkeypatch.setenv('ROUTING_LEGACY_RECOVERY', 'true')
     monkeypatch.delenv('ROUTING_ISSUE_NUMBER', raising=False)
     monkeypatch.delenv('ROUTING_PULL_REQUEST_NUMBER', raising=False)
     monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
@@ -1030,12 +1025,7 @@ def test_cli_daily_recovery_outputs_six_matrix_routes(tmp_path: Path, monkeypatc
 
     selected = dict(line.split('=', 1) for line in output.read_text().splitlines())
     routes = json.loads(selected.pop('routes'))
-    assert selected == {
-        'should_assign': 'true',
-        'number': '1',
-        'owner': 'dsfaccini',
-        'evidence': 'label:MCP',
-    }
+    assert selected == {'should_assign': 'true'}
     assert [route['number'] for route in routes] == [1, 2, 3, 4, 5, 6]
 
 
@@ -1043,6 +1033,15 @@ def test_cli_failure_is_redacted(monkeypatch: pytest.MonkeyPatch, capsys: pytest
     monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
     monkeypatch.delenv('GITHUB_TOKEN', raising=False)
     monkeypatch.delenv('GH_TOKEN', raising=False)
+
+    assert router.main() == 1
+    assert capsys.readouterr().err == 'owner routing failed: ValueError\n'
+
+
+def test_cli_rejects_non_boolean_legacy_recovery(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
+    monkeypatch.setenv('GITHUB_TOKEN', 'token')
+    monkeypatch.setenv('ROUTING_LEGACY_RECOVERY', '6')
 
     assert router.main() == 1
     assert capsys.readouterr().err == 'owner routing failed: ValueError\n'
@@ -1096,8 +1095,8 @@ def test_workflow_is_notification_first_and_least_privilege():
     prepare, notify, assign = jobs['route']['steps'][1:]
     select_step = jobs['select']['steps'][1]
     assert select_step['env']['ROUTING_PARTICIPANT_LOGIN'] == '${{ github.event.comment.user.login }}'
-    assert select_step['env']['ROUTING_LEGACY_LIMIT'] == (
-        "${{ (github.event.schedule == '40 7 * * *' || inputs.legacy_recovery) && '6' || '0' }}"
+    assert select_step['env']['ROUTING_LEGACY_RECOVERY'] == (
+        "${{ github.event.schedule == '40 7 * * *' || inputs.legacy_recovery }}"
     )
     assert prepare['id'] == 'prepare'
     assert prepare['env']['ROUTE_NUMBER'] == '${{ matrix.route.number }}'

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -896,6 +896,7 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
     with pytest.raises(ValueError, match='selected owner'):
         router._slack_payload(  # pyright: ignore[reportPrivateUsage]
             CORE,
+            'Issue',
             router.Decision(number=7, owner='DouweM', evidence='label:durable exec'),
             value,
         )
@@ -904,13 +905,84 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
 def test_notification_payload_contains_only_canonical_fields():
     payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
         HARNESS,
+        'PullRequest',
         router.Decision(number=620, owner='dsfaccini', evidence='label:cap:compaction'),
         MENTIONS,
     )
 
     assert json.loads(payload) == {
-        'text': 'Routing intent: pydantic/pydantic-ai-harness#620 → <@UDAVID>\nWhy: label:cap:compaction'
+        'text': (
+            'Routing intent: Pull request '
+            '<https://github.com/pydantic/pydantic-ai-harness/pull/620|pydantic/pydantic-ai-harness#620> → <@UDAVID>\n'
+            'Why: Matched ownership label `cap:compaction`.'
+        )
     }
+
+
+def test_participant_notification_names_and_links_issue_with_readable_reason():
+    payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
+        CORE,
+        'Issue',
+        router.Decision(number=7177, owner='dsfaccini', evidence='participant:dsfaccini'),
+        MENTIONS,
+    )
+
+    assert json.loads(payload) == {
+        'text': (
+            'Routing intent: Issue '
+            '<https://github.com/pydantic/pydantic-ai/issues/7177|pydantic/pydantic-ai#7177> → <@UDAVID>\n'
+            'Why: <@UDAVID> was the most recent qualified maintainer to participate.'
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ('decision', 'reason'),
+    [
+        (
+            router.Decision(number=7, owner='adtyavrdhn', evidence='author:adtyavrdhn'),
+            '<@UADITYA> authored this pull request.',
+        ),
+        (
+            router.Decision(
+                number=7,
+                owner='dsfaccini',
+                evidence='path:pydantic_ai_slim/pydantic_ai/models/',
+            ),
+            'Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
+        ),
+        (
+            router.Decision(number=7, owner='adtyavrdhn', evidence='manual:conflict-or-unknown'),
+            'No single semantic owner matched, so this needs manual triage.',
+        ),
+        (
+            router.Decision(number=7, owner='adtyavrdhn', evidence='manual:unavailable-owner:dsfaccini'),
+            'The matched semantic owner is unavailable, so this needs manual triage.',
+        ),
+    ],
+)
+def test_notification_explains_canonical_routing_evidence(decision: router.Decision, reason: str):
+    payload = router._slack_payload(CORE, 'PullRequest', decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
+
+    assert json.loads(payload)['text'].endswith(f'\nWhy: {reason}')
+
+
+@pytest.mark.parametrize(
+    ('item_type', 'evidence'),
+    [
+        ('Discussion', 'label:streaming'),
+        ('Issue', 'label:<!channel>'),
+        ('Issue', 'manual:unavailable-owner:attacker'),
+    ],
+)
+def test_notification_rejects_noncanonical_type_and_evidence(item_type: str, evidence: str):
+    with pytest.raises(ValueError, match='canonical'):
+        router._slack_payload(  # pyright: ignore[reportPrivateUsage]
+            CORE,
+            item_type,
+            router.Decision(number=7, owner='adtyavrdhn', evidence=evidence),
+            MENTIONS,
+        )
 
 
 def test_no_attacker_text_is_used_in_output_or_notification():
@@ -923,7 +995,7 @@ def test_no_attacker_text_is_used_in_output_or_notification():
     serialized = json.dumps(decision)
     assert attacker not in serialized
 
-    assert attacker not in router._slack_payload(CORE, decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
+    assert attacker not in router._slack_payload(CORE, 'Issue', decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_stale_route_is_not_prepared():

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -34,7 +34,6 @@ def item(
     labels: list[str] | None = None,
     assignees: list[str] | None = None,
     pull_request: bool = False,
-    author: str = 'contributor',
     state: str = 'open',
 ) -> dict[str, Any]:
     value: dict[str, Any] = {
@@ -48,7 +47,6 @@ def item(
     }
     if pull_request:
         value['pull_request'] = {'url': f'https://api.github.com/pulls/{number}'}
-        value['author'] = {'login': author}
     return value
 
 
@@ -107,7 +105,6 @@ class FakeClient(router.attention.GitHubClient):
                     value.update(
                         {
                             'isDraft': number in self.drafts,
-                            'author': source['author'],
                             'changedFiles': self.changed_counts.get(number, len(filenames)),
                             'files': {
                                 'nodes': [{'path': filename} for filename in filenames],
@@ -151,29 +148,12 @@ def test_repository_allowlist_is_exact():
         router.select(client, 'attacker/repository', None, None)
 
 
-def test_graphql_projection_never_requests_title_or_body():
+def test_graphql_projection_never_requests_title_body_or_author():
     compact = ''.join(router._ITEM_QUERY.split()).casefold()
 
     assert 'title' not in compact
     assert 'body' not in compact
-
-
-@pytest.mark.parametrize(
-    ('permission', 'expected'),
-    [
-        ('write', ('adtyavrdhn', 'author:adtyavrdhn')),
-        ('read', ('dsfaccini', 'path:pydantic_ai_slim/pydantic_ai/models/')),
-    ],
-)
-def test_pr_author_precedence_requires_current_maintainer_permission(permission: str, expected: tuple[str, str]):
-    client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
-    client.permissions['adtyavrdhn'] = permission
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert (decision['owner'], decision['evidence']) == expected
+    assert 'author' not in compact
 
 
 @pytest.mark.parametrize(
@@ -828,59 +808,21 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
     with pytest.raises(ValueError, match='selected owner'):
         router._slack_payload(  # pyright: ignore[reportPrivateUsage]
             CORE,
-            'Issue',
             router.Decision(number=7, owner='DouweM', evidence='label:durable exec'),
             value,
         )
 
 
-def test_participant_notification_names_and_links_issue_with_readable_reason():
+def test_notification_payload_contains_only_canonical_fields():
     payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
-        CORE,
-        'Issue',
-        router.Decision(number=7177, owner='dsfaccini', evidence='participant:dsfaccini'),
+        HARNESS,
+        router.Decision(number=620, owner='dsfaccini', evidence='label:cap:compaction'),
         MENTIONS,
     )
 
-    assert json.loads(payload)['text'] == (
-        'Routing intent: Issue '
-        '<https://github.com/pydantic/pydantic-ai/issues/7177|pydantic/pydantic-ai#7177> → <@UDAVID>\n'
-        'Why: <@UDAVID> was the most recent qualified maintainer to participate.'
-    )
-
-
-@pytest.mark.parametrize(
-    ('decision', 'reason'),
-    [
-        (router.Decision(number=7, owner='dsfaccini', evidence='label:MCP'), 'Matched ownership label `MCP`.'),
-        (
-            router.Decision(number=7, owner='dsfaccini', evidence='path:pydantic_ai_slim/pydantic_ai/models/'),
-            'Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
-        ),
-        (
-            router.Decision(number=7, owner='adtyavrdhn', evidence='author:adtyavrdhn'),
-            '<@UADITYA> authored this pull request.',
-        ),
-        (
-            router.Decision(number=7, owner='adtyavrdhn', evidence='manual:conflict-or-unknown'),
-            'Automatic routing could not determine an available semantic owner, so this needs manual triage.',
-        ),
-    ],
-)
-def test_notification_explains_other_routing_evidence(decision: router.Decision, reason: str):
-    payload = router._slack_payload(CORE, 'PullRequest', decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
-
-    assert json.loads(payload)['text'].endswith(f'\nWhy: {reason}')
-
-
-def test_notification_rejects_noncanonical_item_type():
-    with pytest.raises(ValueError, match='canonical'):
-        router._slack_payload(  # pyright: ignore[reportPrivateUsage]
-            CORE,
-            'Discussion',
-            router.Decision(number=7, owner='adtyavrdhn', evidence='label:streaming'),
-            MENTIONS,
-        )
+    assert json.loads(payload) == {
+        'text': 'Routing intent: pydantic/pydantic-ai-harness#620 → <@UDAVID>\nWhy: label:cap:compaction'
+    }
 
 
 def test_no_attacker_text_is_used_in_output_or_notification():
@@ -892,6 +834,7 @@ def test_no_attacker_text_is_used_in_output_or_notification():
     assert decision is not None
     serialized = json.dumps(decision)
     assert attacker not in serialized
+    assert attacker not in router._slack_payload(CORE, decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_stale_route_is_not_prepared():

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -60,6 +60,7 @@ class FakeClient(router.attention.GitHubClient):
         self.drafts: set[int] = set()
         self.changed_counts: dict[int, int] = {}
         self.timelines: dict[int, list[dict[str, Any]]] = {}
+        self.search_results: list[list[int]] = []
         self.permissions = {login: 'write' for login in ('adtyavrdhn', 'dsfaccini', 'DouweM', 'mpfaffenberger')}
         self.calls: list[tuple[str, str, object | None]] = []
 
@@ -76,12 +77,12 @@ class FakeClient(router.attention.GitHubClient):
             variables = payload['variables']
             assert isinstance(variables, Mapping)
             if 'number' not in variables:
+                numbers = self.search_results.pop(0) if self.search_results else self.items
                 return {
                     'data': {
                         'search': {
                             'nodes': [
-                                {'number': value['number'], 'updatedAt': value['updated_at']}
-                                for value in self.items.values()
+                                {'number': number, 'updatedAt': self.items[number]['updated_at']} for number in numbers
                             ]
                         }
                     }
@@ -157,31 +158,22 @@ def test_graphql_projection_never_requests_title_or_body():
     assert 'body' not in compact
 
 
-def test_maintainer_authored_pr_routes_to_its_author_before_path_rules():
+@pytest.mark.parametrize(
+    ('permission', 'expected'),
+    [
+        ('write', ('adtyavrdhn', 'author:adtyavrdhn')),
+        ('read', ('dsfaccini', 'path:pydantic_ai_slim/pydantic_ai/models/')),
+    ],
+)
+def test_pr_author_precedence_requires_current_maintainer_permission(permission: str, expected: tuple[str, str]):
     client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
+    client.permissions['adtyavrdhn'] = permission
     client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
 
     decision = router.decision_for(client, CORE, 7)['decision']
 
-    assert decision == {
-        'number': 7,
-        'owner': 'adtyavrdhn',
-        'evidence': 'author:adtyavrdhn',
-    }
-
-
-def test_offboarded_pr_author_uses_semantic_routing():
-    client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
-    client.permissions['adtyavrdhn'] = 'read'
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision == {
-        'number': 7,
-        'owner': 'dsfaccini',
-        'evidence': 'path:pydantic_ai_slim/pydantic_ai/models/',
-    }
+    assert decision is not None
+    assert (decision['owner'], decision['evidence']) == expected
 
 
 @pytest.mark.parametrize(
@@ -793,93 +785,33 @@ def test_recovery_skips_full_assignee_list_without_starving_the_next():
     assert selected['number'] == 8
 
 
-class RecoveryClient(FakeClient):
-    def __init__(
-        self,
-        values: dict[int, dict[str, Any]],
-        *,
-        recent: list[int],
-        legacy: list[int],
-    ) -> None:
-        super().__init__(values)
-        self.recent = recent
-        self.legacy = legacy
+def test_daily_recovery_is_opt_in_lower_priority_and_bounded():
+    client = FakeClient({number: item(number, labels=['MCP']) for number in range(1, 9)})
 
-    def post(self, path: str, payload: Mapping[str, object]) -> Any:
-        if path == '/graphql':
-            variables = payload['variables']
-            assert isinstance(variables, Mapping)
-            if 'number' not in variables:
-                self.calls.append(('POST', path, payload))
-                query = str(variables['query'])
-                numbers = self.recent if 'created:>=' in query else self.legacy
-                return {'data': {'search': {'nodes': [{'number': number} for number in numbers]}}}
-        return super().post(path, payload)
+    client.search_results = [[]]
+    assert router.select_batch(client, CORE, None, None) == []
 
+    client.search_results = [[8]]
+    assert [
+        selection['number'] for selection in router.select_batch(client, CORE, None, None, legacy_recovery=True)
+    ] == [8]
 
-def test_daily_recovery_routes_six_recently_active_legacy_items():
-    client = RecoveryClient(
-        {number: item(number, labels=['MCP']) for number in range(1, 8)},
-        recent=[],
-        legacy=list(range(1, 8)),
-    )
-
+    client.search_results = [[], list(range(1, 8))]
     selected = router.select_batch(client, CORE, None, None, legacy_recovery=True)
-
     assert [selection['number'] for selection in selected] == [1, 2, 3, 4, 5, 6]
-    queries = [
+
+    legacy_queries = [
         str(cast(Mapping[str, object], payload)['variables']['query'])
         for method, path, payload in client.calls
         if method == 'POST'
         and path == '/graphql'
         and isinstance(payload, Mapping)
         and isinstance(payload.get('variables'), Mapping)
-        and 'query' in payload['variables']
+        and 'created:<' in str(payload['variables'].get('query'))
     ]
-    assert queries == [
-        'repo:pydantic/pydantic-ai is:open created:>=2026-08-18 -draft:true '
-        '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger '
-        'sort:created-asc',
+    assert legacy_queries == [
         'repo:pydantic/pydantic-ai is:open created:<2026-08-18 -draft:true no:assignee sort:updated-desc',
     ]
-
-
-def test_daily_recovery_keeps_post_rollout_item_ahead_of_legacy_batch():
-    client = RecoveryClient(
-        {7: item(7, labels=['MCP']), 8: item(8, labels=['tools'])},
-        recent=[7],
-        legacy=[8],
-    )
-
-    selected = router.select_batch(client, CORE, None, None, legacy_recovery=True)
-
-    assert [selection['number'] for selection in selected] == [7]
-    assert not any(
-        'created:<' in str(cast(Mapping[str, object], payload)['variables']['query'])
-        for method, path, payload in client.calls
-        if method == 'POST'
-        and path == '/graphql'
-        and isinstance(payload, Mapping)
-        and isinstance(payload.get('variables'), Mapping)
-        and 'query' in payload['variables']
-    )
-
-
-def test_regular_recovery_never_queries_legacy_items():
-    client = RecoveryClient({8: item(8, labels=['tools'])}, recent=[], legacy=[8])
-
-    selected = router.select_batch(client, CORE, None, None)
-
-    assert selected == []
-    assert not any(
-        'created:<' in str(cast(Mapping[str, object], payload)['variables']['query'])
-        for method, path, payload in client.calls
-        if method == 'POST'
-        and path == '/graphql'
-        and isinstance(payload, Mapping)
-        and isinstance(payload.get('variables'), Mapping)
-        and 'query' in payload['variables']
-    )
 
 
 @pytest.mark.parametrize(
@@ -902,23 +834,6 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
         )
 
 
-def test_notification_payload_contains_only_canonical_fields():
-    payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
-        HARNESS,
-        'PullRequest',
-        router.Decision(number=620, owner='dsfaccini', evidence='label:cap:compaction'),
-        MENTIONS,
-    )
-
-    assert json.loads(payload) == {
-        'text': (
-            'Routing intent: Pull request '
-            '<https://github.com/pydantic/pydantic-ai-harness/pull/620|pydantic/pydantic-ai-harness#620> → <@UDAVID>\n'
-            'Why: Matched ownership label `cap:compaction`.'
-        )
-    }
-
-
 def test_participant_notification_names_and_links_issue_with_readable_reason():
     payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
         CORE,
@@ -927,41 +842,32 @@ def test_participant_notification_names_and_links_issue_with_readable_reason():
         MENTIONS,
     )
 
-    assert json.loads(payload) == {
-        'text': (
-            'Routing intent: Issue '
-            '<https://github.com/pydantic/pydantic-ai/issues/7177|pydantic/pydantic-ai#7177> → <@UDAVID>\n'
-            'Why: <@UDAVID> was the most recent qualified maintainer to participate.'
-        )
-    }
+    assert json.loads(payload)['text'] == (
+        'Routing intent: Issue '
+        '<https://github.com/pydantic/pydantic-ai/issues/7177|pydantic/pydantic-ai#7177> → <@UDAVID>\n'
+        'Why: <@UDAVID> was the most recent qualified maintainer to participate.'
+    )
 
 
 @pytest.mark.parametrize(
     ('decision', 'reason'),
     [
+        (router.Decision(number=7, owner='dsfaccini', evidence='label:MCP'), 'Matched ownership label `MCP`.'),
+        (
+            router.Decision(number=7, owner='dsfaccini', evidence='path:pydantic_ai_slim/pydantic_ai/models/'),
+            'Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
+        ),
         (
             router.Decision(number=7, owner='adtyavrdhn', evidence='author:adtyavrdhn'),
             '<@UADITYA> authored this pull request.',
         ),
         (
-            router.Decision(
-                number=7,
-                owner='dsfaccini',
-                evidence='path:pydantic_ai_slim/pydantic_ai/models/',
-            ),
-            'Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
-        ),
-        (
             router.Decision(number=7, owner='adtyavrdhn', evidence='manual:conflict-or-unknown'),
-            'No single semantic owner matched, so this needs manual triage.',
-        ),
-        (
-            router.Decision(number=7, owner='adtyavrdhn', evidence='manual:unavailable-owner:dsfaccini'),
-            'The matched semantic owner is unavailable, so this needs manual triage.',
+            'Automatic routing could not determine an available semantic owner, so this needs manual triage.',
         ),
     ],
 )
-def test_notification_explains_canonical_routing_evidence(decision: router.Decision, reason: str):
+def test_notification_explains_other_routing_evidence(decision: router.Decision, reason: str):
     payload = router._slack_payload(CORE, 'PullRequest', decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
 
     assert json.loads(payload)['text'].endswith(f'\nWhy: {reason}')
@@ -986,8 +892,6 @@ def test_no_attacker_text_is_used_in_output_or_notification():
     assert decision is not None
     serialized = json.dumps(decision)
     assert attacker not in serialized
-
-    assert attacker not in router._slack_payload(CORE, 'Issue', decision, MENTIONS)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_stale_route_is_not_prepared():
@@ -1068,44 +972,10 @@ def test_cli_modes_write_the_workflow_contract(tmp_path: Path, monkeypatch: pyte
     }
 
 
-def test_cli_daily_recovery_outputs_six_matrix_routes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    output = tmp_path / 'github-output'
-    client = RecoveryClient(
-        {number: item(number, labels=['MCP']) for number in range(1, 8)},
-        recent=[],
-        legacy=list(range(1, 8)),
-    )
-    monkeypatch.setattr(router.attention, 'GitHubClient', lambda token: client)
-    monkeypatch.setenv('GITHUB_TOKEN', 'token')
-    monkeypatch.setenv('GITHUB_REPOSITORY', CORE)
-    monkeypatch.setenv('GITHUB_OUTPUT', str(output))
-    monkeypatch.setenv('ROUTING_LEGACY_RECOVERY', 'true')
-    monkeypatch.delenv('ROUTING_ISSUE_NUMBER', raising=False)
-    monkeypatch.delenv('ROUTING_PULL_REQUEST_NUMBER', raising=False)
-    monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
-    monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
-
-    assert router.main() == 0
-
-    selected = dict(line.split('=', 1) for line in output.read_text().splitlines())
-    routes = json.loads(selected.pop('routes'))
-    assert selected == {'should_assign': 'true'}
-    assert [route['number'] for route in routes] == [1, 2, 3, 4, 5, 6]
-
-
 def test_cli_failure_is_redacted(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
     monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
     monkeypatch.delenv('GITHUB_TOKEN', raising=False)
     monkeypatch.delenv('GH_TOKEN', raising=False)
-
-    assert router.main() == 1
-    assert capsys.readouterr().err == 'owner routing failed: ValueError\n'
-
-
-def test_cli_rejects_non_boolean_legacy_recovery(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
-    monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
-    monkeypatch.setenv('GITHUB_TOKEN', 'token')
-    monkeypatch.setenv('ROUTING_LEGACY_RECOVERY', '6')
 
     assert router.main() == 1
     assert capsys.readouterr().err == 'owner routing failed: ValueError\n'

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -8,7 +8,7 @@ import urllib.parse
 from collections.abc import Mapping
 from email.message import Message
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 import yaml
@@ -863,7 +863,9 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
         ),
     ],
 )
-def test_notification_is_linked_typed_and_explained(item_type: str, decision: router.Decision, expected: str):
+def test_notification_is_linked_typed_and_explained(
+    item_type: Literal['Issue', 'PullRequest'], decision: router.Decision, expected: str
+):
     payload = router._slack_payload(  # pyright: ignore[reportPrivateUsage]
         CORE,
         item_type,
@@ -896,6 +898,20 @@ def test_stale_route_is_not_prepared():
     )
 
     assert payload is None
+
+
+def test_prepare_rejects_non_allowlisted_repository_before_fetching():
+    client = FakeClient({7: item(7, labels=['streaming'])})
+
+    with pytest.raises(ValueError, match='not allowlisted'):
+        router.prepare_current(
+            client,
+            'attacker/repository',
+            router.Decision(number=7, owner='adtyavrdhn', evidence='label:streaming'),
+            MENTIONS,
+        )
+
+    assert client.calls == []
 
 
 def test_serialized_rerun_prepares_and_assigns_once():

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -764,6 +764,97 @@ def test_recovery_skips_full_assignee_list_without_starving_the_next():
     assert selected['number'] == 8
 
 
+class RecoveryClient(FakeClient):
+    def __init__(
+        self,
+        values: dict[int, dict[str, Any]],
+        *,
+        recent: list[int],
+        legacy: list[int],
+    ) -> None:
+        super().__init__(values)
+        self.recent = recent
+        self.legacy = legacy
+
+    def post(self, path: str, payload: Mapping[str, object]) -> Any:
+        if path == '/graphql':
+            variables = payload['variables']
+            assert isinstance(variables, Mapping)
+            if 'number' not in variables:
+                self.calls.append(('POST', path, payload))
+                query = str(variables['query'])
+                numbers = self.recent if 'created:>=' in query else self.legacy
+                return {'data': {'search': {'nodes': [{'number': number} for number in numbers]}}}
+        return super().post(path, payload)
+
+
+def test_daily_recovery_routes_six_recently_active_legacy_items():
+    client = RecoveryClient(
+        {number: item(number, labels=['MCP']) for number in range(1, 8)},
+        recent=[],
+        legacy=list(range(1, 8)),
+    )
+
+    selected = router.select_batch(client, CORE, None, None, legacy_limit=6)
+
+    assert [selection['number'] for selection in selected] == [1, 2, 3, 4, 5, 6]
+    queries = [
+        str(cast(Mapping[str, object], payload)['variables']['query'])
+        for method, path, payload in client.calls
+        if method == 'POST'
+        and path == '/graphql'
+        and isinstance(payload, Mapping)
+        and isinstance(payload.get('variables'), Mapping)
+        and 'query' in payload['variables']
+    ]
+    assert queries == [
+        'repo:pydantic/pydantic-ai is:open created:>=2026-08-18 -draft:true '
+        '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger '
+        'sort:created-asc',
+        'repo:pydantic/pydantic-ai is:open created:<2026-08-18 -draft:true '
+        '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger '
+        'sort:updated-desc',
+    ]
+
+
+def test_daily_recovery_keeps_post_rollout_item_ahead_of_legacy_batch():
+    client = RecoveryClient(
+        {7: item(7, labels=['MCP']), 8: item(8, labels=['tools'])},
+        recent=[7],
+        legacy=[8],
+    )
+
+    selected = router.select_batch(client, CORE, None, None, legacy_limit=6)
+
+    assert [selection['number'] for selection in selected] == [7]
+    assert not any(
+        'created:<' in str(cast(Mapping[str, object], payload)['variables']['query'])
+        for method, path, payload in client.calls
+        if method == 'POST'
+        and path == '/graphql'
+        and isinstance(payload, Mapping)
+        and isinstance(payload.get('variables'), Mapping)
+        and 'query' in payload['variables']
+    )
+
+
+def test_regular_recovery_never_queries_legacy_items():
+    client = RecoveryClient({8: item(8, labels=['tools'])}, recent=[], legacy=[8])
+
+    selected = router.select_batch(client, CORE, None, None)
+
+    assert selected == []
+    assert not any(
+        'created:<' in str(cast(Mapping[str, object], payload)['variables']['query'])
+        for method, path, payload in client.calls
+        if method == 'POST'
+        and path == '/graphql'
+        and isinstance(payload, Mapping)
+        and isinstance(payload.get('variables'), Mapping)
+        and 'query' in payload['variables']
+    )
+
+
 @pytest.mark.parametrize(
     'value',
     [
@@ -866,6 +957,7 @@ def test_cli_modes_write_the_workflow_contract(tmp_path: Path, monkeypatch: pyte
         'number': '7',
         'owner': 'adtyavrdhn',
         'evidence': 'label:streaming',
+        'routes': '[{"number":7,"owner":"adtyavrdhn","evidence":"label:streaming"}]',
     }
 
     output.write_text('')
@@ -886,6 +978,36 @@ def test_cli_modes_write_the_workflow_contract(tmp_path: Path, monkeypatch: pyte
         'owner': 'adtyavrdhn',
         'evidence': 'label:streaming',
     }
+
+
+def test_cli_daily_recovery_outputs_six_matrix_routes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    output = tmp_path / 'github-output'
+    client = RecoveryClient(
+        {number: item(number, labels=['MCP']) for number in range(1, 8)},
+        recent=[],
+        legacy=list(range(1, 8)),
+    )
+    monkeypatch.setattr(router.attention, 'GitHubClient', lambda token: client)
+    monkeypatch.setenv('GITHUB_TOKEN', 'token')
+    monkeypatch.setenv('GITHUB_REPOSITORY', CORE)
+    monkeypatch.setenv('GITHUB_OUTPUT', str(output))
+    monkeypatch.setenv('ROUTING_LEGACY_LIMIT', '6')
+    monkeypatch.delenv('ROUTING_ISSUE_NUMBER', raising=False)
+    monkeypatch.delenv('ROUTING_PULL_REQUEST_NUMBER', raising=False)
+    monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
+    monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
+
+    assert router.main() == 0
+
+    selected = dict(line.split('=', 1) for line in output.read_text().splitlines())
+    routes = json.loads(selected.pop('routes'))
+    assert selected == {
+        'should_assign': 'true',
+        'number': '1',
+        'owner': 'dsfaccini',
+        'evidence': 'label:MCP',
+    }
+    assert [route['number'] for route in routes] == [1, 2, 3, 4, 5, 6]
 
 
 def test_cli_failure_is_redacted(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
@@ -936,10 +1058,22 @@ def test_workflow_is_notification_first_and_least_privilege():
         'issues': 'write',
         'pull-requests': 'write',
     }
+    assert jobs['route']['strategy'] == {
+        'fail-fast': False,
+        'max-parallel': 1,
+        'matrix': {'route': '${{ fromJSON(needs.select.outputs.routes) }}'},
+    }
+    assert jobs['route']['concurrency']['group'] == 'semantic-owner-${{ github.repository }}-${{ matrix.route.number }}'
     prepare, notify, assign = jobs['route']['steps'][1:]
     select_step = jobs['select']['steps'][1]
     assert select_step['env']['ROUTING_PARTICIPANT_LOGIN'] == '${{ github.event.comment.user.login }}'
+    assert select_step['env']['ROUTING_LEGACY_LIMIT'] == (
+        "${{ (github.event.schedule == '40 7 * * *' || inputs.legacy_recovery) && '6' || '0' }}"
+    )
     assert prepare['id'] == 'prepare'
+    assert prepare['env']['ROUTE_NUMBER'] == '${{ matrix.route.number }}'
+    assert prepare['env']['ROUTE_OWNER'] == '${{ matrix.route.owner }}'
+    assert prepare['env']['ROUTE_EVIDENCE'] == '${{ matrix.route.evidence }}'
     assert notify['uses'] == 'slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c'
     assert notify['with']['payload'] == '${{ steps.prepare.outputs.slack_payload }}'
     assert notify['with']['errors'] is True

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -855,6 +855,12 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
             'Routing intent: Pull request <https://github.com/pydantic/pydantic-ai/pull/7|pydantic/pydantic-ai#7> '
             '→ <@UDAVID>\nWhy: Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
         ),
+        (
+            'Issue',
+            router.Decision(number=7, owner='dsfaccini', evidence='future-policy:evidence'),
+            'Routing intent: Issue <https://github.com/pydantic/pydantic-ai/issues/7|pydantic/pydantic-ai#7> '
+            '→ <@UDAVID>\nWhy: Matched the semantic ownership policy.',
+        ),
     ],
 )
 def test_notification_is_linked_typed_and_explained(item_type: str, decision: router.Decision, expected: str):

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -34,6 +34,7 @@ def item(
     labels: list[str] | None = None,
     assignees: list[str] | None = None,
     pull_request: bool = False,
+    author: str = 'contributor',
     state: str = 'open',
 ) -> dict[str, Any]:
     value: dict[str, Any] = {
@@ -47,6 +48,7 @@ def item(
     }
     if pull_request:
         value['pull_request'] = {'url': f'https://api.github.com/pulls/{number}'}
+        value['author'] = {'login': author}
     return value
 
 
@@ -104,6 +106,7 @@ class FakeClient(router.attention.GitHubClient):
                     value.update(
                         {
                             'isDraft': number in self.drafts,
+                            'author': source['author'],
                             'changedFiles': self.changed_counts.get(number, len(filenames)),
                             'files': {
                                 'nodes': [{'path': filename} for filename in filenames],
@@ -147,12 +150,38 @@ def test_repository_allowlist_is_exact():
         router.select(client, 'attacker/repository', None, None)
 
 
-def test_graphql_projection_never_requests_title_body_or_author():
+def test_graphql_projection_never_requests_title_or_body():
     compact = ''.join(router._ITEM_QUERY.split()).casefold()
 
     assert 'title' not in compact
     assert 'body' not in compact
-    assert 'author' not in compact
+
+
+def test_maintainer_authored_pr_routes_to_its_author_before_path_rules():
+    client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
+    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision == {
+        'number': 7,
+        'owner': 'adtyavrdhn',
+        'evidence': 'author:adtyavrdhn',
+    }
+
+
+def test_offboarded_pr_author_uses_semantic_routing():
+    client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
+    client.permissions['adtyavrdhn'] = 'read'
+    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision == {
+        'number': 7,
+        'owner': 'dsfaccini',
+        'evidence': 'path:pydantic_ai_slim/pydantic_ai/models/',
+    }
 
 
 @pytest.mark.parametrize(

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -967,20 +967,12 @@ def test_notification_explains_canonical_routing_evidence(decision: router.Decis
     assert json.loads(payload)['text'].endswith(f'\nWhy: {reason}')
 
 
-@pytest.mark.parametrize(
-    ('item_type', 'evidence'),
-    [
-        ('Discussion', 'label:streaming'),
-        ('Issue', 'label:<!channel>'),
-        ('Issue', 'manual:unavailable-owner:attacker'),
-    ],
-)
-def test_notification_rejects_noncanonical_type_and_evidence(item_type: str, evidence: str):
+def test_notification_rejects_noncanonical_item_type():
     with pytest.raises(ValueError, match='canonical'):
         router._slack_payload(  # pyright: ignore[reportPrivateUsage]
             CORE,
-            item_type,
-            router.Decision(number=7, owner='adtyavrdhn', evidence=evidence),
+            'Discussion',
+            router.Decision(number=7, owner='adtyavrdhn', evidence='label:streaming'),
             MENTIONS,
         )
 

--- a/.github/workflows/pydantic-ai-owner-routing.yml
+++ b/.github/workflows/pydantic-ai-owner-routing.yml
@@ -10,8 +10,15 @@ on:
     types: [opened, reopened, ready_for_review]
   schedule:
     - cron: '25 */6 * * *'
+    - cron: '40 7 * * *'
   workflow_dispatch:
   workflow_call:
+    inputs:
+      legacy_recovery:
+        description: Route up to six recently active items from before the recovery epoch
+        required: false
+        type: boolean
+        default: false
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL:
         required: true
@@ -20,7 +27,7 @@ permissions: {}
 
 jobs:
   select:
-    name: Select one item
+    name: Select routing batch
     # Keep this cheap runner gate aligned with `_PARTICIPATION_OWNERS` in the routing policy.
     if: >-
       (github.repository == 'pydantic/pydantic-ai' || github.repository == 'pydantic/pydantic-ai-harness') &&
@@ -36,9 +43,7 @@ jobs:
       pull-requests: read
     outputs:
       should_route: ${{ steps.select.outputs.should_assign }}
-      number: ${{ steps.select.outputs.number }}
-      owner: ${{ steps.select.outputs.owner }}
-      evidence: ${{ steps.select.outputs.evidence }}
+      routes: ${{ steps.select.outputs.routes }}
     steps:
       - name: Check out trusted routing policy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -57,6 +62,7 @@ jobs:
           ROUTING_ISSUE_NUMBER: ${{ github.event.issue.number }}
           ROUTING_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           ROUTING_PARTICIPANT_LOGIN: ${{ github.event.comment.user.login }}
+          ROUTING_LEGACY_LIMIT: ${{ (github.event.schedule == '40 7 * * *' || inputs.legacy_recovery) && '6' || '0' }}
         run: python .github/scripts/semantic_owner_router.py select
 
   route:
@@ -65,8 +71,13 @@ jobs:
     if: needs.select.outputs.should_route == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        route: ${{ fromJSON(needs.select.outputs.routes) }}
     concurrency:
-      group: semantic-owner-${{ github.repository }}-${{ needs.select.outputs.number }}
+      group: semantic-owner-${{ github.repository }}-${{ matrix.route.number }}
       cancel-in-progress: false
     permissions:
       contents: read
@@ -89,9 +100,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PYDANTIC_AI_TRIAGE_SLACK_MENTIONS: ${{ vars.PYDANTIC_AI_TRIAGE_SLACK_MENTIONS }}
-          ROUTE_NUMBER: ${{ needs.select.outputs.number }}
-          ROUTE_OWNER: ${{ needs.select.outputs.owner }}
-          ROUTE_EVIDENCE: ${{ needs.select.outputs.evidence }}
+          ROUTE_NUMBER: ${{ matrix.route.number }}
+          ROUTE_OWNER: ${{ matrix.route.owner }}
+          ROUTE_EVIDENCE: ${{ matrix.route.evidence }}
         run: >-
           python .github/scripts/semantic_owner_router.py prepare
           --number "$ROUTE_NUMBER"
@@ -109,9 +120,9 @@ jobs:
         if: steps.prepare.outputs.should_notify == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          ROUTE_NUMBER: ${{ needs.select.outputs.number }}
-          ROUTE_OWNER: ${{ needs.select.outputs.owner }}
-          ROUTE_EVIDENCE: ${{ needs.select.outputs.evidence }}
+          ROUTE_NUMBER: ${{ matrix.route.number }}
+          ROUTE_OWNER: ${{ matrix.route.owner }}
+          ROUTE_EVIDENCE: ${{ matrix.route.evidence }}
         run: >-
           python .github/scripts/semantic_owner_router.py assign
           --number "$ROUTE_NUMBER"

--- a/.github/workflows/pydantic-ai-owner-routing.yml
+++ b/.github/workflows/pydantic-ai-owner-routing.yml
@@ -55,14 +55,14 @@ jobs:
             .github/scripts/issue_pr_attention_monitor.py
             .github/scripts/semantic_owner_router.py
           sparse-checkout-cone-mode: false
-      - name: Select one exact item
+      - name: Select routing decisions
         id: select
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ROUTING_ISSUE_NUMBER: ${{ github.event.issue.number }}
           ROUTING_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           ROUTING_PARTICIPANT_LOGIN: ${{ github.event.comment.user.login }}
-          ROUTING_LEGACY_LIMIT: ${{ (github.event.schedule == '40 7 * * *' || inputs.legacy_recovery) && '6' || '0' }}
+          ROUTING_LEGACY_RECOVERY: ${{ github.event.schedule == '40 7 * * *' || inputs.legacy_recovery }}
         run: python .github/scripts/semantic_owner_router.py select
 
   route:


### PR DESCRIPTION
This PR improves semantic owner routing in three explicit areas:

1. **Bounded legacy recovery:** once daily, after the existing post-rollout recovery lane finds nothing routeable, select up to six pre-rollout items in `updated-desc` order. The legacy query intentionally uses `no:assignee`: this follows the later decision to recover items that were never assigned, rather than items assigned to a non-maintainer.
2. **Maintainer-author precedence:** a non-draft pull request authored by a currently qualified configured maintainer routes back to that maintainer before participant or path/label routing.
3. **Actionable Slack notices:** identify the item as an issue or pull request, link the canonical `repo#number`, and turn internal routing evidence into a readable explanation.

The existing six-hour one-item recovery behavior remains unchanged. Event routing changes only for the documented maintainer-author precedence.

### Design and safety

- The route-decision interface remains unchanged. Batch selection produces the existing decision shape, and the compatibility `select()` entry point is retained.
- Each selected item runs through a serial matrix with per-item concurrency, then revalidates before notification and again before assignment. Concurrent or stale runs therefore cannot silently double-assign an item.
- Author precedence trusts only the GraphQL author login, matches it against the fixed owner allowlist, and refreshes repository permission before routing.
- Slack rendering excludes attacker-controlled titles and bodies. Repository, item type, item number, owner mention, and routing evidence are validated before use.
- Notification preparation performs one bounded metadata read to identify issue versus pull request. This keeps presentation metadata out of the route-decision interface and avoids a wider refactor.
- Unknown future routing evidence falls back to a safe generic explanation rather than suppressing the notification.
- The reusable workflow exposes a boolean `legacy_recovery` input so pinned callers such as Harness can opt into the same daily behavior. The six-item limit remains internal policy.

- Closes #7765

### Validation

- `uv run pytest .github/scripts/test_semantic_owner_router.py` (98 passed)
- targeted Ruff, formatting, and Pyright on the production script
- pre-commit YAML, formatting, lint, and zizmor hooks
- live serial-matrix workflow: https://github.com/pydantic/pydantic-ai/actions/runs/32877364278
- live legacy search: 315 matches; all first-page results were unassigned
- diff: +274/−57 across three files
- Repository-wide Pyright is unavailable locally because the optional `pydantic_ai_harness` package is not installed; canonical CI runs it with that dependency.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).