### PR TITLE
fix(bedrock): allow GPT-5.6 OpenAI models on Converse

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -240,8 +240,9 @@ class BedrockModelProfile(ModelProfile, total=False):
     """Whether this model is served by the Bedrock Converse API. Default: `True`.
 
     Set to `False` for models that Bedrock serves only through the Mantle OpenAI-compatible API (today,
-    the proprietary OpenAI GPT models); `BedrockConverseModel` raises at construction so the user gets an
-    actionable pointer to `BedrockMantleProvider` instead of an opaque Converse error at request time.
+    proprietary OpenAI GPT models other than GPT-5.6); `BedrockConverseModel` raises at construction so
+    the user gets an actionable pointer to `BedrockMantleProvider` instead of an opaque Converse error at
+    request time.
     """
 
 
@@ -497,20 +498,23 @@ def bedrock_nvidia_model_profile(model_name: str) -> ModelProfile | None:
 
 def bedrock_openai_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for an OpenAI model used via Bedrock Converse."""
-    # Only the open-weight GPT-OSS family is served on Converse; every proprietary GPT model (GPT-5.4+
-    # today, and future GPT-6/7/… tomorrow) is Bedrock Mantle-only. Flag those as unsupported so
-    # `BedrockConverseModel` raises an actionable error at construction rather than failing later with an
-    # opaque Converse error.
-    if not model_name.startswith('gpt-oss'):
-        return BedrockModelProfile(bedrock_supported_on_converse=False)
-    # TODO(v3): default `bedrock:` to Bedrock Mantle (with a deprecation warning steering users who want
-    # Converse to a `bedrock-converse:` prefix), mirroring the OpenAI Responses transition.
-    # Converse rejects `reasoning_effort='none'` — mark always-on.
-    return BedrockModelProfile(
-        bedrock_thinking_variant='openai',
-        supports_thinking=True,
-        thinking_always_enabled=True,
-    )
+    # GPT-OSS and GPT-5.6 are served on Converse. Other proprietary GPT models (GPT-5.4/5.5 and
+    # not-yet-shipped generations) remain Bedrock Mantle-only. Flag those as unsupported so
+    # `BedrockConverseModel` raises an actionable error at construction rather than failing later
+    # with an opaque Converse error.
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+    if model_name.startswith('gpt-oss'):
+        # TODO(v3): default `bedrock:` to Bedrock Mantle (with a deprecation warning steering users who want
+        # Converse to a `bedrock-converse:` prefix), mirroring the OpenAI Responses transition.
+        # Converse rejects `reasoning_effort='none'` — mark always-on.
+        return BedrockModelProfile(
+            bedrock_thinking_variant='openai',
+            supports_thinking=True,
+            thinking_always_enabled=True,
+        )
+    if model_name.startswith('gpt-5.6'):
+        return BedrockModelProfile(bedrock_supported_on_converse=True)
+    return BedrockModelProfile(bedrock_supported_on_converse=False)
 
 
 def _strip_builtin_tools(profile: ModelProfile | None) -> ModelProfile:

--- a/tests/providers/test_bedrock_mantle.py
+++ b/tests/providers/test_bedrock_mantle.py
@@ -200,16 +200,30 @@ def test_bedrock_mantle_model_rejects_wrong_endpoint_family() -> None:
 
 
 def test_bedrock_converse_rejects_proprietary_openai() -> None:
-    # Proprietary GPT models are not served by the Converse API: the profile flags them
-    # (`bedrock_supported_on_converse=False`) and `BedrockConverseModel` raises at construction with a
-    # pointer to `BedrockMantleProvider`. Family-based (not GPT-OSS), so it survives future GPT generations.
-    for model_name in ('openai.gpt-5.6-luna', 'openai.gpt-6', 'openai.gpt-8-turbo'):
+    # Proprietary GPT models other than GPT-5.6 are not served by the Converse API: the profile
+    # flags them (`bedrock_supported_on_converse=False`) and `BedrockConverseModel` raises at
+    # construction with a pointer to `BedrockMantleProvider`.
+    for model_name in ('openai.gpt-5.4', 'openai.gpt-5.5', 'openai.gpt-6', 'openai.gpt-8-turbo'):
         assert BedrockProvider.model_profile(model_name) == snapshot({'bedrock_supported_on_converse': False})
         with pytest.raises(UserError, match='BedrockMantleProvider'):
             infer_model(f'bedrock:{model_name}')
     # The open-weight GPT-OSS family remains available on Converse.
     assert isinstance(infer_model('bedrock:openai.gpt-oss-120b'), BedrockConverseModel)
     assert isinstance(infer_model('bedrock:openai.gpt-oss-safeguard-20b'), BedrockConverseModel)
+
+
+def test_bedrock_converse_accepts_gpt56() -> None:
+    # AWS serves GPT-5.6 (Sol/Luna/Terra) on bedrock-runtime Converse, including cross-region
+    # inference-profile IDs. Construction must not raise the Mantle-only UserError.
+    for model_name in (
+        'openai.gpt-5.6-sol',
+        'openai.gpt-5.6-luna',
+        'openai.gpt-5.6-terra',
+        'us.openai.gpt-5.6-sol',
+        'global.openai.gpt-5.6-luna',
+    ):
+        assert BedrockProvider.model_profile(model_name) == snapshot({'bedrock_supported_on_converse': True})
+        assert isinstance(infer_model(f'bedrock:{model_name}'), BedrockConverseModel)
 
 
 def test_gateway_bedrock_remains_on_converse() -> None:


### PR DESCRIPTION
## Summary

`bedrock_openai_model_profile()` treated every non-`gpt-oss` OpenAI Bedrock model id as Mantle-only (`bedrock_supported_on_converse=False`). AWS now serves GPT-5.6 (Sol/Luna/Terra) on `bedrock-runtime` Converse, so `BedrockConverseModel('us.openai.gpt-5.6-sol')` raised `UserError` at construction even though plain `boto3` `converse()` succeeds.

This change allows `gpt-5.6*` on Converse and keeps the Mantle-only gate for other proprietary GPT ids (e.g. GPT-5.4/5.5). The gpt-oss thinking profile is unchanged.

## Test plan

- [x] `uv run pytest tests/providers/test_bedrock_mantle.py -q`
- [x] New cases cover Sol/Luna/Terra and cross-region `us.` / `global.` prefixes
- [x] Existing Mantle-only rejection still covers GPT-5.4/5.5 and future GPT-6+ ids

Fixes #7793

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

