### PR TITLE
Fix real-time maintainer routing for opened issues

### DIFF
--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -427,7 +427,7 @@ def decision_for(
     participant = _participant_decision(client, repo, number, participant_login)
     if participant is not None:
         return Selection(number=number, decision=participant, status='route')
-    if participant_login is not None:
+    if participant_login:
         return Selection(number=number, decision=None, status='superseded-maintainer-response')
     filenames: list[str] | None = None
     if is_pull_request:

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -425,6 +425,18 @@ def test_recent_maintainer_response_takes_ownership_over_topic_routing():
     }
 
 
+def test_issue_event_without_comment_routes_by_topic():
+    client = FakeClient({7: item(7, labels=['MCP'])})
+
+    selected = router.select(client, CORE, '7', None, '')
+
+    assert selected['decision'] == {
+        'number': 7,
+        'owner': 'dsfaccini',
+        'evidence': 'label:MCP',
+    }
+
+
 def test_only_the_latest_maintainer_response_can_take_ownership():
     client = FakeClient({7: item(7, labels=['streaming'])})
     client.timelines[7] = [

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -950,7 +950,9 @@ def test_cli_modes_write_the_workflow_contract(tmp_path: Path, monkeypatch: pyte
     monkeypatch.setenv('GITHUB_OUTPUT', str(output))
     monkeypatch.setenv('PYDANTIC_AI_TRIAGE_SLACK_MENTIONS', MENTIONS)
     monkeypatch.setenv('ROUTING_ISSUE_NUMBER', '7')
+    monkeypatch.setenv('ROUTING_PULL_REQUEST_NUMBER', '')
     monkeypatch.setenv('ROUTING_PARTICIPANT_LOGIN', '')
+    monkeypatch.setenv('ROUTING_LEGACY_RECOVERY', '')
     monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
 
     monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -425,18 +425,6 @@ def test_recent_maintainer_response_takes_ownership_over_topic_routing():
     }
 
 
-def test_issue_event_without_comment_routes_by_topic():
-    client = FakeClient({7: item(7, labels=['MCP'])})
-
-    selected = router.select(client, CORE, '7', None, '')
-
-    assert selected['decision'] == {
-        'number': 7,
-        'owner': 'dsfaccini',
-        'evidence': 'label:MCP',
-    }
-
-
 def test_only_the_latest_maintainer_response_can_take_ownership():
     client = FakeClient({7: item(7, labels=['streaming'])})
     client.timelines[7] = [
@@ -962,6 +950,7 @@ def test_cli_modes_write_the_workflow_contract(tmp_path: Path, monkeypatch: pyte
     monkeypatch.setenv('GITHUB_OUTPUT', str(output))
     monkeypatch.setenv('PYDANTIC_AI_TRIAGE_SLACK_MENTIONS', MENTIONS)
     monkeypatch.setenv('ROUTING_ISSUE_NUMBER', '7')
+    monkeypatch.setenv('ROUTING_PARTICIPANT_LOGIN', '')
     monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
 
     monkeypatch.setattr(sys, 'argv', ['semantic_owner_router.py', 'select'])
@@ -1027,6 +1016,7 @@ def test_workflow_is_notification_first_and_least_privilege():
     jobs = workflow['jobs']
 
     text = workflow_path.read_text(encoding='utf-8')
+    assert workflow[True]['issues']['types'] == ['opened', 'reopened']
     assert 'issue_comment:' in text
     assert 'types: [created]' in text
     assert jobs['route']['needs'] == 'select'


### PR DESCRIPTION
An absent comment login is exported as an empty string for issue events. Treat it as no participant so opened and reopened issues continue through semantic owner routing in the same workflow run.

The regression test exercises the complete Actions environment through `main()`, verifies a route is emitted, and pins the `opened` and `reopened` workflow triggers.

- Closes #7812

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Verification

- `uv run pytest .github/scripts/test_semantic_owner_router.py -q`
- `uv run ruff check .github/scripts/semantic_owner_router.py .github/scripts/test_semantic_owner_router.py`
- `uv run ruff format --check .github/scripts/semantic_owner_router.py .github/scripts/test_semantic_owner_router.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright .github/scripts/semantic_owner_router.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

