### PR TITLE
docs: add attenu-guard to third-party capabilities (Guardrails & Safety)

### DIFF
--- a/docs/capabilities/third-party.md
+++ b/docs/capabilities/third-party.md
@@ -27,6 +27,7 @@ Pydantic AI supports [multi-agent patterns](../multi-agent-applications.md) dire
 [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/guardrails/) provides input and output guardrails that validate or block requests and responses, and Pydantic AI enforces usage, token, and request limits via [`UsageLimits`](../agent.md#usage-limits). As a community alternative bundling several ready-made shields, including USD cost tracking:
 
 * [`pydantic-ai-shields`](https://github.com/vstorm-co/pydantic-ai-shields) - Ready-to-use guardrail capabilities: `CostTracking` (tracks token usage and USD cost per run, raises `BudgetExceededError` on budget overrun); `ToolGuard` (block or require approval for specific tools); `InputGuard` and `OutputGuard` (custom sync or async validation functions); `PromptInjection`, `PiiDetector`, `SecretRedaction`, `BlockedKeywords`, and `NoRefusals` content shields.
+* [`attenu-guard`](https://github.com/attenu-io/attenu-guard) - Per-agent permission enforcement: `DelegationGuard` is a capability whose `before_tool_execute` checks every tool call against the run's permission set before it runs, and `GuardedDeps.delegate()` fits the agent-delegation pattern so a delegated agent's permissions are computed as a subset of the caller's (chain ceilings, revocation). Every decision lands in a hash-chained audit log that `attenu-guard verify` checks offline.
 
 ## File Operations & Sandboxing {#file-operations-sandboxing}
 


### PR DESCRIPTION
Adds one bullet under **Guardrails & Safety**, as the page invites.

[`attenu-guard`](https://github.com/attenu-io/attenu-guard) (Apache-2.0, PyPI `attenu-guard`, extra `attenu-guard[pydantic-ai]`) integrates with Pydantic AI through public APIs only: a `DelegationGuard` capability (`before_tool_execute`) that checks each tool call against the run's permission set before it executes, and `GuardedDeps.delegate()` for the documented agent-delegation pattern so a delegated agent's permissions are a computed subset of the caller's. Decisions are written to a hash-chained audit log verified offline with `attenu-guard verify`. Tested against pydantic-ai-slim 2.31.

Disclosure: I maintain attenu-guard. Happy to shorten the wording.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

