### PR TITLE
Reduce the default Temporal metric export frequency

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -496,7 +496,11 @@ async def main():
     )
 ```
 
-By default, the `LogfirePlugin` will instrument Temporal (including metrics) and Pydantic AI and send all data to Logfire. If your application already called `logfire.configure()` itself, the plugin keeps that configuration instead of replacing it, so your scrubbing options, exporters, sampling, and console settings are left alone. To customize Logfire configuration and instrumentation, you can pass a `setup_logfire` function to the `LogfirePlugin` constructor and return a custom `Logfire` instance (i.e. the result of `logfire.configure()`). To disable sending Temporal metrics to Logfire, you can pass `metrics=False` to the `LogfirePlugin` constructor.
+By default, the `LogfirePlugin` will instrument Temporal (including metrics) and Pydantic AI and send all data to Logfire. Temporal metrics are exported every 60 seconds. You can change the interval by passing a `datetime.timedelta` as `metric_periodicity` to the `LogfirePlugin` constructor.
+
+If your application already called `logfire.configure()` itself, the plugin keeps that configuration instead of replacing it, so your scrubbing options, exporters, sampling, and console settings are left alone. To customize Logfire configuration and instrumentation, you can pass a `setup_logfire` function to the `LogfirePlugin` constructor and return a custom `Logfire` instance (i.e. the result of `logfire.configure()`).
+
+To disable sending Temporal metrics to Logfire, pass `metrics=False` to the `LogfirePlugin` constructor. This also lets you supply your own [`Runtime`](https://python.temporal.io/temporalio.runtime.Runtime.html) to `Client.connect()` when you need to configure other Temporal telemetry options; the plugin will still configure tracing.
 
 ## Known Issues
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from temporalio.plugin import SimplePlugin
@@ -38,9 +39,21 @@ def _default_setup_logfire() -> Logfire:
 
 
 class LogfirePlugin(SimplePlugin):
-    """Temporal client plugin for Logfire."""
+    """Temporal client plugin for Logfire.
 
-    def __init__(self, setup_logfire: Callable[[], Logfire] = _default_setup_logfire, *, metrics: bool = True):
+    Args:
+        setup_logfire: Function that configures and returns a Logfire instance.
+        metrics: Whether to send Temporal metrics to Logfire.
+        metric_periodicity: How often to export Temporal metrics. Defaults to 60 seconds.
+    """
+
+    def __init__(
+        self,
+        setup_logfire: Callable[[], Logfire] = _default_setup_logfire,
+        *,
+        metrics: bool = True,
+        metric_periodicity: timedelta = timedelta(seconds=60),
+    ) -> None:
         try:
             import logfire  # noqa: F401 # pyright: ignore[reportUnusedImport]
             from opentelemetry.trace import get_tracer
@@ -53,6 +66,7 @@ class LogfirePlugin(SimplePlugin):
 
         self.setup_logfire = setup_logfire
         self.metrics = metrics
+        self.metric_periodicity = metric_periodicity
 
         super().__init__(  # type: ignore[reportUnknownMemberType]
             name='LogfirePlugin',
@@ -73,7 +87,13 @@ class LogfirePlugin(SimplePlugin):
                 headers = {'Authorization': f'Bearer {token}'}
 
                 config.runtime = Runtime(
-                    telemetry=TelemetryConfig(metrics=OpenTelemetryConfig(url=metrics_url, headers=headers))
+                    telemetry=TelemetryConfig(
+                        metrics=OpenTelemetryConfig(
+                            url=metrics_url,
+                            headers=headers,
+                            metric_periodicity=self.metric_periodicity,
+                        )
+                    )
                 )
 
         return await next(config)

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -3381,13 +3381,26 @@ async def test_logfire_plugin(client: Client):
     else:
         assert False, f'Unexpected tracer type: {type(interceptor.tracer)}'  # pragma: no cover
 
-    new_client = await Client.connect(client.service_client.config.target_host, plugins=[plugin])
-    # We can't check if the metrics URL was actually set correctly because it's on a `temporalio.bridge.runtime.Runtime` that we can't read from.
+    with patch.object(
+        temporal_logfire, 'OpenTelemetryConfig', wraps=temporal_logfire.OpenTelemetryConfig
+    ) as open_telemetry_config:
+        new_client = await Client.connect(client.service_client.config.target_host, plugins=[plugin])
     assert new_client.service_client.config.runtime is not None
+    assert open_telemetry_config.call_args.kwargs['metric_periodicity'] == timedelta(seconds=60)
+
+    plugin = LogfirePlugin(setup_logfire, metric_periodicity=timedelta(minutes=5))
+    with patch.object(
+        temporal_logfire, 'OpenTelemetryConfig', wraps=temporal_logfire.OpenTelemetryConfig
+    ) as open_telemetry_config:
+        await Client.connect(client.service_client.config.target_host, plugins=[plugin])
+    assert open_telemetry_config.call_args.kwargs['metric_periodicity'] == timedelta(minutes=5)
 
     plugin = LogfirePlugin(setup_logfire, metrics=False)
-    new_client = await Client.connect(client.service_client.config.target_host, plugins=[plugin])
-    assert new_client.service_client.config.runtime is None
+    custom_runtime = temporal_logfire.Runtime(telemetry=temporal_logfire.TelemetryConfig())
+    new_client = await Client.connect(
+        client.service_client.config.target_host, plugins=[plugin], runtime=custom_runtime
+    )
+    assert new_client.service_client.config.runtime is custom_runtime
 
     plugin = LogfirePlugin(lambda: setup_logfire(send_to_logfire=False))
     new_client = await Client.connect(client.service_client.config.target_host, plugins=[plugin])


### PR DESCRIPTION
## Summary

- export Temporal metrics configured by `LogfirePlugin` every 60 seconds by default instead of inheriting Temporal Core's one-second default
- allow callers to override `metric_periodicity`
- document and test the custom `Runtime` escape hatch with `metrics=False`

## Tests

- `pytest tests/test_temporal.py -k logfire_plugin -q`
- `pre-commit run --files pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_logfire.py tests/test_temporal.py docs/durable_execution/temporal.md`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

