### PR TITLE
Pre-combine coverage data files in each CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,14 @@ jobs:
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
 
+      # Merge this job's per-worker/per-subprocess data files into one before upload: the
+      # combine work runs in parallel across the matrix instead of serially in the `coverage`
+      # job, which would otherwise merge hundreds of files on the critical path.
+      - name: combine coverage files
+        run: uv run ${{ matrix.install.command }} coverage combine
+        env:
+          COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
+
       - name: store coverage files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -419,6 +427,14 @@ jobs:
           uv run ${{ matrix.resolution == 'lowest' && '--no-sync' || '--all-extras --no-extra mcp-tasks' }}
           coverage run -m pytest --durations=20 -n logical --dist=loadgroup
           tests/durable_exec
+        env:
+          COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-durable-exec-${{ matrix.resolution }}
+
+      # See the matching step in the `test` job.
+      - name: combine coverage files
+        run: >-
+          uv run ${{ matrix.resolution == 'lowest' && '--no-sync' || '--all-extras --no-extra mcp-tasks' }}
+          coverage combine
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-durable-exec-${{ matrix.resolution }}
 
@@ -521,6 +537,12 @@ jobs:
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
 
+      # See the matching step in the `test` job.
+      - name: combine coverage files
+        run: uv run --no-sync coverage combine
+        env:
+          COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
+
       - name: store coverage files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -617,6 +639,13 @@ jobs:
           coverage run -m pytest
           tests/test_mcp.py
           tests/models/test_mcp_sampling.py
+        env:
+          COVERAGE_FILE: .coverage/.coverage.fastmcp-4
+
+      # See the matching step in the `test` job. Plain `uv run`: combining is
+      # environment-independent, so the FastMCP 4 `--with` overlay isn't needed.
+      - name: combine coverage files
+        run: uv run --all-extras --no-extra mcp-tasks --all-packages coverage combine
         env:
           COVERAGE_FILE: .coverage/.coverage.fastmcp-4
 


### PR DESCRIPTION
## Why we make these changes

Every test job runs pytest under `-n logical` with `concurrency = multiprocessing` and `patch = ["subprocess"]`, so each xdist worker and spawned subprocess writes its own coverage data file - tens per job, roughly a thousand across the 36 jobs. The central `coverage` job then merges all of them single-threaded, on the critical path between the last test job and the green `check` (~100-140s).

Each job now runs `coverage combine` on its own files before upload, so the merge cost runs in parallel across the matrix (~2-5s each) and the central job combines 36 files instead of ~1000. Artifact size shrinks correspondingly.

## New public surface

none

## Verification

Verified locally that `coverage combine` with the job's `COVERAGE_FILE` merges the worker files into exactly the per-job filename already uploaded today, and that the combined file reports correctly. The `coverage` job on this PR still combines to 100%.

## What changes for existing users

Nothing - CI-only change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

