### PR TITLE
Reject mismatched deferred result categories on agent resume

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -685,6 +685,30 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                 'Tool call results were provided, but the message history does not contain any unprocessed tool calls.'
             )
 
+        # Prepare the tool manager before deferred result categories are flattened below.
+        run_context = replace(
+            build_run_context(ctx),
+            retry=ctx.state.output_retries_used,
+            max_retries=ctx.deps.tool_manager.default_max_retries,
+        )
+        ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)
+
+        # Runtime deferrals from `'function'` tools cannot be distinguished from message history alone.
+        for call in last_model_response.tool_calls:
+            tool_def = ctx.deps.tool_manager.get_tool_def(call.tool_name)
+            if tool_def is None:
+                continue
+            if tool_def.kind == 'unapproved' and call.tool_call_id in deferred_tool_results.calls:
+                raise exceptions.UserError(
+                    f'Tool call {call.tool_call_id!r} requires approval, so its result must be provided in '
+                    '`DeferredToolResults.approvals`, not `DeferredToolResults.calls`.'
+                )
+            elif tool_def.kind == 'external' and call.tool_call_id in deferred_tool_results.approvals:
+                raise exceptions.UserError(
+                    f'Tool call {call.tool_call_id!r} requires external execution, so its result must be provided in '
+                    '`DeferredToolResults.calls`, not `DeferredToolResults.approvals`.'
+                )
+
         tool_call_results: dict[str, DeferredToolResult | Literal['skip']] = {}
         tool_call_results.update(deferred_tool_results.to_tool_call_results())
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -974,8 +974,7 @@ class ToolManager(Generic[AgentDepsT]):
         assert validated.tool is not None
         assert validated.validated_args is not None
 
-        if validated.tool.tool_def.kind == 'external':
-            raise RuntimeError('External tools cannot be called')
+        assert validated.tool.tool_def.kind != 'external', 'External tools cannot be called'
 
         try:
             tool_result = await self._run_execute_hooks(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2589,7 +2589,9 @@ def test_parallel_tool_return_with_deferred():
     )
 
 
-def test_deferred_tool_call_approved_fails():
+def test_deferred_external_tool_cannot_be_approved():
+    """Not a VCR test: `FunctionModel` directly exercises deferred resume validation."""
+
     def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         return ModelResponse(
             parts=[
@@ -2611,7 +2613,7 @@ def test_deferred_tool_call_approved_fails():
         DeferredToolRequests(calls=[ToolCallPart(tool_name='foo', args={'x': 0}, tool_call_id='foo')])
     )
 
-    with pytest.raises(RuntimeError, match='External tools cannot be called'):
+    with pytest.raises(UserError, match="Tool call 'foo' requires external execution"):
         agent.run_sync(
             message_history=result.all_messages(),
             deferred_tool_results=DeferredToolResults(
@@ -2620,6 +2622,49 @@ def test_deferred_tool_call_approved_fails():
                 },
             ),
         )
+
+
+def test_deferred_tool_results_wrong_category_requires_approval():
+    """Not a VCR test: pins resume validation of `DeferredToolResults` categories via `FunctionModel`.
+
+    A `requires_approval=True` tool call must be resolved via `approvals`; a result supplied
+    via `calls` would otherwise skip the approval gate entirely (https://github.com/pydantic/pydantic-ai/issues/7815).
+    """
+    executed = False
+
+    def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('delete_file', {'path': '.env'}, tool_call_id='delete_file')])
+        return ModelResponse(parts=[TextPart('Done!')])
+
+    agent = Agent(FunctionModel(llm), output_type=[str, DeferredToolRequests])
+
+    @agent.tool_plain(requires_approval=True)
+    def delete_file(path: str) -> str:
+        nonlocal executed
+        executed = True
+        return f'{path} deleted'
+
+    result = agent.run_sync('Delete .env')
+    assert result.output == snapshot(
+        DeferredToolRequests(
+            approvals=[ToolCallPart(tool_name='delete_file', args={'path': '.env'}, tool_call_id='delete_file')]
+        )
+    )
+
+    with pytest.raises(UserError, match="Tool call 'delete_file' requires approval"):
+        agent.run_sync(
+            message_history=result.all_messages(),
+            deferred_tool_results=DeferredToolResults(calls={'delete_file': 'fake result'}),
+        )
+    assert executed is False
+
+    result = agent.run_sync(
+        message_history=result.all_messages(),
+        deferred_tool_results=DeferredToolResults(approvals={'delete_file': True}),
+    )
+    assert result.output == 'Done!'
+    assert executed is True
 
 
 def test_unapproved_tool_invalid_args_retry():


### PR DESCRIPTION
Addresses #7815

`Agent.run(deferred_tool_results=...)` flattened approval decisions and external results before checking their categories. The resume path now prepares the current tool definitions first and rejects mismatches it can prove:

- a `calls` result for a tool with `requires_approval=True`
- an `approvals` result for an external tool

This does not add persisted metadata or change message history. Tools that defer dynamically by raising `ApprovalRequired` or `CallDeferred` remain unchanged because their category is not present in message history. #7815 stays open for that separate API design question.

### Testing

- `uv run pytest tests/test_tools.py -k deferred -q`: 17 passed
- `uv run pytest tests/test_agent.py -k "deferred_tool_results or deferred" -q`: 10 passed
- Changed-file Ruff, formatting, and Pyright: clean
- Pre-commit: all available hooks passed; full typecheck is blocked locally by the unrelated missing optional `pydantic_ai_harness` package
- Adversarial Fable rewrite and independent edge-case review: clean

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. No compatibility impact applies.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).