### PR TITLE
Fix `SpanQuery` mis-evaluating descendant/ancestor conditions after the first when `stop_recursing_when` is set

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -351,7 +351,9 @@ class SpanNode:
         def pruned_descendants():
             stop_recursing_when = query.get('stop_recursing_when')
             return (
-                self._filter_descendants(lambda _: True, stop_recursing_when) if stop_recursing_when else descendants()
+                list(self._filter_descendants(lambda _: True, stop_recursing_when))
+                if stop_recursing_when
+                else descendants()
             )
 
         if (min_descendant_count := query.get('min_descendant_count')) and len(descendants()) < min_descendant_count:
@@ -382,7 +384,11 @@ class SpanNode:
         @cache
         def pruned_ancestors():
             stop_recursing_when = query.get('stop_recursing_when')
-            return self._filter_ancestors(lambda _: True, stop_recursing_when) if stop_recursing_when else ancestors()
+            return (
+                list(self._filter_ancestors(lambda _: True, stop_recursing_when))
+                if stop_recursing_when
+                else ancestors()
+            )
 
         if (min_depth := query.get('min_depth')) and len(ancestors()) < min_depth:
             return False

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -584,6 +584,104 @@ async def test_span_tree_descendants_methods():
     )
 
 
+async def test_span_query_stop_recursing_when_with_multiple_conditions():
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/7484.
+
+    When `stop_recursing_when` was present, the pruned descendants/ancestors were cached as a
+    generator rather than a list, so only the first descendant/ancestor condition in the query saw
+    any nodes and every later condition was evaluated against an (at least partially) exhausted
+    iterator: `no_*_has` and `all_*_have` passed vacuously, `some_*_has` failed vacuously.
+    """
+    with context_subtree() as tree:
+        with logfire.span('root', depth=0):
+            with logfire.span('level1', depth=1):
+                with logfire.span('level2', depth=2):
+                    with logfire.span('level3', depth=3):
+                        logfire.info('leaf', depth=4)
+    assert isinstance(tree, SpanTree)
+
+    root_node = tree.roots[0]
+    leaf_node = root_node.first_descendant(lambda node: node.name == 'leaf')
+    assert leaf_node is not None
+
+    # An inert prune (matching no node) must not change the result of any multi-condition query.
+    # `no_descendant_has` after another descendant condition: 'level2' IS a descendant, so this must fail.
+    query: SpanQuery = {
+        'all_descendants_have': {'has_attribute_keys': ['depth']},
+        'no_descendant_has': {'name_equals': 'level2'},
+    }
+    assert not root_node.matches(query)
+    assert not root_node.matches({**query, 'stop_recursing_when': {'name_equals': 'never-matches'}})
+
+    # `all_descendants_have` after another descendant condition: 'leaf' does not contain 'level'.
+    query = {
+        'some_descendant_has': {'name_equals': 'leaf'},
+        'all_descendants_have': {'name_contains': 'level'},
+    }
+    assert not root_node.matches(query)
+    assert not root_node.matches({**query, 'stop_recursing_when': {'name_equals': 'never-matches'}})
+
+    # Same on the ancestor side: 'root' IS an ancestor of the leaf, so this must fail.
+    query = {
+        'all_ancestors_have': {'has_attribute_keys': ['depth']},
+        'no_ancestor_has': {'name_equals': 'root'},
+    }
+    assert not leaf_node.matches(query)
+    assert not leaf_node.matches({**query, 'stop_recursing_when': {'name_equals': 'never-matches'}})
+
+    # 'root' does not contain 'level'.
+    query = {
+        'some_ancestor_has': {'name_equals': 'root'},
+        'all_ancestors_have': {'name_contains': 'level'},
+    }
+    assert not leaf_node.matches(query)
+    assert not leaf_node.matches({**query, 'stop_recursing_when': {'name_equals': 'never-matches'}})
+
+    # An effective prune applies to every condition in the query, not just the first: pruning at
+    # 'level2' leaves ['level1', 'level2'], and 'level1' is in there, so `no_descendant_has` must fail
+    # even though `some_descendant_has` already consumed past it.
+    assert not root_node.matches(
+        {
+            'some_descendant_has': {'name_equals': 'level2'},
+            'no_descendant_has': {'name_equals': 'level1'},
+            'stop_recursing_when': {'name_equals': 'level2'},
+        }
+    )
+    assert not leaf_node.matches(
+        {
+            'some_ancestor_has': {'name_equals': 'level2'},
+            'no_ancestor_has': {'name_equals': 'level3'},
+            'stop_recursing_when': {'name_equals': 'level2'},
+        }
+    )
+
+    # The workaround of splitting each condition into its own `and_` sub-query, each carrying its own
+    # `stop_recursing_when`, behaves identically to the combined queries above.
+    assert not root_node.matches(
+        {
+            'and_': [
+                {'some_descendant_has': {'name_equals': 'level2'}, 'stop_recursing_when': {'name_equals': 'level2'}},
+                {'no_descendant_has': {'name_equals': 'level1'}, 'stop_recursing_when': {'name_equals': 'level2'}},
+            ]
+        }
+    )
+    assert root_node.matches(
+        {
+            'and_': [
+                {'some_descendant_has': {'name_equals': 'level2'}, 'stop_recursing_when': {'name_equals': 'level2'}},
+                {'no_descendant_has': {'name_equals': 'level3'}, 'stop_recursing_when': {'name_equals': 'level2'}},
+            ]
+        }
+    )
+    assert root_node.matches(
+        {
+            'some_descendant_has': {'name_equals': 'level2'},
+            'no_descendant_has': {'name_equals': 'level3'},
+            'stop_recursing_when': {'name_equals': 'level2'},
+        }
+    )
+
+
 async def test_log_levels_and_exceptions():
     """Test recording different log levels and exceptions in spans."""
     with context_subtree() as tree:


### PR DESCRIPTION
- Closes #7484

When a `SpanQuery` carries `stop_recursing_when`, the cached `pruned_descendants()` / `pruned_ancestors()` helpers in `SpanNode._matches_query` returned the raw generators from `_filter_descendants` / `_filter_ancestors`. The first descendant/ancestor condition in the query drained the generator, so every later condition ran against an (at least partially) exhausted iterator: `no_*_has` and `all_*_have` passed vacuously, `some_*_has` failed vacuously. The dangerous case is the false negative, "no descendant has status error" reporting success on a trace that contains one.

The fix materializes both pruned sequences with `list(...)` before caching, matching what the other callers of `_filter_descendants` / `_filter_ancestors` (`find_descendants`, `first_descendant`, `find_ancestors`, `first_ancestor`) already do. Behavior without `stop_recursing_when` is unchanged (those branches already returned lists).

The regression test covers multiple descendant and ancestor conditions after a `stop_recursing_when` (both the inert-prune and effective-prune cases), and verifies the workaround of splitting conditions into `and_` sub-queries that each carry their own `stop_recursing_when` still behaves identically.

Note: #7494 previously proposed the same materialization but was auto-closed on the assignment policy.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

