### PR TITLE
Don't treat an empty CompactionPart summary as a wire boundary

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2842,7 +2842,8 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    # Empty plaintext cannot stand in for the history it would replace; match `has_content()`.
+    return not requires_encrypted_content and part.has_content()
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -65,6 +65,8 @@ from pydantic_ai.messages import (
     LoadCapabilityReturnPart,
     RealtimeSessionErrorEvent,
     ToolReturnContent,
+    _compaction_part_is_wire_boundary,  # pyright: ignore[reportPrivateUsage]
+    _post_compaction_window_for_response,  # pyright: ignore[reportPrivateUsage]
     is_multi_modal_content,
     narrow_message_parts,
     post_compaction_window,
@@ -2865,3 +2867,68 @@ def test_post_compaction_window_accepts_a_minimal_sequence():
     assert len(window) == 2
     assert isinstance(window[0], ModelResponse)
     assert isinstance(window[1], ModelRequest)
+
+
+def test_empty_compaction_part_is_not_a_wire_boundary():
+    """An empty plaintext summary is a failed compaction, not a boundary.
+
+    `content is not None` used to treat `''` as payload, so `_post_compaction_window_for_response`
+    dropped the history the empty summary cannot replace. Align with `has_content()`.
+    This is a unit test because no recorded provider currently emits an empty compaction block.
+    """
+    empty = CompactionPart(content='', provider_name='anthropic')
+    missing = CompactionPart(content=None, provider_name='anthropic')
+    summary = CompactionPart(content='latest summary', provider_name='anthropic')
+    encrypted = CompactionPart(
+        content=None,
+        provider_name='openai',
+        provider_details={'encrypted_content': 'opaque'},
+    )
+    encrypted_empty_text = CompactionPart(
+        content='',
+        provider_name='openai',
+        provider_details={'encrypted_content': 'opaque'},
+    )
+
+    assert empty.has_content() is False
+    assert _compaction_part_is_wire_boundary(empty, 'anthropic') is False
+    assert _compaction_part_is_wire_boundary(missing, 'anthropic') is False
+    assert _compaction_part_is_wire_boundary(summary, 'anthropic') is True
+    assert _compaction_part_is_wire_boundary(encrypted, 'openai') is True
+    assert _compaction_part_is_wire_boundary(encrypted_empty_text, 'openai') is True
+    assert _compaction_part_is_wire_boundary(empty, 'openai') is False
+
+
+def test_post_compaction_window_for_response_keeps_history_when_summary_is_empty():
+    """Empty compaction must not discard the pre-boundary messages that justified later tool calls."""
+    serving = ModelResponse(parts=[TextPart(content='follow-up')], provider_name='anthropic')
+    messages: list[ModelMessage] = [
+        ModelRequest.user_text_prompt('old context'),
+        ModelResponse(parts=[CompactionPart(content='', provider_name='anthropic')], provider_name='anthropic'),
+        ModelRequest.user_text_prompt('tail'),
+        serving,
+    ]
+
+    window = _post_compaction_window_for_response(messages, serving)
+
+    assert window == messages
+
+
+def test_post_compaction_window_for_response_slices_at_nonempty_compaction():
+    """A real summary still trims history for the serving provider."""
+    serving = ModelResponse(parts=[TextPart(content='follow-up')], provider_name='anthropic')
+    compaction = ModelResponse(
+        parts=[CompactionPart(content='latest summary', provider_name='anthropic')],
+        provider_name='anthropic',
+    )
+    tail = ModelRequest.user_text_prompt('tail')
+    messages: list[ModelMessage] = [
+        ModelRequest.user_text_prompt('old context'),
+        compaction,
+        tail,
+        serving,
+    ]
+
+    window = _post_compaction_window_for_response(messages, serving)
+
+    assert window == [compaction, tail, serving]


### PR DESCRIPTION
- Closes #7773

`_compaction_part_is_wire_boundary` treated `content is not None` as payload, so an empty `CompactionPart` summary was a compaction boundary. `_post_compaction_window_for_response` then dropped every earlier message even though an empty summary cannot stand in for that history.

Use the same non-empty semantics as `CompactionPart.has_content()`. Encrypted compaction is unchanged: a part with `encrypted_content` in `provider_details` is still a boundary.

This is the one-line plaintext check suggested on the issue, plus regression tests. Empty summaries are not currently emitted by recorded providers, so these are unit tests rather than VCR tests.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

