### PR TITLE
Un-cap the `dbos` extra; add `opentelemetry-instrumentation-logging` as a test dependency instead

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -156,9 +156,7 @@ retries = ["tenacity>=8.2.3", "httpx>=0.27"]
 # Temporal
 temporal = ["temporalio>=1.24.0"]
 # DBOS
-# `<2.31.0`: their default `DBOS.__init__` path needs `opentelemetry-instrumentation-logging` without
-# requiring their `[otel]` extra. https://github.com/dbos-inc/dbos-transact-py/issues/832
-dbos = ["dbos>=2.10.0,<2.31.0"]
+dbos = ["dbos>=2.10.0"]
 # Prefect
 prefect = ["prefect>=3.7.5"]
 # Spec (YAML agent specs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,11 @@ dev = [
     "pip>=26.1",
     "genai-prices>=0.1.0",
     "brotli>=1.2.0",
+    # `tests/test_dbos.py`'s fixture sets `enable_otlp=True` to cover DBOS's OTLP integration, and
+    # dbos's own `config_logger` imports this unconditionally on that path without requiring its
+    # `[otel]` extra (only a real bug for callers who set `enable_otlp=True` without it — most don't,
+    # so the public `dbos` extra doesn't need this): https://github.com/dbos-inc/dbos-transact-py/issues/832
+    "opentelemetry-instrumentation-logging>=0.63b0",
     # Tests use `FastMCP(...)` in-process servers via fastmcp's server module — the user-facing
     # `[mcp]` extra ships `fastmcp-slim[client]` which lacks server support, so devs need the full
     # `fastmcp` package alongside, tracking the same range as the `[mcp]` extra (#6661).

--- a/uv.lock
+++ b/uv.lock
@@ -4364,6 +4364,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/0a/b70a9cddbc7b314a783e62739dbb1184f8538c1f85e8ded6d340142b9b54/opentelemetry_instrumentation_logging-0.65b0.tar.gz", hash = "sha256:c0a50cade5d54db6c6af12e2c69227ecd26f2b3b779e99ff850561d3d8dd77e3", size = 19783, upload-time = "2026-07-16T15:26:09.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/8e/7577914681d77b180f8d6dcbac435be8e4ca6add6315da2d01ac4289eaa3/opentelemetry_instrumentation_logging-0.65b0-py3-none-any.whl", hash = "sha256:68365b31755c844f1e85f07dcd217839ff92f2d278a214bdf02d4dc806f9d915", size = 15727, upload-time = "2026-07-16T15:25:18.774Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-sqlite3"
 version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
@@ -5334,6 +5348,7 @@ dev = [
     { name = "inline-snapshot" },
     { name = "markdownify" },
     { name = "mcp-types" },
+    { name = "opentelemetry-instrumentation-logging" },
     { name = "pip" },
     { name = "pydocket", version = "0.22.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pytest" },
@@ -5404,6 +5419,7 @@ dev = [
     { name = "inline-snapshot", specifier = ">=0.32.5" },
     { name = "markdownify", specifier = ">=1.2" },
     { name = "mcp-types", specifier = ">=2.0.0" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.63b0" },
     { name = "pip", specifier = ">=26.1" },
     { name = "pydocket", specifier = ">=0.20.2" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -5633,7 +5649,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.63" },
     { name = "botocore", marker = "extra == 'bedrock-mantle'", specifier = ">=1.42.63" },
     { name = "cohere", marker = "sys_platform != 'emscripten' and extra == 'cohere'", specifier = ">=5.20.6" },
-    { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0,<2.31.0" },
+    { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0" },
     { name = "ddgs", marker = "extra == 'duckduckgo'", specifier = ">=9.0.0" },
     { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.0.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },


### PR DESCRIPTION
Follow-up to #7804. That PR capped the public `dbos` extra to `<2.31.0` to unblock a release quickly, but the real scope is narrower — see the correction on the upstream issue: https://github.com/dbos-inc/dbos-transact-py/issues/832#issuecomment-5441876955 (wrong link fixed below).

### What actually breaks

`dbos>=2.31.0`'s `DBOS.__init__` imports `opentelemetry.instrumentation.logging.handler.LoggingHandler` whenever `enable_otlp=True`, but only declares that package under their own optional `[otel]` extra. A bare `DBOS()` construction is unaffected — verified directly, and confirmed by the dbos maintainer ([dbos-inc/dbos-transact-py#832](https://github.com/dbos-inc/dbos-transact-py/issues/832)).

Our own `tests/test_dbos.py` fixture sets `enable_otlp=True` to cover DBOS's OTLP integration — that's the only place we hit this, not real end-user usage of the `dbos` extra.

### The fix

- Revert the `dbos<2.31.0` cap on the public extra — real users aren't affected by this regardless of dbos version.
- Add `opentelemetry-instrumentation-logging` to our own `dev` dependency group instead, so our test suite has what it needs.

Verified locally: with `dbos==2.31.0` resolved and this dev dependency present, `tests/test_dbos.py` passes.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
