### PR TITLE
Make Macroscope ignore recorded artifacts

### DIFF
--- a/.macroscope/correctness/review-discipline.md
+++ b/.macroscope/correctness/review-discipline.md
@@ -1,13 +1,3 @@
----
-include:
-  - "**/*.py"
-  - "**/*.md"
-  - "**/*.yml"
-  - "**/*.yaml"
-  - "**/*.ts"
-  - "**/*.tsx"
----
-
 Two rules that keep findings precise, applied to every finding.
 
 ## Flag what this PR introduces, not what it inherits

--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,13 +1,15 @@
+---
+ignoreTests: false
+---
+
 # Repository-wide Macroscope ignore (code review + any check-run agents).
 #
 # A custom ignore file REPLACES Macroscope's built-in defaults, so this copies
 # their default "base" patterns verbatim to preserve them, then adds this repo's
 # own recorded/generated files on top. https://docs.macroscope.com/
 #
-# Macroscope's default *test-file* patterns are deliberately NOT copied here: we
-# want Macroscope to review test code. Recorded cassettes and binary fixtures
-# under tests/ stay ignored via the base binary/data patterns plus the explicit
-# cassettes rule below, so only real test *code* is reviewed.
+# Test code is reviewed because `ignoreTests` is false. Recorded cassettes and
+# binary fixtures under tests/ remain ignored by the patterns below.
 
 # ---- Macroscope default base patterns (copied to preserve them) ----
 **/.git/**
@@ -29,15 +31,21 @@
 **/jspm_packages/**
 **/.next/**
 **/.svelte-kit/**
+**/.nuxt/**
+**/.output/**
+**/.vercel/**
+**/.angular/**
 **/vendor/**
 **/_vendor/**
 **/third_party/**
 **/Pods/**
 **/.bundle/**
 build/**
+out/**
 env/**
 ENV/**
 **/target/**
+**/dist/**
 **/generated/**
 **/intermediates/**
 **/generated_sources/**
@@ -46,6 +54,9 @@ ENV/**
 **/src/main/generated/**
 **/*.min.js
 **/*.min.css
+**/*.bundle.js
+**/.pnp.cjs
+**/.pnp.loader.mjs
 **/*_pb.d.ts
 **/*_pb.js
 **/*.pb.go
@@ -59,6 +70,11 @@ ENV/**
 **/*.g.dart
 **/*.pb.dart
 **/*_pb.rb
+**/*.d.ts
+**/*.gen.ts
+**/*.gen.tsx
+**/*.gen.js
+**/*.gen.jsx
 **/go.mod
 **/package.json
 **/*.pbxproj


### PR DESCRIPTION
Macroscope was still reviewing recorded cassettes because the broad `include` block in the shared review-discipline rule overrode the repository ignore file.

This change removes that redundant include block, explicitly keeps test code in scope with `ignoreTests: false`, and refreshes the copied base ignore patterns from Macroscope's current defaults. Recorded cassettes and generated artifacts can now be excluded without excluding normal tests.

### Verification

- `prek run --files .macroscope/ignore.md .macroscope/correctness/review-discipline.md`
- Compared the copied base patterns with the current Macroscope defaults
- Confirmed the repository cassette and workflow-lock exclusions remain present

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

