### PR TITLE
Use `anyio` in the realtime voice example

### DIFF
--- a/docs/examples/realtime-voice.md
+++ b/docs/examples/realtime-voice.md
@@ -12,10 +12,10 @@ Demonstrates:
 The agent exposes a single `get_weather` tool the model can call mid-conversation, and the terminal
 shows a running transcript of both sides of the conversation plus any tool calls.
 
-Both audio directions use bounded buffers, dropping the oldest audio rather than growing without
-limit: microphone capture that outruns the network drops the oldest block to preserve conversational
-latency, and playback that falls more than five seconds behind the model drops its oldest audio, so a
-machine that stutters glitches instead of ending the call.
+Both audio directions stay bounded rather than growing without limit: microphone capture relies on
+PortAudio's own input buffer, which drops audio on overflow if the network falls behind, and playback
+that falls more than five seconds behind the model drops its oldest audio, so a machine that stutters
+glitches instead of ending the call.
 
 Barge-in itself is handled by the provider — the model stops as soon as the user speaks. What the
 example adds is the half the provider can't see: it clears queued *and* partially consumed playback

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -16,12 +16,13 @@ Run with:
 
 from __future__ import annotations
 
-import asyncio
 import threading
 from collections import deque
-from contextlib import suppress
 from functools import partial
+from typing import Any
 
+import anyio
+import anyio.to_thread
 import logfire
 
 from pydantic_ai import (
@@ -58,7 +59,6 @@ logfire.instrument_pydantic_ai()
 SAMPLE_RATE = 24000
 CHANNELS = 1
 BLOCK_SIZE = 2400  # 100 ms per audio block
-MIC_QUEUE_BLOCKS = 10
 PLAYBACK_BUFFER_SECONDS = 5
 
 agent = Agent(
@@ -70,26 +70,6 @@ agent = Agent(
 def get_weather(city: str) -> str:
     """Look up the current weather in a city."""
     return f'It is currently 21 degrees and sunny in {city}.'
-
-
-def capture_mic(
-    loop: asyncio.AbstractEventLoop,
-    mic_queue: asyncio.Queue[bytes],
-    indata: object,
-    *_: object,
-) -> None:
-    """Microphone callback (PortAudio thread): hand captured audio to the event loop safely."""
-    loop.call_soon_threadsafe(enqueue_latest, mic_queue, bytes(indata))
-
-
-def enqueue_latest(audio_queue: asyncio.Queue[bytes], chunk: bytes) -> None:
-    """Keep microphone latency bounded by dropping the oldest block on overflow."""
-    if audio_queue.full():
-        try:
-            audio_queue.get_nowait()
-        except asyncio.QueueEmpty:
-            pass
-    audio_queue.put_nowait(chunk)
 
 
 class PlaybackBuffer:
@@ -193,9 +173,17 @@ async def handle_event(
             print(f'[{result.tool_name} returned: {result.content}]')
 
 
-async def stream_mic(session: RealtimeSession, mic_queue: asyncio.Queue[bytes]) -> None:
+async def stream_mic(session: RealtimeSession, mic: Any) -> None:
+    """Read microphone blocks in a worker thread and forward them to the session.
+
+    The blocking `read` waits for PortAudio to capture one block; if the network falls behind,
+    PortAudio's own input buffer absorbs the slack and drops audio on overflow, so latency stays
+    bounded without any queue of our own.
+    """
+    read = partial(mic.read, BLOCK_SIZE)
     while True:
-        await session.send_audio(await mic_queue.get())
+        data, _overflowed = await anyio.to_thread.run_sync(read, abandon_on_cancel=True)
+        await session.send_audio(bytes(data))
 
 
 async def main():
@@ -206,8 +194,6 @@ async def main():
             'On Linux you also need the PortAudio system library (`apt install libportaudio2`).'
         ) from _sounddevice_error
 
-    loop = asyncio.get_running_loop()
-    mic_queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=MIC_QUEUE_BLOCKS)
     playback = PlaybackBuffer(
         max_bytes=SAMPLE_RATE * CHANNELS * 2 * PLAYBACK_BUFFER_SECONDS
     )
@@ -215,9 +201,7 @@ async def main():
     stream_kwargs = dict(
         samplerate=SAMPLE_RATE, channels=CHANNELS, dtype='int16', blocksize=BLOCK_SIZE
     )
-    mic = sounddevice.RawInputStream(
-        callback=partial(capture_mic, loop, mic_queue), **stream_kwargs
-    )
+    mic = sounddevice.RawInputStream(**stream_kwargs)
     speaker = sounddevice.RawOutputStream(
         callback=partial(fill_speaker, playback), **stream_kwargs
     )
@@ -226,19 +210,16 @@ async def main():
     # conversation began is queued up and sent to the model as stale input.
     async with agent.realtime('openai:gpt-realtime').session() as session:
         with mic, speaker:
-            pump = asyncio.create_task(stream_mic(session, mic_queue))
-            print('Listening — start talking (Ctrl-C to quit).')
-            try:
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(stream_mic, session, mic)
+                print('Listening — start talking (Ctrl-C to quit).')
                 async for event in session:
                     await handle_event(session, event, playback)
-            finally:
-                pump.cancel()
-                with suppress(asyncio.CancelledError):
-                    await pump
+                tg.cancel_scope.cancel()
 
 
 if __name__ == '__main__':
     try:
-        asyncio.run(main())
+        anyio.run(main)
     except KeyboardInterrupt:
         pass

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -174,13 +174,7 @@ async def handle_event(
 
 
 async def stream_mic(session: RealtimeSession, mic: Any) -> None:
-    """Read microphone blocks in a worker thread and forward them to the session.
-
-    The blocking `read` waits for PortAudio to capture one block; if the network falls behind,
-    PortAudio's own input buffer absorbs the slack and drops audio on overflow, so latency stays
-    bounded without any queue of our own. Cancellation waits for the in-flight read (at most one
-    100 ms block) so the stream is never closed under an active native read.
-    """
+    """Read microphone blocks in a worker thread and forward them to the session."""
     read = partial(mic.read, BLOCK_SIZE)
     while True:
         data, _overflowed = await anyio.to_thread.run_sync(read)

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -175,9 +175,8 @@ async def handle_event(
 
 async def stream_mic(session: RealtimeSession, mic: Any) -> None:
     """Read microphone blocks in a worker thread and forward them to the session."""
-    read = partial(mic.read, BLOCK_SIZE)
     while True:
-        data, _overflowed = await anyio.to_thread.run_sync(read)
+        data, _overflowed = await anyio.to_thread.run_sync(mic.read, BLOCK_SIZE)
         await session.send_audio(bytes(data))
 
 

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -178,11 +178,12 @@ async def stream_mic(session: RealtimeSession, mic: Any) -> None:
 
     The blocking `read` waits for PortAudio to capture one block; if the network falls behind,
     PortAudio's own input buffer absorbs the slack and drops audio on overflow, so latency stays
-    bounded without any queue of our own.
+    bounded without any queue of our own. Cancellation waits for the in-flight read (at most one
+    100 ms block) so the stream is never closed under an active native read.
     """
     read = partial(mic.read, BLOCK_SIZE)
     while True:
-        data, _overflowed = await anyio.to_thread.run_sync(read, abandon_on_cancel=True)
+        data, _overflowed = await anyio.to_thread.run_sync(read)
         await session.send_audio(bytes(data))
 
 


### PR DESCRIPTION
Converts `examples/pydantic_ai_examples/realtime_voice.py` from raw `asyncio` to `anyio`, matching the library's own structured-concurrency convention.

- The PortAudio mic callback + `asyncio.Queue` + `loop.call_soon_threadsafe` plumbing is replaced by reading blocks with the blocking `mic.read()` via `anyio.to_thread.run_sync(..., abandon_on_cancel=True)`; PortAudio's own input buffer bounds mic latency, so the hand-rolled drop-oldest queue is gone.
- The mic pump task now runs in an `anyio` task group instead of a manually cancelled `asyncio.Task`, and the entrypoint uses `anyio.run()`.
- `docs/examples/realtime-voice.md` updated to describe the new mic buffering.

Verified with `tests/test_realtime_examples.py` and by running the example live against `gpt-realtime`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

