### PR TITLE
Add compaction lifecycle events (`CompactionStartEvent`, `CompactionEndEvent`), emitted by stateless `OpenAICompaction`

### DIFF
--- a/docs/capabilities/compaction.md
+++ b/docs/capabilities/compaction.md
@@ -35,3 +35,33 @@ To compact on any model, edit the message history yourself with a [history proce
 ## Pydantic AI Harness
 
 [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/) packages a menu of ready-made, model-agnostic [compaction strategies](https://pydantic.dev/docs/ai/harness/compaction/): mostly zero-LLM history editing (sliding-window trimming, clearing old tool results, deduplicating repeated file reads, clamping oversized message parts) plus LLM summarization for when that's not enough, and a `TieredCompaction` orchestrator (the recommended default) that escalates from cheap to expensive strategies only as far as needed to fit the target.
+
+## Compaction events
+
+Compaction is a memory wipe: whatever it drops, the model can never get back. So that other capabilities and application code can react — or object — the compaction capabilities that run client-side announce their work through one shared [capability event](overview.md#capability-events) family (a [history processor](#model-agnostic-compaction) you write yourself doesn't emit these automatically, but it can emit the same family):
+
+- [`CompactionStartEvent`][pydantic_ai.capabilities.CompactionStartEvent] is emitted before compaction runs. It is [dispatched immediately](overview.md#reacting-to-events), and any listener may call [`cancel()`][pydantic_ai.capabilities.CompactionStartEvent.cancel] to skip this attempt — for example, a capability that is mid-activity and needs the full history intact for one more turn. Cancelling is per-attempt: the compacting capability re-attempts the next time its trigger condition is met.
+- [`CompactionEndEvent`][pydantic_ai.capabilities.CompactionEndEvent] is emitted after history was actually compacted, with before/after message counts (and token sizes, when the emitter knows them).
+
+A capability subscribes with [`@on_event`][pydantic_ai.capabilities.on_event]; application code can use [`hooks.on.event`](../hooks.md):
+
+```python {title="hold_compaction.py"}
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    CompactionStartEvent,
+    on_event,
+)
+
+
+class KeepFullHistory(AbstractCapability[Any]):
+    @on_event(CompactionStartEvent)
+    async def _hold(
+        self, ctx: RunContext[Any], event: CompactionStartEvent
+    ) -> None:
+        event.cancel('history must stay intact')
+```
+
+The events are emitted wherever the compacting code runs client-side and can observe (or decide) the compaction: [`OpenAICompaction`][pydantic_ai.models.openai.OpenAICompaction] in stateless mode emits both, around its `/responses/compact` call. Server-side compaction — Anthropic's, and OpenAI's stateful mode — is decided and performed by the provider inside the model response itself, so there is no client-side moment to cancel; it surfaces as a [`CompactionPart`][pydantic_ai.messages.CompactionPart] in the response stream instead.

--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -313,7 +313,7 @@ Name the classes when you can. Beyond narrowing the `event` argument for the typ
 
 Listeners run sequentially in capability order, and marked methods within one capability run in definition order. The emitting capability also receives its own events. By default, listeners run when the event reaches its position in the stream, so listener ordering always matches stream ordering and listener work does not add to the emitter's latency. For events emitted during tool execution, listeners run before the next model request. An event emitted during `before_model_request` may only reach listeners after that request begins, with the same as-soon-as-possible timing as [`ctx.enqueue()`][pydantic_ai.tools.RunContext.enqueue].
 
-Decision events that need listener mutations before the emitter continues declare `dispatch='immediate'` on the event class:
+Decision events that need listener mutations before the emitter continues declare `dispatch='immediate'` on the event class, with the decision fields alongside. The built-in [compaction events](compaction.md#compaction-events) are declared this way: [`CompactionStartEvent`][pydantic_ai.capabilities.CompactionStartEvent] carries `cancelled`/`cancel_reason` and a `cancel()` method, so any capability can hold a compaction attempt.
 
 Building on the file-system capability above, a write can announce itself before it happens and let a listener veto it:
 

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -383,6 +383,8 @@ agent = Agent(
 
 The mode is inferred from which parameters you pass: supplying `message_count_threshold` or `trigger` implies stateless mode, otherwise stateful mode is used. You can also pass `stateless=True` or `stateless=False` explicitly. Mixing parameters from different modes raises [`UserError`][pydantic_ai.exceptions.UserError].
 
+Because stateless mode decides compaction client-side, it emits the [compaction lifecycle events](../capabilities/compaction.md#compaction-events): a cancellable [`CompactionStartEvent`][pydantic_ai.capabilities.CompactionStartEvent] before calling the endpoint and a [`CompactionEndEvent`][pydantic_ai.capabilities.CompactionEndEvent] after.
+
 !!! tip
     Stateful compaction pairs especially well with [`openai_previous_response_id='auto'`](#referencing-earlier-responses) or [`openai_conversation_id`](#using-durable-conversations). Both rely on OpenAI's server-side conversation state, so OpenAI can use a previously compacted context as the starting point for the next turn without you having to resend it.
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -37,6 +37,7 @@ from .abstract import (
 )
 from .capability import Capability
 from .combined import CombinedCapability
+from .compaction import COMPACTION_EVENT_NAMESPACE, CompactionEndEvent, CompactionStartEvent
 from .content_filter import RaiseContentFilterError
 from .deferred_tool_handler import HandleDeferredToolCalls
 from .durable_operation import durable_operation
@@ -129,6 +130,9 @@ __all__ = [
     'RaiseContentFilterError',
     'Capability',
     'CAPABILITY_TYPES',
+    'COMPACTION_EVENT_NAMESPACE',
+    'CompactionEndEvent',
+    'CompactionStartEvent',
     'ImageGeneration',
     'Instrumentation',
     'IncludeToolReturnSchemas',

--- a/pydantic_ai_slim/pydantic_ai/capabilities/compaction.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/compaction.py
@@ -1,0 +1,88 @@
+"""Lifecycle events for history compaction.
+
+One event family shared by everything that compacts history: the provider-native
+[`OpenAICompaction`][pydantic_ai.models.openai.OpenAICompaction] and
+[`AnthropicCompaction`][pydantic_ai.models.anthropic.AnthropicCompaction] capabilities, and the
+model-agnostic [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/compaction/) strategies.
+Subscribers use one vocabulary regardless of which mechanism is doing the compacting.
+
+The events are only emitted where the compacting code runs client-side and can observe (or decide)
+the compaction. Server-side compaction — Anthropic's `context_management`, OpenAI's stateful mode —
+happens inside the model response itself, surfacing as a
+[`CompactionPart`][pydantic_ai.messages.CompactionPart] in the stream instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai.messages import CapabilityEvent
+
+COMPACTION_EVENT_NAMESPACE = 'compaction'
+"""The [`CapabilityEvent`][pydantic_ai.messages.CapabilityEvent] namespace of the compaction event family."""
+
+
+@dataclass(repr=False, kw_only=True)
+class CompactionStartEvent(CapabilityEvent, namespace=COMPACTION_EVENT_NAMESPACE, name='start', dispatch='immediate'):
+    """Emitted before history is compacted; listeners may [`cancel()`][pydantic_ai.capabilities.CompactionStartEvent.cancel] the attempt.
+
+    Dispatched immediately: the emitter awaits the listener chain before proceeding and honors
+    [`cancelled`][pydantic_ai.capabilities.CompactionStartEvent.cancelled], so a
+    capability (or app code via `hooks.on.event`) can hold compaction while it's mid-activity.
+    Cancelling skips this attempt only — the compacting capability re-attempts the next time its
+    trigger condition is met.
+    """
+
+    strategy: str
+    """A stable identifier for the compacting mechanism, e.g. `'openai'` or `'summarizing'`.
+
+    Emitters must pick an explicit identifier that is safe to persist and branch on — never a
+    Python class name, which a refactor could silently change under dashboards and stored records.
+    """
+
+    messages_before: int
+    """The number of messages subject to this compaction attempt.
+
+    Emitters that compact a slice of the history (e.g. everything except the current request)
+    count that slice, not the full message list.
+    """
+
+    tokens_before: int | None = None
+    """The emitter's (typically estimated) token size of the history being compacted, when it has one."""
+
+    cancelled: bool = False
+    """Whether a listener cancelled this compaction attempt."""
+
+    cancel_reason: str | None = None
+    """The reason given by the cancelling listener, if any."""
+
+    def cancel(self, reason: str | None = None) -> None:
+        """Cancel this compaction attempt.
+
+        Args:
+            reason: Optional human-readable reason, stored on
+                [`cancel_reason`][pydantic_ai.capabilities.CompactionStartEvent.cancel_reason].
+        """
+        self.cancelled = True
+        self.cancel_reason = reason
+
+
+@dataclass(repr=False, kw_only=True)
+class CompactionEndEvent(CapabilityEvent, namespace=COMPACTION_EVENT_NAMESPACE, name='end'):
+    """Emitted after history was actually compacted (not when an attempt was cancelled or a no-op)."""
+
+    strategy: str
+    """Identifies the compaction mechanism, matching
+    [`CompactionStartEvent.strategy`][pydantic_ai.capabilities.CompactionStartEvent.strategy]."""
+
+    messages_before: int
+    """The number of messages the compaction operated on."""
+
+    messages_after: int
+    """The number of messages that replaced them."""
+
+    tokens_before: int | None = None
+    """The history's token size before compaction, when the emitter knows it."""
+
+    tokens_after: int | None = None
+    """The history's token size after compaction, when the emitter knows it."""

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -39,6 +39,7 @@ from .._utils import (
     number_to_datetime,
 )
 from ..capabilities.abstract import AbstractCapability
+from ..capabilities.compaction import CompactionEndEvent, CompactionStartEvent
 from ..exceptions import SuspendedResponseExpired, UserError
 from ..messages import (
     STANDING_PROMPT_PLANTED_KEY,
@@ -4812,6 +4813,11 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
 
       Requires either `message_count_threshold` or a custom `trigger` callable.
 
+      Because compaction is decided client-side in this mode, the capability emits a
+      cancellable [`CompactionStartEvent`][pydantic_ai.capabilities.CompactionStartEvent]
+      before calling the endpoint and a
+      [`CompactionEndEvent`][pydantic_ai.capabilities.CompactionEndEvent] after.
+
     If `stateless` is not set, it is inferred from which parameters you
     provide: passing any stateless-only parameter (`message_count_threshold`
     or `trigger`) implies `stateless=True`; otherwise stateful mode is used.
@@ -4949,10 +4955,15 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
         if len(request_context.messages) < 2:  # pragma: no cover
             return request_context
 
-        # Compact all messages except the last (current) request
+        # All messages except the last (current) request are compacted; the events count that window.
+        compact_window = request_context.messages[:-1]
+        start_event = await ctx.emit(CompactionStartEvent(strategy='openai', messages_before=len(compact_window)))
+        if start_event.cancelled:
+            return request_context
+
         compact_ctx = ModelRequestContext(
             model=request_context.model,
-            messages=request_context.messages[:-1],
+            messages=compact_window,
             model_settings=request_context.model_settings,
             model_request_parameters=request_context.model_request_parameters,
         )
@@ -4960,6 +4971,13 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
 
         # Replace message history with compaction + last request
         request_context.messages = [compacted_response, request_context.messages[-1]]
+        await ctx.emit(
+            CompactionEndEvent(
+                strategy='openai',
+                messages_before=len(compact_window),
+                messages_after=1,
+            )
+        )
         return request_context
 
     @classmethod

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_compact_emits_lifecycle_events.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_compact_emits_lifecycle_events.yaml
@@ -1,0 +1,382 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '169'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 2+2?
+        role: user
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+      stream: true
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_08c971828c85c4d4006a8f9af99c6c87d1a88453c153fa5cc4","object":"response","created_at":1787796217,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_08c971828c85c4d4006a8f9af99c6c87d1a88453c153fa5cc4","object":"response","created_at":1787796217,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"u6AbCwi0020UCTB","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"krwMtvJmwhfJ7G","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"YTxZ4A9uwWdcUWu","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"Wu4WKfMuhKCotzG","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"7NgMhaYze1AWk9","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"Xvl8HLOOszBC8rL","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"3jylhaKi6RuEM9I","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"obfuscation":"jVF5OOYdG8CA3LA","output_index":0,"sequence_number":11}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","logprobs":[],"output_index":0,"sequence_number":12,"text":"2 + 2 = 4."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2 + 2 = 4."},"sequence_number":13}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2 + 2 = 4."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_08c971828c85c4d4006a8f9af99c6c87d1a88453c153fa5cc4","object":"response","created_at":1787796217,"status":"completed","background":false,"completed_at":1787796219,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_08c971828c85c4d4006a8f9afb739c87d1b401234e3cd42e94","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2 + 2 = 4."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":29,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38},"user":null,"metadata":{}},"sequence_number":15}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '283'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '258'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 2+2?
+        role: user
+      - content: 2 + 2 = 4.
+        role: assistant
+      - content: And 3+3?
+        role: user
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+      stream: true
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_0d8f57ee10bf6ae4006a8f9afbfca487d1986ce8a5f6b026ca","object":"response","created_at":1787796220,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_0d8f57ee10bf6ae4006a8f9afbfca487d1986ce8a5f6b026ca","object":"response","created_at":1787796220,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"3","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"lVhsGOWSrugKteR","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"YL53IpIc0jZk2L","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"1CLBn4OjESKvti8","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"3","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"rZDd11fi9gd6NRQ","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"1byN7AXU3svJBy","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"ScFk87CvtHyM8yj","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"6","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"belwOgq4137sLby","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"obfuscation":"uLP4BCep8lR9Bky","output_index":0,"sequence_number":11}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","logprobs":[],"output_index":0,"sequence_number":12,"text":"3 + 3 = 6."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"3 + 3 = 6."},"sequence_number":13}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"3 + 3 = 6."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_0d8f57ee10bf6ae4006a8f9afbfca487d1986ce8a5f6b026ca","object":"response","created_at":1787796220,"status":"completed","background":false,"completed_at":1787796224,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_0d8f57ee10bf6ae4006a8f9b00230887d1b08a23b23413b564","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"3 + 3 = 6."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":51,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":60},"user":null,"metadata":{}},"sequence_number":15}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '149'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '290'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 2+2?
+        role: user
+      - content: 2 + 2 = 4.
+        role: assistant
+      - content: And 3+3?
+        role: user
+      - content: 3 + 3 = 6.
+        role: assistant
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+    uri: https://api.openai.com/v1/responses/compact
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '3959'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '3174'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      created_at: 1787796227
+      id: resp_05d83fb410978bbd016a8f9b009ec487d188c6fa5bf7f6c3ac
+      object: response.compaction
+      output:
+      - content:
+        - text: What is 2+2?
+          type: input_text
+        id: msg_05d83fb410978bbd016a8f9b00a4e487d1b936f1ca18efe295
+        role: user
+        status: completed
+        type: message
+      - content:
+        - text: And 3+3?
+          type: input_text
+        id: msg_05d83fb410978bbd016a8f9b00a51c87d1a651724591b16ae1
+        role: user
+        status: completed
+        type: message
+      - encrypted_content: gAAAAABqj5sDNyZeD6k_HfCoxvLitd0zAB2cTvfSZtXhZqPfm4EuxFJHRMYQM97TqAtIE9W0DqaaHd6opJBoQDLNxiqjFjeck1HE8E4VFl1JnuoebNBzCPyPELjUhzKf42zVSr4OQ559AcOZPeT1q2nhqA-snJcnxrZCrB6wrI7tvA7C_GYvUhJQQBqqXbQSwR98x5rAYO9sB5MqiafuzA2Z9JGOdGfluTtQWUIy0MmDEve038Ggro9AW8Qt_8sUPPjIA8EAo-ECqdbBS7zOgwoAqgyuj4rbJI7dBw4DduH8rBkrMmK4GIRN6HK84754jMA1LyzBuaRF9uHgdQTykJoN5FC3kivVNQ_Qj3GCCdA7mPFDnr_wI3o7ZqnohRPrZ0bjoenAeUc97JgbMwGLmXYCC2xlRC9AqnSUWRP-uJq-O5X4CwnyOwFwIHs6-PAPMmZMbh5xSI9E--ejj5S1YwezfP9a6R83lB6suX2ZcBFKu2u2-_j7KfVLmDuL_XSJjFEPBhkUJnF06b3G3LNl6fh5jHqgBWEt6cAaq3W2cgDMEsfthsKWufqsxJTNa6veGGjnlkDSzQqoTkv7gGnEbu69dZAlGEPQChXhNhQWGKAANAvYtevyGjOWO3a2TwLOiiyfRJkxOzEV8zhO2Pbt1rKLjYvzlVdAtoS3BpOCiqlOSTBTq2PzZeb8NbhgpCH6Zu63VETSspakEGnMp9rccsG1ALDb_ZBfPGh-nV3p6WOwWOSJ7KDbyn-mnaW2nwsHVKhUJ6bVGCx3bsXg3E-fDGRW4Pj7gylMEwrZO050cSQKo30cnTtAoyTwA1EuOtfG65rPPNj650ZbM8Z3gXKF4iR057_XbZ1xnrFi7ggamGf7i7p0x6lP8EJvSsecDYQ4dyP0n6Kej2d7ezyXV6iBe1mhqUkLNLSomn5quMMBCLGU51IoX4UXPPY_1_3-ZbyW0R2f9DUoq42-ZH24KRDdVPmsT75YKRHmopp3bhtCitIsvNF62zoATgtE5wMPJX8JBHO44LZcPTmb4Zm-KnG8j610X8nQ2mKxj2DmqLw28pCyPAgvFmpBAu_UKq8WPF5PZtbsxwQKfzi0Jrhmm4-l7yYq3L7t99r1NuG-igu4hNrIRWLTRddVgOAT7Rm9MHaffkeFOoJc7OyDlMrW1LJkK1-o2FlA9ZCC0uMDG_nvrHWLxlErN658z75EWUG6MfJaAaRVzwsAzxdHBYvMEZrgsdgvJYd4G7eeynMru6ZbCKH5SibDkE7QlC3TZHJ9r4Qr8khKY_eq8DE9YV_6uGmx7UM5YxOH6UrBagJuJOQAdJGbGGOmne0mSwdYJpw7ETnxFBmS8zT9reP7HwmnTb4Lg28Vxv72ABq4n0QuIwPfTrqeMNb7ZnHPEuj9xP1pTPicxI7n13dUgZjFCA3PKZoEshMCAaiZcgsvTXIoBnGFRnq5og5M6ZEFFeYVcTLHD2W8vFXexfnnU4yc3_6WIYURWhp6tVHijwSAQ5DF30rUvXsOVJ1q6TsoNmqmeg7IukGRSTlOjIb7CoXvYqKHdj0eBScUcWJPOlhtl6drYqZuZ_VfAX6-r8XL_6w6GIZX8rTwvzcZsPpgF9Ht9gpJ0IIHOhPtEyWVVSPIGC0gHo6ZyxPIe2G23FC4_32hhluEqirde8B0xXC0MC8YYR3g7KdCQeq9WwerghXC1xDhegjSFfpNxVLD4wDnNlzqyqatOxa7-0YfbQ84wTLw9ocA9cvpQdzRz3HDVjiUX85s7xqQapQSXc90--yi7UR3slAZfdRzXX8GgXgRCT7JDajzPF8k1URIsTRroiKNv6UBuAD2FEsXd2E2yZqFKVCF8DHHWm-XoNjDA0mkZZq17Nw03EaMcE_IfsiBSqNmu6P0ga3ibmLjGrju-yCMTkHWBKiyGybiiDd2tJ75-zqZBFXsl-1XVynEpQoyVGwmW1yC8mcdI2rTNEBNBdYZUAfcsK94m3vtt6ABK21igjIMgD-P3ymvYzlraupteAPaFXbC8u_yARg8Swdgrv1hLnjogF3Q0IcFBqnu_jarMvYcfxKowle7xw-GauzYaviMeRGV3Qz7QpRw9tW_8NOwYq6xlxadmD4LBvQ8CqitbWHFf1GitymKcYB5Qs2UMUM3gIRGevGFgmIkaBBdAtBJORxV1YBzZD9ypWpMgopPOCoA27lEJ1Fmv2yCofMb6TuOIo8cfJsx1GfDO-X8Fxh7eooqEBDCb-BgqtytsdyLr9jtcWcHm-96Ytnl4ea8i89ACpSbU_L_ryN5ePcGz1I0upNBfSjgC4O9G71a9v5tZZk2KjKQVwV-ZBh6uUgLbjZLP7vPN1fnr40BXyf8GsgWUuPcLSQfbsGi4q7fjeSZeqk6t4VBQuLAAVHh0Lcu9tsZrM5urqNL0tDJvrj8U9u15oOT43irurLNZR4PSkIqIK9ZzcaMtUd-fKOUJmGOsk_atOQ0I428kmM_KxJjSC2HNw64E27Vu75-J1mXxiYrZbrOJHKnE9hIzPKUiDIodXNp6MFXpchgvzceH8BJJxfMmQLNUncqa_Rbs34r5Tbeugyw8yVA_SQCKdYmuHnfF2NhSc0HSEgwwRsjYA2ykYrU2qAA47OPql8vslhGN7J9DkNOthSHf2ezqlOESBMuHraGi6dxmuI7B57MokubLLQwlNhyMoafxSjp3Mj3C3FIbmkEIbTNblDkjo_DUTV2GJRbeFU1NnYSFbNYnfTlCilQD2rQikuPPEoNK8tLObssX-6ckA6CK0KrdAxKsxPZ-eUUb2xgH0_YTPjvtgdOdGWGnNTzOxN-GZBe3d37zTpXgCw1NVOiP5eMEuNjB4eC4PNUFYEpKUgtrUuWGg_p96yO-BtumSLahCfV4iHHtsFnpGIc_0gTV3omeD-21qpZXlHG-J6w794_kn4mpjUNF_mPTxzNhjwwQqkXMJGrLyDk3zqtqxTXmdu850NzJk6hy4kCPHzc-3Wobb2ZgnNbjod6sjIrj8xLq1voX3PfjgMRpoWWtZsgdMYg6krPg4sTRhChIXOEmaabfHu8hyQOliyKxDD9xaD_J2DYKZmC4mZFQgKY4L0khOZhTyaVdPtg4M8WUA7G1p1gT5pcVSnxTfME8rPuNpK7ZV3t4wACD5DMdFic
+        id: cmp_05d83fb410978bbd016a8f9b01f27487d1934e3b6fc9d3cbdb
+        type: compaction
+      usage:
+        input_tokens: 156
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 178
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 334
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '3426'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - encrypted_content: gAAAAABqj5sDNyZeD6k_HfCoxvLitd0zAB2cTvfSZtXhZqPfm4EuxFJHRMYQM97TqAtIE9W0DqaaHd6opJBoQDLNxiqjFjeck1HE8E4VFl1JnuoebNBzCPyPELjUhzKf42zVSr4OQ559AcOZPeT1q2nhqA-snJcnxrZCrB6wrI7tvA7C_GYvUhJQQBqqXbQSwR98x5rAYO9sB5MqiafuzA2Z9JGOdGfluTtQWUIy0MmDEve038Ggro9AW8Qt_8sUPPjIA8EAo-ECqdbBS7zOgwoAqgyuj4rbJI7dBw4DduH8rBkrMmK4GIRN6HK84754jMA1LyzBuaRF9uHgdQTykJoN5FC3kivVNQ_Qj3GCCdA7mPFDnr_wI3o7ZqnohRPrZ0bjoenAeUc97JgbMwGLmXYCC2xlRC9AqnSUWRP-uJq-O5X4CwnyOwFwIHs6-PAPMmZMbh5xSI9E--ejj5S1YwezfP9a6R83lB6suX2ZcBFKu2u2-_j7KfVLmDuL_XSJjFEPBhkUJnF06b3G3LNl6fh5jHqgBWEt6cAaq3W2cgDMEsfthsKWufqsxJTNa6veGGjnlkDSzQqoTkv7gGnEbu69dZAlGEPQChXhNhQWGKAANAvYtevyGjOWO3a2TwLOiiyfRJkxOzEV8zhO2Pbt1rKLjYvzlVdAtoS3BpOCiqlOSTBTq2PzZeb8NbhgpCH6Zu63VETSspakEGnMp9rccsG1ALDb_ZBfPGh-nV3p6WOwWOSJ7KDbyn-mnaW2nwsHVKhUJ6bVGCx3bsXg3E-fDGRW4Pj7gylMEwrZO050cSQKo30cnTtAoyTwA1EuOtfG65rPPNj650ZbM8Z3gXKF4iR057_XbZ1xnrFi7ggamGf7i7p0x6lP8EJvSsecDYQ4dyP0n6Kej2d7ezyXV6iBe1mhqUkLNLSomn5quMMBCLGU51IoX4UXPPY_1_3-ZbyW0R2f9DUoq42-ZH24KRDdVPmsT75YKRHmopp3bhtCitIsvNF62zoATgtE5wMPJX8JBHO44LZcPTmb4Zm-KnG8j610X8nQ2mKxj2DmqLw28pCyPAgvFmpBAu_UKq8WPF5PZtbsxwQKfzi0Jrhmm4-l7yYq3L7t99r1NuG-igu4hNrIRWLTRddVgOAT7Rm9MHaffkeFOoJc7OyDlMrW1LJkK1-o2FlA9ZCC0uMDG_nvrHWLxlErN658z75EWUG6MfJaAaRVzwsAzxdHBYvMEZrgsdgvJYd4G7eeynMru6ZbCKH5SibDkE7QlC3TZHJ9r4Qr8khKY_eq8DE9YV_6uGmx7UM5YxOH6UrBagJuJOQAdJGbGGOmne0mSwdYJpw7ETnxFBmS8zT9reP7HwmnTb4Lg28Vxv72ABq4n0QuIwPfTrqeMNb7ZnHPEuj9xP1pTPicxI7n13dUgZjFCA3PKZoEshMCAaiZcgsvTXIoBnGFRnq5og5M6ZEFFeYVcTLHD2W8vFXexfnnU4yc3_6WIYURWhp6tVHijwSAQ5DF30rUvXsOVJ1q6TsoNmqmeg7IukGRSTlOjIb7CoXvYqKHdj0eBScUcWJPOlhtl6drYqZuZ_VfAX6-r8XL_6w6GIZX8rTwvzcZsPpgF9Ht9gpJ0IIHOhPtEyWVVSPIGC0gHo6ZyxPIe2G23FC4_32hhluEqirde8B0xXC0MC8YYR3g7KdCQeq9WwerghXC1xDhegjSFfpNxVLD4wDnNlzqyqatOxa7-0YfbQ84wTLw9ocA9cvpQdzRz3HDVjiUX85s7xqQapQSXc90--yi7UR3slAZfdRzXX8GgXgRCT7JDajzPF8k1URIsTRroiKNv6UBuAD2FEsXd2E2yZqFKVCF8DHHWm-XoNjDA0mkZZq17Nw03EaMcE_IfsiBSqNmu6P0ga3ibmLjGrju-yCMTkHWBKiyGybiiDd2tJ75-zqZBFXsl-1XVynEpQoyVGwmW1yC8mcdI2rTNEBNBdYZUAfcsK94m3vtt6ABK21igjIMgD-P3ymvYzlraupteAPaFXbC8u_yARg8Swdgrv1hLnjogF3Q0IcFBqnu_jarMvYcfxKowle7xw-GauzYaviMeRGV3Qz7QpRw9tW_8NOwYq6xlxadmD4LBvQ8CqitbWHFf1GitymKcYB5Qs2UMUM3gIRGevGFgmIkaBBdAtBJORxV1YBzZD9ypWpMgopPOCoA27lEJ1Fmv2yCofMb6TuOIo8cfJsx1GfDO-X8Fxh7eooqEBDCb-BgqtytsdyLr9jtcWcHm-96Ytnl4ea8i89ACpSbU_L_ryN5ePcGz1I0upNBfSjgC4O9G71a9v5tZZk2KjKQVwV-ZBh6uUgLbjZLP7vPN1fnr40BXyf8GsgWUuPcLSQfbsGi4q7fjeSZeqk6t4VBQuLAAVHh0Lcu9tsZrM5urqNL0tDJvrj8U9u15oOT43irurLNZR4PSkIqIK9ZzcaMtUd-fKOUJmGOsk_atOQ0I428kmM_KxJjSC2HNw64E27Vu75-J1mXxiYrZbrOJHKnE9hIzPKUiDIodXNp6MFXpchgvzceH8BJJxfMmQLNUncqa_Rbs34r5Tbeugyw8yVA_SQCKdYmuHnfF2NhSc0HSEgwwRsjYA2ykYrU2qAA47OPql8vslhGN7J9DkNOthSHf2ezqlOESBMuHraGi6dxmuI7B57MokubLLQwlNhyMoafxSjp3Mj3C3FIbmkEIbTNblDkjo_DUTV2GJRbeFU1NnYSFbNYnfTlCilQD2rQikuPPEoNK8tLObssX-6ckA6CK0KrdAxKsxPZ-eUUb2xgH0_YTPjvtgdOdGWGnNTzOxN-GZBe3d37zTpXgCw1NVOiP5eMEuNjB4eC4PNUFYEpKUgtrUuWGg_p96yO-BtumSLahCfV4iHHtsFnpGIc_0gTV3omeD-21qpZXlHG-J6w794_kn4mpjUNF_mPTxzNhjwwQqkXMJGrLyDk3zqtqxTXmdu850NzJk6hy4kCPHzc-3Wobb2ZgnNbjod6sjIrj8xLq1voX3PfjgMRpoWWtZsgdMYg6krPg4sTRhChIXOEmaabfHu8hyQOliyKxDD9xaD_J2DYKZmC4mZFQgKY4L0khOZhTyaVdPtg4M8WUA7G1p1gT5pcVSnxTfME8rPuNpK7ZV3t4wACD5DMdFic
+        id: cmp_05d83fb410978bbd016a8f9b01f27487d1934e3b6fc9d3cbdb
+        type: compaction
+      - content: And 5+5?
+        role: user
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+      stream: true
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_05d83fb410978bbd006a8f9b03f95487d1b3d07c1be64e5ecd","object":"response","created_at":1787796228,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_05d83fb410978bbd006a8f9b03f95487d1b3d07c1be64e5ecd","object":"response","created_at":1787796228,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"5","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"Q0tI65MOffxg0EW","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"ACbqGTagXibYWT","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"tvscVxq7cCEzAPD","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"5","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"jN4uyrTDMfH6Zyd","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"N3Qyp7dz2C39X6","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"oKt5w4mnaK1hbAA","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"10","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"AeaM9F1iXrdqPl","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"obfuscation":"mrvhiCmYEJdpJTa","output_index":0,"sequence_number":11}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","logprobs":[],"output_index":0,"sequence_number":12,"text":"5 + 5 = 10."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"5 + 5 = 10."},"sequence_number":13}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"5 + 5 = 10."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_05d83fb410978bbd006a8f9b03f95487d1b3d07c1be64e5ecd","object":"response","created_at":1787796228,"status":"completed","background":false,"completed_at":1787796229,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_05d83fb410978bbd006a8f9b05907487d1a0d1020d9e3f3720","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"5 + 5 = 10."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":286,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":295},"user":null,"metadata":{}},"sequence_number":15}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '182'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_compact_start_event_cancellation.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_compact_start_event_cancellation.yaml
@@ -1,0 +1,303 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '169'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 2+2?
+        role: user
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+      stream: true
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_077598e6d9d04f4a006a8f9b06360c87d195274b7c99a181c4","object":"response","created_at":1787796230,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_077598e6d9d04f4a006a8f9b06360c87d195274b7c99a181c4","object":"response","created_at":1787796230,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"rDIYmA8JH0AZNaD","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"LoEQiRD1tvbjPE","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"Mvslc4wauctkAl1","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"p42IfNjilOJ4nyG","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"ZnFHgSuRKrcsBg","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"tYFdv70S1AzaBgp","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"WQ53mQGssEpoh7v","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"obfuscation":"6lc5IkCVCYnQ7Nx","output_index":0,"sequence_number":11}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","logprobs":[],"output_index":0,"sequence_number":12,"text":"2 + 2 = 4."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2 + 2 = 4."},"sequence_number":13}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2 + 2 = 4."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_077598e6d9d04f4a006a8f9b06360c87d195274b7c99a181c4","object":"response","created_at":1787796230,"status":"completed","background":false,"completed_at":1787796231,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_077598e6d9d04f4a006a8f9b07747887d193fc13392cf4c84e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2 + 2 = 4."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":29,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38},"user":null,"metadata":{}},"sequence_number":15}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '216'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '258'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 2+2?
+        role: user
+      - content: 2 + 2 = 4.
+        role: assistant
+      - content: And 3+3?
+        role: user
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+      stream: true
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_0e2665700c5df6c5006a8f9b07ff7c87d1b3d4aa9e00d9db29","object":"response","created_at":1787796232,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_0e2665700c5df6c5006a8f9b07ff7c87d1b3d4aa9e00d9db29","object":"response","created_at":1787796232,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"3","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"1P4fCjKzp5BT5cs","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"tPnUmtIkBjrlM6","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"0D3AUnbQGzyW33D","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"3","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"wWGaGXUWZ9lPnse","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"EIoVk3IhY8fBUN","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"0JW2Aeh630otjoA","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"6","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"vwpR33756VBV3iq","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"obfuscation":"Rg6M50as1YP3qqg","output_index":0,"sequence_number":11}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","logprobs":[],"output_index":0,"sequence_number":12,"text":"3 + 3 = 6."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"3 + 3 = 6."},"sequence_number":13}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"3 + 3 = 6."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_0e2665700c5df6c5006a8f9b07ff7c87d1b3d4aa9e00d9db29","object":"response","created_at":1787796232,"status":"completed","background":false,"completed_at":1787796233,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_0e2665700c5df6c5006a8f9b09a3e887d18f8342c9ebad8e0b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"3 + 3 = 6."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":51,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":60},"user":null,"metadata":{}},"sequence_number":15}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '282'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '347'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: What is 2+2?
+        role: user
+      - content: 2 + 2 = 4.
+        role: assistant
+      - content: And 3+3?
+        role: user
+      - content: 3 + 3 = 6.
+        role: assistant
+      - content: And 5+5?
+        role: user
+      instructions: You are a helpful math assistant. Give short answers.
+      model: gpt-4o-mini
+      stream: true
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_08630c2c45c00e04006a8f9b0a3a6487d1a1f84df4e816c4fc","object":"response","created_at":1787796234,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_08630c2c45c00e04006a8f9b0a3a6487d1a1f84df4e816c4fc","object":"response","created_at":1787796234,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","item":{"id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"5","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"cqVXocDCdMYw0i0","output_index":0,"sequence_number":4}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"Yxf4zlvZJ2EaKT","output_index":0,"sequence_number":5}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"DSew6cAY2oJL4kf","output_index":0,"sequence_number":6}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"5","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"USdEavIPcEF6Scm","output_index":0,"sequence_number":7}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"beBLS7mRuPaVZU","output_index":0,"sequence_number":8}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"VdVBKOKJ8BkCHhA","output_index":0,"sequence_number":9}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"10","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"3iBKlacd3XLNrK","output_index":0,"sequence_number":10}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"obfuscation":"uCmQoLdTpEYfX2S","output_index":0,"sequence_number":11}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","logprobs":[],"output_index":0,"sequence_number":12,"text":"5 + 5 = 10."}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"5 + 5 = 10."},"sequence_number":13}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"5 + 5 = 10."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_08630c2c45c00e04006a8f9b0a3a6487d1a1f84df4e816c4fc","object":"response","created_at":1787796234,"status":"completed","background":false,"completed_at":1787796234,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful math assistant. Give short answers.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_08630c2c45c00e04006a8f9b0a91a887d196d0185f56c16e05","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"5 + 5 = 10."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":73,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":82},"user":null,"metadata":{}},"sequence_number":15}
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '234'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import re
 import warnings
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import replace
@@ -53,17 +53,29 @@ from pydantic_ai import (
     capture_run_messages,
 )
 from pydantic_ai.agent import Agent
-from pydantic_ai.capabilities import NativeTool
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    CompactionEndEvent,
+    CompactionStartEvent,
+    NativeTool,
+    on_event,
+)
 from pydantic_ai.direct import model_request as direct_model_request
 from pydantic_ai.exceptions import ContentFilterError, ModelHTTPError, ModelRetry, SuspendedResponseExpired
-from pydantic_ai.messages import INVALID_JSON_KEY, ToolSearchCallPart, ToolSearchReturnPart, sanitize_messages
+from pydantic_ai.messages import (
+    INVALID_JSON_KEY,
+    AgentStreamEvent,
+    ToolSearchCallPart,
+    ToolSearchReturnPart,
+    sanitize_messages,
+)
 from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAspectRatio, MCPServerTool, WebSearchTool
 from pydantic_ai.native_tools._tool_search import ToolSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 from .._inline_snapshot import snapshot
@@ -106,6 +118,7 @@ with try_import() as imports_successful:
 
     from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
     from pydantic_ai.models.openai import (
+        OpenAICompaction,
         OpenAIResponsesModel,
         OpenAIResponsesModelSettings,
         _resolve_openai_image_generation_size,  # pyright: ignore[reportPrivateUsage]
@@ -13526,6 +13539,97 @@ async def test_openai_responses_compact_messages(allow_model_requests: None, ope
     assert compaction.provider_name == 'openai'
     assert compaction.provider_details is not None
     assert 'encrypted_content' in compaction.provider_details
+
+
+async def test_openai_responses_compact_emits_lifecycle_events(allow_model_requests: None, openai_api_key: str):
+    """Stateless `OpenAICompaction` emits an immediately dispatched `CompactionStartEvent` and a `CompactionEndEvent` around `/compact`."""
+    model = OpenAIResponsesModel('gpt-4o-mini', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(
+        model=model,
+        instructions='You are a helpful math assistant. Give short answers.',
+        capabilities=[OpenAICompaction(message_count_threshold=4)],
+    )
+
+    events: list[AgentStreamEvent] = []
+
+    async def handler(ctx: RunContext[Any], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        async for event in stream:
+            events.append(event)
+
+    message_history: list[Any] = []
+    result = await agent.run('What is 2+2?', message_history=message_history, event_stream_handler=handler)
+    message_history = result.all_messages()
+    result = await agent.run('And 3+3?', message_history=message_history, event_stream_handler=handler)
+    message_history = result.all_messages()
+    # Third run exceeds the threshold and compacts
+    result = await agent.run('And 5+5?', message_history=message_history, event_stream_handler=handler)
+
+    assert any(
+        isinstance(part, CompactionPart)
+        for msg in result.all_messages()
+        if isinstance(msg, ModelResponse)
+        for part in msg.parts
+    )
+    compaction_events = [event for event in events if isinstance(event, CompactionStartEvent | CompactionEndEvent)]
+    assert compaction_events == snapshot(
+        [
+            CompactionStartEvent(capability_id='open_ai_compaction', strategy='openai', messages_before=4),
+            CompactionEndEvent(
+                capability_id='open_ai_compaction', strategy='openai', messages_before=4, messages_after=1
+            ),
+        ]
+    )
+
+
+async def test_openai_responses_compact_start_event_cancellation(allow_model_requests: None, openai_api_key: str):
+    """A listener cancelling `CompactionStartEvent` makes stateless `OpenAICompaction` skip the `/compact` call.
+
+    The cassette holds only regular `/responses` exchanges, so a regression that still calls
+    `/compact` fails to find a matching recording.
+    """
+
+    class HoldCompaction(AbstractCapability[Any]):
+        @on_event(CompactionStartEvent)
+        async def _hold(self, ctx: RunContext[Any], event: CompactionStartEvent) -> None:
+            event.cancel('history must stay intact')
+
+    model = OpenAIResponsesModel('gpt-4o-mini', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(
+        model=model,
+        instructions='You are a helpful math assistant. Give short answers.',
+        capabilities=[OpenAICompaction(message_count_threshold=4), HoldCompaction()],
+    )
+
+    events: list[AgentStreamEvent] = []
+
+    async def handler(ctx: RunContext[Any], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        async for event in stream:
+            events.append(event)
+
+    message_history: list[Any] = []
+    result = await agent.run('What is 2+2?', message_history=message_history, event_stream_handler=handler)
+    message_history = result.all_messages()
+    result = await agent.run('And 3+3?', message_history=message_history, event_stream_handler=handler)
+    message_history = result.all_messages()
+    result = await agent.run('And 5+5?', message_history=message_history, event_stream_handler=handler)
+
+    all_msgs = result.all_messages()
+    assert not any(
+        isinstance(part, CompactionPart) for msg in all_msgs if isinstance(msg, ModelResponse) for part in msg.parts
+    )
+    assert len(all_msgs) == 6
+    compaction_events = [event for event in events if isinstance(event, CompactionStartEvent | CompactionEndEvent)]
+    assert compaction_events == snapshot(
+        [
+            CompactionStartEvent(
+                capability_id='open_ai_compaction',
+                strategy='openai',
+                messages_before=4,
+                cancelled=True,
+                cancel_reason='history must stay intact',
+            )
+        ]
+    )
 
 
 async def test_openai_responses_trims_before_latest_compaction(allow_model_requests: None):

--- a/tests/test_capability_events.py
+++ b/tests/test_capability_events.py
@@ -10,7 +10,15 @@ import pydantic
 import pytest
 
 from pydantic_ai import Agent, CapabilityEvent, CustomEvent, RunContext, UnknownCapabilityEvent
-from pydantic_ai.capabilities import AbstractCapability, Capability, Hooks, ProcessEventStream, WrapperCapability
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    Capability,
+    CompactionEndEvent,
+    CompactionStartEvent,
+    Hooks,
+    ProcessEventStream,
+    WrapperCapability,
+)
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     CAPABILITY_EVENT_TYPES,
@@ -290,6 +298,37 @@ def test_mutable_decision_field_serializes():
     event = ThingStartEvent()
     event.cancel()
     assert pydantic.TypeAdapter[AgentStreamEvent](AgentStreamEvent).dump_python(event)['cancelled'] is True
+
+
+def test_builtin_compaction_event_family():
+    """The core compaction lifecycle events register under stable kinds shared by provider capabilities and Harness strategies."""
+    start = CompactionStartEvent(strategy='summarizing', messages_before=12, tokens_before=40_000)
+    assert start.kind == 'compaction.start'
+    assert type(start).event_dispatch == 'immediate'
+    start.cancel('a plan step is mid-flight')
+    assert start.cancelled
+    assert start.cancel_reason == 'a plan step is mid-flight'
+
+    end = CompactionEndEvent(strategy='summarizing', messages_before=12, messages_after=3, tokens_before=40_000)
+    assert end.kind == 'compaction.end'
+    assert type(end).event_dispatch == 'stream'
+
+    adapter = pydantic.TypeAdapter[CapabilityEvent](CapabilityEvent)
+    assert adapter.dump_python(end) == snapshot(
+        {
+            'kind': 'compaction.end',
+            'capability_id': None,
+            'tool_call_id': None,
+            'tool_name': None,
+            'event_kind': 'capability',
+            'strategy': 'summarizing',
+            'messages_before': 12,
+            'messages_after': 3,
+            'tokens_before': 40000,
+            'tokens_after': None,
+        }
+    )
+    assert adapter.validate_python(adapter.dump_python(start)) == start
 
 
 def _has_tool_return(messages: list[ModelMessage]) -> bool:


### PR DESCRIPTION
Stacked on #6258 (base branch `emit-custom-events`), which introduces the `CapabilityEvent` family and `@on_event` this PR builds on.

This adds the **compaction lifecycle event family** to core, as the shared vocabulary for everything that compacts history — the provider-native capabilities here, and the model-agnostic [Pydantic AI Harness strategies](https://pydantic.dev/docs/ai/harness/compaction/) (Harness PR to follow, importing this family). It's the "all-in core" resolution of the `before_compaction` intervention point from the [capability-domain-hooks proposal](https://github.com/pydantic/pydantic-ai-notes/blob/mpfaffenberger/capability-domain-hooks/features/capability-domain-hooks/2026-08-20%20proposal%20-%20unified%20domain%20events%20and%20intervention%20hooks%20for%20harness%20capabilities.md), and a strict superset of Code Puppy's advisory-only `pre_compact(agent_name, strategy, message_count, token_count)` callback: same data points, plus an actual cancellation channel.

## The family

`pydantic_ai.capabilities.compaction`, kinds `compaction.start` / `compaction.end`:

- **`CompactionStartEvent`** (`dispatch='inline'`, cancellable): `strategy`, `message_count`, `estimated_tokens`, `cancelled`/`cancel_reason` + `cancel(reason)`. Emitted *before* compacting; because it's inline-dispatched, the emitter reads `cancelled` off the event before proceeding, so any capability (or app code via `hooks.on.event`) can hold compaction while it's mid-activity. Cancelling is per-attempt — the strategy re-attempts on its next trigger.
- **`CompactionEndEvent`**: `strategy`, `messages_before`/`messages_after`, `tokens_before`/`tokens_after` — emitted only when history was actually compacted.

## Who emits, and who deliberately doesn't (yet)

Events are emitted where the compacting code runs client-side and can decide the compaction:

- **`OpenAICompaction` stateless mode** emits both, around its `/responses/compact` call from `before_model_request` — the one provider-native path with a genuine client-side decision point. A cancelled start event skips the endpoint call entirely (pinned by a cassette that holds only regular `/responses` exchanges, so a regression that still calls `/compact` can't find a matching recording).
- **Server-side compaction — Anthropic, and OpenAI's stateful mode — emits nothing here.** The provider decides and performs compaction inside the model response itself, so there is no client-side moment to cancel: Anthropic's only client-visible signals are the compaction content block streaming by (already surfaced as `PartStartEvent(part=CompactionPart)`) and, with `pause_after_compaction=True`, `stop_reason='compaction'`. Emitting an observational `CompactionEndEvent` when a `CompactionPart` is seen is feasible via an `@on_event` listener on the capability, but is deliberately left to a follow-up: a listener auto-enables streaming for every existing `AnthropicCompaction` user (a wire-mode change that deserves its own consideration), and the client-side data would be thin (no before/after counts — the server compacted mid-request).

Harness strategies (summarizing, tiered, sliding-window, …) all run client-side, so all of them get the full Start/End pair — that's the follow-up Harness PR.

## Docs

- `docs/capabilities/compaction.md` gains a **Compaction events** section (the family, the cancellable guard with a listener example, where events are and aren't emitted).
- The decision-event example in `docs/capabilities/overview.md` now demonstrates the real `CompactionStartEvent` instead of defining a lookalike in the now-taken `compaction` namespace.
- `docs/models/openai.md` notes the stateless-mode emission.

- Related: #6258, https://github.com/pydantic/pydantic-ai-notes/pull/15

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

