### PR TITLE
Drop the coverage HTML report and its smokeshow upload from CI

### DIFF
--- a/.github/workflows/after-ci.yml
+++ b/.github/workflows/after-ci.yml
@@ -45,33 +45,3 @@ jobs:
           name: ci-duration-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
           path: ci-duration-record.json
           retention-days: 7
-
-  smokeshow:
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-
-    steps:
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          python-version: "3.12"
-
-      - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: ci.yml
-          name: "(diff-)?coverage-html.*"
-          name_is_regexp: true
-          commit: ${{ github.event.workflow_run.head_sha }}
-          allow_forks: true
-          workflow_conclusion: completed
-          if_no_artifact_found: warn
-
-      - run: uvx smokeshow upload coverage-html
-        if: hashFiles('coverage-html/*.html') != ''
-        env:
-          SMOKESHOW_GITHUB_STATUS_DESCRIPTION: Coverage {coverage-percentage}
-          SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 95
-          SMOKESHOW_GITHUB_CONTEXT: coverage
-          SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          SMOKESHOW_AUTH_KEY: ${{ secrets.SMOKESHOW_AUTH_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,8 +643,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # needed for diff-cover
-          fetch-depth: 0
           persist-credentials: false
 
       - name: get coverage files
@@ -666,13 +664,6 @@ jobs:
       - run: uv run strict-no-cover
         env:
           COVERAGE_FILE: .coverage/.coverage
-
-      - run: uv run coverage html --show-contexts --title "Pydantic AI coverage for ${{ github.sha }}"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-html
-          path: htmlcov
-          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:


### PR DESCRIPTION
## Why we make these changes

The `coverage` job is the last serial link before the `check` gate turns green (~2 min after the final test job). A large chunk of it is `coverage html --show-contexts` over 139k statements plus branch data, then uploading the artifact - consumed only by the `smokeshow` job in `after-ci.yml`, which publishes a browsable report nobody uses (the gating signal is `coverage report` with `fail_under = 100` plus `strict-no-cover`, both unchanged).

This removes the HTML build/upload from the `coverage` job, the `smokeshow` job, and the now-unneeded `fetch-depth: 0` checkout (a leftover for `diff-cover`, which CI no longer runs).

## New public surface

none

## Verification

`coverage` job on this PR still combines all artifacts and enforces 100%; the job should drop from ~120s to ~60-80s, pulling the green `check` in by roughly the same amount.

## What changes for existing users

Contributors no longer get the smokeshow "Coverage" commit status/browsable report; the enforced coverage gate is unchanged.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

