### PR TITLE
Use the `sysmon` coverage core on Python 3.14 CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,10 @@ jobs:
       # `TMPRL1101`. The cost: a genuine in-workflow blocking call now hangs to the job timeout
       # instead of failing in 2s.
       TEMPORAL_DEBUG: '1'
+      # `sys.monitoring`-based tracing: much lower overhead than the default C tracer, but
+      # it can only measure branch coverage on Python 3.14+. On older versions coverage
+      # falls back with a `no-sysmon` warning, so gate it to 3.14 rather than set it globally.
+      COVERAGE_CORE: ${{ matrix.python-version == '3.14' && 'sysmon' || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -374,6 +378,8 @@ jobs:
       BLOCKBUSTER_ENABLED: false
       # See the note on the `test` job: same runner shape, same deadlock-detector false positives.
       TEMPORAL_DEBUG: '1'
+      # See the note on the `test` job: sysmon can only measure branches on 3.14+.
+      COVERAGE_CORE: ${{ matrix.python-version == '3.14' && 'sysmon' || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Why we make these changes

Coverage's default C tracer adds substantial overhead to every test job. The `sys.monitoring`-based core (`COVERAGE_CORE=sysmon`) is significantly cheaper, but it can only measure branch coverage (this repo sets `branch = true`) on Python 3.14+; on 3.12/3.13 coverage falls back to the default core with a `no-sysmon` warning. So this gates the env var to the 3.14 matrix cells of `test` and `test-lowest-versions`. This is part of an effort to roughly halve total CI test time.

Verified locally on 3.14: `coverage run --branch` under `COVERAGE_CORE=sysmon` collects without falling back, and the suite passes.

## New public surface

none

## Verification

CI timings of the 3.14 cells on this PR vs recent `main` runs; the `coverage` job still combines to 100%.

## What changes for existing users

Nothing - CI-only change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

