### PR TITLE
Accept async iterables in `RealtimeSession.send_audio()` and move the voice example to `listentome`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ def order_status(order_id: str) -> str:
     return f'Order {order_id}: shipped, arriving Thursday.'
 
 async with agent.realtime('openai:gpt-realtime-2.1').session() as session:
-    microphone = asyncio.create_task(stream_microphone(session))  # chunks → session.send_audio()
+    microphone = asyncio.create_task(session.send_audio(microphone_chunks()))  # your microphone → the model
     speaker = asyncio.create_task(play_audio(session.stream_audio()))  # model audio → your speaker
     async for part in session.stream_transcripts():
         print(f'{part.speaker}: {part.transcript}')

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ uv add "pydantic-ai[openai-realtime]"
 ```
 
 ```python
-import anyio
+import asyncio
 
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import MCP
@@ -137,12 +137,9 @@ def order_status(order_id: str) -> str:
     """Look up the status of an order."""
     return f'Order {order_id}: shipped, arriving Thursday.'
 
-async with (
-    agent.realtime('openai:gpt-realtime-2.1').session() as session,
-    anyio.create_task_group() as tg,
-):
-    tg.start_soon(session.send_audio, microphone_chunks())  # your microphone → the model
-    tg.start_soon(play_audio, session.stream_audio())  # model audio → your speaker
+async with agent.realtime('openai:gpt-realtime-2.1').session() as session:
+    microphone = asyncio.create_task(session.send_audio(microphone_chunks()))  # your microphone → the model
+    speaker = asyncio.create_task(play_audio(session.stream_audio()))  # model audio → your speaker
     async for part in session.stream_transcripts():
         print(f'{part.speaker}: {part.transcript}')
 ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ uv add "pydantic-ai[openai-realtime]"
 ```
 
 ```python
-import asyncio
+import anyio
 
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import MCP
@@ -137,9 +137,12 @@ def order_status(order_id: str) -> str:
     """Look up the status of an order."""
     return f'Order {order_id}: shipped, arriving Thursday.'
 
-async with agent.realtime('openai:gpt-realtime-2.1').session() as session:
-    microphone = asyncio.create_task(session.send_audio(microphone_chunks()))  # your microphone → the model
-    speaker = asyncio.create_task(play_audio(session.stream_audio()))  # model audio → your speaker
+async with (
+    agent.realtime('openai:gpt-realtime-2.1').session() as session,
+    anyio.create_task_group() as tg,
+):
+    tg.start_soon(session.send_audio, microphone_chunks())  # your microphone → the model
+    tg.start_soon(play_audio, session.stream_audio())  # model audio → your speaker
     async for part in session.stream_transcripts():
         print(f'{part.speaker}: {part.transcript}')
 ```

--- a/docs/examples/realtime-voice.md
+++ b/docs/examples/realtime-voice.md
@@ -12,14 +12,17 @@ Demonstrates:
 The agent exposes a single `get_weather` tool the model can call mid-conversation, and the terminal
 shows a running transcript of both sides of the conversation plus any tool calls.
 
-Both audio directions stay bounded rather than growing without limit: microphone capture relies on
-PortAudio's own input buffer, which drops audio on overflow if the network falls behind, and playback
-that falls more than five seconds behind the model drops its oldest audio, so a machine that stutters
-glitches instead of ending the call.
+Audio I/O runs on [`listentome`](https://github.com/Kludex/listentome), whose microphone is an
+async iterator that [`send_audio()`][pydantic_ai.realtime.RealtimeSession.send_audio] consumes
+directly, and whose speaker `write()` suspends until the device has played each chunk from
+[`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]. Both audio directions stay
+bounded rather than growing without limit: the microphone stream and the session's audio buffer
+each drop their oldest blocks if their consumer falls behind, so a machine that stutters glitches
+instead of ending the call.
 
 Barge-in itself is handled by the provider — the model stops as soon as the user speaks. What the
-example adds is the half the provider can't see: it clears queued *and* partially consumed playback
-audio, then reports the duration actually played to
+example adds is the half the provider can't see: it drops the model audio that hadn't reached the
+speaker yet, then reports the duration actually played to
 [`interrupt()`][pydantic_ai.realtime.RealtimeSession.interrupt], so the provider truncates its
 transcript to what the user really heard rather than the whole turn. It only does so when unheard
 audio was actually dropped, since the speech-start event also fires on an ordinary turn where the
@@ -28,9 +31,9 @@ user heard the previous reply in full.
 ## Running the Example
 
 The examples dependencies include
-[`sounddevice`](https://python-sounddevice.readthedocs.io) for microphone and speaker access. It
-also requires the PortAudio system library; on Linux, install `libportaudio2` if importing
-`sounddevice` fails.
+[`listentome`](https://github.com/Kludex/listentome) for microphone and speaker access. It
+also requires the PortAudio system library: `brew install portaudio` on macOS,
+`apt install libportaudio2` on Debian/Ubuntu.
 
 The realtime model runs on `gpt-realtime`, so you'll need an OpenAI API key set via
 `OPENAI_API_KEY`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,7 +152,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
         return f'Order {order_id}: shipped, arriving Thursday.'
 
     async with agent.realtime('openai:gpt-realtime-2.1').session() as session:
-        microphone = asyncio.create_task(stream_microphone(session))  # chunks → session.send_audio()
+        microphone = asyncio.create_task(session.send_audio(microphone_chunks()))  # your microphone → the model
         speaker = asyncio.create_task(play_audio(session.stream_audio()))  # model audio → your speaker
         async for part in session.stream_transcripts():
             print(f'{part.speaker}: {part.transcript}')

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     ```
 
     ```python {test="skip" lint="skip"}
-    import asyncio
+    import anyio
 
     from pydantic_ai import Agent
     from pydantic_ai.capabilities import MCP
@@ -151,9 +151,12 @@ From simple typed data extraction to complex, long-running multi-agent collabora
         """Look up the status of an order."""
         return f'Order {order_id}: shipped, arriving Thursday.'
 
-    async with agent.realtime('openai:gpt-realtime-2.1').session() as session:
-        microphone = asyncio.create_task(session.send_audio(microphone_chunks()))  # your microphone → the model
-        speaker = asyncio.create_task(play_audio(session.stream_audio()))  # model audio → your speaker
+    async with (
+        agent.realtime('openai:gpt-realtime-2.1').session() as session,
+        anyio.create_task_group() as tg,
+    ):
+        tg.start_soon(session.send_audio, microphone_chunks())  # your microphone → the model
+        tg.start_soon(play_audio, session.stream_audio())  # model audio → your speaker
         async for part in session.stream_transcripts():
             print(f'{part.speaker}: {part.transcript}')
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     ```
 
     ```python {test="skip" lint="skip"}
-    import anyio
+    import asyncio
 
     from pydantic_ai import Agent
     from pydantic_ai.capabilities import MCP
@@ -151,12 +151,9 @@ From simple typed data extraction to complex, long-running multi-agent collabora
         """Look up the status of an order."""
         return f'Order {order_id}: shipped, arriving Thursday.'
 
-    async with (
-        agent.realtime('openai:gpt-realtime-2.1').session() as session,
-        anyio.create_task_group() as tg,
-    ):
-        tg.start_soon(session.send_audio, microphone_chunks())  # your microphone → the model
-        tg.start_soon(play_audio, session.stream_audio())  # model audio → your speaker
+    async with agent.realtime('openai:gpt-realtime-2.1').session() as session:
+        microphone = asyncio.create_task(session.send_audio(microphone_chunks()))  # your microphone → the model
+        speaker = asyncio.create_task(play_audio(session.stream_audio()))  # model audio → your speaker
         async for part in session.stream_transcripts():
             print(f'{part.speaker}: {part.transcript}')
     ```

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -8,7 +8,9 @@ playback and captions. Use the high-level session views for media and transcript
 
 You send and receive raw audio samples; there is no container or codec in the live path.
 [`send_audio()`][pydantic_ai.realtime.RealtimeSession.send_audio] accepts raw, signed 16-bit
-little-endian mono PCM. [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
+little-endian mono PCM — a single chunk, or an async iterable of chunks (a microphone stream, a
+WebSocket receive loop) that it forwards until the iterable ends, so a whole capture loop can be
+one task. [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
 returns the same format. Capture at
 [`session.audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]
 and play at

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -32,9 +32,8 @@ shutdown, use the [realtime voice assistant example](../examples/realtime-voice.
 Run media views alongside the main iterator:
 
 ```python
+import asyncio
 from collections.abc import AsyncIterator
-
-import anyio
 
 from pydantic_ai import Agent
 from pydantic_ai.messages import SpeechPart
@@ -55,15 +54,15 @@ async def show_transcripts(parts: AsyncIterator[SpeechPart]) -> None:
 
 
 async def main():
-    async with anyio.create_task_group() as tg:
-        async with agent.realtime('openai:gpt-realtime').session() as session:
-            tg.start_soon(play_audio, session.stream_audio())
-            tg.start_soon(show_transcripts, session.stream_transcripts())
-            async for event in session:
-                if isinstance(event, RealtimeTurnCompleteEvent):
-                    break
-        # Leaving the `async with` block closes the session, which ends every live view,
-        # so the task group finishes on its own.
+    async with agent.realtime('openai:gpt-realtime').session() as session:
+        audio_task = asyncio.create_task(play_audio(session.stream_audio()))
+        transcript_task = asyncio.create_task(show_transcripts(session.stream_transcripts()))
+        async for event in session:
+            if isinstance(event, RealtimeTurnCompleteEvent):
+                break
+
+    # Leaving the `async with` block closes the session, which ends every live view.
+    await asyncio.gather(audio_task, transcript_task)
 ```
 
 Each view is independently bounded; a slow consumer drops its oldest item rather than stalling

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -32,8 +32,9 @@ shutdown, use the [realtime voice assistant example](../examples/realtime-voice.
 Run media views alongside the main iterator:
 
 ```python
-import asyncio
 from collections.abc import AsyncIterator
+
+import anyio
 
 from pydantic_ai import Agent
 from pydantic_ai.messages import SpeechPart
@@ -54,15 +55,15 @@ async def show_transcripts(parts: AsyncIterator[SpeechPart]) -> None:
 
 
 async def main():
-    async with agent.realtime('openai:gpt-realtime').session() as session:
-        audio_task = asyncio.create_task(play_audio(session.stream_audio()))
-        transcript_task = asyncio.create_task(show_transcripts(session.stream_transcripts()))
-        async for event in session:
-            if isinstance(event, RealtimeTurnCompleteEvent):
-                break
-
-    # Leaving the `async with` block closes the session, which ends every live view.
-    await asyncio.gather(audio_task, transcript_task)
+    async with anyio.create_task_group() as tg:
+        async with agent.realtime('openai:gpt-realtime').session() as session:
+            tg.start_soon(play_audio, session.stream_audio())
+            tg.start_soon(show_transcripts, session.stream_transcripts())
+            async for event in session:
+                if isinstance(event, RealtimeTurnCompleteEvent):
+                    break
+        # Leaving the `async with` block closes the session, which ends every live view,
+        # so the task group finishes on its own.
 ```
 
 Each view is independently bounded; a slow consumer drops its oldest item rather than stalling

--- a/docs/realtime/deployment.md
+++ b/docs/realtime/deployment.md
@@ -94,9 +94,8 @@ demonstrates this setup end to end; a minimal FastAPI relay — the browser send
 frames and plays the frames it receives — is:
 
 ```python
-from collections.abc import AsyncIterator
+import asyncio
 
-import anyio
 from fastapi import FastAPI, WebSocket
 
 from pydantic_ai import Agent
@@ -108,19 +107,18 @@ app = FastAPI()
 @app.websocket('/voice')
 async def voice_socket(websocket: WebSocket):
     await websocket.accept()
-    async with (
-        agent.realtime('openai:gpt-realtime').session() as session,
-        anyio.create_task_group() as tg,
-    ):
+    async with agent.realtime('openai:gpt-realtime').session() as session:
 
-        async def receive_audio() -> AsyncIterator[bytes]:
+        async def pump_input():
             while True:
-                yield await websocket.receive_bytes()
+                await session.send_audio(await websocket.receive_bytes())
 
-        tg.start_soon(session.send_audio, receive_audio())
-        async for chunk in session.stream_audio():
-            await websocket.send_bytes(chunk)
-        tg.cancel_scope.cancel()
+        input_task = asyncio.create_task(pump_input())
+        try:
+            async for chunk in session.stream_audio():
+                await websocket.send_bytes(chunk)
+        finally:
+            input_task.cancel()
 ```
 
 ## SIP/telephony bridge

--- a/docs/realtime/deployment.md
+++ b/docs/realtime/deployment.md
@@ -94,8 +94,9 @@ demonstrates this setup end to end; a minimal FastAPI relay — the browser send
 frames and plays the frames it receives — is:
 
 ```python
-import asyncio
+from collections.abc import AsyncIterator
 
+import anyio
 from fastapi import FastAPI, WebSocket
 
 from pydantic_ai import Agent
@@ -107,18 +108,19 @@ app = FastAPI()
 @app.websocket('/voice')
 async def voice_socket(websocket: WebSocket):
     await websocket.accept()
-    async with agent.realtime('openai:gpt-realtime').session() as session:
+    async with (
+        agent.realtime('openai:gpt-realtime').session() as session,
+        anyio.create_task_group() as tg,
+    ):
 
-        async def pump_input():
+        async def receive_audio() -> AsyncIterator[bytes]:
             while True:
-                await session.send_audio(await websocket.receive_bytes())
+                yield await websocket.receive_bytes()
 
-        input_task = asyncio.create_task(pump_input())
-        try:
-            async for chunk in session.stream_audio():
-                await websocket.send_bytes(chunk)
-        finally:
-            input_task.cancel()
+        tg.start_soon(session.send_audio, receive_audio())
+        async for chunk in session.stream_audio():
+            await websocket.send_bytes(chunk)
+        tg.cancel_scope.cancel()
 ```
 
 ## SIP/telephony bridge

--- a/docs/realtime/overview.md
+++ b/docs/realtime/overview.md
@@ -34,7 +34,6 @@ import contextlib
 from collections.abc import AsyncIterator
 
 from pydantic_ai import Agent
-from pydantic_ai.realtime import RealtimeSession
 
 agent = Agent(instructions='You take reservations for The Terrace. Keep replies short.')
 
@@ -45,8 +44,8 @@ async def check_availability(day: str, party_size: int) -> str:
     return f'One table for {party_size} is free at 7 pm {day}.'
 
 
-async def stream_microphone(session: RealtimeSession) -> None:
-    ...  # capture signed 16-bit mono PCM chunks and `await session.send_audio(chunk)`
+async def microphone_chunks() -> AsyncIterator[bytes]:
+    yield b'...'  # capture signed 16-bit mono PCM chunks from your microphone
 
 
 async def play_audio(chunks: AsyncIterator[bytes]) -> None:
@@ -56,7 +55,7 @@ async def play_audio(chunks: AsyncIterator[bytes]) -> None:
 
 async def main():
     async with agent.realtime('openai:gpt-realtime').session() as session:
-        microphone = asyncio.create_task(stream_microphone(session))
+        microphone = asyncio.create_task(session.send_audio(microphone_chunks()))
         speaker = asyncio.create_task(play_audio(session.stream_audio()))
 
         async for part in session.stream_transcripts():
@@ -84,7 +83,7 @@ which depend on your audio stack)_
 Capture and play at the sample rates the model expects — they're reported by the model's profile
 and can differ between input and output (see [Provider support](#provider-support) below). The
 [voice assistant example](../examples/realtime-voice.md) fills the placeholders in with
-`sounddevice` for a runnable microphone-and-speaker loop; the
+[`listentome`](https://github.com/Kludex/listentome) for a runnable microphone-and-speaker loop; the
 [text-to-audio example](../examples/realtime-text-to-audio.md) skips audio input entirely by
 sending a text prompt and saving the spoken reply to a WAV file.
 

--- a/docs/realtime/overview.md
+++ b/docs/realtime/overview.md
@@ -29,9 +29,9 @@ out, and a transcript log. The model hears the user, calls your tool on your bac
 out loud:
 
 ```python {title="reservations.py" dunder_name="not_main"}
+import asyncio
+import contextlib
 from collections.abc import AsyncIterator
-
-import anyio
 
 from pydantic_ai import Agent
 
@@ -54,12 +54,9 @@ async def play_audio(chunks: AsyncIterator[bytes]) -> None:
 
 
 async def main():
-    async with (
-        agent.realtime('openai:gpt-realtime').session() as session,
-        anyio.create_task_group() as tg,
-    ):
-        tg.start_soon(session.send_audio, microphone_chunks())
-        tg.start_soon(play_audio, session.stream_audio())
+    async with agent.realtime('openai:gpt-realtime').session() as session:
+        microphone = asyncio.create_task(session.send_audio(microphone_chunks()))
+        speaker = asyncio.create_task(play_audio(session.stream_audio()))
 
         async for part in session.stream_transcripts():
             print(f'{part.speaker}: {part.transcript}')
@@ -68,13 +65,16 @@ async def main():
             if part.speaker == 'assistant':
                 break  # keep listening in a real call; we stop after one exchange
 
-        # The microphone and speaker run on live streams that outlast one exchange, so stop
-        # their tasks explicitly; leaving the `async with` block then closes the session.
-        tg.cancel_scope.cancel()
+    # Leaving the `async with` block closes the session, which ends the speaker's audio stream —
+    # but the microphone reads an external source, so stop it explicitly.
+    microphone.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await microphone
+    await speaker
 
 
 if __name__ == '__main__':
-    anyio.run(main)
+    asyncio.run(main())
 ```
 
 _(This example is complete, it can be run "as is" — after filling in the two audio placeholders,

--- a/docs/realtime/overview.md
+++ b/docs/realtime/overview.md
@@ -29,9 +29,9 @@ out, and a transcript log. The model hears the user, calls your tool on your bac
 out loud:
 
 ```python {title="reservations.py" dunder_name="not_main"}
-import asyncio
-import contextlib
 from collections.abc import AsyncIterator
+
+import anyio
 
 from pydantic_ai import Agent
 
@@ -54,9 +54,12 @@ async def play_audio(chunks: AsyncIterator[bytes]) -> None:
 
 
 async def main():
-    async with agent.realtime('openai:gpt-realtime').session() as session:
-        microphone = asyncio.create_task(session.send_audio(microphone_chunks()))
-        speaker = asyncio.create_task(play_audio(session.stream_audio()))
+    async with (
+        agent.realtime('openai:gpt-realtime').session() as session,
+        anyio.create_task_group() as tg,
+    ):
+        tg.start_soon(session.send_audio, microphone_chunks())
+        tg.start_soon(play_audio, session.stream_audio())
 
         async for part in session.stream_transcripts():
             print(f'{part.speaker}: {part.transcript}')
@@ -65,16 +68,13 @@ async def main():
             if part.speaker == 'assistant':
                 break  # keep listening in a real call; we stop after one exchange
 
-    # Leaving the `async with` block closes the session, which ends the speaker's audio stream —
-    # but the microphone reads an external source, so stop it explicitly.
-    microphone.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await microphone
-    await speaker
+        # The microphone and speaker run on live streams that outlast one exchange, so stop
+        # their tasks explicitly; leaving the `async with` block then closes the session.
+        tg.cancel_scope.cancel()
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    anyio.run(main)
 ```
 
 _(This example is complete, it can be run "as is" — after filling in the two audio placeholders,

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -6,8 +6,10 @@ exposes a single `get_weather` tool the model can call mid-conversation.
 
 Talk to it — and try interrupting while it's speaking: the model stops and listens (barge-in).
 
-It needs the `sounddevice` package for microphone and speaker access
-(`pip install sounddevice`), and an OpenAI API key set via `OPENAI_API_KEY`.
+It needs the `listentome` package for microphone and speaker access
+(`pip install listentome`), which requires the PortAudio system library
+(`brew install portaudio` on macOS, `apt install libportaudio2` on Debian/Ubuntu),
+and an OpenAI API key set via `OPENAI_API_KEY`.
 
 Run with:
 
@@ -16,13 +18,8 @@ Run with:
 
 from __future__ import annotations
 
-import threading
-from collections import deque
-from functools import partial
-from typing import Any
-
 import anyio
-import anyio.to_thread
+import listentome
 import logfire
 
 from pydantic_ai import (
@@ -35,31 +32,11 @@ from pydantic_ai import (
     SpeechPart,
     SpeechPartDelta,
 )
-from pydantic_ai.realtime import (
-    RealtimeEvent,
-    RealtimeInputSpeechStartEvent,
-    RealtimeSession,
-)
-
-try:
-    import sounddevice
-except (ImportError, OSError) as e:  # pragma: no cover
-    # `sounddevice` needs the PortAudio system library, which raises `OSError` (not `ImportError`)
-    # when missing — e.g. on headless CI. Defer the failure to `main()` so the module still imports.
-    sounddevice = None
-    _sounddevice_error: Exception | None = e
-else:
-    _sounddevice_error = None
+from pydantic_ai.realtime import RealtimeInputSpeechStartEvent, RealtimeSession
 
 # 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
 logfire.configure(send_to_logfire='if-token-present')
 logfire.instrument_pydantic_ai()
-
-# OpenAI's realtime models speak and listen in 24 kHz mono PCM16 audio.
-SAMPLE_RATE = 24000
-CHANNELS = 1
-BLOCK_SIZE = 2400  # 100 ms per audio block
-PLAYBACK_BUFFER_SECONDS = 5
 
 agent = Agent(
     instructions='You are a friendly voice assistant. Keep your replies short and conversational.'
@@ -72,144 +49,81 @@ def get_weather(city: str) -> str:
     return f'It is currently 21 degrees and sunny in {city}.'
 
 
-class PlaybackBuffer:
-    """Thread-safe, bounded model-audio buffer with playback accounting."""
+async def conversation(session: RealtimeSession) -> None:
+    """Wire the microphone and speaker to the session and run the conversation."""
+    # Capture and play at the rates this model expects; they can differ per direction.
+    mic = listentome.InputStream(
+        samplerate=session.audio_input_sample_rate,
+        channels=1,
+        dtype='int16',
+        blocksize=session.audio_input_sample_rate // 10,  # 100 ms per block
+    )
+    speaker = listentome.OutputStream(
+        samplerate=session.audio_output_sample_rate, channels=1, dtype='int16'
+    )
+    byte_rate = session.audio_output_sample_rate * 2  # bytes per second of mono PCM16
 
-    def __init__(self, max_bytes: int):
-        self._max_bytes = max_bytes
-        self._chunks: deque[bytes] = deque()
-        self._carry = bytearray()
-        self._buffered_bytes = 0
-        self._played_bytes = 0
-        self._lock = threading.Lock()
+    async with mic, speaker, anyio.create_task_group() as tg:
+        # The microphone is an async iterator of PCM blocks; `send_audio` forwards them
+        # all. If the network falls behind, the stream drops its oldest blocks rather
+        # than letting latency grow without bound.
+        tg.start_soon(session.send_audio, mic)
 
-    def start_turn(self) -> None:
-        with self._lock:
-            self._chunks.clear()
-            self._carry.clear()
-            self._buffered_bytes = 0
-            self._played_bytes = 0
+        # `write()` returns once the device has consumed a chunk, so playback advances at
+        # speaker pace while the model runs ahead; `stream_audio()`'s own buffer bounds
+        # the backlog, dropping its oldest chunks if playback falls too far behind, so a
+        # machine that stutters glitches instead of ending the call. Received and played
+        # bytes are tracked per assistant turn so barge-in can report how much of its
+        # reply the user actually heard.
+        received = played = 0
 
-    def add(self, chunk: bytes) -> None:
-        with self._lock:
-            # If the speaker falls far enough behind that the model is seconds ahead of what the
-            # caller hears, drop the oldest audio rather than raise: a glitch is recoverable, and
-            # ending a live call because one machine stuttered is not. (After a drop the
-            # played-duration accounting is approximate, which is fine for a glitch.)
-            # A chunk longer than the whole window keeps its tail.
-            chunk = chunk[-self._max_bytes :]
-            while (over := self._buffered_bytes + len(chunk) - self._max_bytes) > 0:
-                # Oldest first: whatever `fill` already staged for the speaker, then queued chunks.
-                if self._carry:
-                    drop = min(len(self._carry), over)
-                    del self._carry[:drop]
-                else:
-                    drop = len(self._chunks.popleft())
-                self._buffered_bytes -= drop
-            self._chunks.append(chunk)
-            self._buffered_bytes += len(chunk)
+        async def play_audio(scope: anyio.CancelScope) -> None:
+            nonlocal played
+            with scope:
+                async for chunk in session.stream_audio():
+                    await speaker.write(chunk)
+                    played += len(chunk)
 
-    def fill(self, outdata: bytearray) -> None:
-        """Fill one speaker block, padding an underrun with silence."""
-        with self._lock:
-            want = len(outdata)
-            while len(self._carry) < want and self._chunks:
-                self._carry.extend(self._chunks.popleft())
-            played = min(want, len(self._carry))
-            outdata[:] = bytes(self._carry[:played]).ljust(want, b'\x00')
-            del self._carry[:played]
-            self._buffered_bytes -= played
-            self._played_bytes += played
+        playback = anyio.CancelScope()
+        tg.start_soon(play_audio, playback)
 
-    def interrupt(self) -> int | None:
-        """Drop unheard audio; return milliseconds played, or `None` if nothing was left unheard.
-
-        A turn the user heard in full needs no truncation — reporting one anyway would only make
-        the provider discard part of a completed turn — so an interruption is only reported when
-        unplayed audio was actually dropped.
-        """
-        with self._lock:
-            if not self._chunks and not self._carry:
-                return None
-            self._chunks.clear()
-            self._carry.clear()
-            self._buffered_bytes = 0
-            played_ms = self._played_bytes * 1000 // (SAMPLE_RATE * CHANNELS * 2)
-            self._played_bytes = 0
-            return played_ms
-
-
-def fill_speaker(playback: PlaybackBuffer, outdata: bytearray, *_: object) -> None:
-    """Speaker callback (PortAudio thread)."""
-    playback.fill(outdata)
-
-
-async def handle_event(
-    session: RealtimeSession,
-    event: RealtimeEvent,
-    playback: PlaybackBuffer,
-) -> None:
-    """Handle one session event."""
-    match event:
-        case PartDeltaEvent(delta=SpeechPartDelta(audio_chunk=chunk)) if chunk:
-            playback.add(chunk)
-        case RealtimeInputSpeechStartEvent():
-            # The provider stops the model on its own when the user speaks; what it can't know is how
-            # much of its audio actually reached the speaker. Drop what didn't, and report the rest so
-            # the provider doesn't record a turn the user never heard. The event fires whenever the
-            # user starts speaking — including when nothing is playing — so only interrupt when
-            # unheard audio was actually dropped.
-            if (played_ms := playback.interrupt()) is not None:
-                await session.interrupt(played_ms=played_ms)
-        case PartStartEvent(part=SpeechPart(speaker='assistant')):
-            playback.start_turn()
-        case PartEndEvent(part=SpeechPart(speaker='user', transcript=transcript)):
-            print(f'you: {transcript}')
-        case PartEndEvent(part=SpeechPart(speaker='assistant', transcript=transcript)):
-            print(f'assistant: {transcript}')
-        case FunctionToolCallEvent(part=call):
-            print(f'[calling {call.tool_name}]')
-        case FunctionToolResultEvent(part=result):
-            print(f'[{result.tool_name} returned: {result.content}]')
-
-
-async def stream_mic(session: RealtimeSession, mic: Any) -> None:
-    """Read microphone blocks in a worker thread and forward them to the session."""
-    while True:
-        data, _overflowed = await anyio.to_thread.run_sync(mic.read, BLOCK_SIZE)
-        await session.send_audio(bytes(data))
+        print('Listening — start talking (Ctrl-C to quit).')
+        async for event in session:
+            match event:
+                case PartDeltaEvent(delta=SpeechPartDelta(audio_chunk=bytes(chunk))):
+                    received += len(chunk)
+                case RealtimeInputSpeechStartEvent():
+                    # The provider stops the model on its own when the user speaks; what
+                    # it can't know is how much of its audio actually reached the
+                    # speaker. Drop what didn't — by replacing the playback task with one
+                    # subscribed to a fresh `stream_audio()`, which only carries live
+                    # audio — and report the rest, so the provider doesn't record a turn
+                    # the user never heard. The event fires whenever the user starts
+                    # speaking — including when nothing is playing — so only interrupt
+                    # when unheard audio was actually dropped.
+                    if received > played:
+                        playback.cancel()
+                        playback = anyio.CancelScope()
+                        tg.start_soon(play_audio, playback)
+                        await session.interrupt(played_ms=played * 1000 // byte_rate)
+                case PartStartEvent(part=SpeechPart(speaker='assistant')):
+                    received = played = 0
+                case PartEndEvent(part=SpeechPart() as part) if part.transcript:
+                    print(f'{part.speaker}: {part.transcript}')
+                case FunctionToolCallEvent(part=call):
+                    print(f'[calling {call.tool_name}]')
+                case FunctionToolResultEvent(part=result):
+                    print(f'[{result.tool_name} returned: {result.content}]')
+                case _:
+                    pass
+        tg.cancel_scope.cancel()
 
 
 async def main():
-    if sounddevice is None:  # pragma: no cover
-        raise ImportError(
-            'This example needs the `sounddevice` package for microphone and speaker access. '
-            'Install it with `pip install sounddevice`. '
-            'On Linux you also need the PortAudio system library (`apt install libportaudio2`).'
-        ) from _sounddevice_error
-
-    playback = PlaybackBuffer(
-        max_bytes=SAMPLE_RATE * CHANNELS * 2 * PLAYBACK_BUFFER_SECONDS
-    )
-
-    stream_kwargs = dict(
-        samplerate=SAMPLE_RATE, channels=CHANNELS, dtype='int16', blocksize=BLOCK_SIZE
-    )
-    mic = sounddevice.RawInputStream(**stream_kwargs)
-    speaker = sounddevice.RawOutputStream(
-        callback=partial(fill_speaker, playback), **stream_kwargs
-    )
-
-    # The session opens before the microphone starts capturing, so no audio from before the
-    # conversation began is queued up and sent to the model as stale input.
+    # The session opens before the microphone starts capturing, so no audio from before
+    # the conversation began is queued up and sent to the model as stale input.
     async with agent.realtime('openai:gpt-realtime').session() as session:
-        with mic, speaker:
-            async with anyio.create_task_group() as tg:
-                tg.start_soon(stream_mic, session, mic)
-                print('Listening — start talking (Ctrl-C to quit).')
-                async for event in session:
-                    await handle_event(session, event, playback)
-                tg.cancel_scope.cancel()
+        await conversation(session)
 
 
 if __name__ == '__main__':

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -73,9 +73,11 @@ async def conversation(session: RealtimeSession) -> None:
         # speaker pace while the model runs ahead; `stream_audio()`'s own buffer bounds
         # the backlog, dropping its oldest chunks if playback falls too far behind, so a
         # machine that stutters glitches instead of ending the call. Received and played
-        # bytes are tracked per assistant turn so barge-in can report how much of its
-        # reply the user actually heard.
-        received = played = 0
+        # byte counts run for the whole session — a new turn can start while the previous
+        # turn's tail is still playing (after a quick tool call, say), so per-turn resets
+        # would misattribute that tail. `turn_start` marks where the current turn begins
+        # in the received count, letting barge-in report how much of it was really heard.
+        received = played = turn_start = 0
 
         async def play_audio(scope: anyio.CancelScope) -> None:
             nonlocal played
@@ -105,9 +107,13 @@ async def conversation(session: RealtimeSession) -> None:
                         playback.cancel()
                         playback = anyio.CancelScope()
                         tg.start_soon(play_audio, playback)
-                        await session.interrupt(played_ms=played * 1000 // byte_rate)
+                        # If the previous turn's tail was still playing, none of this
+                        # turn was heard yet, so its played duration clamps to zero.
+                        played_ms = max(0, played - turn_start) * 1000 // byte_rate
+                        await session.interrupt(played_ms=played_ms)
+                        played = received  # the dropped audio is settled; stay in sync
                 case PartStartEvent(part=SpeechPart(speaker='assistant')):
-                    received = played = 0
+                    turn_start = received  # older audio belongs to earlier turns
                 case PartEndEvent(part=SpeechPart() as part) if part.transcript:
                     print(f'{part.speaker}: {part.transcript}')
                 case FunctionToolCallEvent(part=call):

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "datasets>=4.0.0",
     "pandas>=2.3.3",
     "twelvelabs>=1.2.8",
-    "sounddevice>=0.5.0",
+    "listentome>=0.1.0",
     # On Python 3.14, the locked numpy 2.2.6 has no cp314 wheel and would be
     # source-built in CI. numpy 2.3.2+ ships cp314 wheels, so require it there.
     "numpy>=2.3.2 ; python_version >= '3.14'",

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1130,15 +1130,23 @@ class RealtimeSession:
                     messages.pop(index)
                     return
 
-    async def send_audio(self, data: bytes) -> None:
-        """Stream a chunk of mono PCM16 audio to the model.
+    async def send_audio(self, data: bytes | AsyncIterable[bytes]) -> None:
+        """Stream mono PCM16 audio to the model: a single chunk, or an async iterable of chunks.
 
-        Resample it to
+        Given an async iterable — a microphone stream, a WebSocket receive loop — each chunk is
+        forwarded as it arrives and the call returns when the iterable is exhausted, so a whole
+        capture loop can be one task: `asyncio.create_task(session.send_audio(microphone))`.
+
+        Resample the audio to
         [`audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]
         first (24 kHz on the OpenAI-protocol providers, 16 kHz on Gemini):
         raw bytes carry no rate, so the wrong one is heard as a chipmunk rather than reported.
         """
         self._require_media_ownership('send_audio')
+        if isinstance(data, AsyncIterable):
+            async for chunk in data:
+                await self.send_audio(chunk)
+            return
         user_turn_was_active = self._user_turn_active
         if not user_turn_was_active:
             # Audio starting is the earliest sign of a user turn, and the only one on a provider that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,8 @@ build-constraint-dependencies = [
 
 [tool.uv.exclude-newer-package]
 # These are our own packages, not worth defending from supply chain attacks on them.
+# `listentome` is maintained by a Pydantic team member and counts as one of ours.
+listentome = false
 pydantic = false
 pydantic-core = false
 pydantic-extra-types = false
@@ -376,7 +378,6 @@ executionEnvironments = [
 ]
 exclude = [
     "examples/pydantic_ai_examples/weather_agent_gradio.py",
-    "examples/pydantic_ai_examples/realtime_voice.py",       # optional, untyped `sounddevice` audio dep
     "pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py",   # voyageai package has no type stubs
 ]
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2440,6 +2440,27 @@ async def test_send_helpers_forward_to_connection() -> None:
     ]
 
 
+async def test_send_audio_accepts_async_iterable() -> None:
+    """`send_audio` drains an async iterable chunk by chunk, so a capture loop can be one call.
+
+    Unit test: the per-chunk forwarding of a caller-supplied iterator has no wire signature of its
+    own — a cassette can't distinguish it from a caller looping over `send_audio(chunk)`.
+    """
+    conn = FakeRealtimeConnection([])
+    session = RealtimeSession(conn, _noop_runner)
+
+    async def microphone() -> AsyncIterator[bytes]:
+        yield b'\x01\x02'
+        yield b'\x03\x04'
+
+    await session.send_audio(microphone())
+
+    assert conn.sent == [
+        BinaryAudio(data=b'\x01\x02', media_type='audio/pcm'),
+        BinaryAudio(data=b'\x03\x04', media_type='audio/pcm'),
+    ]
+
+
 async def test_send_dispatches_through_bookkeeping_helpers() -> None:
     # `send(<str>)` must route through the text-turn path, so the user turn lands in history rather
     # than bypassing it (the raw pass-through used to skip all session bookkeeping).

--- a/tests/test_realtime_examples.py
+++ b/tests/test_realtime_examples.py
@@ -1,80 +1,186 @@
 """Unit tests for the realtime examples' own helpers.
 
 `test_examples.py` runs the documented snippets; these cover the parts of the runnable examples that
-no snippet reaches — the playback buffer's eviction bounds and the camera server's origin check —
+no snippet reaches — the voice assistant's barge-in accounting and the camera server's origin check —
 because both are load-bearing and neither is exercised by simply importing the module.
 """
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from .conftest import try_import
 
 with try_import() as imports_successful:
     from examples.pydantic_ai_examples import realtime_voice
     from examples.pydantic_ai_examples.realtime_camera import app as realtime_camera
+    from pydantic_ai.messages import BinaryAudio, RealtimeInputSpeechStartEvent
+    from pydantic_ai.realtime.codec import (
+        AudioDelta,
+        CancelResponse,
+        RealtimeCodecEvent,
+        RealtimeConnection,
+        RealtimeInput,
+        ResponseDone,
+        TruncateOutput,
+    )
+    from pydantic_ai.realtime.openai import OpenAIRealtimeModel
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='extras not installed'),
 ]
 
-
-def test_playback_buffer_evicts_carry_before_adding_audio() -> None:
-    playback = realtime_voice.PlaybackBuffer(max_bytes=6)
-    playback.add(b'abcdef')
-    playback.fill(bytearray(2))
-
-    playback.add(b'ghij')
-    output = bytearray(6)
-    playback.fill(output)
-
-    assert output == b'efghij'
+MIC_CHUNK = b'\xaa' * 4
+SLOW_CHUNK = b'\x01' * 4  # playback of this chunk never completes
+FAST_CHUNK = b'\x02' * 4  # playback of this chunk completes immediately
 
 
-def test_playback_buffer_truncates_oversized_chunk() -> None:
-    playback = realtime_voice.PlaybackBuffer(max_bytes=4)
-    playback.add(b'abcdef')
-    output = bytearray(4)
-    playback.fill(output)
+class FakeMicrophone:
+    """A `listentome.InputStream` stand-in that captures one block and then stays live."""
 
-    assert output == b'cdef'
+    def __init__(self, **kwargs: Any) -> None:
+        self._captured = False
+
+    async def __aenter__(self) -> FakeMicrophone:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    def __aiter__(self) -> FakeMicrophone:
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self._captured:
+            self._captured = True
+            return MIC_CHUNK
+        await asyncio.Event().wait()  # keep capturing until the conversation is cancelled
+        raise StopAsyncIteration  # pragma: no cover
+
+    async def read(self) -> bytes:  # pragma: no cover - part of the stream interface
+        return await self.__anext__()
 
 
-def test_playback_buffer_new_turn_discards_old_audio() -> None:
-    playback = realtime_voice.PlaybackBuffer(max_bytes=8)
-    playback.start_turn()
-    playback.add(b'old')
+class FakeSpeaker:
+    """A `listentome.OutputStream` stand-in whose `write()` mimics device pacing.
 
-    playback.start_turn()
-    playback.add(b'new')
-    output = bytearray(3)
-    playback.fill(output)
-
-    assert output == b'new'
-
-
-def test_playback_buffer_interrupt_only_reports_dropped_audio() -> None:
-    """`interrupt()` reports played milliseconds only when it actually drops unheard audio.
-
-    A turn the user heard in full needs no truncation — reporting one anyway would make the provider
-    discard part of a completed reply — so after everything was played, `interrupt()` is a no-op.
+    `SLOW_CHUNK` never finishes playing — like a real speaker mid-chunk when the user barges in —
+    while any other chunk is consumed immediately. `played` fires when a chunk finishes.
     """
-    bytes_per_ms = realtime_voice.SAMPLE_RATE * realtime_voice.CHANNELS * 2 // 1000
-    playback = realtime_voice.PlaybackBuffer(max_bytes=8 * bytes_per_ms)
 
-    playback.start_turn()
-    playback.add(b'\x00' * (2 * bytes_per_ms))
-    playback.fill(bytearray(2 * bytes_per_ms))  # the user heard the whole turn
-    assert playback.interrupt() is None
+    def __init__(self, **kwargs: Any) -> None:
+        self.written: list[bytes] = []
+        self.played = asyncio.Event()
 
-    playback.start_turn()
-    playback.add(b'\x00' * (4 * bytes_per_ms))
-    playback.fill(bytearray(3 * bytes_per_ms))  # barge-in with 1 ms still unheard
-    assert playback.interrupt() == 3
-    assert playback.interrupt() is None  # already flushed; nothing further to report
+    async def __aenter__(self) -> FakeSpeaker:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    async def write(self, data: bytes) -> None:
+        if data == SLOW_CHUNK:
+            await asyncio.Event().wait()  # cancelled when barge-in replaces the playback task
+        self.written.append(data)
+        self.played.set()
+
+
+class ScriptedConnection(RealtimeConnection):
+    """Replays an assistant turn and a user barge-in, recording what the session sends back."""
+
+    def __init__(self, *, chunk: bytes, wait_for_playback: asyncio.Event | None = None) -> None:
+        self._chunk = chunk
+        self._wait_for_playback = wait_for_playback
+        self.sent: list[RealtimeInput] = []
+        self._response_cancelled = asyncio.Event()
+
+    async def send(self, content: RealtimeInput) -> None:
+        self.sent.append(content)
+        if isinstance(content, CancelResponse):
+            self._response_cancelled.set()
+
+    async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+        yield AudioDelta(data=self._chunk)
+        if self._wait_for_playback is not None:
+            # Only report the user speaking once the speaker finished the chunk, so the turn was
+            # heard in full by the time the example handles the speech-start event.
+            await self._wait_for_playback.wait()
+            yield RealtimeInputSpeechStartEvent()
+        else:
+            yield RealtimeInputSpeechStartEvent()
+            # A real provider only speaks again after the barge-in cancelled the response; the
+            # reply must reach the freshly subscribed playback task, not the cancelled one.
+            await self._response_cancelled.wait()
+            yield AudioDelta(data=FAST_CHUNK)
+        yield ResponseDone()
+
+
+def _fake_audio_io(monkeypatch: pytest.MonkeyPatch) -> FakeSpeaker:
+    """Route the example's audio I/O through the fakes and return the speaker."""
+    speaker = FakeSpeaker()
+
+    def output_stream(**kwargs: Any) -> FakeSpeaker:
+        return speaker
+
+    monkeypatch.setattr('listentome.InputStream', FakeMicrophone)
+    monkeypatch.setattr('listentome.OutputStream', output_stream)
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    return speaker
+
+
+def _script_connection(mocker: MockerFixture, connection: ScriptedConnection) -> None:
+    @asynccontextmanager
+    async def connect(self: OpenAIRealtimeModel, **kwargs: Any) -> AsyncGenerator[RealtimeConnection]:
+        yield connection
+
+    mocker.patch.object(OpenAIRealtimeModel, 'connect', new=connect)
+
+
+async def test_voice_assistant_barge_in_drops_unheard_audio(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Barge-in mid-chunk truncates to what was played and replaces the playback subscription.
+
+    The model's chunk never finishes playing, so when the user speaks the example must report 0 ms
+    played, and the model's next reply must come out of the speaker — proving the replacement
+    playback task subscribed to live audio after the stale subscription was cancelled.
+    """
+    speaker = _fake_audio_io(monkeypatch)
+    connection = ScriptedConnection(chunk=SLOW_CHUNK)
+    _script_connection(mocker, connection)
+
+    await realtime_voice.main()
+
+    assert TruncateOutput(audio_end_ms=0) in connection.sent
+    assert CancelResponse() in connection.sent
+    assert speaker.written == [FAST_CHUNK]
+    # The microphone block was forwarded through `send_audio(mic)`.
+    assert BinaryAudio(data=MIC_CHUNK, media_type='audio/pcm') in connection.sent
+
+
+async def test_voice_assistant_no_interrupt_when_turn_was_heard_in_full(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A speech-start event after playback finished must not interrupt.
+
+    The speech-start event also fires on an ordinary turn where the user heard the whole previous
+    reply; reporting an interruption then would make the provider discard part of a completed turn.
+    """
+    speaker = _fake_audio_io(monkeypatch)
+    connection = ScriptedConnection(chunk=FAST_CHUNK, wait_for_playback=speaker.played)
+    _script_connection(mocker, connection)
+
+    await realtime_voice.main()
+
+    assert speaker.written == [FAST_CHUNK]
+    assert not any(isinstance(frame, (TruncateOutput, CancelResponse)) for frame in connection.sent)
 
 
 def test_camera_websocket_origin_guard(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_realtime_examples.py
+++ b/tests/test_realtime_examples.py
@@ -40,9 +40,16 @@ with try_import() as imports_successful:
         at module level it would raise `NameError` in environments without the realtime extras.
         """
 
-        def __init__(self, *, chunk: bytes, wait_for_playback: asyncio.Event | None = None) -> None:
+        def __init__(
+            self,
+            *,
+            chunk: bytes,
+            wait_for_playback: asyncio.Event | None = None,
+            completed_turn: tuple[bytes, asyncio.Event] | None = None,
+        ) -> None:
             self._chunk = chunk
             self._wait_for_playback = wait_for_playback
+            self._completed_turn = completed_turn
             self.sent: list[RealtimeInput] = []
             self._response_cancelled = asyncio.Event()
 
@@ -52,6 +59,12 @@ with try_import() as imports_successful:
                 self._response_cancelled.set()
 
         async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            if self._completed_turn is not None:
+                # A full earlier turn, spoken and played to the end before the next turn starts.
+                prior_chunk, prior_played = self._completed_turn
+                yield AudioDelta(data=prior_chunk)
+                yield ResponseDone()
+                await prior_played.wait()
             yield AudioDelta(data=self._chunk)
             if self._wait_for_playback is not None:
                 # Only report the user speaking once the speaker finished the chunk, so the turn was
@@ -72,8 +85,9 @@ pytestmark = [
 ]
 
 MIC_CHUNK = b'\xaa' * 4
-SLOW_CHUNK = b'\x01' * 4  # playback of this chunk never completes
-FAST_CHUNK = b'\x02' * 4  # playback of this chunk completes immediately
+# 100 ms each at gpt-realtime's 24 kHz mono PCM16, so misattributed playback shows up in `played_ms`.
+SLOW_CHUNK = b'\x01' * 4800  # playback of this chunk never completes
+FAST_CHUNK = b'\x02' * 4800  # playback of this chunk completes immediately
 
 
 class FakeMicrophone:
@@ -167,6 +181,25 @@ async def test_voice_assistant_barge_in_drops_unheard_audio(
     assert speaker.written == [FAST_CHUNK]
     # The microphone block was forwarded through `send_audio(mic)`.
     assert BinaryAudio(data=MIC_CHUNK, media_type='audio/pcm') in connection.sent
+
+
+async def test_voice_assistant_barge_in_excludes_earlier_turns_from_played_ms(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`played_ms` reports playback of the interrupted turn only, not of earlier completed turns.
+
+    A whole first turn plays to the end (100 ms of audio); the second turn's chunk never finishes
+    playing. Interrupting the second turn must truncate it at 0 ms — a per-session counter without
+    the turn-start watermark would misreport the first turn's 100 ms as heard second-turn audio.
+    """
+    speaker = _fake_audio_io(monkeypatch)
+    connection = ScriptedConnection(chunk=SLOW_CHUNK, completed_turn=(FAST_CHUNK, speaker.played))
+    _script_connection(mocker, connection)
+
+    await realtime_voice.main()
+
+    assert TruncateOutput(audio_end_ms=0) in connection.sent
+    assert speaker.written == [FAST_CHUNK, FAST_CHUNK]
 
 
 async def test_voice_assistant_no_interrupt_when_turn_was_heard_in_full(

--- a/tests/test_realtime_examples.py
+++ b/tests/test_realtime_examples.py
@@ -33,6 +33,40 @@ with try_import() as imports_successful:
     )
     from pydantic_ai.realtime.openai import OpenAIRealtimeModel
 
+    class ScriptedConnection(RealtimeConnection):
+        """Replays an assistant turn and a user barge-in, recording what the session sends back.
+
+        Defined inside the `try_import` block because its base class is one of the guarded imports:
+        at module level it would raise `NameError` in environments without the realtime extras.
+        """
+
+        def __init__(self, *, chunk: bytes, wait_for_playback: asyncio.Event | None = None) -> None:
+            self._chunk = chunk
+            self._wait_for_playback = wait_for_playback
+            self.sent: list[RealtimeInput] = []
+            self._response_cancelled = asyncio.Event()
+
+        async def send(self, content: RealtimeInput) -> None:
+            self.sent.append(content)
+            if isinstance(content, CancelResponse):
+                self._response_cancelled.set()
+
+        async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            yield AudioDelta(data=self._chunk)
+            if self._wait_for_playback is not None:
+                # Only report the user speaking once the speaker finished the chunk, so the turn was
+                # heard in full by the time the example handles the speech-start event.
+                await self._wait_for_playback.wait()
+                yield RealtimeInputSpeechStartEvent()
+            else:
+                yield RealtimeInputSpeechStartEvent()
+                # A real provider only speaks again after the barge-in cancelled the response; the
+                # reply must reach the freshly subscribed playback task, not the cancelled one.
+                await self._response_cancelled.wait()
+                yield AudioDelta(data=FAST_CHUNK)
+            yield ResponseDone()
+
+
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='extras not installed'),
 ]
@@ -90,36 +124,6 @@ class FakeSpeaker:
             await asyncio.Event().wait()  # cancelled when barge-in replaces the playback task
         self.written.append(data)
         self.played.set()
-
-
-class ScriptedConnection(RealtimeConnection):
-    """Replays an assistant turn and a user barge-in, recording what the session sends back."""
-
-    def __init__(self, *, chunk: bytes, wait_for_playback: asyncio.Event | None = None) -> None:
-        self._chunk = chunk
-        self._wait_for_playback = wait_for_playback
-        self.sent: list[RealtimeInput] = []
-        self._response_cancelled = asyncio.Event()
-
-    async def send(self, content: RealtimeInput) -> None:
-        self.sent.append(content)
-        if isinstance(content, CancelResponse):
-            self._response_cancelled.set()
-
-    async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
-        yield AudioDelta(data=self._chunk)
-        if self._wait_for_playback is not None:
-            # Only report the user speaking once the speaker finished the chunk, so the turn was
-            # heard in full by the time the example handles the speech-start event.
-            await self._wait_for_playback.wait()
-            yield RealtimeInputSpeechStartEvent()
-        else:
-            yield RealtimeInputSpeechStartEvent()
-            # A real provider only speaks again after the barge-in cancelled the response; the
-            # reply must reach the freshly subscribed playback task, not the cancelled one.
-            await self._response_cancelled.wait()
-            yield AudioDelta(data=FAST_CHUNK)
-        yield ResponseDone()
 
 
 def _fake_audio_io(monkeypatch: pytest.MonkeyPatch) -> FakeSpeaker:

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+listentome = false
 logfire = false
 pydantic-settings = false
 pydantic-handlebars = false
@@ -3207,6 +3208,20 @@ wheels = [
 ]
 
 [[package]]
+name = "listentome"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "cffi" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/b7041034d6c6af1e1373f1ea3505ddfa500b62dc63f147fed8dfcbb0970b/listentome-0.1.0.tar.gz", hash = "sha256:0dfb5db8da7d1999c019785c0c3b81d3ad4949d925214772c6601f3a167acb7c", size = 67471, upload-time = "2026-08-27T19:40:45.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/f9/8cf1fd057313335d946e7755dd29b2c22bc98df5c3313652c443b4886149/listentome-0.1.0-py3-none-any.whl", hash = "sha256:b656247c13c408d05db8051e8dcea4ba4caf96cb11f392aab5fda0fe186c0619", size = 10638, upload-time = "2026-08-27T19:40:46.155Z" },
+]
+
+[[package]]
 name = "logfire"
 version = "4.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5448,6 +5463,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "gradio" },
+    { name = "listentome" },
     { name = "logfire", extra = ["asyncpg", "fastapi", "httpx", "sqlite3"] },
     { name = "mcp", version = "1.28.1", source = { registry = "https://pypi.org/simple" }, extra = ["cli"], marker = "extra == 'group-11-pydantic-ai-dev'" },
     { name = "mcp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["cli"], marker = "extra == 'extra-11-pydantic-ai-mcp-tasks' or extra == 'extra-16-pydantic-ai-slim-mcp-tasks' or extra != 'group-11-pydantic-ai-dev'" },
@@ -5459,7 +5475,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rich" },
-    { name = "sounddevice" },
     { name = "twelvelabs" },
     { name = "uvicorn" },
 ]
@@ -5472,6 +5487,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.4.2" },
     { name = "fastapi", specifier = ">=0.117.0" },
     { name = "gradio", specifier = ">=6.7.0" },
+    { name = "listentome", specifier = ">=0.1.0" },
     { name = "logfire", extras = ["asyncpg", "fastapi", "httpx", "sqlite3"], specifier = ">=3.14.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
     { name = "modal", specifier = ">=1.0.4" },
@@ -5482,7 +5498,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.17" },
     { name = "rich", specifier = ">=13.9.2" },
-    { name = "sounddevice", specifier = ">=0.5.0" },
     { name = "twelvelabs", specifier = ">=1.2.8" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
@@ -7146,22 +7161,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
-]
-
-[[package]]
-name = "sounddevice"
-version = "0.5.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
[`listentome`](https://github.com/Kludex/listentome) is @Kludex's new async-first audio I/O library, built for exactly this use case: realtime speech-to-speech agents without audio plumbing. Its microphone is an async iterator of PCM blocks and its speaker `write()` suspends until the device consumed the audio.

To let the two libraries compose as directly as possible, [`RealtimeSession.send_audio()`][1] now also accepts an `AsyncIterable[bytes]` and forwards it chunk by chunk until it ends, so a whole capture loop becomes one call — `tg.start_soon(session.send_audio, mic)` — mirroring how `stream_audio()` already hands playback an async iterator on the output side. Passing a single `bytes` chunk works exactly as before.

The voice assistant example then moves from `sounddevice` to `listentome`, which dissolves the example's hand-rolled `PlaybackBuffer` (PortAudio callback, thread-safe deque, drop-oldest policy, playback accounting): the mic loop is `send_audio(mic)`, playback is `async for chunk in session.stream_audio(): await speaker.write(chunk)` with `stream_audio()`'s own bounded buffer as the drop-oldest policy, and barge-in keeps a per-turn received/played byte count so it can report to `interrupt()` how much the user actually heard — only when unheard audio was actually dropped, as before. The example now also reads the capture/playback sample rates off the session profile instead of hardcoding 24 kHz. The old `PlaybackBuffer` unit tests are replaced by two scripted-session tests that pin the barge-in behavior end-to-end through `main()`.

The companion `listentome` PR — an async-iterable form of `OutputStream.write()`, plus `clear()` to drop the written-but-unplayed tail on barge-in — is Kludex/listentome#1. This PR only relies on the released `listentome` 0.1.0; once that one merges and releases, the example here can adopt `speaker.clear()` to also drop the in-flight chunk remainder on barge-in.

`listentome` 0.1.0 was published inside the workspace's 7-day `exclude-newer` window, so it gets an `exclude-newer-package` entry alongside the other packages we maintain ourselves.

[1]: https://ai.pydantic.dev/api/realtime/#pydantic_ai.realtime.RealtimeSession.send_audio

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



