### PR TITLE
Document how to persist sessions in `docs/message-history.md`

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -401,6 +401,24 @@ result = agent.run_sync('Tell me a different joke.', message_history=message_his
 
 Each sanitization can be turned off individually when the corresponding parts were created by trusted server-side code: pass `strip_system_prompts=False`, add schemes to `allowed_file_url_schemes`, add values to `allowed_file_url_force_download`, or set `allow_uploaded_files=True`. See [file URL input security](input.md#user-side-download-vs-direct-file-url) for the file input trust model.
 
+## Persisting sessions
+
+[Serializing a history](#storing-and-loading-messages-to-json) turns it into bytes and back, but that is only the primitive. Deciding where those bytes live, which conversation they belong to, and when to reload them is left to your application. The [`conversation_id`](#correlating-runs-with-run_id-and-conversation_id) every message already carries is the key to store them under, whether it came from Pydantic AI or from a chat thread ID you passed in yourself.
+
+For a chat application that is usually the whole design: load a thread's history, pass it as `message_history`, and write back [`new_messages()`][pydantic_ai.agent.AgentRunResult.new_messages] once the run finishes. Appending each run's new messages rather than rewriting the full list keeps each write proportional to the turn instead of to the conversation, and leaves the stored order intact.
+
+[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/) packages that pattern as capabilities you add to an agent, so the load and save calls are not yours to write:
+
+| Capability | What it stores | Scoped by |
+| --- | --- | --- |
+| [`StepPersistence`](https://pydantic.dev/docs/ai/harness/step-persistence/) | Message snapshots taken at settled points in a run, alongside an event log and a tool-effect ledger, so a run that ends early can be continued or forked from its last settled point rather than restarted | `conversation_id` and `run_id` |
+| [`ConversationSearch`](https://pydantic.dev/docs/ai/harness/conversation-search/) | Nothing of its own: it ranks the history `StepPersistence` already stored and gives the model a tool to pull earlier turns back into context on demand, including turns [compaction](capabilities/compaction.md) dropped | `conversation_id` |
+| [`Memory`](https://pydantic.dev/docs/ai/harness/memory/) | Markdown notes the agent writes and reads itself, deliberately outliving any single conversation | A namespace you choose |
+
+`StepPersistence` ships in-memory, file, SQLite, and MongoDB backends, and its store is a protocol you can implement against your own database.
+
+As an alternative to holding the history yourself, some providers keep conversation state on their side and reconstruct earlier turns from it, so each request carries only what is new. On the OpenAI Responses API that is [`openai_conversation_id`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_conversation_id], covered under [Using durable conversations](models/openai.md#using-durable-conversations). Weigh it against a store of your own: it is one provider's feature, OpenAI documents that earlier input tokens in a chain are still billed, and it is unavailable to organizations with Zero Data Retention enabled.
+
 ## Trust boundary for client-supplied history
 
 Pydantic AI's server-side surfaces are stateless: a run is reconstructed from the `message_history` (and any `deferred_tool_results`) supplied with the request, whether that request arrives through a [UI adapter](ui/overview.md) or through an endpoint you wrote yourself. A client that can submit history can therefore fabricate it — including [`ToolCallPart`][pydantic_ai.messages.ToolCallPart]s the model never emitted and [approvals](deferred-tools.md#human-in-the-loop-tool-approval) no human granted — and the server will process them as genuine, up to and including executing the tools they name.

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -403,7 +403,7 @@ Each sanitization can be turned off individually when the corresponding parts we
 
 ## Persisting sessions
 
-[Serializing a history](#storing-and-loading-messages-to-json) turns it into bytes and back, but that is only the primitive. Deciding where those bytes live, which conversation they belong to, and when to reload them is left to your application. The [`conversation_id`](#correlating-runs-with-run_id-and-conversation_id) every message already carries is the key to store them under, whether it came from Pydantic AI or from a chat thread ID you passed in yourself.
+[Serializing a history](#storing-and-loading-messages-to-json) turns it into bytes and back, but that is only the primitive. Deciding where those bytes live, which conversation they belong to, and when to reload them is left to your application. [`conversation_id`](#correlating-runs-with-run_id-and-conversation_id) is the key to store them under: pass your own chat thread ID, or let Pydantic AI resolve one, and read the resolved value back off the result as [`AgentRunResult.conversation_id`][pydantic_ai.agent.AgentRunResult.conversation_id].
 
 For a chat application that is usually the whole design: load a thread's history, pass it as `message_history`, and write back [`new_messages()`][pydantic_ai.agent.AgentRunResult.new_messages] once the run finishes. Appending each run's new messages rather than rewriting the full list keeps each write proportional to the turn instead of to the conversation, and leaves the stored order intact.
 


### PR DESCRIPTION
Refs #530. Deliberately does **not** close it: this ships the "easily findable in our docs" half of that issue, while the session-storage concept work (what we ship, where the abstraction lives, how it relates to #4773) stays open.

### Why we make these changes

`docs/message-history.md` explains how to serialize a history with `ModelMessagesTypeAdapter` and stops there. A reader who wants to keep a conversation across HTTP requests is left to invent the rest, and the first-party answers we already ship are not reachable from the page where they look: Harness `StepPersistence`, `ConversationSearch` and `Memory` live on a separate docs site under Capabilities, and provider-side conversation state is documented only on the OpenAI model page.

That gap is why #530 keeps attracting hand-rolled Redis, Postgres and SQLite stores in its comments: not because the pieces are missing, but because nothing routes people to them.

### New public surface

None. Documentation only.

### User-visible behavior

No behavior change. A new `## Persisting sessions` section is added to `docs/message-history.md`, immediately after `Storing and loading messages (to JSON)` and its untrusted-history subsection. It covers:

- Which identifier to store history under (the existing `conversation_id`), and why appending `new_messages()` beats rewriting `all_messages()` each turn.
- A table routing to the three Harness capabilities, with what each one actually stores and what it is scoped by.
- Provider-side conversation state as the alternative, with the two trade-offs that decide it: earlier input tokens in a chain are still billed, and it is unavailable under Zero Data Retention.

### Verification

No code examples were added, so `tests/test_examples.py` has nothing new to execute. Checked locally:

- `lychee --offline --include-fragments` over `docs/message-history.md`: 39 OK, 0 errors, so every new cross-reference and `#anchor` resolves.
- `pre-commit run --files docs/message-history.md`: all applicable hooks pass.

### What changes for existing users

Nothing.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
