### PR TITLE
Bump `strict-no-cover` to the in-process rework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ dev = [
     "pytest-recording>=0.13.2",
     "diff-cover>=9.2.0",
     "boto3-stubs[bedrock-runtime]>=1.42.63",
-    "strict-no-cover @ git+https://github.com/Kludex/strict-no-cover.git@8712cae7e2ccdbff2feae2273791b7907be5da0d",
+    "strict-no-cover @ git+https://github.com/pydantic/strict-no-cover.git@6c644106e03138abae01d8d60105d4a7ad4916a1",
     "pytest-xdist>=3.6.1",
     # Needed for PyCharm users
     "pip>=26.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ dev = [
     "pytest-recording>=0.13.2",
     "diff-cover>=9.2.0",
     "boto3-stubs[bedrock-runtime]>=1.42.63",
-    "strict-no-cover @ git+https://github.com/pydantic/strict-no-cover.git@7fc59da2c4dff919db2095a0f0e47101b657131d",
+    "strict-no-cover @ git+https://github.com/Kludex/strict-no-cover.git@989ef1062576abe2c1b062cc2fc024bf4cc7eeb5",
     "pytest-xdist>=3.6.1",
     # Needed for PyCharm users
     "pip>=26.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ dev = [
     "pytest-recording>=0.13.2",
     "diff-cover>=9.2.0",
     "boto3-stubs[bedrock-runtime]>=1.42.63",
-    "strict-no-cover @ git+https://github.com/Kludex/strict-no-cover.git@989ef1062576abe2c1b062cc2fc024bf4cc7eeb5",
+    "strict-no-cover @ git+https://github.com/Kludex/strict-no-cover.git@8712cae7e2ccdbff2feae2273791b7907be5da0d",
     "pytest-xdist>=3.6.1",
     # Needed for PyCharm users
     "pip>=26.1",

--- a/uv.lock
+++ b/uv.lock
@@ -5428,7 +5428,7 @@ dev = [
     { name = "pytest-pretty", specifier = ">=1.3.0" },
     { name = "pytest-recording", specifier = ">=0.13.2" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "strict-no-cover", git = "https://github.com/Kludex/strict-no-cover.git?rev=989ef1062576abe2c1b062cc2fc024bf4cc7eeb5" },
+    { name = "strict-no-cover", git = "https://github.com/Kludex/strict-no-cover.git?rev=8712cae7e2ccdbff2feae2273791b7907be5da0d" },
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
 lint = [
@@ -7256,7 +7256,7 @@ wheels = [
 [[package]]
 name = "strict-no-cover"
 version = "0.1.1"
-source = { git = "https://github.com/Kludex/strict-no-cover.git?rev=989ef1062576abe2c1b062cc2fc024bf4cc7eeb5#989ef1062576abe2c1b062cc2fc024bf4cc7eeb5" }
+source = { git = "https://github.com/Kludex/strict-no-cover.git?rev=8712cae7e2ccdbff2feae2273791b7907be5da0d#8712cae7e2ccdbff2feae2273791b7907be5da0d" }
 dependencies = [
     { name = "coverage" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -5428,7 +5428,7 @@ dev = [
     { name = "pytest-pretty", specifier = ">=1.3.0" },
     { name = "pytest-recording", specifier = ">=0.13.2" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "strict-no-cover", git = "https://github.com/Kludex/strict-no-cover.git?rev=8712cae7e2ccdbff2feae2273791b7907be5da0d" },
+    { name = "strict-no-cover", git = "https://github.com/pydantic/strict-no-cover.git?rev=6c644106e03138abae01d8d60105d4a7ad4916a1" },
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
 lint = [
@@ -7256,7 +7256,7 @@ wheels = [
 [[package]]
 name = "strict-no-cover"
 version = "0.1.1"
-source = { git = "https://github.com/Kludex/strict-no-cover.git?rev=8712cae7e2ccdbff2feae2273791b7907be5da0d#8712cae7e2ccdbff2feae2273791b7907be5da0d" }
+source = { git = "https://github.com/pydantic/strict-no-cover.git?rev=6c644106e03138abae01d8d60105d4a7ad4916a1#6c644106e03138abae01d8d60105d4a7ad4916a1" }
 dependencies = [
     { name = "coverage" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -5428,7 +5428,7 @@ dev = [
     { name = "pytest-pretty", specifier = ">=1.3.0" },
     { name = "pytest-recording", specifier = ">=0.13.2" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "strict-no-cover", git = "https://github.com/pydantic/strict-no-cover.git?rev=7fc59da2c4dff919db2095a0f0e47101b657131d" },
+    { name = "strict-no-cover", git = "https://github.com/Kludex/strict-no-cover.git?rev=989ef1062576abe2c1b062cc2fc024bf4cc7eeb5" },
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
 lint = [
@@ -7256,9 +7256,9 @@ wheels = [
 [[package]]
 name = "strict-no-cover"
 version = "0.1.1"
-source = { git = "https://github.com/pydantic/strict-no-cover.git?rev=7fc59da2c4dff919db2095a0f0e47101b657131d#7fc59da2c4dff919db2095a0f0e47101b657131d" }
+source = { git = "https://github.com/Kludex/strict-no-cover.git?rev=989ef1062576abe2c1b062cc2fc024bf4cc7eeb5#989ef1062576abe2c1b062cc2fc024bf4cc7eeb5" }
 dependencies = [
-    { name = "pydantic" },
+    { name = "coverage" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why we make these changes

[pydantic/strict-no-cover#4](https://github.com/pydantic/strict-no-cover/pull/4) (now merged) reworks `strict-no-cover` to use the coverage API in-process instead of shelling out to `uv run coverage json`, and fixes wrongly-marked-pragma detection. Benchmarked on this repo's `coverage` job: the `strict-no-cover` step drops from 30s to **10s**, shortening the serial tail between the last test job and the green `check`.

The pin moves from `7fc59da` to upstream main's `6c64410`.

## New public surface

none

## Verification

CI `coverage` job on this PR: `strict-no-cover` at ~10s with zero findings; verified separately that a deliberately wrong pragma on an executed line still fails the check (exit 1).

## What changes for existing users

Nothing - CI dependency bump.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.