### PR TITLE
Cap `dbos` below 2.31.0 to avoid a missing `opentelemetry-instrumentation-logging` import

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -156,7 +156,9 @@ retries = ["tenacity>=8.2.3", "httpx>=0.27"]
 # Temporal
 temporal = ["temporalio>=1.24.0"]
 # DBOS
-dbos = ["dbos>=2.10.0"]
+# `<2.31.0`: their default `DBOS.__init__` path needs `opentelemetry-instrumentation-logging` without
+# requiring their `[otel]` extra. https://github.com/dbos-inc/dbos-transact-py/issues/832
+dbos = ["dbos>=2.10.0,<2.31.0"]
 # Prefect
 prefect = ["prefect>=3.7.5"]
 # Spec (YAML agent specs)

--- a/uv.lock
+++ b/uv.lock
@@ -5633,7 +5633,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.63" },
     { name = "botocore", marker = "extra == 'bedrock-mantle'", specifier = ">=1.42.63" },
     { name = "cohere", marker = "sys_platform != 'emscripten' and extra == 'cohere'", specifier = ">=5.20.6" },
-    { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0" },
+    { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0,<2.31.0" },
     { name = "ddgs", marker = "extra == 'duckduckgo'", specifier = ">=9.0.0" },
     { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.0.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },


### PR DESCRIPTION
The `latest-versions` canary caught this ahead of today's release: `dbos==2.31.0` (published yesterday) added an unconditional import of `opentelemetry.instrumentation.logging` in `DBOS.__init__`'s default `config_logger` path, but only declares that package under their own optional `[otel]` extra — which we don't request. A fresh `pip install 'pydantic-ai[dbos]'` now breaks on first `DBOS()` construction.

Capping the upper bound until dbos fixes their packaging. Filed upstream: [dbos-inc/dbos-transact-py#832](https://github.com/dbos-inc/dbos-transact-py/issues/832).

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

