### PR TITLE
Fix a `SyncStreamBridge` test flake: cancel the init watchdog before the liveness check

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -951,6 +951,9 @@ def test_sync_stream_bridge_init_propagates_base_exception(error_type: type[Base
     try:
         with pytest.raises(error_type) as exc_info:
             SyncStreamBridge(FailingContextManager(), async_alternative='`async_method`')
+        # The watchdog only guards against a hung constructor; cancel it before the liveness
+        # check so a slow worker can't have it fire mid-`run_until_complete`.
+        stop_handle.cancel()
         assert exc_info.value is error
         assert not forced_stop
         assert loop.run_until_complete(asyncio.sleep(0)) is None


### PR DESCRIPTION
`test_sync_stream_bridge_init_propagates_base_exception` flakes on loaded CI workers (seen twice today, on the 3.14 and 3.13 all-extras lanes, once per parametrized case): its 1-second `call_later` watchdog exists to stop the loop if `SyncStreamBridge` hangs, but when the worker is slow enough that more than a second elapses between the constructor raising and the follow-up liveness check, the watchdog fires *during* `loop.run_until_complete(asyncio.sleep(0))` and the test dies with `RuntimeError: Event loop stopped before Future completed` — after `assert not forced_stop` already passed.

Cancel the watchdog as soon as the constructor has returned: its only job (guarding a hung constructor) is done, and the liveness check can then never race it. The `finally` cancel stays for the raising path.

- No issue: trivial deflake of a single test, no behavior change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

