### PR TITLE
Fix join() with a fanned producer silently dropping that branch's contribution (#7785)

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -832,6 +832,17 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                                     if t.task_id not in new_task_ids:  # pragma: no cover
                                         await self._finish_task(t.task_id)
                                 self._handle_execution_request(maybe_overridden_result)
+
+                                # Finalizing this join dispatched new tasks (e.g. the tail of a fanned-out
+                                # branch). Those tasks may feed another join that is still pending in
+                                # `active_reducers`. If we keep finalizing joins from this pre-snapshotted
+                                # list, the downstream join could be finalized in the same pass -- before the
+                                # newly dispatched task has run and delivered its contribution -- and silently
+                                # drop its input. Stop here so the new tasks run first; the pending join(s)
+                                # will be finalized on a later pass once those tasks complete.
+                                # See https://github.com/pydantic/pydantic-ai/issues/7785
+                                if new_tasks:
+                                    break
             except GeneratorExit:
                 self.task_group.cancel_scope.cancel()
                 return

--- a/tests/graph/builder/test_joins_and_reducers.py
+++ b/tests/graph/builder/test_joins_and_reducers.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 import pytest
 
 from pydantic_graph import GraphBuilder, StepContext
+from pydantic_graph.id_types import ForkID, JoinID
 from pydantic_graph.join import (
     ReduceFirstValue,
     ReducerContext,
@@ -438,3 +439,72 @@ async def test_reduce_first_value_keeps_side_effect_of_cancelled_sibling():
     # side-effect line and never recorded. The winner writes only after the event is set, so it
     # always trails the surviving side effect.
     assert state.completed == ['effect-then-suspend', 'winner']
+
+
+async def test_join_with_fanned_producer_does_not_drop_branch():
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/7785.
+
+    A join (`merge`) with two producers -- one the tail of a fanned/mapped branch and the
+    other an ordinary step -- must reduce both contributions. Previously the fallback
+    finalization loop finalized `merge` in the same pass that finalized the fanned join and
+    dispatched the branch's tail task (which had not run yet), silently dropping the fanned
+    branch's contribution.
+
+    This is deterministic (no timing involved), so we run it several times to be sure.
+    """
+
+    for _ in range(10):
+        fan_started = asyncio.Event()
+        g = GraphBuilder(name="repro_7785", input_type=str, output_type=list)
+
+        @g.step
+        async def root(ctx: StepContext[None, None, str]) -> str:
+            return ctx.inputs
+
+        @g.step
+        async def fan_prepare(ctx: StepContext[None, None, object]) -> list[int]:
+            fan_started.set()
+            return [1, 2, 3]
+
+        @g.step
+        async def fan_unit(ctx: StepContext[None, None, int]) -> int:
+            return ctx.inputs * 10
+
+        fan_join = g.join(reduce_list_append, initial_factory=list, node_id="fan_join")
+
+        @g.step
+        async def fan_result(ctx: StepContext[None, None, list]) -> list[int]:
+            return sorted(ctx.inputs)
+
+        @g.step
+        async def plain_producer(ctx: StepContext[None, None, object]) -> str:
+            await fan_started.wait()
+            return "plain"
+
+        merge = g.join(reduce_list_append, initial_factory=list, node_id="merge")
+
+        @g.step
+        async def downstream(ctx: StepContext[None, None, list]) -> list:
+            return ctx.inputs
+
+        g.add_edge(g.start_node, root)
+        g.add_edge(root, fan_prepare)
+        g.add_edge(root, plain_producer)
+        g.add_mapping_edge(
+            fan_prepare, fan_unit, fork_id=ForkID("fan_fork"), downstream_join_id=JoinID("fan_join")
+        )
+        g.add_edge(fan_unit, fan_join)
+        g.add_edge(fan_join, fan_result)
+        g.add_edge(fan_result, merge)
+        g.add_edge(plain_producer, merge)
+        g.add_edge(merge, downstream)
+        g.add_edge(downstream, g.end_node)
+
+        result = await g.build().run(inputs="go")
+
+        # `merge` collects both contributions: the plain string and the fanned list.
+        flat = [x for sub in result for x in (sub if isinstance(sub, list) else [sub])]
+        assert "plain" in flat
+        for value in (10, 20, 30):
+            assert value in flat, f"fanned branch value {value} dropped: {result}"
+


### PR DESCRIPTION
Closes #7785

## Problem

A join() with two producers — one the tail of a fanned/mapped branch, the other an ordinary step — deterministically drops the fanned branch's contribution. The run exits successfully with no warning, but the downstream node fires with only the plain producer's value.

## Root cause

In the fallback finalization loop of _GraphIterator.iter_graph (pydantic_graph/graph_builder.py), joins are popped and finalized one at a time from a pre-snapshotted list within a single pass. When the join at the tail of a fanned-out branch is finalized, it dispatches its downstream task — which has not run yet. The should_skip / intermediate_join_nodes check only shields a join while the upstream join is still in active_reducers; once the fan join is popped earlier in the same pass, a downstream join that waits on that dispatched task loses its shield and is finalized before the new task can deliver anything. The fan contribution later arrives into an orphaned reducer and is lost.

This is the residual case left open by #3337 (chained-join fix), as flagged in that PR.

## Fix

Stop the fallback finalization pass as soon as a join's finalization dispatches new tasks, so those tasks run first. Pending joins are finalized on a later pass once the dispatched tasks complete. This is a narrow change to existing internal finalization bookkeeping; ordinary joins and the already-covered chained-join behavior are unaffected.

## Testing

- Added regression test test_join_with_fanned_producer_does_not_drop_branch in tests/graph/builder/test_joins_and_reducers.py, covering:
  - a fanned producer converging with an ordinary producer at a second join;
  - 10 repeated runs to confirm the result is deterministic and complete.
- The test fails on main (returns ['plain']) and passes with this change (['plain', [10, 20, 30]]).
- Full tests/graph/builder/ suite passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

