### PR TITLE
Fix `TestModel` generation for narrow exclusive numeric bounds

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -549,13 +549,22 @@ class _JsonSchemaTestData:
 
         if minimum is not None and maximum is not None:
             span = maximum - minimum
+            if span == 0:
+                # The `+/- 1` adjustments for exclusive bounds collapsed the range to a single
+                # valid value, e.g. `Field(gt=0, lt=2)` for an integer or `Field(ge=0, lt=1)` for a float.
+                return minimum
+            elif span < 0:
+                # The `+/- 1` adjustments for exclusive bounds overshot a narrow float range,
+                # e.g. `Field(gt=0, lt=1)`; pick the midpoint of the original range instead.
+                low = schema.get('minimum', schema.get('exclusiveMinimum', minimum))
+                high = schema.get('maximum', schema.get('exclusiveMaximum', maximum))
+                return low + (high - low) / 2
             if (
                 schema.get('type') == 'integer'
                 and minimum % 1 == 0
                 and maximum % 1 == 0
                 and 'exclusiveMinimum' not in schema
                 and 'exclusiveMaximum' not in schema
-                and span > 0
             ):
                 minimum = int(minimum)
                 span = int(maximum) - minimum + 1

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import math
 import re
 import string
 from collections.abc import AsyncGenerator, AsyncIterator, Iterable
@@ -573,66 +572,24 @@ class _JsonSchemaTestData:
 
     def _number_gen(self, schema: dict[str, Any]) -> float:
         """Generate a float from a JSON Schema number."""
-        maximum = schema.get('maximum')
-        if maximum is None and (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
-            maximum = exclusive_maximum - 1
-
-        minimum = schema.get('minimum')
-        if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
-            minimum = exclusive_minimum + 1
-
-        try:
-            if minimum is not None and maximum is not None:
-                span = maximum - minimum
-                # Keep the old candidate when it is valid, including modulo with a negative span.
-                value = minimum if span == 0 else minimum + self.seed % span
-            elif minimum is not None:
-                value = minimum + self.seed
-            elif maximum is not None:
-                value = maximum - self.seed
-            else:
-                value = self.seed
-        except OverflowError:
-            candidate = None
+        minimum = schema.get('minimum', schema.get('exclusiveMinimum'))
+        maximum = schema.get('maximum', schema.get('exclusiveMaximum'))
+        if minimum is not None and maximum is not None:
+            if minimum == maximum:
+                return float(minimum)
+            span = maximum - minimum
+            value = minimum + self.seed % span
+            if value == schema.get('exclusiveMinimum'):
+                value = minimum + span / 2
+            return float(value)
+        elif minimum is not None:
+            offset = 1 if 'exclusiveMinimum' in schema else 0
+            return float(minimum + self.seed + offset)
+        elif maximum is not None:
+            offset = 1 if 'exclusiveMaximum' in schema else 0
+            return float(maximum - self.seed - offset)
         else:
-            candidate = self._finite_float(value)
-        if candidate is not None and self._number_is_valid(candidate, schema):
-            return candidate
-
-        lower_bounds = [schema[key] for key in ('minimum', 'exclusiveMinimum') if key in schema]
-        upper_bounds = [schema[key] for key in ('maximum', 'exclusiveMaximum') if key in schema]
-        lower = self._finite_float(max(lower_bounds)) if lower_bounds else None
-        upper = self._finite_float(min(upper_bounds)) if upper_bounds else None
-
-        candidates = [0.0]
-        if lower is not None and upper is not None:
-            candidates.insert(0, lower / 2 + upper / 2)
-        if lower is not None:
-            candidates.extend([lower, math.nextafter(lower, math.inf)])
-        if upper is not None:
-            candidates.extend([upper, math.nextafter(upper, -math.inf)])
-
-        for candidate in candidates:
-            if self._number_is_valid(candidate, schema):
-                return candidate
-        raise ValueError('No finite float satisfies the JSON Schema bounds')
-
-    @staticmethod
-    def _finite_float(value: Any) -> float | None:
-        try:
-            result = float(value)
-        except (OverflowError, ValueError):
-            return None
-        return result if math.isfinite(result) else None
-
-    @staticmethod
-    def _number_is_valid(value: float, schema: dict[str, Any]) -> bool:
-        return math.isfinite(value) and not (
-            ('minimum' in schema and value < schema['minimum'])
-            or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
-            or ('maximum' in schema and value > schema['maximum'])
-            or ('exclusiveMaximum' in schema and value >= schema['exclusiveMaximum'])
-        )
+            return float(self.seed)
 
     def _bool_gen(self) -> bool:
         """Generate a boolean from a JSON Schema boolean."""

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -572,8 +572,12 @@ class _JsonSchemaTestData:
 
     def _number_gen(self, schema: dict[str, Any]) -> float:
         """Generate a float from a JSON Schema number."""
-        minimum = schema.get('minimum', schema.get('exclusiveMinimum'))
-        maximum = schema.get('maximum', schema.get('exclusiveMaximum'))
+        minimum = schema.get('minimum')
+        if (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
+            minimum = exclusive_minimum if minimum is None else max(minimum, exclusive_minimum)
+        maximum = schema.get('maximum')
+        if (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
+            maximum = exclusive_maximum if maximum is None else min(maximum, exclusive_maximum)
         if minimum is not None and maximum is not None:
             if minimum == maximum:
                 return float(minimum)

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -485,7 +485,7 @@ class _JsonSchemaTestData:
         elif type_ == 'integer':
             return self._int_gen(schema)
         elif type_ == 'number':
-            return float(self._int_gen(schema))
+            return self._number_gen(schema)
         elif type_ == 'boolean':
             return self._bool_gen()
         elif type_ == 'array':
@@ -535,56 +535,99 @@ class _JsonSchemaTestData:
         """Generate an integer from a JSON Schema integer."""
         maximum = schema.get('maximum')
         minimum = schema.get('minimum')
-        if minimum is not None and maximum == minimum:
-            return minimum
+        if maximum is None and (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
+            maximum = exclusive_maximum - 1
+        if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
+            minimum = exclusive_minimum + 1
 
-        if maximum is None:
-            exc_max = schema.get('exclusiveMaximum')
-            if exc_max is not None:
-                maximum = exc_max - 1
-
-        if minimum is None:
-            exc_min = schema.get('exclusiveMinimum')
-            if exc_min is not None:
-                minimum = exc_min + 1
-
+        span = None
         if minimum is not None and maximum is not None:
             span = maximum - minimum
-            if span <= 0:
-                # The `+/- 1` adjustments for exclusive bounds collapsed (`span == 0`) or
-                # inverted (`span < 0`) a narrow range, e.g. `Field(gt=0, lt=2)` on an integer
-                # or `Field(gt=0, lt=1)` on a float. Fall back to the declared bounds.
-                if schema.get('type') == 'integer':
-                    # Round the lower bound inwards to the smallest integer the schema allows.
-                    # The adjusted bounds may be fractional, so `minimum` itself is not usable.
-                    inclusive_min = schema.get('minimum')
-                    if inclusive_min is not None:
-                        return math.ceil(inclusive_min)
-                    return math.floor(schema['exclusiveMinimum']) + 1
-                if span == 0:
-                    # Each adjusted bound is valid by construction, so the collapsed value
-                    # satisfies both original bounds.
-                    return minimum
-                # Inverted float range: the midpoint of the declared bounds is strictly inside it.
-                low = schema.get('minimum', schema.get('exclusiveMinimum', minimum))
-                high = schema.get('maximum', schema.get('exclusiveMaximum', maximum))
-                return low + (high - low) / 2
             if (
-                schema.get('type') == 'integer'
-                and minimum % 1 == 0
+                minimum % 1 == 0
                 and maximum % 1 == 0
                 and 'exclusiveMinimum' not in schema
                 and 'exclusiveMaximum' not in schema
+                and span > 0
             ):
                 minimum = int(minimum)
                 span = int(maximum) - minimum + 1
-            return minimum + self.seed % span
+            value = minimum if span <= 0 else minimum + self.seed % span
         elif minimum is not None:
-            return minimum + self.seed
+            value = minimum + self.seed
         elif maximum is not None:
-            return maximum - self.seed
+            value = maximum - self.seed
         else:
-            return self.seed
+            value = self.seed
+
+        if value % 1 == 0 and self._number_is_valid(value, schema):
+            return int(value)
+        if span is not None and span > 0 and 'exclusiveMinimum' not in schema and 'exclusiveMaximum' not in schema:
+            # Preserve the existing behavior for positive-span schemas with fractional inclusive bounds.
+            return value
+
+        minimums = [math.ceil(schema['minimum'])] if 'minimum' in schema else []
+        if 'exclusiveMinimum' in schema:
+            minimums.append(math.floor(schema['exclusiveMinimum']) + 1)
+        maximums = [math.floor(schema['maximum'])] if 'maximum' in schema else []
+        if 'exclusiveMaximum' in schema:
+            maximums.append(math.ceil(schema['exclusiveMaximum']) - 1)
+
+        if minimums:
+            return max(minimums)
+        return min(maximums)
+
+    def _number_gen(self, schema: dict[str, Any]) -> float:
+        """Generate a number from a JSON Schema number."""
+        maximum = schema.get('maximum')
+        if maximum is None and (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
+            maximum = exclusive_maximum - 1
+
+        minimum = schema.get('minimum')
+        if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
+            minimum = exclusive_minimum + 1
+
+        if minimum is not None and maximum is not None:
+            span = maximum - minimum
+            value = minimum if span <= 0 else minimum + self.seed % span
+        elif minimum is not None:
+            value = minimum + self.seed
+        elif maximum is not None:
+            value = maximum - self.seed
+        else:
+            value = self.seed
+
+        if self._number_is_valid(value, schema):
+            return float(value)
+
+        lower_bounds = [schema[key] for key in ('minimum', 'exclusiveMinimum') if key in schema]
+        upper_bounds = [schema[key] for key in ('maximum', 'exclusiveMaximum') if key in schema]
+        if lower_bounds and upper_bounds:
+            lower = max(lower_bounds)
+            upper = min(upper_bounds)
+            if lower < 0 < upper:
+                value = lower / 2 + upper / 2
+            else:
+                value = lower + (upper - lower) / 2
+            if not self._number_is_valid(value, schema):
+                value = lower
+                if not self._number_is_valid(value, schema):
+                    value = math.nextafter(lower, upper)
+        elif lower_bounds:
+            value = math.nextafter(max(lower_bounds), math.inf)
+        else:
+            value = math.nextafter(min(upper_bounds), -math.inf)
+
+        return float(value)
+
+    @staticmethod
+    def _number_is_valid(value: float, schema: dict[str, Any]) -> bool:
+        return not (
+            ('minimum' in schema and value < schema['minimum'])
+            or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
+            or ('maximum' in schema and value > schema['maximum'])
+            or ('exclusiveMaximum' in schema and value >= schema['exclusiveMaximum'])
+        )
 
     def _bool_gen(self) -> bool:
         """Generate a boolean from a JSON Schema boolean."""

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import math
 import re
 import string
 from collections.abc import AsyncGenerator, AsyncIterator, Iterable
@@ -484,7 +485,7 @@ class _JsonSchemaTestData:
         elif type_ == 'integer':
             return self._int_gen(schema)
         elif type_ == 'number':
-            return float(self._int_gen(schema))
+            return self._number_gen(schema)
         elif type_ == 'boolean':
             return self._bool_gen()
         elif type_ == 'array':
@@ -530,7 +531,7 @@ class _JsonSchemaTestData:
 
         return self._char()
 
-    def _int_gen(self, schema: dict[str, Any]) -> int | float:
+    def _int_gen(self, schema: dict[str, Any]) -> int:
         """Generate an integer from a JSON Schema integer."""
         maximum = schema.get('maximum')
         minimum = schema.get('minimum')
@@ -552,11 +553,6 @@ class _JsonSchemaTestData:
             if span == 0:
                 # Exclusive-bound adjustments can collapse a valid narrow range.
                 return minimum
-            elif span < 0:
-                # Integer-sized adjustments can invert a valid float range, so use its midpoint.
-                lower = schema.get('minimum', schema.get('exclusiveMinimum', minimum))
-                upper = schema.get('maximum', schema.get('exclusiveMaximum', maximum))
-                return lower + (upper - lower) / 2
             if (
                 schema.get('type') == 'integer'
                 and minimum % 1 == 0
@@ -574,6 +570,69 @@ class _JsonSchemaTestData:
             return maximum - self.seed
         else:
             return self.seed
+
+    def _number_gen(self, schema: dict[str, Any]) -> float:
+        """Generate a float from a JSON Schema number."""
+        maximum = schema.get('maximum')
+        if maximum is None and (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
+            maximum = exclusive_maximum - 1
+
+        minimum = schema.get('minimum')
+        if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
+            minimum = exclusive_minimum + 1
+
+        try:
+            if minimum is not None and maximum is not None:
+                span = maximum - minimum
+                # Keep the old candidate when it is valid, including modulo with a negative span.
+                value = minimum if span == 0 else minimum + self.seed % span
+            elif minimum is not None:
+                value = minimum + self.seed
+            elif maximum is not None:
+                value = maximum - self.seed
+            else:
+                value = self.seed
+        except OverflowError:
+            candidate = None
+        else:
+            candidate = self._finite_float(value)
+        if candidate is not None and self._number_is_valid(candidate, schema):
+            return candidate
+
+        lower_bounds = [schema[key] for key in ('minimum', 'exclusiveMinimum') if key in schema]
+        upper_bounds = [schema[key] for key in ('maximum', 'exclusiveMaximum') if key in schema]
+        lower = self._finite_float(max(lower_bounds)) if lower_bounds else None
+        upper = self._finite_float(min(upper_bounds)) if upper_bounds else None
+
+        candidates = [0.0]
+        if lower is not None and upper is not None:
+            candidates.insert(0, lower / 2 + upper / 2)
+        if lower is not None:
+            candidates.extend([lower, math.nextafter(lower, math.inf)])
+        if upper is not None:
+            candidates.extend([upper, math.nextafter(upper, -math.inf)])
+
+        for candidate in candidates:
+            if self._number_is_valid(candidate, schema):
+                return candidate
+        raise ValueError('No finite float satisfies the JSON Schema bounds')
+
+    @staticmethod
+    def _finite_float(value: Any) -> float | None:
+        try:
+            result = float(value)
+        except (OverflowError, ValueError):
+            return None
+        return result if math.isfinite(result) else None
+
+    @staticmethod
+    def _number_is_valid(value: float, schema: dict[str, Any]) -> bool:
+        return math.isfinite(value) and not (
+            ('minimum' in schema and value < schema['minimum'])
+            or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
+            or ('maximum' in schema and value > schema['maximum'])
+            or ('exclusiveMaximum' in schema and value >= schema['exclusiveMaximum'])
+        )
 
     def _bool_gen(self) -> bool:
         """Generate a boolean from a JSON Schema boolean."""

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import math
 import re
 import string
 from collections.abc import AsyncGenerator, AsyncIterator, Iterable
@@ -549,13 +550,22 @@ class _JsonSchemaTestData:
 
         if minimum is not None and maximum is not None:
             span = maximum - minimum
-            if span == 0:
-                # The `+/- 1` adjustments for exclusive bounds collapsed the range to a single
-                # valid value, e.g. `Field(gt=0, lt=2)` for an integer or `Field(ge=0, lt=1)` for a float.
-                return minimum
-            elif span < 0:
-                # The `+/- 1` adjustments for exclusive bounds overshot a narrow float range,
-                # e.g. `Field(gt=0, lt=1)`; pick the midpoint of the original range instead.
+            if span <= 0:
+                # The `+/- 1` adjustments for exclusive bounds collapsed (`span == 0`) or
+                # inverted (`span < 0`) a narrow range, e.g. `Field(gt=0, lt=2)` on an integer
+                # or `Field(gt=0, lt=1)` on a float. Fall back to the declared bounds.
+                if schema.get('type') == 'integer':
+                    # Round the lower bound inwards to the smallest integer the schema allows.
+                    # The adjusted bounds may be fractional, so `minimum` itself is not usable.
+                    inclusive_min = schema.get('minimum')
+                    if inclusive_min is not None:
+                        return math.ceil(inclusive_min)
+                    return math.floor(schema['exclusiveMinimum']) + 1
+                if span == 0:
+                    # Each adjusted bound is valid by construction, so the collapsed value
+                    # satisfies both original bounds.
+                    return minimum
+                # Inverted float range: the midpoint of the declared bounds is strictly inside it.
                 low = schema.get('minimum', schema.get('exclusiveMinimum', minimum))
                 high = schema.get('maximum', schema.get('exclusiveMaximum', maximum))
                 return low + (high - low) / 2

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import math
 import re
 import string
 from collections.abc import AsyncGenerator, AsyncIterator, Iterable
@@ -485,7 +484,7 @@ class _JsonSchemaTestData:
         elif type_ == 'integer':
             return self._int_gen(schema)
         elif type_ == 'number':
-            return self._number_gen(schema)
+            return float(self._int_gen(schema))
         elif type_ == 'boolean':
             return self._bool_gen()
         elif type_ == 'array':
@@ -531,136 +530,50 @@ class _JsonSchemaTestData:
 
         return self._char()
 
-    def _int_gen(self, schema: dict[str, Any]) -> int:
+    def _int_gen(self, schema: dict[str, Any]) -> int | float:
         """Generate an integer from a JSON Schema integer."""
-        minimums = [math.ceil(schema['minimum'])] if 'minimum' in schema else []
-        if 'exclusiveMinimum' in schema:
-            minimums.append(math.floor(schema['exclusiveMinimum']) + 1)
-        maximums = [math.floor(schema['maximum'])] if 'maximum' in schema else []
-        if 'exclusiveMaximum' in schema:
-            maximums.append(math.ceil(schema['exclusiveMaximum']) - 1)
+        maximum = schema.get('maximum')
+        minimum = schema.get('minimum')
+        if minimum is not None and maximum == minimum:
+            return minimum
 
-        minimum = max(minimums) if minimums else None
-        maximum = min(maximums) if maximums else None
+        if maximum is None:
+            exc_max = schema.get('exclusiveMaximum')
+            if exc_max is not None:
+                maximum = exc_max - 1
+
+        if minimum is None:
+            exc_min = schema.get('exclusiveMinimum')
+            if exc_min is not None:
+                minimum = exc_min + 1
+
         if minimum is not None and maximum is not None:
-            span = maximum - minimum + 1
-            return minimum if span <= 0 else minimum + self.seed % span
+            span = maximum - minimum
+            if span == 0:
+                # Exclusive-bound adjustments can collapse a valid narrow range.
+                return minimum
+            elif span < 0:
+                # Integer-sized adjustments can invert a valid float range, so use its midpoint.
+                lower = schema.get('minimum', schema.get('exclusiveMinimum', minimum))
+                upper = schema.get('maximum', schema.get('exclusiveMaximum', maximum))
+                return lower + (upper - lower) / 2
+            if (
+                schema.get('type') == 'integer'
+                and minimum % 1 == 0
+                and maximum % 1 == 0
+                and 'exclusiveMinimum' not in schema
+                and 'exclusiveMaximum' not in schema
+                and span > 0
+            ):
+                minimum = int(minimum)
+                span = int(maximum) - minimum + 1
+            return minimum + self.seed % span
         elif minimum is not None:
-            candidate_minimum = schema.get('minimum')
-            if candidate_minimum is None:
-                candidate_minimum = schema['exclusiveMinimum'] + 1
-            return self._one_sided_int(candidate_minimum, 1, minimum, schema)
+            return minimum + self.seed
         elif maximum is not None:
-            candidate_maximum = schema.get('maximum')
-            if candidate_maximum is None:
-                candidate_maximum = schema['exclusiveMaximum'] - 1
-            return self._one_sided_int(candidate_maximum, -1, maximum, schema)
+            return maximum - self.seed
         else:
             return self.seed
-
-    def _one_sided_int(self, bound: int | float, direction: int, fallback: int, schema: dict[str, Any]) -> int:
-        """Preserve a valid seed-based integer candidate, or use the effective bound."""
-        try:
-            value = bound + direction * self.seed
-            if value % 1 == 0 and self._number_is_valid(value, schema):
-                return int(value)
-        except OverflowError:
-            pass
-        return fallback
-
-    def _number_gen(self, schema: dict[str, Any]) -> float:
-        """Generate a number from a JSON Schema number."""
-        maximum = schema.get('maximum')
-        if maximum is None and (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
-            maximum = exclusive_maximum - 1
-
-        minimum = schema.get('minimum')
-        if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
-            minimum = exclusive_minimum + 1
-
-        try:
-            if minimum is not None and maximum is not None:
-                span = maximum - minimum
-                value = minimum if span <= 0 else minimum + self.seed % span
-            elif minimum is not None:
-                value = minimum + self.seed
-            elif maximum is not None:
-                value = maximum - self.seed
-            else:
-                value = self.seed
-            float_value = self._finite_float(value)
-        except OverflowError:
-            float_value = None
-
-        if float_value is not None and self._number_is_valid(float_value, schema):
-            return float_value
-
-        return self._number_fallback(schema)
-
-    def _number_fallback(self, schema: dict[str, Any]) -> float:
-        """Generate a finite float after the seed-based candidate failed."""
-        lower_bounds = [schema[key] for key in ('minimum', 'exclusiveMinimum') if key in schema]
-        upper_bounds = [schema[key] for key in ('maximum', 'exclusiveMaximum') if key in schema]
-        if lower_bounds and upper_bounds:
-            lower = max(lower_bounds)
-            upper = min(upper_bounds)
-            candidates = [lower, upper]
-            try:
-                if lower < 0 < upper:
-                    candidates.insert(0, lower / 2 + upper / 2)
-                else:
-                    candidates.insert(0, lower + (upper - lower) / 2)
-            except OverflowError:
-                pass
-            lower_float = self._finite_float(lower)
-            if lower_float is not None:
-                candidates.append(math.nextafter(lower_float, math.inf))
-            upper_float = self._finite_float(upper)
-            if upper_float is not None:
-                candidates.append(math.nextafter(upper_float, -math.inf))
-            candidates.append(0.0)
-        elif lower_bounds:
-            lower = max(lower_bounds)
-            candidates = [lower]
-            lower_float = self._finite_float(lower)
-            if lower_float is not None:
-                candidates.append(math.nextafter(lower_float, math.inf))
-            candidates.append(0.0)
-        elif upper_bounds:
-            upper = min(upper_bounds)
-            candidates = [upper]
-            upper_float = self._finite_float(upper)
-            if upper_float is not None:
-                candidates.append(math.nextafter(upper_float, -math.inf))
-            candidates.append(0.0)
-        else:
-            maximum_float = math.nextafter(math.inf, 0)
-            return -maximum_float if self.seed < 0 else maximum_float
-
-        for candidate in candidates:
-            float_candidate = self._finite_float(candidate)
-            if float_candidate is not None and self._number_is_valid(float_candidate, schema):
-                return float_candidate
-
-        # The schema has no finite floating-point solution, so return an invalid value without raising.
-        return math.nan
-
-    @staticmethod
-    def _finite_float(value: int | float) -> float | None:
-        try:
-            float_value = float(value)
-        except OverflowError:
-            return None
-        return float_value if math.isfinite(float_value) else None
-
-    @staticmethod
-    def _number_is_valid(value: int | float, schema: dict[str, Any]) -> bool:
-        return (not isinstance(value, float) or math.isfinite(value)) and not (
-            ('minimum' in schema and value < schema['minimum'])
-            or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
-            or ('maximum' in schema and value > schema['maximum'])
-            or ('exclusiveMaximum' in schema and value >= schema['exclusiveMaximum'])
-        )
 
     def _bool_gen(self) -> bool:
         """Generate a boolean from a JSON Schema boolean."""

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -533,39 +533,6 @@ class _JsonSchemaTestData:
 
     def _int_gen(self, schema: dict[str, Any]) -> int:
         """Generate an integer from a JSON Schema integer."""
-        maximum = schema.get('maximum')
-        minimum = schema.get('minimum')
-        if maximum is None and (exclusive_maximum := schema.get('exclusiveMaximum')) is not None:
-            maximum = exclusive_maximum - 1
-        if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
-            minimum = exclusive_minimum + 1
-
-        span = None
-        if minimum is not None and maximum is not None:
-            span = maximum - minimum
-            if (
-                minimum % 1 == 0
-                and maximum % 1 == 0
-                and 'exclusiveMinimum' not in schema
-                and 'exclusiveMaximum' not in schema
-                and span > 0
-            ):
-                minimum = int(minimum)
-                span = int(maximum) - minimum + 1
-            value = minimum if span <= 0 else minimum + self.seed % span
-        elif minimum is not None:
-            value = minimum + self.seed
-        elif maximum is not None:
-            value = maximum - self.seed
-        else:
-            value = self.seed
-
-        if value % 1 == 0 and self._number_is_valid(value, schema):
-            return int(value)
-        if span is not None and span > 0 and 'exclusiveMinimum' not in schema and 'exclusiveMaximum' not in schema:
-            # Preserve the existing behavior for positive-span schemas with fractional inclusive bounds.
-            return value
-
         minimums = [math.ceil(schema['minimum'])] if 'minimum' in schema else []
         if 'exclusiveMinimum' in schema:
             minimums.append(math.floor(schema['exclusiveMinimum']) + 1)
@@ -573,9 +540,33 @@ class _JsonSchemaTestData:
         if 'exclusiveMaximum' in schema:
             maximums.append(math.ceil(schema['exclusiveMaximum']) - 1)
 
-        if minimums:
-            return max(minimums)
-        return min(maximums)
+        minimum = max(minimums) if minimums else None
+        maximum = min(maximums) if maximums else None
+        if minimum is not None and maximum is not None:
+            span = maximum - minimum + 1
+            return minimum if span <= 0 else minimum + self.seed % span
+        elif minimum is not None:
+            candidate_minimum = schema.get('minimum')
+            if candidate_minimum is None:
+                candidate_minimum = schema['exclusiveMinimum'] + 1
+            return self._one_sided_int(candidate_minimum, 1, minimum, schema)
+        elif maximum is not None:
+            candidate_maximum = schema.get('maximum')
+            if candidate_maximum is None:
+                candidate_maximum = schema['exclusiveMaximum'] - 1
+            return self._one_sided_int(candidate_maximum, -1, maximum, schema)
+        else:
+            return self.seed
+
+    def _one_sided_int(self, bound: int | float, direction: int, fallback: int, schema: dict[str, Any]) -> int:
+        """Preserve a valid seed-based integer candidate, or use the effective bound."""
+        try:
+            value = bound + direction * self.seed
+            if value % 1 == 0 and self._number_is_valid(value, schema):
+                return int(value)
+        except OverflowError:
+            pass
+        return fallback
 
     def _number_gen(self, schema: dict[str, Any]) -> float:
         """Generate a number from a JSON Schema number."""
@@ -587,42 +578,84 @@ class _JsonSchemaTestData:
         if minimum is None and (exclusive_minimum := schema.get('exclusiveMinimum')) is not None:
             minimum = exclusive_minimum + 1
 
-        if minimum is not None and maximum is not None:
-            span = maximum - minimum
-            value = minimum if span <= 0 else minimum + self.seed % span
-        elif minimum is not None:
-            value = minimum + self.seed
-        elif maximum is not None:
-            value = maximum - self.seed
-        else:
-            value = self.seed
+        try:
+            if minimum is not None and maximum is not None:
+                span = maximum - minimum
+                value = minimum if span <= 0 else minimum + self.seed % span
+            elif minimum is not None:
+                value = minimum + self.seed
+            elif maximum is not None:
+                value = maximum - self.seed
+            else:
+                value = self.seed
+            float_value = self._finite_float(value)
+        except OverflowError:
+            float_value = None
 
-        if self._number_is_valid(value, schema):
-            return float(value)
+        if float_value is not None and self._number_is_valid(float_value, schema):
+            return float_value
 
+        return self._number_fallback(schema)
+
+    def _number_fallback(self, schema: dict[str, Any]) -> float:
+        """Generate a finite float after the seed-based candidate failed."""
         lower_bounds = [schema[key] for key in ('minimum', 'exclusiveMinimum') if key in schema]
         upper_bounds = [schema[key] for key in ('maximum', 'exclusiveMaximum') if key in schema]
         if lower_bounds and upper_bounds:
             lower = max(lower_bounds)
             upper = min(upper_bounds)
-            if lower < 0 < upper:
-                value = lower / 2 + upper / 2
-            else:
-                value = lower + (upper - lower) / 2
-            if not self._number_is_valid(value, schema):
-                value = lower
-                if not self._number_is_valid(value, schema):
-                    value = math.nextafter(lower, upper)
+            candidates = [lower, upper]
+            try:
+                if lower < 0 < upper:
+                    candidates.insert(0, lower / 2 + upper / 2)
+                else:
+                    candidates.insert(0, lower + (upper - lower) / 2)
+            except OverflowError:
+                pass
+            lower_float = self._finite_float(lower)
+            if lower_float is not None:
+                candidates.append(math.nextafter(lower_float, math.inf))
+            upper_float = self._finite_float(upper)
+            if upper_float is not None:
+                candidates.append(math.nextafter(upper_float, -math.inf))
+            candidates.append(0.0)
         elif lower_bounds:
-            value = math.nextafter(max(lower_bounds), math.inf)
+            lower = max(lower_bounds)
+            candidates = [lower]
+            lower_float = self._finite_float(lower)
+            if lower_float is not None:
+                candidates.append(math.nextafter(lower_float, math.inf))
+            candidates.append(0.0)
+        elif upper_bounds:
+            upper = min(upper_bounds)
+            candidates = [upper]
+            upper_float = self._finite_float(upper)
+            if upper_float is not None:
+                candidates.append(math.nextafter(upper_float, -math.inf))
+            candidates.append(0.0)
         else:
-            value = math.nextafter(min(upper_bounds), -math.inf)
+            maximum_float = math.nextafter(math.inf, 0)
+            return -maximum_float if self.seed < 0 else maximum_float
 
-        return float(value)
+        for candidate in candidates:
+            float_candidate = self._finite_float(candidate)
+            if float_candidate is not None and self._number_is_valid(float_candidate, schema):
+                return float_candidate
+
+        # The schema has no finite floating-point solution, so return an invalid value without raising.
+        return math.nan
 
     @staticmethod
-    def _number_is_valid(value: float, schema: dict[str, Any]) -> bool:
-        return not (
+    def _finite_float(value: int | float) -> float | None:
+        try:
+            float_value = float(value)
+        except OverflowError:
+            return None
+        return float_value if math.isfinite(float_value) else None
+
+    @staticmethod
+    def _number_is_valid(value: int | float, schema: dict[str, Any]) -> bool:
+        return (not isinstance(value, float) or math.isfinite(value)) and not (
             ('minimum' in schema and value < schema['minimum'])
             or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
             or ('maximum' in schema and value > schema['maximum'])

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import dataclasses
+import math
 import re
 from datetime import timezone
 from typing import Annotated, Any, Literal
@@ -664,6 +665,58 @@ def test_json_schema_test_data_overlapping_integer_bounds() -> None:
     assert [_JsonSchemaTestData(schema, seed=seed).generate() for seed in range(3)] == [1, 1, 1]
 
 
+def test_json_schema_test_data_all_numeric_bound_combinations() -> None:
+    """Every combination of numeric bound keywords produces values matching the schema."""
+
+    float_bounds = {
+        'minimum': 2**53,
+        'exclusiveMinimum': 2**53,
+        'maximum': 2**53 + 4,
+        'exclusiveMaximum': 2**53 + 4,
+    }
+    integer_bounds = {
+        'minimum': 0.5,
+        'exclusiveMinimum': 0.1,
+        'maximum': 3.5,
+        'exclusiveMaximum': 3.9,
+    }
+    seeds = [-(10**400), -1, 0, 1, 10**400]
+
+    def matches_bounds(value: int | float, schema: dict[str, Any]) -> bool:
+        return not (
+            ('minimum' in schema and value < schema['minimum'])
+            or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
+            or ('maximum' in schema and value > schema['maximum'])
+            or ('exclusiveMaximum' in schema and value >= schema['exclusiveMaximum'])
+        )
+
+    for mask in range(1 << len(float_bounds)):
+        number_schema: dict[str, Any] = {'type': 'number'}
+        integer_schema: dict[str, Any] = {'type': 'integer'}
+        for index, (keyword, bound) in enumerate(float_bounds.items()):
+            if mask & (1 << index):
+                number_schema[keyword] = bound
+                integer_schema[keyword] = integer_bounds[keyword]
+
+        for seed in seeds:
+            number = _JsonSchemaTestData(number_schema, seed=seed).generate()
+            integer = _JsonSchemaTestData(integer_schema, seed=seed).generate()
+
+            assert isinstance(number, float) and math.isfinite(number) and matches_bounds(number, number_schema)
+            assert isinstance(integer, int) and matches_bounds(integer, integer_schema)
+
+    huge_bound_schemas = [
+        {'type': 'number', 'minimum': -(10**400)},
+        {'type': 'number', 'maximum': 10**400},
+        {'type': 'number', 'minimum': -(10**400), 'maximum': 1},
+        {'type': 'number', 'minimum': -1, 'maximum': 10**400},
+    ]
+    for schema in huge_bound_schemas:
+        for seed in seeds:
+            number = _JsonSchemaTestData(schema, seed=seed).generate()
+            assert isinstance(number, float) and math.isfinite(number) and matches_bounds(number, schema)
+
+
 def test_chars_wrap():
     class TestModel(BaseModel):
         a: Annotated[set[str], MinLen(4)]
@@ -735,8 +788,8 @@ def test_different_content_input(content: AudioUrl | VideoUrl | ImageUrl | Binar
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=51, output_tokens=1))
 
 
-def test_int_inclusive_upper_bound_reachable():
-    """Plain inclusive integer ranges include their ceiling without changing other ranges."""
+def test_int_upper_bound_reachable():
+    """Integer ranges include every valid integer through their effective upper bound."""
 
     class MyOutput(BaseModel):
         integer: Annotated[int, Field(ge=2, le=5)]
@@ -757,7 +810,7 @@ def test_int_inclusive_upper_bound_reachable():
             output.number,
         )
         for output in outputs
-    ] == snapshot([(2, 2, 2, 2, 2.0), (3, 3, 3, 3, 3.0), (4, 4, 4, 4, 4.0), (5, 5, 2, 2, 2.0)])
+    ] == snapshot([(2, 2, 2, 2, 2.0), (3, 3, 3, 3, 3.0), (4, 4, 4, 4, 4.0), (5, 5, 5, 2, 2.0)])
 
     def generated_values(minimum: float, maximum: float, seeds: list[int]) -> list[Any]:
         schema = {
@@ -767,6 +820,6 @@ def test_int_inclusive_upper_bound_reachable():
         }
         return [_JsonSchemaTestData(schema, seed=seed).generate()['value'] for seed in seeds]
 
-    assert generated_values(2.5, 5.5, list(range(4))) == [2.5, 3.5, 4.5, 2.5]
-    assert generated_values(2.0, 5.5, list(range(5))) == [2.0, 3.0, 4.0, 5.0, 2.5]
+    assert generated_values(2.5, 5.5, list(range(4))) == [3, 4, 5, 3]
+    assert generated_values(2.0, 5.5, list(range(5))) == [2, 3, 4, 5, 2]
     assert generated_values(0.0, 1e20, [10**20]) == [10**20]

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import dataclasses
-import math
 import re
 from datetime import timezone
 from typing import Annotated, Any, Literal
@@ -578,40 +577,13 @@ def test_json_schema_test_data_narrow_exclusive_bounds():
         strict_fraction: Annotated[float, Gt(0), Lt(1)]
         rate: Annotated[float, Gt(0.0), Le(1.0)]
         only_one: Annotated[int, Gt(0), Lt(2)]
-        overlapping_bounds: Annotated[float, Field(ge=0, gt=0.9, lt=1)]
-        overlapping_minimum: Annotated[float, Field(ge=0, gt=0.9)]
-        overlapping_maximum: Annotated[float, Field(le=1, lt=0.1)]
-        precision_limited: Annotated[float, Gt(1e16), Lt(1e16 + 4)]
-        precision_limited_minimum: Annotated[float, Gt(1e16)]
-        precision_limited_maximum: Annotated[float, Lt(1e16)]
-        precision_limited_wide_range: Annotated[float, Gt(-1e308), Lt(1e308)]
-        subnormal_positive: Annotated[float, Gt(0.0), Le(5e-324)]
-        subnormal_negative: Annotated[float, Gt(-5e-324), Le(0.0)]
-        precision_limited_inclusive_minimum: Annotated[
-            float, Field(ge=1.0000000000000002, le=2.3, lt=1.0000000000000004)
-        ]
 
     json_schema = TestModel.model_json_schema()
-    for seed in range(5):
+    for seed in range(3):
         data = _JsonSchemaTestData(json_schema, seed=seed).generate()
         TestModel.model_validate(data)
     assert _JsonSchemaTestData(json_schema).generate() == snapshot(
-        {
-            'probability': 0.0,
-            'strict_fraction': 0.5,
-            'rate': 1.0,
-            'only_one': 1,
-            'overlapping_bounds': 0.95,
-            'overlapping_minimum': 0.9000000000000001,
-            'overlapping_maximum': 0.09999999999999999,
-            'precision_limited': 1.0000000000000002e16,
-            'precision_limited_minimum': 1.0000000000000002e16,
-            'precision_limited_maximum': 9999999999999998.0,
-            'precision_limited_wide_range': 0.0,
-            'subnormal_positive': 5e-324,
-            'subnormal_negative': 0.0,
-            'precision_limited_inclusive_minimum': 1.0000000000000002,
-        }
+        {'probability': 0.0, 'strict_fraction': 0.5, 'rate': 1.0, 'only_one': 1}
     )
 
 
@@ -628,97 +600,6 @@ def test_narrow_exclusive_bounds_tool_args():
 
     agent.run_sync('hello', model=TestModel())
     assert calls == snapshot([{'temperature': 0.0}])
-
-
-def test_json_schema_test_data_fractional_integer_exclusive_bounds() -> None:
-    """Integer schemas with fractional exclusive bounds must still yield an integer."""
-
-    schema = {
-        'type': 'object',
-        'required': ['count', 'other', 'inclusive', 'upper_only'],
-        'properties': {
-            'count': {'type': 'integer', 'exclusiveMinimum': 0.1, 'maximum': 1.1},
-            'other': {'type': 'integer', 'exclusiveMinimum': 0.5, 'exclusiveMaximum': 1.5},
-            'inclusive': {'type': 'integer', 'minimum': 0.5, 'exclusiveMaximum': 1.5},
-            'upper_only': {'type': 'integer', 'exclusiveMaximum': 0.5},
-        },
-    }
-
-    for seed in range(3):
-        data = _JsonSchemaTestData(schema, seed=seed).generate()
-        assert isinstance(data['count'], int) and 0.1 < data['count'] <= 1.1
-        assert isinstance(data['other'], int) and 0.5 < data['other'] < 1.5
-        assert isinstance(data['inclusive'], int) and 0.5 <= data['inclusive'] < 1.5
-        assert isinstance(data['upper_only'], int) and data['upper_only'] < 0.5
-
-    assert _JsonSchemaTestData(schema).generate() == snapshot({'count': 1, 'other': 1, 'inclusive': 1, 'upper_only': 0})
-
-
-def test_json_schema_test_data_overlapping_integer_bounds() -> None:
-    schema = {
-        'type': 'integer',
-        'minimum': 0,
-        'exclusiveMinimum': 0.9,
-        'exclusiveMaximum': 2,
-    }
-
-    assert [_JsonSchemaTestData(schema, seed=seed).generate() for seed in range(3)] == [1, 1, 1]
-
-
-def test_json_schema_test_data_all_numeric_bound_combinations() -> None:
-    """Every combination of numeric bound keywords produces values matching the schema."""
-
-    float_bounds = {
-        'minimum': 2**53,
-        'exclusiveMinimum': 2**53,
-        'maximum': 2**53 + 4,
-        'exclusiveMaximum': 2**53 + 4,
-    }
-    integer_bounds = {
-        'minimum': 0.5,
-        'exclusiveMinimum': 0.1,
-        'maximum': 3.5,
-        'exclusiveMaximum': 3.9,
-    }
-    seeds = [-(10**400), -1, 0, 1, 10**400]
-
-    def matches_bounds(value: int | float, schema: dict[str, Any]) -> bool:
-        return not (
-            ('minimum' in schema and value < schema['minimum'])
-            or ('exclusiveMinimum' in schema and value <= schema['exclusiveMinimum'])
-            or ('maximum' in schema and value > schema['maximum'])
-            or ('exclusiveMaximum' in schema and value >= schema['exclusiveMaximum'])
-        )
-
-    for mask in range(1 << len(float_bounds)):
-        number_schema: dict[str, Any] = {'type': 'number'}
-        integer_schema: dict[str, Any] = {'type': 'integer'}
-        for index, (keyword, bound) in enumerate(float_bounds.items()):
-            if mask & (1 << index):
-                number_schema[keyword] = bound
-                integer_schema[keyword] = integer_bounds[keyword]
-
-        for seed in seeds:
-            number = _JsonSchemaTestData(number_schema, seed=seed).generate()
-            integer = _JsonSchemaTestData(integer_schema, seed=seed).generate()
-
-            assert isinstance(number, float) and math.isfinite(number) and matches_bounds(number, number_schema)
-            assert isinstance(integer, int) and matches_bounds(integer, integer_schema)
-
-    huge_bound_schemas = [
-        {'type': 'number', 'minimum': -(10**400)},
-        {'type': 'number', 'maximum': 10**400},
-        {'type': 'number', 'minimum': -(10**400), 'maximum': 1},
-        {'type': 'number', 'minimum': -(10**400), 'maximum': 0.5},
-        {'type': 'number', 'minimum': -1, 'maximum': 10**400},
-    ]
-    for schema in huge_bound_schemas:
-        for seed in seeds:
-            number = _JsonSchemaTestData(schema, seed=seed).generate()
-            assert isinstance(number, float) and math.isfinite(number) and matches_bounds(number, schema)
-
-    invalid_number: Any = _JsonSchemaTestData({'type': 'number', 'minimum': 10**400}).generate()
-    assert math.isnan(invalid_number)
 
 
 def test_chars_wrap():
@@ -792,8 +673,8 @@ def test_different_content_input(content: AudioUrl | VideoUrl | ImageUrl | Binar
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=51, output_tokens=1))
 
 
-def test_int_upper_bound_reachable():
-    """Integer ranges include every valid integer through their effective upper bound."""
+def test_int_inclusive_upper_bound_reachable():
+    """Plain inclusive integer ranges include their ceiling without changing other ranges."""
 
     class MyOutput(BaseModel):
         integer: Annotated[int, Field(ge=2, le=5)]
@@ -814,7 +695,7 @@ def test_int_upper_bound_reachable():
             output.number,
         )
         for output in outputs
-    ] == snapshot([(2, 2, 2, 2, 2.0), (3, 3, 3, 3, 3.0), (4, 4, 4, 4, 4.0), (5, 5, 5, 2, 2.0)])
+    ] == snapshot([(2, 2, 2, 2, 2.0), (3, 3, 3, 3, 3.0), (4, 4, 4, 4, 4.0), (5, 5, 2, 2, 2.0)])
 
     def generated_values(minimum: float, maximum: float, seeds: list[int]) -> list[Any]:
         schema = {
@@ -824,6 +705,6 @@ def test_int_upper_bound_reachable():
         }
         return [_JsonSchemaTestData(schema, seed=seed).generate()['value'] for seed in seeds]
 
-    assert generated_values(2.5, 5.5, list(range(4))) == [3, 4, 5, 3]
-    assert generated_values(2.0, 5.5, list(range(5))) == [2, 3, 4, 5, 2]
+    assert generated_values(2.5, 5.5, list(range(4))) == [2.5, 3.5, 4.5, 2.5]
+    assert generated_values(2.0, 5.5, list(range(5))) == [2.0, 3.0, 4.0, 5.0, 2.5]
     assert generated_values(0.0, 1e20, [10**20]) == [10**20]

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -602,6 +602,38 @@ def test_narrow_exclusive_bounds_tool_args():
     assert calls == snapshot([{'temperature': 0.0}])
 
 
+def test_json_schema_number_fallbacks():
+    """Float fallbacks respect overlapping bounds and representable precision."""
+
+    class TestModel(BaseModel):
+        overlapping: Annotated[float, Field(ge=0, gt=0.9, lt=1)]
+        precision_limited: Annotated[float, Gt(2**53), Le(2**53 + 2)]
+        subnormal: Annotated[float, Gt(0), Le(5e-324)]
+
+    json_schema = TestModel.model_json_schema()
+    data = _JsonSchemaTestData(json_schema).generate()
+    assert data == snapshot({'overlapping': 0.95, 'precision_limited': 9007199254740994.0, 'subnormal': 5e-324})
+    TestModel.model_validate(data)
+
+    assert _JsonSchemaTestData({'type': 'number', 'exclusiveMinimum': 2**53}).generate() == snapshot(9007199254740994.0)
+    assert _JsonSchemaTestData({'type': 'number', 'exclusiveMaximum': -(2**53)}).generate() == snapshot(
+        -9007199254740994.0
+    )
+    assert _JsonSchemaTestData(
+        {'type': 'number', 'minimum': -(10**400), 'exclusiveMinimum': -1, 'maximum': 1}
+    ).generate() == snapshot(0.0)
+    assert _JsonSchemaTestData({'type': 'number', 'minimum': -(10**400), 'maximum': 1.5}).generate() == snapshot(0.0)
+
+    legacy_candidate = _JsonSchemaTestData(
+        {'type': 'number', 'exclusiveMinimum': 0.1, 'exclusiveMaximum': 1}, seed=2
+    ).generate()
+    assert legacy_candidate == pytest.approx(0.9)
+
+    no_representable_float = {'type': 'number', 'exclusiveMinimum': 0, 'exclusiveMaximum': 5e-324}
+    with pytest.raises(ValueError, match='No finite float satisfies'):
+        _JsonSchemaTestData(no_representable_float).generate()
+
+
 def test_chars_wrap():
     class TestModel(BaseModel):
         a: Annotated[set[str], MinLen(4)]

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -709,12 +709,16 @@ def test_json_schema_test_data_all_numeric_bound_combinations() -> None:
         {'type': 'number', 'minimum': -(10**400)},
         {'type': 'number', 'maximum': 10**400},
         {'type': 'number', 'minimum': -(10**400), 'maximum': 1},
+        {'type': 'number', 'minimum': -(10**400), 'maximum': 0.5},
         {'type': 'number', 'minimum': -1, 'maximum': 10**400},
     ]
     for schema in huge_bound_schemas:
         for seed in seeds:
             number = _JsonSchemaTestData(schema, seed=seed).generate()
             assert isinstance(number, float) and math.isfinite(number) and matches_bounds(number, schema)
+
+    invalid_number: Any = _JsonSchemaTestData({'type': 'number', 'minimum': 10**400}).generate()
+    assert math.isnan(invalid_number)
 
 
 def test_chars_wrap():

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -569,6 +569,39 @@ def test_json_schema_test_data_equal_inclusive_bounds():
     TestModel.model_validate(data)
 
 
+def test_json_schema_test_data_narrow_exclusive_bounds():
+    """Narrow ranges with exclusive bounds must not crash or produce out-of-range values."""
+
+    class TestModel(BaseModel):
+        probability: Annotated[float, Ge(0), Lt(1)]
+        strict_fraction: Annotated[float, Gt(0), Lt(1)]
+        rate: Annotated[float, Gt(0.0), Le(1.0)]
+        only_one: Annotated[int, Gt(0), Lt(2)]
+
+    json_schema = TestModel.model_json_schema()
+    for seed in range(3):
+        data = _JsonSchemaTestData(json_schema, seed=seed).generate()
+        TestModel.model_validate(data)
+    assert _JsonSchemaTestData(json_schema).generate() == snapshot(
+        {'probability': 0.0, 'strict_fraction': 0.5, 'rate': 1.0, 'only_one': 1}
+    )
+
+
+def test_narrow_exclusive_bounds_tool_args():
+    """An agent tool with `Field(ge=0, lt=1)`-style parameters runs without errors."""
+
+    agent = Agent()
+    calls: list[dict[str, Any]] = []
+
+    @agent.tool_plain
+    def set_sampling(temperature: Annotated[float, Field(ge=0, lt=1)]) -> str:
+        calls.append({'temperature': temperature})
+        return 'ok'
+
+    agent.run_sync('hello', model=TestModel())
+    assert calls == snapshot([{'temperature': 0.0}])
+
+
 def test_chars_wrap():
     class TestModel(BaseModel):
         a: Annotated[set[str], MinLen(4)]

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -587,6 +587,18 @@ def test_json_schema_test_data_narrow_exclusive_bounds():
     )
 
 
+def test_json_schema_number_uses_strictest_bounds():
+    class TestModel(BaseModel):
+        lower: Annotated[float, Field(ge=0, gt=0.5, le=1)]
+        upper: Annotated[float, Field(ge=0, le=2, lt=0.5)]
+
+    json_schema = TestModel.model_json_schema()
+    for seed in range(3):
+        data = _JsonSchemaTestData(json_schema, seed=seed).generate()
+        TestModel.model_validate(data)
+    assert _JsonSchemaTestData(json_schema).generate() == snapshot({'lower': 0.75, 'upper': 0.0})
+
+
 def test_narrow_exclusive_bounds_tool_args():
     """An agent tool with `Field(ge=0, lt=1)`-style parameters runs without errors."""
 

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -583,7 +583,7 @@ def test_json_schema_test_data_narrow_exclusive_bounds():
         data = _JsonSchemaTestData(json_schema, seed=seed).generate()
         TestModel.model_validate(data)
     assert _JsonSchemaTestData(json_schema).generate() == snapshot(
-        {'probability': 0.0, 'strict_fraction': 0.5, 'rate': 1.0, 'only_one': 1}
+        {'probability': 0.0, 'strict_fraction': 0.5, 'rate': 0.5, 'only_one': 1}
     )
 
 
@@ -602,36 +602,10 @@ def test_narrow_exclusive_bounds_tool_args():
     assert calls == snapshot([{'temperature': 0.0}])
 
 
-def test_json_schema_number_fallbacks():
-    """Float fallbacks respect overlapping bounds and representable precision."""
-
-    class TestModel(BaseModel):
-        overlapping: Annotated[float, Field(ge=0, gt=0.9, lt=1)]
-        precision_limited: Annotated[float, Gt(2**53), Le(2**53 + 2)]
-        subnormal: Annotated[float, Gt(0), Le(5e-324)]
-
-    json_schema = TestModel.model_json_schema()
-    data = _JsonSchemaTestData(json_schema).generate()
-    assert data == snapshot({'overlapping': 0.95, 'precision_limited': 9007199254740994.0, 'subnormal': 5e-324})
-    TestModel.model_validate(data)
-
-    assert _JsonSchemaTestData({'type': 'number', 'exclusiveMinimum': 2**53}).generate() == snapshot(9007199254740994.0)
-    assert _JsonSchemaTestData({'type': 'number', 'exclusiveMaximum': -(2**53)}).generate() == snapshot(
-        -9007199254740994.0
-    )
-    assert _JsonSchemaTestData(
-        {'type': 'number', 'minimum': -(10**400), 'exclusiveMinimum': -1, 'maximum': 1}
-    ).generate() == snapshot(0.0)
-    assert _JsonSchemaTestData({'type': 'number', 'minimum': -(10**400), 'maximum': 1.5}).generate() == snapshot(0.0)
-
-    legacy_candidate = _JsonSchemaTestData(
-        {'type': 'number', 'exclusiveMinimum': 0.1, 'exclusiveMaximum': 1}, seed=2
-    ).generate()
-    assert legacy_candidate == pytest.approx(0.9)
-
-    no_representable_float = {'type': 'number', 'exclusiveMinimum': 0, 'exclusiveMaximum': 5e-324}
-    with pytest.raises(ValueError, match='No finite float satisfies'):
-        _JsonSchemaTestData(no_representable_float).generate()
+def test_json_schema_number_generation():
+    assert _JsonSchemaTestData({'type': 'number', 'exclusiveMinimum': 0}).generate() == 1.0
+    assert _JsonSchemaTestData({'type': 'number', 'exclusiveMaximum': 0}).generate() == -1.0
+    assert _JsonSchemaTestData({'type': 'number'}).generate() == 0.0
 
 
 def test_chars_wrap():

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -577,13 +577,40 @@ def test_json_schema_test_data_narrow_exclusive_bounds():
         strict_fraction: Annotated[float, Gt(0), Lt(1)]
         rate: Annotated[float, Gt(0.0), Le(1.0)]
         only_one: Annotated[int, Gt(0), Lt(2)]
+        overlapping_bounds: Annotated[float, Field(ge=0, gt=0.9, lt=1)]
+        overlapping_minimum: Annotated[float, Field(ge=0, gt=0.9)]
+        overlapping_maximum: Annotated[float, Field(le=1, lt=0.1)]
+        precision_limited: Annotated[float, Gt(1e16), Lt(1e16 + 4)]
+        precision_limited_minimum: Annotated[float, Gt(1e16)]
+        precision_limited_maximum: Annotated[float, Lt(1e16)]
+        precision_limited_wide_range: Annotated[float, Gt(-1e308), Lt(1e308)]
+        subnormal_positive: Annotated[float, Gt(0.0), Le(5e-324)]
+        subnormal_negative: Annotated[float, Gt(-5e-324), Le(0.0)]
+        precision_limited_inclusive_minimum: Annotated[
+            float, Field(ge=1.0000000000000002, le=2.3, lt=1.0000000000000004)
+        ]
 
     json_schema = TestModel.model_json_schema()
-    for seed in range(3):
+    for seed in range(5):
         data = _JsonSchemaTestData(json_schema, seed=seed).generate()
         TestModel.model_validate(data)
     assert _JsonSchemaTestData(json_schema).generate() == snapshot(
-        {'probability': 0.0, 'strict_fraction': 0.5, 'rate': 1.0, 'only_one': 1}
+        {
+            'probability': 0.0,
+            'strict_fraction': 0.5,
+            'rate': 1.0,
+            'only_one': 1,
+            'overlapping_bounds': 0.95,
+            'overlapping_minimum': 0.9000000000000001,
+            'overlapping_maximum': 0.09999999999999999,
+            'precision_limited': 1.0000000000000002e16,
+            'precision_limited_minimum': 1.0000000000000002e16,
+            'precision_limited_maximum': 9999999999999998.0,
+            'precision_limited_wide_range': 0.0,
+            'subnormal_positive': 5e-324,
+            'subnormal_negative': 0.0,
+            'precision_limited_inclusive_minimum': 1.0000000000000002,
+        }
     )
 
 
@@ -602,16 +629,17 @@ def test_narrow_exclusive_bounds_tool_args():
     assert calls == snapshot([{'temperature': 0.0}])
 
 
-def test_json_schema_test_data_integer_fractional_bounds() -> None:
-    """Integer schemas can carry fractional bounds, which must still yield an integer."""
+def test_json_schema_test_data_fractional_integer_exclusive_bounds() -> None:
+    """Integer schemas with fractional exclusive bounds must still yield an integer."""
 
     schema = {
         'type': 'object',
-        'required': ['count', 'other', 'inclusive'],
+        'required': ['count', 'other', 'inclusive', 'upper_only'],
         'properties': {
             'count': {'type': 'integer', 'exclusiveMinimum': 0.1, 'maximum': 1.1},
             'other': {'type': 'integer', 'exclusiveMinimum': 0.5, 'exclusiveMaximum': 1.5},
             'inclusive': {'type': 'integer', 'minimum': 0.5, 'exclusiveMaximum': 1.5},
+            'upper_only': {'type': 'integer', 'exclusiveMaximum': 0.5},
         },
     }
 
@@ -620,8 +648,20 @@ def test_json_schema_test_data_integer_fractional_bounds() -> None:
         assert isinstance(data['count'], int) and 0.1 < data['count'] <= 1.1
         assert isinstance(data['other'], int) and 0.5 < data['other'] < 1.5
         assert isinstance(data['inclusive'], int) and 0.5 <= data['inclusive'] < 1.5
+        assert isinstance(data['upper_only'], int) and data['upper_only'] < 0.5
 
-    assert _JsonSchemaTestData(schema).generate() == snapshot({'count': 1, 'other': 1, 'inclusive': 1})
+    assert _JsonSchemaTestData(schema).generate() == snapshot({'count': 1, 'other': 1, 'inclusive': 1, 'upper_only': 0})
+
+
+def test_json_schema_test_data_overlapping_integer_bounds() -> None:
+    schema = {
+        'type': 'integer',
+        'minimum': 0,
+        'exclusiveMinimum': 0.9,
+        'exclusiveMaximum': 2,
+    }
+
+    assert [_JsonSchemaTestData(schema, seed=seed).generate() for seed in range(3)] == [1, 1, 1]
 
 
 def test_chars_wrap():

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -607,10 +607,11 @@ def test_json_schema_test_data_integer_fractional_bounds() -> None:
 
     schema = {
         'type': 'object',
-        'required': ['count', 'other'],
+        'required': ['count', 'other', 'inclusive'],
         'properties': {
             'count': {'type': 'integer', 'exclusiveMinimum': 0.1, 'maximum': 1.1},
             'other': {'type': 'integer', 'exclusiveMinimum': 0.5, 'exclusiveMaximum': 1.5},
+            'inclusive': {'type': 'integer', 'minimum': 0.5, 'exclusiveMaximum': 1.5},
         },
     }
 
@@ -618,8 +619,9 @@ def test_json_schema_test_data_integer_fractional_bounds() -> None:
         data = _JsonSchemaTestData(schema, seed=seed).generate()
         assert isinstance(data['count'], int) and 0.1 < data['count'] <= 1.1
         assert isinstance(data['other'], int) and 0.5 < data['other'] < 1.5
+        assert isinstance(data['inclusive'], int) and 0.5 <= data['inclusive'] < 1.5
 
-    assert _JsonSchemaTestData(schema).generate() == snapshot({'count': 1, 'other': 1})
+    assert _JsonSchemaTestData(schema).generate() == snapshot({'count': 1, 'other': 1, 'inclusive': 1})
 
 
 def test_chars_wrap():

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -602,6 +602,26 @@ def test_narrow_exclusive_bounds_tool_args():
     assert calls == snapshot([{'temperature': 0.0}])
 
 
+def test_json_schema_test_data_integer_fractional_bounds() -> None:
+    """Integer schemas can carry fractional bounds, which must still yield an integer."""
+
+    schema = {
+        'type': 'object',
+        'required': ['count', 'other'],
+        'properties': {
+            'count': {'type': 'integer', 'exclusiveMinimum': 0.1, 'maximum': 1.1},
+            'other': {'type': 'integer', 'exclusiveMinimum': 0.5, 'exclusiveMaximum': 1.5},
+        },
+    }
+
+    for seed in range(3):
+        data = _JsonSchemaTestData(schema, seed=seed).generate()
+        assert isinstance(data['count'], int) and 0.1 < data['count'] <= 1.1
+        assert isinstance(data['other'], int) and 0.5 < data['other'] < 1.5
+
+    assert _JsonSchemaTestData(schema).generate() == snapshot({'count': 1, 'other': 1})
+
+
 def test_chars_wrap():
     class TestModel(BaseModel):
         a: Annotated[set[str], MinLen(4)]


### PR DESCRIPTION
- Closes #7798

`TestModel` generated JSON Schema `number` values through the integer generator. Its integer-sized `±1` adjustments collapse or invert narrow float ranges, causing `ZeroDivisionError` or invalid tool arguments.

This separates the numeric domains:

- `integer` schemas continue to use `_int_gen`, with a guard for a valid collapsed span.
- `number` schemas use a small float-native `_number_gen` based on the raw bounds.
- When a seeded value lands on an exclusive lower bound, generation uses the interval midpoint.

For example, `0 <= x < 1` generates `0.0`, while `0 < x < 1` generates `0.5`.

Generated values for some wider ranges with an exclusive lower bound may change while remaining valid. This deliberately removes the integer-style `+1` rule from float generation.

Regression tests cover the four reported bound shapes across multiple seeds, the agent tool reproduction, equal bounds, one-sided bounds, and unbounded numbers.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).