### PR TITLE
Do not treat an empty `CompactionPart` summary as a wire boundary

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2842,7 +2842,7 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    return not requires_encrypted_content and bool(part.content)
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -65,6 +65,8 @@ from pydantic_ai.messages import (
     LoadCapabilityReturnPart,
     RealtimeSessionErrorEvent,
     ToolReturnContent,
+    _compaction_part_is_wire_boundary,  # pyright: ignore[reportPrivateUsage]
+    _post_compaction_window_for_response,  # pyright: ignore[reportPrivateUsage]
     is_multi_modal_content,
     narrow_message_parts,
     post_compaction_window,
@@ -2865,3 +2867,40 @@ def test_post_compaction_window_accepts_a_minimal_sequence():
     assert len(window) == 2
     assert isinstance(window[0], ModelResponse)
     assert isinstance(window[1], ModelRequest)
+
+
+def test_empty_compaction_summary_is_not_a_wire_boundary():
+    """An empty plaintext summary cannot replace compacted history, so it is not a boundary.
+
+    `has_content()` already rejects `''`; the wire-boundary check used `content is not None`,
+    which treated the empty string as payload. No real provider is known to emit this, so this
+    is not a VCR test.
+    """
+    part = CompactionPart(content='', provider_name='anthropic')
+    assert not part.has_content()
+    assert not _compaction_part_is_wire_boundary(part, 'anthropic')
+    assert _compaction_part_is_wire_boundary(CompactionPart(content='summary', provider_name='anthropic'), 'anthropic')
+    encrypted = CompactionPart(
+        content='',
+        provider_name='openai',
+        provider_details={'encrypted_content': 'enc'},
+    )
+    assert _compaction_part_is_wire_boundary(encrypted, 'openai')
+
+
+def test_post_compaction_window_for_response_does_not_cut_at_empty_summary():
+    """An empty CompactionPart is a failed compaction; the evidence window keeps pre-boundary history."""
+    justifying = ModelRequest.user_text_prompt('justifying history')
+    empty_compaction = ModelResponse(
+        parts=[CompactionPart(content='', provider_name='anthropic')],
+        provider_name='anthropic',
+    )
+    serving = ModelResponse(
+        parts=[ToolCallPart(tool_name='hidden', args={}, tool_call_id='h1')],
+        provider_name='anthropic',
+    )
+    messages: list[ModelMessage] = [justifying, empty_compaction, serving]
+
+    window = _post_compaction_window_for_response(messages, serving)
+
+    assert window == messages

--- a/tests/test_tool_availability.py
+++ b/tests/test_tool_availability.py
@@ -60,6 +60,7 @@ _INVALID_WIRE_BOUNDARIES = [
     pytest.param(CompactionPart(content='foreign', provider_name='anthropic'), 'openai', id='foreign-provider'),
     pytest.param(CompactionPart(provider_name='openai'), 'openai', id='openai-without-encrypted-content'),
     pytest.param(CompactionPart(provider_name='anthropic'), 'anthropic', id='anthropic-without-content'),
+    pytest.param(CompactionPart(content='', provider_name='anthropic'), 'anthropic', id='anthropic-empty-content'),
 ]
 
 


### PR DESCRIPTION
- Closes #7773

`_compaction_part_is_wire_boundary` treated `CompactionPart.content == ''` as payload because it used `content is not None`. That disagrees with `CompactionPart.has_content()` (`bool(self.content)`) and with the helper's own docstring: a part carrying neither payload is a failed compaction and a boundary for nobody.

`_post_compaction_window_for_response` then discarded every message before that empty part, so a later tool call can fail the evidence check.

Use the same non-empty check as `has_content()` for the plaintext path. Encrypted-content parts are unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

