### PR TITLE
Make the `STATE_SNAPSHOT` tool-return assertion in `test_ag_ui.py` version-agnostic

### DIFF
--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import pytest
+from dirty_equals import IsJson, IsPartialDict
 from pydantic import BaseModel, ValidationError
 
 from pydantic_ai import (
@@ -1252,7 +1253,7 @@ async def test_tool_local_single_event() -> None:
                 'timestamp': IsInt(),
                 'messageId': IsStr(),
                 'toolCallId': tool_call_id,
-                'content': '{"type":"STATE_SNAPSHOT","timestamp":null,"raw_event":null,"snapshot":{"key":"value"}}',
+                'content': IsJson(IsPartialDict(type='STATE_SNAPSHOT', snapshot={'key': 'value'})),
                 'role': 'tool',
             },
             {'type': 'STATE_SNAPSHOT', 'timestamp': IsInt(), 'snapshot': {'key': 'value'}},


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-sonnet-5 on behalf of David.

Discovered while cutting today's release: the `latest versions canary` job failed because `ag-ui-protocol` 0.1.21 (published today) stopped serializing `None`-valued optional fields as explicit JSON `null`s. Our actual AG-UI wire output was never affected — `AGUIEventStream.encode_event` already serializes with `exclude_none=True` via `ag_ui.encoder.EventEncoder` — but `tests/test_ag_ui.py::test_tool_local_single_event` hardcoded the old null-inclusive JSON shape for a `STATE_SNAPSHOT` event embedded as a tool-return value, so it broke against the new dependency version.

Verified locally against both `ag-ui-protocol==0.1.19` (currently locked) and `==0.1.21` (latest) — the assertion now holds either way, since it checks the parsed content structurally instead of the exact wire bytes.

No behavior change; test-only.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

