### PR TITLE
fix(fireworks): inline tool schema defs for MiniMax models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -47,6 +47,8 @@ class FireworksProvider(_OpenAICompatibleProvider):
         model_name = model_name.lower()
         prefix_to_profile = {
             'llama': meta_model_profile,
+            # MiniMax cannot resolve `$ref` / `$defs` in tool schemas (same as Llama/Qwen).
+            'minimax': meta_model_profile,
             'qwen': qwen_model_profile,
             'deepseek': deepseek_model_profile,
             'mistral': mistral_model_profile,

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -73,6 +73,11 @@ def test_fireworks_provider_model_profile(mocker: MockerFixture):
     assert meta_profile is not None
     assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
+    minimax_profile = provider.model_profile('accounts/fireworks/models/minimax-m3')
+    meta_model_profile_mock.assert_called_with('minimax-m3')
+    assert minimax_profile is not None
+    assert minimax_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+
     qwen_profile = provider.model_profile('accounts/fireworks/models/qwen3-235b-a22b')
     qwen_model_profile_mock.assert_called_with('qwen3-235b-a22b')
     assert qwen_profile is not None
@@ -112,3 +117,7 @@ def test_fireworks_mixed_case_model_name_profile_flags():
     deepseek_mixed_path = provider.model_profile('Accounts/Fireworks/Models/DeepSeek-R1')
     assert deepseek_mixed_path is not None
     assert deepseek_mixed_path.get('supports_thinking') is True
+
+    minimax = provider.model_profile('accounts/fireworks/models/MiniMax-M3')
+    assert minimax is not None
+    assert minimax.get('json_schema_transformer') is InlineDefsJsonSchemaTransformer


### PR DESCRIPTION
Fixes #7728

## Problem

`FireworksProvider.model_profile` maps `llama` and `qwen` prefixes to `InlineDefsJsonSchemaTransformer` because those models cannot resolve `$ref` in tool schemas. MiniMax was missing from that map, so `accounts/fireworks/models/minimax-m3` fell through to `OpenAIJsonSchemaTransformer` and kept `$defs`.

A tool whose parameter is a named type (`$ref: #/$defs/Tags`) then gets a wrapper object (`{'item': [...]}`) instead of the array, and retries never succeed.

## Change

Map the `minimax` Fireworks prefix to `meta_model_profile`, which only sets `InlineDefsJsonSchemaTransformer` — the same profile already used for Llama on Fireworks.

## Test

Added coverage for `accounts/fireworks/models/minimax-m3` and mixed-case `MiniMax-M3` in `tests/providers/test_fireworks.py`.

```
pytest tests/providers/test_fireworks.py
5 passed
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

