### PR TITLE
Bump Ubicloud CI test runners from 4 to 8 cores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
 
   test:
     name: test on ${{ matrix.python-version }} (${{ matrix.install.name }})
-    # Use Ubicloud 4-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
+    # Use Ubicloud 8-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
     # `github.event.pull_request` is null on push/tag runs, so those need their own clause to
     # reach Ubicloud -- without it main and release runs silently fall back to `ubuntu-latest`.
@@ -222,7 +222,7 @@ jobs:
           || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-premium-8'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20
@@ -250,7 +250,7 @@ jobs:
       # per-activation budget to `None` instead of 2s). That budget is wall-clock, so it measures
       # runner contention as readily as a blocking call: `tests/test_temporal.py`,
       # `tests/test_prefect.py` and `tests/test_dbos.py` each pin an xdist group, putting three
-      # durable-execution servers on four vCPUs, and a descheduled workflow thread trips it as
+      # durable-execution servers on a few vCPUs, and a descheduled workflow thread trips it as
       # `TMPRL1101`. The cost: a genuine in-workflow blocking call now hangs to the job timeout
       # instead of failing in 2s.
       TEMPORAL_DEBUG: '1'
@@ -347,7 +347,7 @@ jobs:
 
   test-lowest-versions:
     name: test on ${{ matrix.python-version }} (lowest-versions)
-    # Use Ubicloud 4-core runners for maintainers or opted in via 'ci:fast' label
+    # Use Ubicloud 8-core runners for maintainers or opted in via 'ci:fast' label
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
     # See the note on the `test` job for why push/tag runs need their own clause.
     runs-on: >-
@@ -358,7 +358,7 @@ jobs:
           || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-premium-8'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20


### PR DESCRIPTION
## Why we make these changes

The `test` (all-extras) and `test-lowest-versions` jobs are the CI critical path (~8.4 min at the slowest). They already scale with cores via `-n logical`, so moving from `ubicloud-premium-4` to `ubicloud-premium-8` doubles the xdist worker count with no workflow topology change. This is part of an effort to roughly halve total CI test time.

The serial durable-execution xdist groups remain a floor on how far this alone can go; [#7842](https://github.com/pydantic/pydantic-ai/pull/7842) addresses that separately.

## New public surface

none

## Verification

CI timings on this PR vs recent `main` runs (slowest job: 504s on `3.12 all-extras`).

## What changes for existing users

Nothing - CI-only change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

