### PR TITLE
Rename Gateway routing groups to endpoints

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -22,7 +22,7 @@ To help you get started with Pydantic AI Gateway, some code examples on the Pyda
 - **Cost Limits**: Set spending limits at project, user, and API key levels with daily, weekly, and monthly caps.
 - **BYOK and managed providers:** Bring your own API keys (BYOK) from LLM providers, or pay for inference directly through the platform.
 - **Multi-provider support:** Access models from OpenAI, Anthropic, Google Vertex, Groq, and AWS Bedrock. _More providers coming soon_.
-- **Routing groups:** Configure [routing groups](#routing-groups) to fail over between providers serving the same model, or load-balance traffic across them by weight.
+- **Gateway endpoints:** Configure [gateway endpoints](#gateway-endpoints) to fail over between providers serving the same model, or load-balance traffic across them by weight.
 - **Backend observability:** Log every request through [Pydantic Logfire](https://pydantic.dev/logfire) or any OpenTelemetry backend (_coming soon_).
 - **Zero translation**: Unlike traditional AI gateways that translate everything to one common schema, **Pydantic AI Gateway** allows requests to flow through directly in each provider's native format. This gives you immediate access to new model features as soon as they are released.
 - **Enterprise ready**: Inherits Logfire's enterprise features — including SSO, custom roles and permissions.
@@ -128,7 +128,7 @@ The first known use of "hello, world" was in a 1974 textbook about the C program
 
 #### Using a different upstream provider
 
-To use an alternate provider or routing group, you can specify it in the route parameter:
+To use an alternate provider or gateway endpoint, you can specify it in the `route` parameter:
 
 ```python {title="routing_via_provider.py"}
 from pydantic_ai import Agent
@@ -364,31 +364,31 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
     });
     ```
 
-## Routing groups
+## Gateway endpoints {#gateway-endpoints}
 
-A **routing group** is a named collection of providers that all serve the same model. Each member has a **priority**, a **weight**, and an **active** flag, and those three values together let a single group express two different routing strategies:
+A **gateway endpoint** routes requests across one or more providers under a single slug. Each assigned provider has a **priority**, a **weight**, and an **active** flag, and those three values together let a single endpoint express two different routing strategies:
 
-- **Failover / fallback**: Assign members different priorities. The Gateway always tries the highest-priority active member first, and only falls through to a lower-priority member when the higher one is unavailable (for example if it is down, rate-limited, or returns an error).
-- **Load balancing**: Assign two or more members the same priority and give each a weight. The Gateway splits traffic across those members in proportion to their weights.
+- **Failover / fallback**: Assign providers different priorities. The Gateway always tries the highest-priority active provider first, and only falls through to a lower-priority provider when the higher one is unavailable (for example if it is down, rate-limited, or returns an error).
+- **Load balancing**: Assign two or more providers the same priority and give each a weight. The Gateway splits traffic across those providers in proportion to their weights.
 
 The two strategies compose: you can have, for example, a top priority tier with two providers load-balanced 70/30, and a second priority tier that only receives traffic when both top-tier providers fail.
 
-### Creating a routing group
+### Creating a gateway endpoint
 
-Routing groups are managed from your organization's Gateway settings in Logfire:
+Gateway endpoints are managed from your organization's Gateway settings in Logfire:
 
-1. Open **Gateway -> Routing Groups** and click **Add Routing Group**.
-2. Give the group a slug (e.g. `anthropic-routing`) and an optional description.
-3. Open the group's **Members** page and add one or more providers. For each member set:
-    - **Priority** - higher values are tried first. Use different priorities across members for failover.
-    - **Weight** - load-balancing weight used between members that share the same priority.
-    - **Active** - inactive members are skipped during routing.
+1. Open **Gateway -> Endpoints** and click **New Endpoint**.
+2. Give the endpoint a slug (e.g. `anthropic-routing`) and an optional description.
+3. Open the endpoint's **Providers** page and add one or more providers. For each provider set:
+    - **Priority** - higher values are tried first. Use different priorities across providers for failover.
+    - **Weight** - load-balancing weight used between providers that share the same priority.
+    - **Active** - inactive providers are skipped during routing.
 
-### Using a routing group
+### Using a gateway endpoint
 
-Point the Gateway provider at the group via the `route` parameter (the group's slug):
+Point the Gateway provider at the endpoint via the `route` parameter (the endpoint's slug):
 
-```python {title="routing_group.py"}
+```python {title="gateway_endpoint.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.providers.gateway import gateway_provider
@@ -408,7 +408,7 @@ The first known use of "hello, world" was in a 1974 textbook about the C program
 """
 ```
 
-1. The slug of the routing group you created in Logfire.
+1. The slug of the gateway endpoint you created in Logfire.
 
 ## Troubleshooting
 

--- a/pydantic_ai_slim/pydantic_ai/providers/gateway.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/gateway.py
@@ -139,8 +139,8 @@ def gateway_provider(
 
     Args:
         upstream_provider: The upstream provider to use.
-        route: The name of the provider or routing group to use to handle the request. If not provided, the default
-            routing group for the API format will be used.
+        route: The name of the provider or gateway endpoint to use to handle the request. If not provided, the default
+            gateway endpoint for the API format will be used.
         api_key: The API key to use for authentication. If not provided, the `PYDANTIC_AI_GATEWAY_API_KEY`
             environment variable will be used if available.
         base_url: The base URL to use for the Gateway. If not provided, the `PYDANTIC_AI_GATEWAY_BASE_URL`

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -416,7 +416,7 @@ async def test_model_provider_argument():
     assert urlparse(model._provider.base_url).hostname == urlparse(GATEWAY_BASE_URL).hostname  # pyright: ignore[reportPrivateUsage]
 
 
-async def test_gateway_provider_routing_group(gateway_api_key: str):
+async def test_gateway_provider_endpoint(gateway_api_key: str):
     provider = gateway_provider('openai', route='potato', api_key=gateway_api_key, base_url=GATEWAY_BASE_URL)
     assert provider.client.base_url.path.endswith('/potato/')
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://pydantic.dev/docs/ai/project/contributing/ -->

<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

## Summary

- rename user-facing Gateway routing groups to gateway endpoints
- update Logfire navigation instructions and `gateway_provider()` documentation without changing routing behavior
- rename the route-override regression test to match the public terminology

## Test plan

- `.venv/bin/pytest tests/providers/test_gateway.py::test_gateway_provider_endpoint`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 .venv/bin/pyright pydantic_ai_slim/pydantic_ai/providers/gateway.py tests/providers/test_gateway.py`
- pre-commit formatting, lint, codespell, and cassette checks

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

