### PR TITLE
Use uv-managed Python interpreters in CI instead of the runner's system builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   COLUMNS: 150
   UV_PYTHON: 3.12
   UV_FROZEN: "1"
+  # Never fall back to the runner's system interpreter: Ubuntu's python builds are older
+  # (e.g. 3.12.3 on ubuntu-24.04) and slower than uv's PGO/LTO-optimized managed builds,
+  # which showed up as the 3.12 test cells consistently trailing 3.10/3.13 by ~30%.
+  UV_PYTHON_PREFERENCE: only-managed
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ env:
   COLUMNS: 150
   UV_PYTHON: 3.12
   UV_FROZEN: "1"
-  # Never fall back to the runner's system interpreter: Ubuntu's python builds are older
-  # (e.g. 3.12.3 on ubuntu-24.04) and slower than uv's PGO/LTO-optimized managed builds,
-  # which showed up as the 3.12 test cells consistently trailing 3.10/3.13 by ~30%.
+  # Ubuntu's system interpreters are older and slower than uv's optimized managed builds.
   UV_PYTHON_PREFERENCE: only-managed
 
 permissions:


### PR DESCRIPTION
## Why we make these changes

On `ubuntu-latest`, `setup-uv` resolves `python-version: "3.12"` to the runner's preinstalled `/usr/bin/python3.12` - Ubuntu 24.04's 3.12.3, an 18-month-old patch level built without uv's PGO/LTO optimizations. The CI logs show every 3.12 test cell running on it (`Using CPython 3.12.3 interpreter at: /usr/bin/python3.12`) while 3.10/3.13 got uv-managed builds, and the 3.12 cells consistently trail them: `test durable-exec on 3.12` ran pytest in 223s vs 162s (3.10) and 134s (3.13) in the same run.

Setting `UV_PYTHON_PREFERENCE: only-managed` at the workflow level makes every job use uv's optimized managed builds at the current patch level, uniformly across versions - no per-step edits, and no future version can silently fall back to a stale system interpreter.

## New public surface

none

## Verification

CI on this PR: the 3.12 jobs should log a uv-managed `CPython 3.12.x` (no `/usr/bin` path) and their timings should fall in line with 3.10/3.13.

## What changes for existing users

Nothing - CI-only change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

