### PR TITLE
fix(vercel-ai): do not inject data:None into binary mappings without data

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -1154,7 +1154,9 @@ def _coerce_js_binary_data(value: Any) -> Any:
     # Gate on `media_type` (the type-specific field a real `BinaryContent` carries) so this matches
     # the core `ToolReturnContent` discriminator: a plain user mapping that merely reuses
     # `kind: 'binary'` stays untouched instead of having its `data` rewritten to bytes.
-    if coerced.get('kind') == 'binary' and 'media_type' in coerced:
+    # Also require `data` so a mapping with `kind` + `media_type` but no payload is not given
+    # a `data: None` key it never had.
+    if coerced.get('kind') == 'binary' and 'media_type' in coerced and 'data' in coerced:
         coerced['data'] = _js_binary_to_bytes(coerced.get('data'))
     return coerced
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -5039,6 +5039,40 @@ async def test_adapter_load_tool_return_non_multimodal_binary_kind_dict_preserve
     assert tool_returns[0].content == snapshot({'kind': 'binary', 'data': {'0': 104, '1': 105}, 'label': 'foo'})
 
 
+async def test_adapter_load_tool_return_binary_kind_with_media_type_but_no_data_key_preserved():
+    """A user mapping with `kind: 'binary'` and `media_type` but no `data` key stays identical.
+
+    `_coerce_js_binary_data` previously gated only on `kind` + `media_type` and then assigned
+    `coerced['data'] = _js_binary_to_bytes(coerced.get('data'))`, which injected `data: None`
+    into mappings that never had a `data` key. Those mappings still fail the `MultiModalContent`
+    arm and stay plain dicts, so the adapter was mutating user output without turning it into a
+    file. Regression for https://github.com/pydantic/pydantic-ai/issues/7824.
+    """
+    output = {'kind': 'binary', 'media_type': 'application/json', 'rows': [1, 2]}
+    ui_messages: list[UIMessage] = [
+        UIMessage(id='m1', role='user', parts=[TextUIPart(text='go')]),
+        UIMessage(
+            id='m2',
+            role='assistant',
+            parts=[
+                ToolOutputAvailablePart(
+                    type='tool-get_file',
+                    tool_call_id='tc-1',
+                    state='output-available',
+                    input={},
+                    output=output,
+                )
+            ],
+        ),
+    ]
+
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+    tool_returns = list(iter_message_parts(reloaded, ModelRequest, ToolReturnPart))
+    assert len(tool_returns) == 1
+    assert tool_returns[0].content == output
+    assert 'data' not in tool_returns[0].content
+
+
 async def test_adapter_tool_return_text_only_unchanged():
     """Text-only tool returns serialize as the literal string and round-trip unchanged."""
     messages = [


### PR DESCRIPTION
## Summary
- `_coerce_js_binary_data` gated on `kind: 'binary'` + `media_type` and then always wrote `data`, so a user mapping with no `data` key got `data: None`.
- Require `'data' in coerced` before rewriting, so those mappings stay identical (AG-UI already does).

Fixes #7824

## Test plan
- [x] `uv run pytest tests/test_vercel_ai.py::test_adapter_load_tool_return_binary_kind_with_media_type_but_no_data_key_preserved` (and nearby binary tool-return cases)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

