### PR TITLE
test(agent): cover Agent.iter cleanup after tool exceptions

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4232,6 +4232,39 @@ async def test_agent_metadata_persisted_when_run_fails() -> None:
     assert captured_run.result is None
 
 
+async def test_agent_iter_cleans_up_after_tool_exception() -> None:
+    """A failed ``Agent.iter`` run must not leak state into a later run."""
+    model_calls = 0
+
+    def model(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name='explode')])
+        return ModelResponse(parts=[TextPart('second run succeeded')])
+
+    agent = Agent(FunctionModel(model))
+
+    @agent.tool_plain
+    def explode() -> str:
+        raise RuntimeError('tool-failure')
+
+    tasks_before = asyncio.all_tasks()
+    with pytest.raises(RuntimeError, match='tool-failure'):
+        async with agent.iter('first run') as agent_run:
+            async for _ in agent_run:
+                pass
+
+    await asyncio.sleep(0)
+    leaked = asyncio.all_tasks() - tasks_before
+    assert not leaked, f'Orphaned tasks remain after failed Agent.iter run: {leaked}'
+
+    second_result = await agent.run('second run')
+    assert second_result.output == 'second run succeeded'
+    assert [message.kind for message in second_result.new_messages()] == ['request', 'response']
+    assert all('first run' not in str(message) for message in second_result.new_messages())
+
+
 async def test_agent_metadata_recomputed_on_successful_run() -> None:
     agent = Agent(
         TestModel(custom_output_text='recomputed metadata'),


### PR DESCRIPTION
## Summary

Add regression coverage for Agent.iter cleanup when a tool raises.

## Changes

- Verify tool exceptions propagate through the Agent.iter context.
- Verify no asyncio tasks remain after the failed run.
- Reuse the same Agent for a second run and verify independent state.

## Testing

- uv run --python 3.13 --group dev pytest tests/test_agent.py -k "agent_iter or metadata_persisted_when_run_fails" -q
- uv run --python 3.13 --group lint ruff format --check tests/test_agent.py
- uv run --python 3.13 --group lint ruff check tests/test_agent.py
- git diff --check

Resolves #7730

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

