### PR TITLE
Batch provider import-guard checks into a single subprocess

### DIFF
--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -233,6 +233,7 @@ def import_guard_errors() -> dict[str, str | None]:
     return json.loads(result.stdout)
 
 
+@pytest.mark.xdist_group(name='provider_import_guard')
 @pytest.mark.parametrize(('module', 'error_hint'), IMPORT_GUARD_CASES)
 def test_openai_compatible_provider_import_guard(
     module: str, error_hint: str, import_guard_errors: dict[str, str | None]

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -193,11 +193,13 @@ IMPORT_GUARD_CASES = [
 ]
 
 
-# One subprocess for all providers: each interpreter spawn cold-imports pydantic_ai under
-# coverage (~7s in CI), so 20 per-provider subprocesses cost minutes while one costs seconds.
-# Each module still gets a fresh import: the guard fires at module import time, and no
-# provider module is imported twice.
-_IMPORT_GUARD_SCRIPT = """
+@pytest.fixture(scope='module')
+def import_guard_errors() -> dict[str, str | None]:
+    # One subprocess for all providers: each interpreter spawn cold-imports pydantic_ai under
+    # coverage (~7s in CI), so 20 per-provider subprocesses cost minutes while one costs seconds.
+    # Each module still gets a fresh import: the guard fires at module import time, and no
+    # provider module is imported twice.
+    code = """
 import builtins
 import importlib
 import json
@@ -222,14 +224,8 @@ for module in sys.argv[1:]:
         errors[module] = None
 print(json.dumps(errors))
 """
-
-
-@pytest.fixture(scope='module')
-def import_guard_errors() -> dict[str, str | None]:
     modules = [module for module, _ in IMPORT_GUARD_CASES]
-    result = subprocess.run(
-        [sys.executable, '-c', _IMPORT_GUARD_SCRIPT, *modules], text=True, capture_output=True, check=True
-    )
+    result = subprocess.run([sys.executable, '-c', code, *modules], text=True, capture_output=True, check=True)
     return json.loads(result.stdout)
 
 

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -193,11 +193,15 @@ IMPORT_GUARD_CASES = [
 ]
 
 
-@pytest.mark.parametrize(('module', 'error_hint'), IMPORT_GUARD_CASES)
-def test_openai_compatible_provider_import_guard(module: str, error_hint: str) -> None:
-    code = f"""
+# One subprocess for all providers: each interpreter spawn cold-imports pydantic_ai under
+# coverage (~7s in CI), so 20 per-provider subprocesses cost minutes while one costs seconds.
+# Each module still gets a fresh import: the guard fires at module import time, and no
+# provider module is imported twice.
+_IMPORT_GUARD_SCRIPT = """
 import builtins
 import importlib
+import json
+import sys
 
 original_import = builtins.__import__
 
@@ -207,12 +211,35 @@ def import_without_openai(name, globals=None, locals=None, fromlist=(), level=0)
     return original_import(name, globals, locals, fromlist, level)
 
 builtins.__import__ = import_without_openai
-importlib.import_module("pydantic_ai.providers.{module}")
-"""
-    result = subprocess.run([sys.executable, '-c', code], text=True, capture_output=True)
 
-    assert result.returncode != 0
-    assert error_hint in result.stderr
+errors = {}
+for module in sys.argv[1:]:
+    try:
+        importlib.import_module(f"pydantic_ai.providers.{module}")
+    except ImportError as exc:
+        errors[module] = str(exc)
+    else:
+        errors[module] = None
+print(json.dumps(errors))
+"""
+
+
+@pytest.fixture(scope='module')
+def import_guard_errors() -> dict[str, str | None]:
+    modules = [module for module, _ in IMPORT_GUARD_CASES]
+    result = subprocess.run(
+        [sys.executable, '-c', _IMPORT_GUARD_SCRIPT, *modules], text=True, capture_output=True, check=True
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize(('module', 'error_hint'), IMPORT_GUARD_CASES)
+def test_openai_compatible_provider_import_guard(
+    module: str, error_hint: str, import_guard_errors: dict[str, str | None]
+) -> None:
+    error = import_guard_errors[module]
+    assert error is not None, f'importing pydantic_ai.providers.{module} without openai did not raise ImportError'
+    assert error_hint in error
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Why we make these changes

Each of the 20 `test_openai_compatible_provider_import_guard` cases spawned its own Python subprocess that cold-imports `pydantic_ai` under coverage (`patch = ["subprocess"]` + `COVERAGE_PROCESS_START`), costing ~7-8s each in CI - about 2.5 CPU-minutes per matrix job spent re-paying the same interpreter+import+coverage tax. This is part of an effort to roughly halve total CI test time.

One subprocess now checks all providers: the guard fires at module import time and no provider module is imported twice, so per-module isolation within a single interpreter is preserved.

## New public surface

none

## Verification

The same 20 parametrized tests still assert, per provider, that importing the module without `openai` raises an `ImportError` containing the provider-specific hint. Locally: 20 passed in 2.9s (previously ~20 subprocess spawns).

## What changes for existing users

Nothing - test-only change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

