### PR TITLE
Run durable-execution suites in a dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,14 +246,6 @@ jobs:
       # Rebenchmark all-extras after https://github.com/cbornet/blockbuster/pull/61 is released
       # in a compatible version; enable it if the job stays within seven minutes.
       BLOCKBUSTER_ENABLED: ${{ matrix.python-version == '3.13' && matrix.install.name != 'all-extras' }}
-      # Disables Temporal's workflow deadlock detector (temporalio reads this to set the
-      # per-activation budget to `None` instead of 2s). That budget is wall-clock, so it measures
-      # runner contention as readily as a blocking call: `tests/test_temporal.py`,
-      # `tests/test_prefect.py` and `tests/test_dbos.py` each pin an xdist group, putting three
-      # durable-execution servers on four vCPUs, and a descheduled workflow thread trips it as
-      # `TMPRL1101`. The cost: a genuine in-workflow blocking call now hangs to the job timeout
-      # instead of failing in 2s.
-      TEMPORAL_DEBUG: '1'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -279,17 +271,6 @@ jobs:
         with:
           path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
           key: hf-${{ runner.os }}-stsb-bert-tiny-safetensors-f3cb857cba53019a20df283396bcca179cf051a4
-
-      # The Temporal tests download the dev-server binary on first use (see `temporal_env` in
-      # tests/test_temporal.py); cache it so a CDN hiccup can't fail the suite at setup (#5399).
-      - name: cache Temporal dev-server binary
-        if: matrix.install.name == 'all-extras' && matrix.python-version != '3.14'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/temporal-dev-server
-          key: temporal-cli-${{ runner.os }}-${{ runner.arch }}-locked-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            temporal-cli-${{ runner.os }}-${{ runner.arch }}-locked-
 
       # Warm the HF cache out-of-band (retried, non-fatal) so the sentence-transformers
       # test model is on disk when the ST tests load it: the pinned revision is then
@@ -334,7 +315,15 @@ jobs:
       # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
       # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
       # on ubuntu-latest (already 4). See PR benchmark.
-      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
+      # The durable-execution suites are ignored here and run in `test-durable-exec` instead:
+      # each pins a single xdist group around a real server, so their serial chain would
+      # otherwise be the critical-path floor of the all-extras jobs. `test-lowest-versions`
+      # still runs them, proving the minimum `temporalio`/`dbos`/`prefect` bounds.
+      - run: >-
+          uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
+          --ignore=tests/test_temporal.py
+          --ignore=tests/test_dbos.py
+          --ignore=tests/test_prefect.py
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
 
@@ -342,6 +331,83 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.install.name }}
+          path: .coverage
+          include-hidden-files: true
+
+  # The durable-execution suites (Temporal, DBOS, Prefect) each pin all their tests to one
+  # xdist group sharing a real local server, so inside the main matrix they form a serial
+  # chain that dominates the all-extras critical path. Running them in their own job takes
+  # them off that path entirely; serial execution is fine here because nothing waits on it.
+  # New durable-exec tests land in these three files and are picked up automatically.
+  test-durable-exec:
+    name: test durable-exec on ${{ matrix.python-version }}
+    # See the note on the `test` job for the runner selection logic.
+    runs-on: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'ci:slow')
+        && (
+          github.event_name == 'push'
+          || github.event.pull_request.head.repo.full_name == github.repository
+          || contains(github.event.pull_request.labels.*.name, 'ci:fast')
+        )
+        && 'ubicloud-premium-4'
+        || 'ubuntu-latest'
+      }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    env:
+      CI: true
+      COVERAGE_PROCESS_START: ./pyproject.toml
+      # Blocking detection already runs in the Python 3.13 slim, evals, and standard jobs.
+      BLOCKBUSTER_ENABLED: false
+      # Disables Temporal's workflow deadlock detector (temporalio reads this to set the
+      # per-activation budget to `None` instead of 2s). That budget is wall-clock, so it
+      # measures runner contention as readily as a blocking call, and a descheduled workflow
+      # thread trips it as `TMPRL1101`. The cost: a genuine in-workflow blocking call now
+      # hangs to the job timeout instead of failing in 2s.
+      TEMPORAL_DEBUG: '1'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-suffix: durable-exec
+
+      - run: mkdir .coverage
+
+      # The Temporal tests download the dev-server binary on first use (see `temporal_env` in
+      # tests/test_temporal.py); cache it so a CDN hiccup can't fail the suite at setup (#5399).
+      - name: cache Temporal dev-server binary
+        if: matrix.python-version != '3.14'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/temporal-dev-server
+          key: temporal-cli-${{ runner.os }}-${{ runner.arch }}-locked-${{ hashFiles('**/uv.lock') }}
+          restore-keys: |
+            temporal-cli-${{ runner.os }}-${{ runner.arch }}-locked-
+
+      # `--all-extras` matches the all-extras matrix cell these tests used to run in, so
+      # the module-level `try_import` skip-gating (logfire, mcp, openai, anthropic, ...)
+      # behaves identically and coverage combination stays complete.
+      - run: >-
+          uv run --all-extras --no-extra mcp-tasks coverage run -m pytest --durations=20 -n logical --dist=loadgroup
+          tests/test_temporal.py
+          tests/test_dbos.py
+          tests/test_prefect.py
+        env:
+          COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-durable-exec
+
+      - name: store coverage files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-${{ matrix.python-version }}-durable-exec
           path: .coverage
           include-hidden-files: true
 
@@ -563,7 +629,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    needs: [test, test-lowest-versions, test-fastmcp-4]
+    needs: [test, test-durable-exec, test-lowest-versions, test-fastmcp-4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -606,6 +672,7 @@ jobs:
       - mypy
       - docs-assets
       - test
+      - test-durable-exec
       - test-lowest-versions
       - test-temporal-latest
       - test-examples


### PR DESCRIPTION
## Why we make these changes

`tests/test_temporal.py`, `tests/test_dbos.py`, and `tests/test_prefect.py` each pin all their tests to a single xdist group around a real local server (Temporal dev server, DBOS, Prefect harness). Under `--dist=loadgroup` those serial chains dominate the critical path of the slowest matrix jobs (~3+ minutes of the 8.4 min all-extras job). This is part of an effort to roughly halve total CI test time.

This moves those three suites into a new `test-durable-exec` job (same 5 Python versions, `--all-extras` so `try_import` gating and coverage are unchanged) and `--ignore`s them in the main `test` matrix. `test-lowest-versions` still runs them, keeping the minimum `temporalio`/`dbos`/`prefect` bounds proven. It follows the existing precedent of `test-fastmcp-4`: isolating a component with a different runtime profile, not sharding.

Also moves the Temporal dev-server binary cache and `TEMPORAL_DEBUG` env into the new job, where they now belong.

## New public surface

none

## Verification

Coverage artifacts from the new job upload as `coverage-<py>-durable-exec` and are combined by the existing `coverage` job (added to its `needs`); `check` gates on the new job. CI on this PR demonstrates the timing change.

## What changes for existing users

Nothing - CI-only change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

