### PR TITLE
Remove pull requests from triage routing

### DIFF
--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -675,6 +675,12 @@ def _ensure_recipients(
     if current_maintainers and logins != [_FALLBACK_OWNER.casefold()]:
         return current_maintainers
 
+    # Pull requests are never auto-assigned: a human assigns one when an issue
+    # warrants it. Any maintainer already on the PR was a human's choice and
+    # owns it; without one the item stays tracked silently.
+    if 'pull_request' in current:
+        return current_maintainers or None
+
     # A recent unassignment is a decision too: the placeholder heuristic must
     # not hand the item straight back to whoever a human just took off it.
     # Mirrors the router's back-off window.

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -403,18 +403,22 @@ def _pull_request_precedence(
         key = author_login.casefold()
         owner = next((candidate for candidate in _OWNERS if candidate.casefold() == key), None)
         if owner is not None and client.maintainer_login(repo, owner, refresh=True) is not None:
-            return Selection(
-                number=number,
-                decision=Decision(number=number, owner=owner, evidence=f'author:{owner}'),
-                status='route',
-            )
+            # A maintainer's own pull request is already their responsibility:
+            # no assignment and no ping, not even to the author.
+            return Selection(number=number, decision=None, status='maintainer-author')
     return None
 
 
-def _issue_gate(repo: str, item: Mapping[str, Any], normalized: Mapping[str, Any], number: int) -> Selection | None:
-    """Decide whether an issue may be routed at all; None means proceed."""
+def _intake_gate(repo: str, normalized: Mapping[str, Any], number: int) -> Selection | None:
+    """Decide whether an item may be routed at all; None means proceed.
+
+    The gate covers pull requests exactly like issues: no `p:1-highest`,
+    `p:2-high`, or `community-backed` label means no assignment and no ping.
+    pydanty never labels pull requests, so on gated repositories PR intake is
+    off until a human applies a gate label.
+    """
     # A gate label missing from a truncated first page counts as absent, which
-    # fails toward leaving the issue unassigned. `community-backed` (a judged
+    # fails toward leaving the item unassigned. `community-backed` (a judged
     # community-demand verdict, see `community_demand.py`) opens the gate too.
     if repo in _GATED_REPOS and not _labels(normalized) & (_PRIORITY_LABELS | {_COMMUNITY_LABEL}):
         return Selection(number=number, decision=None, status='awaiting-triage')
@@ -444,7 +448,9 @@ def decision_for(client: attention.GitHubClient, repo: str, number: int) -> Sele
     if _recently_unassigned(item):
         return Selection(number=number, decision=None, status='recently-unassigned')
     is_pull_request = item.get('__typename') == 'PullRequest'
-    if not is_pull_request and (gated := _issue_gate(repo, item, normalized, number)) is not None:
+    # The gate outranks every routing precedence, author precedence included:
+    # a maintainer's own ungated pull request stays unassigned too.
+    if (gated := _intake_gate(repo, normalized, number)) is not None:
         return gated
     if _maintainer_assignees(client, repo, normalized):
         return Selection(number=number, decision=None, status='maintainer-present')
@@ -527,11 +533,14 @@ def _gated_numbers(client: attention.GitHubClient, repo: str, qualified: Sequenc
     """List candidates, priority-labeled issues before pull requests."""
     negatives = ' '.join(f'-assignee:{owner}' for owner in qualified)
     if repo in _GATED_REPOS:
+        # Pull requests carry the same gate as issues, so the sweep only
+        # fetches labeled ones; `decision_for` re-checks the label either way.
         priorities = ','.join(f'"{label}"' for label in sorted(_PRIORITY_LABELS))
         issues = f'repo:{repo} is:open is:issue label:{priorities} {negatives} sort:created-asc'
+        pulls = f'repo:{repo} is:open is:pr -draft:true label:{priorities} created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
     else:
         issues = f'repo:{repo} is:open is:issue {negatives} sort:created-asc'
-    pulls = f'repo:{repo} is:open is:pr -draft:true created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
+        pulls = f'repo:{repo} is:open is:pr -draft:true created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
     return list(dict.fromkeys(_search_numbers(client, issues) + _search_numbers(client, pulls)))
 
 

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -6,6 +6,10 @@ Issues enter routing only once triage has applied a priority label
 triage automation's plate. The one exception is community pressure: the
 weekly community-demand sweep judges old-but-active unassigned issues and
 applies `community-backed`, which also opens the gate.
+
+Pull requests are never triaged on gated repositories — a human assigns one
+when an issue warrants it. Ungated repositories blanket-route new intake,
+issues and pull requests alike, to their default owner.
 """
 
 from __future__ import annotations
@@ -18,7 +22,7 @@ import sys
 import urllib.error
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, Literal, TypedDict, cast  # noqa: TID251
 
 import issue_pr_attention_monitor as attention
@@ -40,7 +44,6 @@ _PRIORITY_LABELS = frozenset(attention.PRIORITY_GATE_LABELS)
 _RECENT_BATCH_LIMIT = 3
 _COMMUNITY_BATCH_LIMIT = 3
 _COMMUNITY_LABEL = attention.COMMUNITY_LABEL
-_FILE_LIMIT = 100
 _ASSIGNEE_LIMIT = 10
 _MAX_ITEM_NUMBER = 2_147_483_647
 # Must match the `last:` on both `timelineItems` connections below.
@@ -59,14 +62,13 @@ query RoutingItem($owner: String!, $name: String!, $number: Int!) {
         assignees(first: 10) { nodes { login } pageInfo { hasNextPage } }
       }
       ... on PullRequest {
-        number state isDraft changedFiles
+        number state isDraft
         author { login }
         timelineItems(itemTypes: [UNASSIGNED_EVENT], last: 10) {
           nodes { ... on UnassignedEvent { createdAt actor { __typename } } }
         }
         labels(first: 50) { nodes { name } pageInfo { hasNextPage } }
         assignees(first: 10) { nodes { login } pageInfo { hasNextPage } }
-        files(first: 100) { nodes { path } pageInfo { hasNextPage } }
       }
     }
   }
@@ -90,27 +92,12 @@ class Rule:
 
     owner: str
     labels: tuple[str, ...] = ()
-    paths: tuple[str, ...] = ()
 
 
 _UI_LABELS = ('AG-UI', 'UI adapters', 'area:ui-adapters', 'vercel-ai', 'web-ui')
-_UI_PATHS = (
-    'pydantic_ai_slim/pydantic_ai/ui/',
-    'docs/ui/',
-    'docs/api/ui/',
-    'docs/examples/ag-ui.md',
-    'examples/pydantic_ai_examples/ag_ui/',
-)
 _RULES: dict[str, tuple[Rule, ...]] = {
     'pydantic/pydantic-ai': (
-        Rule(
-            'adtyavrdhn',
-            ('streaming', 'run_stream'),
-            (
-                'pydantic_ai_slim/pydantic_ai/realtime/',
-                'pydantic_ai_slim/pydantic_ai/_cancel.py',
-            ),
-        ),
+        Rule('adtyavrdhn', ('streaming', 'run_stream')),
         Rule(
             'dsfaccini',
             (
@@ -121,33 +108,11 @@ _RULES: dict[str, tuple[Rule, ...]] = {
                 'cross-model-provider-mapping',
                 'provider-parity',
             ),
-            (
-                'pydantic_ai_slim/pydantic_ai/models/',
-                'pydantic_ai_slim/pydantic_ai/providers/',
-                'pydantic_ai_slim/pydantic_ai/profiles/',
-                'pydantic_ai_slim/pydantic_ai/messages.py',
-                'pydantic_ai_slim/pydantic_ai/mcp.py',
-                'pydantic_ai_slim/pydantic_ai/_mcp.py',
-                'pydantic_ai_slim/pydantic_ai/_mcp_compat.py',
-            ),
         ),
         # UI protocols are more specific than cross-cutting signals such as
         # streaming, so a streaming AG-UI/Vercel item remains David's.
-        Rule(
-            'dsfaccini',
-            _UI_LABELS,
-            _UI_PATHS,
-        ),
-        Rule(
-            'DouweM',
-            ('durable exec', 'temporal', 'DBOS', 'deferred-tools'),
-            (
-                'pydantic_ai_slim/pydantic_ai/durable_exec/',
-                'pydantic_ai_slim/pydantic_ai/capabilities/',
-                'pydantic_ai_slim/pydantic_ai/_deferred.py',
-                'pydantic_ai_slim/pydantic_ai/_enqueue.py',
-            ),
-        ),
+        Rule('dsfaccini', _UI_LABELS),
+        Rule('DouweM', ('durable exec', 'temporal', 'DBOS', 'deferred-tools')),
     ),
     'pydantic/pydantic-ai-harness': (),
 }
@@ -251,53 +216,14 @@ def _recently_unassigned(item: Mapping[str, Any]) -> bool:
     return False
 
 
-def _valid_path(value: str) -> bool:
-    if not value or len(value) > 300 or not value.isascii() or '\\' in value or value.startswith('/'):
-        return False
-    if any(ord(character) < 32 or ord(character) == 127 for character in value):
-        return False
-    parts = PurePosixPath(value).parts
-    return bool(parts) and all(part not in {'', '.', '..'} for part in parts)
-
-
-def _path_rule(repo: str, filename: str) -> tuple[str, str] | None:
-    matches: list[tuple[int, str, str]] = []
-    for rule in _RULES[repo]:
-        for prefix in rule.paths:
-            if filename == prefix or (prefix.endswith('/') and filename.startswith(prefix)):
-                matches.append((len(prefix), rule.owner, prefix))
-    if not matches:
-        return None
-    longest = max(length for length, _, _ in matches)
-    owners = {(owner, prefix) for length, owner, prefix in matches if length == longest}
-    if len({owner for owner, _ in owners}) != 1:
-        return None
-    owner, prefix = min(owners)
-    return owner, f'path:{prefix}'
-
-
-def _route(repo: str, labels: set[str], filenames: Sequence[str] | None) -> tuple[str, str]:
+def _route(repo: str, labels: set[str]) -> tuple[str, str]:
     signals: set[tuple[str, str]] = set()
     for rule in _RULES[repo]:
         for label in rule.labels:
             if label.casefold() in labels:
                 signals.add((rule.owner, f'label:{label}'))
-    if filenames is not None:
-        for filename in filenames:
-            if not _valid_path(filename):
-                return _MANUAL_OWNER, 'manual:invalid-file-list'
-            if signal := _path_rule(repo, filename):
-                signals.add(signal)
-            elif not _neutral_path(filename):
-                if default := _DEFAULT_OWNERS.get(repo):
-                    return default, 'default:repo-intake'
-                return _MANUAL_OWNER, 'manual:unowned-production-path'
     has_ui_signal = any(
-        owner == 'dsfaccini'
-        and (
-            evidence in {f'path:{path}' for path in _UI_PATHS} or evidence in {f'label:{label}' for label in _UI_LABELS}
-        )
-        for owner, evidence in signals
+        owner == 'dsfaccini' and evidence in {f'label:{label}' for label in _UI_LABELS} for owner, evidence in signals
     )
     if has_ui_signal:
         signals -= {('adtyavrdhn', 'label:streaming'), ('adtyavrdhn', 'label:run_stream')}
@@ -309,14 +235,6 @@ def _route(repo: str, labels: set[str], filenames: Sequence[str] | None) -> tupl
     owner = owners.pop()
     evidence = min(evidence for signal_owner, evidence in signals if signal_owner == owner)
     return owner, evidence
-
-
-def _neutral_path(filename: str) -> bool:
-    return (
-        filename.startswith(('tests/', 'docs/', 'examples/', '.github/'))
-        or '/tests/' in filename
-        or filename.endswith(('.md', '.rst', '.lock'))
-    )
 
 
 def _maintainer_assignees(
@@ -409,14 +327,8 @@ def _pull_request_precedence(
     return None
 
 
-def _intake_gate(repo: str, normalized: Mapping[str, Any], number: int) -> Selection | None:
-    """Decide whether an item may be routed at all; None means proceed.
-
-    The gate covers pull requests exactly like issues: no `p:1-highest`,
-    `p:2-high`, or `community-backed` label means no assignment and no ping.
-    pydanty never labels pull requests, so on gated repositories PR intake is
-    off until a human applies a gate label.
-    """
+def _issue_gate(repo: str, normalized: Mapping[str, Any], number: int) -> Selection | None:
+    """Decide whether an issue may be routed at all; None means proceed."""
     # A gate label missing from a truncated first page counts as absent, which
     # fails toward leaving the item unassigned. `community-backed` (a judged
     # community-demand verdict, see `community_demand.py`) opens the gate too.
@@ -448,9 +360,12 @@ def decision_for(client: attention.GitHubClient, repo: str, number: int) -> Sele
     if _recently_unassigned(item):
         return Selection(number=number, decision=None, status='recently-unassigned')
     is_pull_request = item.get('__typename') == 'PullRequest'
-    # The gate outranks every routing precedence, author precedence included:
-    # a maintainer's own ungated pull request stays unassigned too.
-    if (gated := _intake_gate(repo, normalized, number)) is not None:
+    # Pull requests are never triaged on gated repositories: a human assigns
+    # one when an issue warrants it. Only ungated blanket-intake repositories
+    # route pull requests, to their default owner.
+    if is_pull_request and repo in _GATED_REPOS:
+        return Selection(number=number, decision=None, status='pull-request')
+    if (gated := _issue_gate(repo, normalized, number)) is not None:
         return gated
     if _maintainer_assignees(client, repo, normalized):
         return Selection(number=number, decision=None, status='maintainer-present')
@@ -458,40 +373,13 @@ def decision_for(client: attention.GitHubClient, repo: str, number: int) -> Sele
         return Selection(number=number, decision=None, status='assignee-capacity')
     if is_pull_request and (precedence := _pull_request_precedence(client, repo, number, item)) is not None:
         return precedence
-    filenames: list[str] | None = None
-    if is_pull_request:
-        changed_files = item.get('changedFiles')
-        files = item.get('files')
-        entries = _connection_nodes(files)
-        page_info = cast(Mapping[str, object], files).get('pageInfo') if isinstance(files, Mapping) else None
-        filenames = []
-        complete = (
-            type(changed_files) is int
-            and 0 <= changed_files <= _FILE_LIMIT
-            and len(entries) == changed_files
-            and isinstance(page_info, Mapping)
-            and cast(Mapping[str, object], page_info).get('hasNextPage') is False
-        )
-        if complete:
-            for entry in entries:
-                path = cast(Mapping[str, object], entry).get('path') if isinstance(entry, Mapping) else None
-                if not isinstance(path, str):
-                    complete = False
-                    break
-                filenames.append(path)
-        if not complete:
-            return Selection(
-                number=number,
-                decision=_decision(client, repo, number, _MANUAL_OWNER, 'manual:incomplete-file-list'),
-                status='route',
-            )
     if not _connection_complete(labels):
         return Selection(
             number=number,
             decision=_decision(client, repo, number, _MANUAL_OWNER, 'manual:incomplete-labels'),
             status='route',
         )
-    owner, evidence = _route(repo, _labels(normalized), filenames)
+    owner, evidence = _route(repo, _labels(normalized))
     return Selection(
         number=number,
         decision=_decision(client, repo, number, owner, evidence),
@@ -533,20 +421,20 @@ def _gated_numbers(client: attention.GitHubClient, repo: str, qualified: Sequenc
     """List candidates, priority-labeled issues before pull requests."""
     negatives = ' '.join(f'-assignee:{owner}' for owner in qualified)
     if repo in _GATED_REPOS:
-        # Pull requests carry the same gate as issues, so the sweep only
-        # fetches labeled ones; `decision_for` re-checks the label either way.
+        # Pull requests are never triaged on gated repositories, so the sweep
+        # does not search them at all.
         priorities = ','.join(f'"{label}"' for label in sorted(_PRIORITY_LABELS))
         issues = f'repo:{repo} is:open is:issue label:{priorities} {negatives} sort:created-asc'
-        pulls = f'repo:{repo} is:open is:pr -draft:true label:{priorities} created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
-    else:
-        issues = f'repo:{repo} is:open is:issue {negatives} sort:created-asc'
-        pulls = f'repo:{repo} is:open is:pr -draft:true created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
+        return _search_numbers(client, issues)
+    # Blanket intake covers new items going forward, not the backlog.
+    issues = f'repo:{repo} is:open is:issue created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
+    pulls = f'repo:{repo} is:open is:pr -draft:true created:>={_RECOVERY_EPOCH} {negatives} sort:created-asc'
     return list(dict.fromkeys(_search_numbers(client, issues) + _search_numbers(client, pulls)))
 
 
 def _community_numbers(client: attention.GitHubClient, repo: str) -> list[int]:
     """List unassigned items the triage agent judged to have genuine community demand."""
-    query = f'repo:{repo} is:open -draft:true no:assignee label:"{_COMMUNITY_LABEL}" sort:updated-desc'
+    query = f'repo:{repo} is:open is:issue no:assignee label:"{_COMMUNITY_LABEL}" sort:updated-desc'
     return _search_numbers(client, query)
 
 

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -530,7 +530,7 @@ def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> boo
     return True
 
 
-def _routing_reason(decision: Decision, mention: str) -> str:
+def _routing_reason(decision: Decision) -> str:
     evidence = decision['evidence']
     source, separator, detail = evidence.partition(':')
     if separator and detail and source == 'label':
@@ -563,7 +563,7 @@ def _slack_payload(
         kind, path = 'Pull request', 'pull'
     number = decision['number']
     item = f'<https://github.com/{repo}/{path}/{number}|{repo}#{number}>'
-    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(decision, mention)}'
+    text = f'Routing intent: {kind} {item} → {mention}\nWhy: {_routing_reason(decision)}'
     return json.dumps({'text': text}, separators=(',', ':'))
 
 

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -346,6 +346,12 @@ def decision_for(client: attention.GitHubClient, repo: str, number: int) -> Sele
         return Selection(number=number, decision=None, status='closed')
     if item.get('number') != number or item.get('__typename') not in {'Issue', 'PullRequest'}:
         raise RuntimeError('GitHub returned mismatched routing metadata')
+    is_pull_request = item.get('__typename') == 'PullRequest'
+    # Pull requests are never triaged on gated repositories: a human assigns
+    # one when an issue warrants it. Only ungated blanket-intake repositories
+    # route pull requests, to their default owner.
+    if is_pull_request and repo in _GATED_REPOS:
+        return Selection(number=number, decision=None, status='pull-request')
     labels = item.get('labels')
     assignees = item.get('assignees')
     if not _connection_complete(assignees):
@@ -359,12 +365,6 @@ def decision_for(client: attention.GitHubClient, repo: str, number: int) -> Sele
     # hours after a maintainer removed them.
     if _recently_unassigned(item):
         return Selection(number=number, decision=None, status='recently-unassigned')
-    is_pull_request = item.get('__typename') == 'PullRequest'
-    # Pull requests are never triaged on gated repositories: a human assigns
-    # one when an issue warrants it. Only ungated blanket-intake repositories
-    # route pull requests, to their default owner.
-    if is_pull_request and repo in _GATED_REPOS:
-        return Selection(number=number, decision=None, status='pull-request')
     if (gated := _issue_gate(repo, normalized, number)) is not None:
         return gated
     if _maintainer_assignees(client, repo, normalized):
@@ -418,7 +418,9 @@ def _qualified_owners(client: attention.GitHubClient, repo: str) -> tuple[str, .
 
 
 def _gated_numbers(client: attention.GitHubClient, repo: str, qualified: Sequence[str]) -> list[int]:
-    """List candidates, priority-labeled issues before pull requests."""
+    """List routing candidates: gated repos search priority-labeled issues
+    only; ungated repos search all new intake, issues before pull requests.
+    """
     negatives = ' '.join(f'-assignee:{owner}' for owner in qualified)
     if repo in _GATED_REPOS:
         # Pull requests are never triaged on gated repositories, so the sweep
@@ -478,7 +480,10 @@ def select_batch(
     gated_numbers = _gated_numbers(client, repo, qualified)
     gated = _select_numbers(client, repo, gated_numbers, limit=_RECENT_BATCH_LIMIT, lane='gate')
     _emit_event('router.sweep', repo=repo, lane='gate', candidates=len(gated_numbers), selected=len(gated))
-    if gated or not community_recovery:
+    # The community-demand judge runs only on gated repos, so the community
+    # lane must not run elsewhere: on an ungated repo it would sweep backlog
+    # items past the new-intake epoch on a hand-applied label.
+    if gated or not community_recovery or repo not in _GATED_REPOS:
         return gated
     community_numbers = _community_numbers(client, repo)
     community = _select_numbers(client, repo, community_numbers, limit=_COMMUNITY_BATCH_LIMIT, lane='community')
@@ -525,11 +530,8 @@ def assign(client: attention.GitHubClient, repo: str, expected: Decision) -> boo
 
 def _routing_reason(decision: Decision, mention: str) -> str:
     evidence = decision['evidence']
-    owner = decision['owner']
-    if evidence == f'author:{owner}':
-        return f'{mention} authored this pull request.'
     source, separator, detail = evidence.partition(':')
-    if separator and detail and source in {'label', 'path'}:
+    if separator and detail and source == 'label':
         return f'Matched ownership {source} `{detail}`.'
     if evidence == 'default:repo-intake':
         return 'All intake for this repository is currently routed to one owner.'

--- a/.github/scripts/semantic_owner_router.py
+++ b/.github/scripts/semantic_owner_router.py
@@ -418,8 +418,10 @@ def _qualified_owners(client: attention.GitHubClient, repo: str) -> tuple[str, .
 
 
 def _gated_numbers(client: attention.GitHubClient, repo: str, qualified: Sequence[str]) -> list[int]:
-    """List routing candidates: gated repos search priority-labeled issues
-    only; ungated repos search all new intake, issues before pull requests.
+    """List routing candidates.
+
+    Gated repos search priority-labeled issues only; ungated repos search
+    all new intake, issues before pull requests.
     """
     negatives = ' '.join(f'-assignee:{owner}' for owner in qualified)
     if repo in _GATED_REPOS:

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -446,6 +446,38 @@ def test_apply_revalidates_then_assigns_and_labels(tmp_path: Path):
     ) in client.calls
 
 
+def test_apply_never_assigns_a_pull_request(tmp_path: Path):
+    # Pull requests are never auto-assigned: a human assigns one when an
+    # issue warrants it. The item stays tracked, silently.
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 8, 'updated_at': OLD}])
+    write_output(output, ['8'])
+    pull = {**item(8), 'pull_request': {'url': 'https://api.github.test/pulls/8'}}
+    client = FakeClient({8: pull})
+
+    lines = monitor.apply_decisions(client, 'r', str(output), str(snapshot), now=NOW)
+
+    assert lines == ['#8: deferred until its owner can be identified']
+    assert monitor._ACTION_LABEL in {label['name'] for label in client.items[8]['labels']}
+    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+
+
+def test_apply_notifies_the_human_assigned_owner_of_a_pull_request(tmp_path: Path):
+    snapshot = tmp_path / 'snapshot.json'
+    output = tmp_path / 'output.json'
+    write_snapshot(snapshot, [{'number': 8, 'updated_at': OLD}])
+    write_output(output, ['8'])
+    pull = {**item(8, assignees=['DouweM']), 'pull_request': {'url': 'https://api.github.test/pulls/8'}}
+    client = FakeClient({8: pull})
+    client.permissions = {'DouweM': 'write'}
+
+    lines = monitor.apply_decisions(client, 'r', str(output), str(snapshot), now=NOW)
+
+    assert lines == ['#8: requested maintainer attention from @DouweM']
+    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
+
+
 def test_owner_selection_reads_the_live_item_not_the_classified_copy():
     stale = item(7, labels=[monitor._ACTION_LABEL])
     current = item(
@@ -477,14 +509,14 @@ def test_owner_selection_finds_a_maintainer_hidden_from_the_collaborator_list():
     assert not any('/collaborators?' in path for _, path, _ in client.calls)
 
 
-def test_owner_selection_keeps_a_maintainer_authored_pull_request():
+def test_owner_selection_never_assigns_a_pull_request_even_to_its_maintainer_author():
     pull = {**item(7, labels=[monitor._ACTION_LABEL]), 'pull_request': {'url': 'https://api.github.com/pulls/7'}}
     pull['user'] = {'login': 'DouweM'}
     client = FakeClient({7: pull})
     client.permissions = {'DouweM': 'admin'}
 
-    assert monitor._ensure_recipients(client, 'r', pull, now=NOW) == ['DouweM']
-    assert ('POST', '/repos/r/issues/7/assignees', {'assignees': ['DouweM']}) in client.calls
+    assert monitor._ensure_recipients(client, 'r', pull, now=NOW) is None
+    assert not any(call[0] == 'POST' and call[1].endswith('/assignees') for call in client.calls)
 
 
 def test_owner_selection_reads_every_pull_request_discussion_surface():

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -174,6 +174,107 @@ def test_ui_and_durable_execution_remain_a_manual_conflict():
     assert decision['evidence'] == 'manual:conflict-or-unknown'
 
 
+def test_conflicting_label_signals_use_manual_route():
+    client = FakeClient({7: item(7, labels=['streaming', 'MCP', 'p:2-high'])})
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision == {
+        'number': 7,
+        'owner': 'adtyavrdhn',
+        'evidence': 'manual:conflict-or-unknown',
+    }
+
+
+@pytest.mark.parametrize(
+    ('repo', 'labels', 'expected'),
+    [
+        (CORE, ['streaming'], ('adtyavrdhn', 'label:streaming')),
+        (CORE, ['MODEL ISSUE'], ('dsfaccini', 'label:model issue')),
+        (CORE, ['AG-UI'], ('dsfaccini', 'label:AG-UI')),
+        (CORE, ['vercel-ai'], ('dsfaccini', 'label:vercel-ai')),
+        (CORE, ['web-ui'], ('dsfaccini', 'label:web-ui')),
+        (CORE, ['durable exec'], ('DouweM', 'label:durable exec')),
+        (HARNESS, ['cap:compaction'], ('mpfaffenberger', 'default:repo-intake')),
+    ],
+)
+def test_exact_semantic_labels_route_to_fixed_owners(repo: str, labels: list[str], expected: tuple[str, str]):
+    client = FakeClient({7: item(7, labels=[*labels, 'p:2-high'])})
+
+    decision = router.decision_for(client, repo, 7)['decision']
+
+    assert decision is not None
+    assert (decision['owner'], decision['evidence']) == expected
+
+
+def test_full_non_maintainer_assignee_list_fails_before_notification():
+    client = FakeClient({7: item(7, labels=['MCP', 'p:2-high'], assignees=[f'user-{index}' for index in range(10)])})
+
+    assert router.decision_for(client, CORE, 7) == {
+        'number': 7,
+        'decision': None,
+        'status': 'assignee-capacity',
+    }
+
+
+def test_highest_priority_label_opens_the_gate():
+    client = FakeClient({7: item(7, labels=['MCP', 'p:1-highest'])})
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision == {'number': 7, 'owner': 'dsfaccini', 'evidence': 'label:MCP'}
+
+
+@pytest.mark.parametrize('labels', [[], ['MCP'], ['p:3-mid'], ['p:4-low', 'streaming'], ['P:2-HIGH!']])
+def test_issue_without_priority_label_stays_on_the_triage_plate(labels: list[str]):
+    client = FakeClient({7: item(7, labels=labels, assignees=['DouweM'])})
+
+    selected = router.decision_for(client, CORE, 7)
+
+    assert selected == {'number': 7, 'decision': None, 'status': 'awaiting-triage'}
+    assert not any('/collaborators/' in path for _, path, _ in client.calls)
+
+
+def test_unavailable_manual_owner_fails_loudly():
+    client = FakeClient({7: item(7, labels=['unknown', 'p:2-high'])})
+    client.permissions['adtyavrdhn'] = 'read'
+
+    with pytest.raises(RuntimeError, match='manual routing owner lacks maintainer permission'):
+        router.decision_for(client, CORE, 7)
+
+
+def test_unavailable_semantic_owner_routes_to_manual_review():
+    client = FakeClient({7: item(7, labels=['MCP', 'p:2-high'])})
+    client.permissions['dsfaccini'] = 'read'
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision == {
+        'number': 7,
+        'owner': 'adtyavrdhn',
+        'evidence': 'manual:unavailable-owner:dsfaccini',
+    }
+
+
+def test_unknown_and_owner_lookalike_labels_use_manual_route():
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=['owner:attacker', 'streaming\n<!channel>', 'streaminɡ', 'STREAMING!', 'p:2-high'],
+            )
+        }
+    )
+
+    decision = router.decision_for(client, CORE, 7)['decision']
+
+    assert decision == {
+        'number': 7,
+        'owner': 'adtyavrdhn',
+        'evidence': 'manual:conflict-or-unknown',
+    }
+
+
 def test_every_harness_issue_routes_to_the_default_owner_without_a_priority_label():
     client = FakeClient({7: item(7, labels=['bug'])})
 
@@ -202,15 +303,19 @@ def test_harness_maintainer_authored_pull_request_is_not_assigned_to_the_default
     assert selected == {'number': 7, 'decision': None, 'status': 'maintainer-author'}
 
 
-def test_harness_candidate_search_has_no_priority_filter():
+def test_harness_candidate_search_is_unlabeled_new_intake_only():
     client = FakeClient({})
     client.search_results = [[], []]
 
     router.select_batch(client, HARNESS)
 
-    issue_query = _search_queries(client)[0]
+    issue_query, pull_query = _search_queries(client)
     assert 'label:' not in issue_query
     assert 'is:issue' in issue_query
+    # Blanket intake covers new items going forward, never the backlog.
+    assert f'created:>={router._RECOVERY_EPOCH}' in issue_query
+    assert 'is:pr' in pull_query
+    assert f'created:>={router._RECOVERY_EPOCH}' in pull_query
 
 
 def test_default_intake_notice_names_the_owner_without_a_slack_ping():
@@ -488,14 +593,6 @@ def test_gated_routing_backs_off_after_a_recent_unassignment():
     assert selection == {'number': 7, 'decision': None, 'status': 'recently-unassigned'}
     assert router.select_batch(client, CORE) == []
 
-    # The back-off protects pull requests the same way.
-    pr_client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn', unassigned_at=[recent])})
-    assert router.decision_for(pr_client, CORE, 7) == {
-        'number': 7,
-        'decision': None,
-        'status': 'recently-unassigned',
-    }
-
 
 def test_bot_unassignments_do_not_suppress_gated_routing():
     recent = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)).isoformat()
@@ -597,18 +694,6 @@ def test_slack_map_rejects_missing_selected_owner_unknown_keys_and_invalid_menti
 @pytest.mark.parametrize(
     ('item_type', 'decision', 'expected'),
     [
-        (
-            'PullRequest',
-            router.Decision(number=7, owner='adtyavrdhn', evidence='author:adtyavrdhn'),
-            'Routing intent: Pull request <https://github.com/pydantic/pydantic-ai/pull/7|pydantic/pydantic-ai#7> '
-            '→ <@UADITYA>\nWhy: <@UADITYA> authored this pull request.',
-        ),
-        (
-            'PullRequest',
-            router.Decision(number=7, owner='dsfaccini', evidence='path:pydantic_ai_slim/pydantic_ai/models/'),
-            'Routing intent: Pull request <https://github.com/pydantic/pydantic-ai/pull/7|pydantic/pydantic-ai#7> '
-            '→ <@UDAVID>\nWhy: Matched ownership path `pydantic_ai_slim/pydantic_ai/models/`.',
-        ),
         (
             'Issue',
             router.Decision(number=7, owner='dsfaccini', evidence='future-policy:evidence'),

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -144,307 +144,47 @@ def test_graphql_projection_never_requests_title_or_body():
     assert 'body' not in compact
 
 
-def test_maintainer_authored_pull_request_is_never_assigned():
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True, author='adtyavrdhn')})
-    client.permissions['adtyavrdhn'] = 'write'
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
+@pytest.mark.parametrize('labels', [[], ['p:1-highest'], ['p:2-high', 'streaming'], ['community-backed']])
+def test_core_pull_requests_are_never_routed(labels: list[str]):
+    # Pull requests are outside triage entirely: a human assigns one when an
+    # issue warrants it. Even a gate label does not open routing for a PR.
+    client = FakeClient({7: item(7, labels=labels, pull_request=True, author='adtyavrdhn')})
 
-    selected = router.decision_for(client, CORE, 7)
-
-    # The author already owns their pull request; assigning and pinging them
-    # about it is pure ceremony.
-    assert selected == {'number': 7, 'decision': None, 'status': 'maintainer-author'}
-
-
-def test_author_without_current_maintainer_permission_routes_by_path():
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True, author='adtyavrdhn')})
-    client.permissions['adtyavrdhn'] = 'read'
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert (decision['owner'], decision['evidence']) == ('dsfaccini', 'path:pydantic_ai_slim/pydantic_ai/models/')
-
-
-def test_pull_request_without_a_gate_label_is_untouched_and_unpinged():
-    # The regression that pinged three PRs the moment the workflow was enabled:
-    # pull requests must wait for a `p:1`/`p:2`/`community-backed` label
-    # exactly like issues do.
-    client = FakeClient({7: item(7, pull_request=True, author='contributor')})
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
-
-    assert router.decision_for(client, CORE, 7) == {'number': 7, 'decision': None, 'status': 'awaiting-triage'}
+    assert router.decision_for(client, CORE, 7) == {'number': 7, 'decision': None, 'status': 'pull-request'}
     assert not any(path.endswith('/assignees') for _, path, _ in client.calls)
 
 
-@pytest.mark.parametrize(
-    ('repo', 'labels', 'expected'),
-    [
-        (CORE, ['streaming'], ('adtyavrdhn', 'label:streaming')),
-        (CORE, ['MODEL ISSUE'], ('dsfaccini', 'label:model issue')),
-        (CORE, ['AG-UI'], ('dsfaccini', 'label:AG-UI')),
-        (CORE, ['vercel-ai'], ('dsfaccini', 'label:vercel-ai')),
-        (CORE, ['web-ui'], ('dsfaccini', 'label:web-ui')),
-        (CORE, ['durable exec'], ('DouweM', 'label:durable exec')),
-        (HARNESS, ['cap:compaction'], ('mpfaffenberger', 'default:repo-intake')),
-    ],
-)
-def test_exact_semantic_labels_route_to_fixed_owners(repo: str, labels: list[str], expected: tuple[str, str]):
-    client = FakeClient({7: item(7, labels=[*labels, 'p:2-high'])})
+def test_gated_sweep_never_searches_pull_requests():
+    # The regression that pinged three PRs the moment the workflow was
+    # enabled: the sweep must not even search pull requests on gated repos.
+    client = FakeClient({})
+    client.search_results = [[]]
 
-    decision = router.decision_for(client, repo, 7)['decision']
+    router.select_batch(client, CORE)
 
-    assert decision is not None
-    assert (decision['owner'], decision['evidence']) == expected
+    queries = _search_queries(client)
+    assert len(queries) == 1
+    assert 'is:pr' not in queries[0]
 
 
-@pytest.mark.parametrize('labels', [[], ['MCP'], ['p:3-mid'], ['p:4-low', 'streaming'], ['P:2-HIGH!']])
-def test_issue_without_priority_label_stays_on_the_triage_plate(labels: list[str]):
-    client = FakeClient({7: item(7, labels=labels, assignees=['DouweM'])})
-
-    selected = router.decision_for(client, CORE, 7)
-
-    assert selected == {'number': 7, 'decision': None, 'status': 'awaiting-triage'}
-    assert not any('/collaborators/' in path for _, path, _ in client.calls)
-
-
-def test_highest_priority_label_opens_the_gate():
-    client = FakeClient({7: item(7, labels=['MCP', 'p:1-highest'])})
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision == {'number': 7, 'owner': 'dsfaccini', 'evidence': 'label:MCP'}
-
-
-def test_unavailable_semantic_owner_routes_to_manual_review():
-    client = FakeClient({7: item(7, labels=['MCP', 'p:2-high'])})
-    client.permissions['dsfaccini'] = 'read'
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision == {
-        'number': 7,
-        'owner': 'adtyavrdhn',
-        'evidence': 'manual:unavailable-owner:dsfaccini',
-    }
-
-
-def test_unavailable_manual_owner_fails_loudly():
-    client = FakeClient({7: item(7, labels=['unknown', 'p:2-high'])})
-    client.permissions['adtyavrdhn'] = 'read'
-
-    with pytest.raises(RuntimeError, match='manual routing owner lacks maintainer permission'):
-        router.decision_for(client, CORE, 7)
-
-
-def test_full_non_maintainer_assignee_list_fails_before_notification():
-    client = FakeClient({7: item(7, labels=['MCP', 'p:2-high'], assignees=[f'user-{index}' for index in range(10)])})
-
-    assert router.decision_for(client, CORE, 7) == {
-        'number': 7,
-        'decision': None,
-        'status': 'assignee-capacity',
-    }
-
-
-def test_unknown_and_owner_lookalike_labels_use_manual_route():
-    client = FakeClient(
-        {
-            7: item(
-                7,
-                labels=['owner:attacker', 'streaming\n<!channel>', 'streaminɡ', 'STREAMING!', 'p:2-high'],
-            )
-        }
-    )
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision == {
-        'number': 7,
-        'owner': 'adtyavrdhn',
-        'evidence': 'manual:conflict-or-unknown',
-    }
-
-
-def test_conflicting_label_signals_use_manual_route():
-    client = FakeClient({7: item(7, labels=['streaming', 'MCP', 'p:2-high'])})
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision == {
-        'number': 7,
-        'owner': 'adtyavrdhn',
-        'evidence': 'manual:conflict-or-unknown',
-    }
-
-
-@pytest.mark.parametrize(
-    ('filename', 'owner', 'evidence'),
-    [
-        (
-            'pydantic_ai_slim/pydantic_ai/providers/openai.py',
-            'dsfaccini',
-            'path:pydantic_ai_slim/pydantic_ai/providers/',
-        ),
-        (
-            'pydantic_ai_harness/compaction/_summarizing.py',
-            'mpfaffenberger',
-            'default:repo-intake',
-        ),
-        (
-            'pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py',
-            'dsfaccini',
-            'path:pydantic_ai_slim/pydantic_ai/ui/',
-        ),
-        ('docs/examples/ag-ui.md', 'dsfaccini', 'path:docs/examples/ag-ui.md'),
-        (
-            'examples/pydantic_ai_examples/ag_ui/app.py',
-            'dsfaccini',
-            'path:examples/pydantic_ai_examples/ag_ui/',
-        ),
-    ],
-)
-def test_pull_request_paths_use_longest_fixed_prefix(filename: str, owner: str, evidence: str):
-    repo = HARNESS if filename.startswith('pydantic_ai_harness') else CORE
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.files[7] = [filename]
-
-    decision = router.decision_for(client, repo, 7)['decision']
-
-    assert decision == {'number': 7, 'owner': owner, 'evidence': evidence}
-
-
-@pytest.mark.parametrize(
-    'filename',
-    [
-        '../pydantic_ai_slim/pydantic_ai/providers/openai.py',
-        '/pydantic_ai_slim/pydantic_ai/providers/openai.py',
-        'pydantic_ai_slim\\pydantic_ai\\providers\\openai.py',
-        'pydantic_ai_slim/pydantic_ai/providers/\x00openai.py',
-        'pydantic_ai_slim/pydantic_ai/providers_evil/openai.py',
-    ],
-)
-def test_malformed_or_prefix_lookalike_paths_never_select_specialist(filename: str):
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.files[7] = [filename]
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert decision['owner'] == 'adtyavrdhn'
-    assert decision['evidence'].startswith('manual:')
-
-
-@pytest.mark.parametrize(
-    'filename',
-    [
-        'pydantic_ai_slim/pydantic_ai/messages.py.attacker',
-        'pydantic_ai_slim/pydantic_ai/_cancel.py.backdoor',
-        'pydantic_ai_slim/pydantic_ai/mcp.py/evil',
-    ],
-)
-def test_exact_file_rules_never_match_suffixes_or_children(filename: str):
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.files[7] = [filename]
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert decision['evidence'] == 'manual:unowned-production-path'
-
-
-def test_provider_and_ui_files_share_davids_semantic_route():
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.files[7] = [
-        'pydantic_ai_slim/pydantic_ai/providers/openai.py',
-        'pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py',
-    ]
+def test_specific_ui_signal_routes_to_david_over_cross_cutting_streaming():
+    client = FakeClient({7: item(7, labels=['streaming', 'AG-UI', 'p:2-high'])})
 
     decision = router.decision_for(client, CORE, 7)['decision']
 
     assert decision is not None
     assert decision['owner'] == 'dsfaccini'
-    assert decision['evidence'] == 'path:pydantic_ai_slim/pydantic_ai/providers/'
+    assert decision['evidence'] == 'label:AG-UI'
 
 
-@pytest.mark.parametrize(
-    'ui_path',
-    [
-        None,
-        'pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py',
-        'docs/ui/ag-ui.md',
-        'docs/api/ui/ag_ui.md',
-        'docs/examples/ag-ui.md',
-        'examples/pydantic_ai_examples/ag_ui/__main__.py',
-    ],
-)
-def test_specific_ui_signal_routes_to_david_over_cross_cutting_streaming(ui_path: str | None):
-    labels = ['streaming', 'AG-UI', 'p:2-high'] if ui_path is None else ['streaming', 'p:2-high']
-    client = FakeClient({7: item(7, labels=labels, pull_request=ui_path is not None)})
-    if ui_path is not None:
-        client.files[7] = [ui_path]
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert decision['owner'] == 'dsfaccini'
-    if ui_path is None:
-        assert decision['evidence'] == 'label:AG-UI'
-    else:
-        assert decision['evidence'].startswith('path:')
-
-
-@pytest.mark.parametrize(
-    ('labels', 'files'),
-    [
-        (['AG-UI', 'durable exec', 'p:2-high'], None),
-        (
-            ['p:2-high'],
-            [
-                'pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py',
-                'pydantic_ai_slim/pydantic_ai/durable_exec/temporal.py',
-            ],
-        ),
-    ],
-)
-def test_ui_and_durable_execution_remain_a_manual_conflict(labels: list[str], files: list[str] | None):
-    client = FakeClient({7: item(7, labels=labels, pull_request=files is not None)})
-    if files is not None:
-        client.files[7] = files
+def test_ui_and_durable_execution_remain_a_manual_conflict():
+    client = FakeClient({7: item(7, labels=['AG-UI', 'durable exec', 'p:2-high'])})
 
     decision = router.decision_for(client, CORE, 7)['decision']
 
     assert decision is not None
     assert decision['owner'] == 'adtyavrdhn'
     assert decision['evidence'] == 'manual:conflict-or-unknown'
-
-
-def test_known_and_unknown_production_paths_use_manual_route():
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.files[7] = [
-        'pydantic_ai_slim/pydantic_ai/providers/openai.py',
-        'pydantic_ai_slim/pydantic_ai/unowned.py',
-        'tests/models/test_openai.py',
-    ]
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert decision['evidence'] == 'manual:unowned-production-path'
-
-
-def test_mike_is_not_selected_in_core_without_reviewed_ownership_evidence():
-    client = FakeClient({7: item(7, labels=['tools', 'p:2-high'], pull_request=True)})
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/toolsets/function.py']
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision == {
-        'number': 7,
-        'owner': 'adtyavrdhn',
-        'evidence': 'manual:unowned-production-path',
-    }
 
 
 def test_every_harness_issue_routes_to_the_default_owner_without_a_priority_label():
@@ -501,33 +241,11 @@ def test_default_intake_notice_names_the_owner_without_a_slack_ping():
     assert 'mpfaffenberger' in payload
 
 
-@pytest.mark.parametrize('changed_count', [101, 2000])
-def test_oversized_file_list_routes_to_manual_review(changed_count: int):
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.changed_counts[7] = changed_count
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert decision['evidence'] == 'manual:incomplete-file-list'
-
-
-def test_incomplete_file_page_routes_to_manual_review():
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
-    client.files[7] = ['pydantic_ai_slim/pydantic_ai/providers/openai.py']
-    client.changed_counts[7] = 2
-
-    decision = router.decision_for(client, CORE, 7)['decision']
-
-    assert decision is not None
-    assert decision['evidence'] == 'manual:incomplete-file-list'
-
-
 def test_draft_pull_request_waits_until_ready():
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
+    client = FakeClient({7: item(7, pull_request=True)})
     client.drafts.add(7)
 
-    assert router.decision_for(client, CORE, 7) == {
+    assert router.decision_for(client, HARNESS, 7) == {
         'number': 7,
         'decision': None,
         'status': 'draft',
@@ -536,7 +254,7 @@ def test_draft_pull_request_waits_until_ready():
 
 @pytest.mark.parametrize('is_draft', [None, 'false', 0, 1])
 def test_malformed_draft_state_fails_closed(is_draft: object):
-    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
+    client = FakeClient({7: item(7, pull_request=True)})
     original_post = client.post
 
     def post(path: str, payload: Mapping[str, object]) -> Any:
@@ -548,7 +266,7 @@ def test_malformed_draft_state_fails_closed(is_draft: object):
 
     client.post = post  # type: ignore[method-assign]
 
-    selected = router.decision_for(client, CORE, 7)
+    selected = router.decision_for(client, HARNESS, 7)
 
     assert selected['decision'] is None
     assert selected['status'] == 'invalid-draft-state'
@@ -670,8 +388,6 @@ def test_gated_selection_queries_exclude_every_fixed_owner():
     negatives = '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger'
     assert _search_queries(client) == [
         f'repo:pydantic/pydantic-ai is:open is:issue label:"p:1-highest","p:2-high" {negatives} sort:created-asc',
-        f'repo:pydantic/pydantic-ai is:open is:pr -draft:true label:"p:1-highest","p:2-high" '
-        f'created:>=2026-08-18 {negatives} sort:created-asc',
     ]
 
 
@@ -758,13 +474,13 @@ def test_community_recovery_is_opt_in_second_choice_and_bounded():
     stale = {number: item(number, labels=['MCP', 'community-backed']) for number in range(1, 9)}
     client = FakeClient(stale)
 
-    client.search_results = [[], []]
+    client.search_results = [[]]
     assert router.select_batch(client, CORE) == []
 
-    client.search_results = [[], [], [8]]
+    client.search_results = [[], [8]]
     assert [selection['number'] for selection in router.select_batch(client, CORE, community_recovery=True)] == [8]
 
-    client.search_results = [[], [], list(range(1, 8))]
+    client.search_results = [[], list(range(1, 8))]
     selected = router.select_batch(client, CORE, community_recovery=True)
     assert [selection['number'] for selection in selected] == [1, 2, 3]
 
@@ -772,7 +488,7 @@ def test_community_recovery_is_opt_in_second_choice_and_bounded():
     assert len(community_queries) == 2
     for query in community_queries:
         assert query == (
-            'repo:pydantic/pydantic-ai is:open -draft:true no:assignee label:"community-backed" sort:updated-desc'
+            'repo:pydantic/pydantic-ai is:open is:issue no:assignee label:"community-backed" sort:updated-desc'
         )
 
 
@@ -851,7 +567,7 @@ def test_community_recovery_backs_off_after_a_recent_unassignment():
         9: item(9, labels=['MCP', 'community-backed'], unassigned_at=[old]),
     }
     client = FakeClient(stale)
-    client.search_results = [[], [], [8, 9]]
+    client.search_results = [[], [8, 9]]
 
     selected = router.select_batch(client, CORE, community_recovery=True)
 

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -58,9 +58,7 @@ class FakeClient(router.attention.GitHubClient):
     def __init__(self, values: dict[int, dict[str, Any]]) -> None:
         super().__init__('token')
         self.items = values
-        self.files: dict[int, list[str]] = {}
         self.drafts: set[int] = set()
-        self.changed_counts: dict[int, int] = {}
         self.search_results: list[list[int]] = []
         self.permissions = {login: 'write' for login in ('adtyavrdhn', 'dsfaccini', 'DouweM', 'mpfaffenberger')}
         self.calls: list[tuple[str, str, object | None]] = []
@@ -109,18 +107,7 @@ class FakeClient(router.attention.GitHubClient):
                     ]
                 }
                 if 'pull_request' in source:
-                    filenames = self.files.get(number, [])
-                    value.update(
-                        {
-                            'isDraft': number in self.drafts,
-                            'author': source['author'],
-                            'changedFiles': self.changed_counts.get(number, len(filenames)),
-                            'files': {
-                                'nodes': [{'path': filename} for filename in filenames],
-                                'pageInfo': {'hasNextPage': False},
-                            },
-                        }
-                    )
+                    value.update({'isDraft': number in self.drafts, 'author': source['author']})
             return {'data': {'repository': {'issueOrPullRequest': value}}}
         number = int(path.split('/issues/')[1].split('/')[0])
         requested = payload['assignees']
@@ -199,7 +186,6 @@ def test_every_harness_issue_routes_to_the_default_owner_without_a_priority_labe
 
 def test_every_harness_pull_request_routes_to_the_default_owner():
     client = FakeClient({7: item(7, pull_request=True)})
-    client.files[7] = ['pydantic_ai_harness/code_mode/_runtime.py']
 
     decision = router.decision_for(client, HARNESS, 7)['decision']
 
@@ -208,7 +194,6 @@ def test_every_harness_pull_request_routes_to_the_default_owner():
 
 def test_harness_maintainer_authored_pull_request_is_not_assigned_to_the_default_owner():
     client = FakeClient({7: item(7, pull_request=True, author='DouweM')})
-    client.files[7] = ['pydantic_ai_harness/code_mode/_runtime.py']
 
     selected = router.decision_for(client, HARNESS, 7)
 

--- a/.github/scripts/test_semantic_owner_router.py
+++ b/.github/scripts/test_semantic_owner_router.py
@@ -144,22 +144,38 @@ def test_graphql_projection_never_requests_title_or_body():
     assert 'body' not in compact
 
 
-@pytest.mark.parametrize(
-    ('permission', 'expected'),
-    [
-        ('write', ('adtyavrdhn', 'author:adtyavrdhn')),
-        ('read', ('dsfaccini', 'path:pydantic_ai_slim/pydantic_ai/models/')),
-    ],
-)
-def test_pr_author_precedence_requires_current_maintainer_permission(permission: str, expected: tuple[str, str]):
-    client = FakeClient({7: item(7, pull_request=True, author='adtyavrdhn')})
-    client.permissions['adtyavrdhn'] = permission
+def test_maintainer_authored_pull_request_is_never_assigned():
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True, author='adtyavrdhn')})
+    client.permissions['adtyavrdhn'] = 'write'
+    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
+
+    selected = router.decision_for(client, CORE, 7)
+
+    # The author already owns their pull request; assigning and pinging them
+    # about it is pure ceremony.
+    assert selected == {'number': 7, 'decision': None, 'status': 'maintainer-author'}
+
+
+def test_author_without_current_maintainer_permission_routes_by_path():
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True, author='adtyavrdhn')})
+    client.permissions['adtyavrdhn'] = 'read'
     client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
 
     decision = router.decision_for(client, CORE, 7)['decision']
 
     assert decision is not None
-    assert (decision['owner'], decision['evidence']) == expected
+    assert (decision['owner'], decision['evidence']) == ('dsfaccini', 'path:pydantic_ai_slim/pydantic_ai/models/')
+
+
+def test_pull_request_without_a_gate_label_is_untouched_and_unpinged():
+    # The regression that pinged three PRs the moment the workflow was enabled:
+    # pull requests must wait for a `p:1`/`p:2`/`community-backed` label
+    # exactly like issues do.
+    client = FakeClient({7: item(7, pull_request=True, author='contributor')})
+    client.files[7] = ['pydantic_ai_slim/pydantic_ai/models/openai.py']
+
+    assert router.decision_for(client, CORE, 7) == {'number': 7, 'decision': None, 'status': 'awaiting-triage'}
+    assert not any(path.endswith('/assignees') for _, path, _ in client.calls)
 
 
 @pytest.mark.parametrize(
@@ -291,7 +307,7 @@ def test_conflicting_label_signals_use_manual_route():
 )
 def test_pull_request_paths_use_longest_fixed_prefix(filename: str, owner: str, evidence: str):
     repo = HARNESS if filename.startswith('pydantic_ai_harness') else CORE
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.files[7] = [filename]
 
     decision = router.decision_for(client, repo, 7)['decision']
@@ -310,7 +326,7 @@ def test_pull_request_paths_use_longest_fixed_prefix(filename: str, owner: str, 
     ],
 )
 def test_malformed_or_prefix_lookalike_paths_never_select_specialist(filename: str):
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.files[7] = [filename]
 
     decision = router.decision_for(client, CORE, 7)['decision']
@@ -329,7 +345,7 @@ def test_malformed_or_prefix_lookalike_paths_never_select_specialist(filename: s
     ],
 )
 def test_exact_file_rules_never_match_suffixes_or_children(filename: str):
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.files[7] = [filename]
 
     decision = router.decision_for(client, CORE, 7)['decision']
@@ -339,7 +355,7 @@ def test_exact_file_rules_never_match_suffixes_or_children(filename: str):
 
 
 def test_provider_and_ui_files_share_davids_semantic_route():
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.files[7] = [
         'pydantic_ai_slim/pydantic_ai/providers/openai.py',
         'pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py',
@@ -364,7 +380,7 @@ def test_provider_and_ui_files_share_davids_semantic_route():
     ],
 )
 def test_specific_ui_signal_routes_to_david_over_cross_cutting_streaming(ui_path: str | None):
-    labels = ['streaming', 'AG-UI', 'p:2-high'] if ui_path is None else ['streaming']
+    labels = ['streaming', 'AG-UI', 'p:2-high'] if ui_path is None else ['streaming', 'p:2-high']
     client = FakeClient({7: item(7, labels=labels, pull_request=ui_path is not None)})
     if ui_path is not None:
         client.files[7] = [ui_path]
@@ -384,7 +400,7 @@ def test_specific_ui_signal_routes_to_david_over_cross_cutting_streaming(ui_path
     [
         (['AG-UI', 'durable exec', 'p:2-high'], None),
         (
-            [],
+            ['p:2-high'],
             [
                 'pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py',
                 'pydantic_ai_slim/pydantic_ai/durable_exec/temporal.py',
@@ -405,7 +421,7 @@ def test_ui_and_durable_execution_remain_a_manual_conflict(labels: list[str], fi
 
 
 def test_known_and_unknown_production_paths_use_manual_route():
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.files[7] = [
         'pydantic_ai_slim/pydantic_ai/providers/openai.py',
         'pydantic_ai_slim/pydantic_ai/unowned.py',
@@ -419,7 +435,7 @@ def test_known_and_unknown_production_paths_use_manual_route():
 
 
 def test_mike_is_not_selected_in_core_without_reviewed_ownership_evidence():
-    client = FakeClient({7: item(7, labels=['tools'], pull_request=True)})
+    client = FakeClient({7: item(7, labels=['tools', 'p:2-high'], pull_request=True)})
     client.files[7] = ['pydantic_ai_slim/pydantic_ai/toolsets/function.py']
 
     decision = router.decision_for(client, CORE, 7)['decision']
@@ -450,13 +466,15 @@ def test_every_harness_pull_request_routes_to_the_default_owner():
     assert decision == {'number': 7, 'owner': 'mpfaffenberger', 'evidence': 'default:repo-intake'}
 
 
-def test_harness_maintainer_authored_pull_request_keeps_author_precedence():
+def test_harness_maintainer_authored_pull_request_is_not_assigned_to_the_default_owner():
     client = FakeClient({7: item(7, pull_request=True, author='DouweM')})
     client.files[7] = ['pydantic_ai_harness/code_mode/_runtime.py']
 
-    decision = router.decision_for(client, HARNESS, 7)['decision']
+    selected = router.decision_for(client, HARNESS, 7)
 
-    assert decision == {'number': 7, 'owner': 'DouweM', 'evidence': 'author:DouweM'}
+    # The author owns it; blanket intake must not hand it to the default owner,
+    # and the author is not assigned to their own pull request either.
+    assert selected == {'number': 7, 'decision': None, 'status': 'maintainer-author'}
 
 
 def test_harness_candidate_search_has_no_priority_filter():
@@ -485,7 +503,7 @@ def test_default_intake_notice_names_the_owner_without_a_slack_ping():
 
 @pytest.mark.parametrize('changed_count', [101, 2000])
 def test_oversized_file_list_routes_to_manual_review(changed_count: int):
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.changed_counts[7] = changed_count
 
     decision = router.decision_for(client, CORE, 7)['decision']
@@ -495,7 +513,7 @@ def test_oversized_file_list_routes_to_manual_review(changed_count: int):
 
 
 def test_incomplete_file_page_routes_to_manual_review():
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.files[7] = ['pydantic_ai_slim/pydantic_ai/providers/openai.py']
     client.changed_counts[7] = 2
 
@@ -506,7 +524,7 @@ def test_incomplete_file_page_routes_to_manual_review():
 
 
 def test_draft_pull_request_waits_until_ready():
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     client.drafts.add(7)
 
     assert router.decision_for(client, CORE, 7) == {
@@ -518,7 +536,7 @@ def test_draft_pull_request_waits_until_ready():
 
 @pytest.mark.parametrize('is_draft', [None, 'false', 0, 1])
 def test_malformed_draft_state_fails_closed(is_draft: object):
-    client = FakeClient({7: item(7, pull_request=True)})
+    client = FakeClient({7: item(7, labels=['p:2-high'], pull_request=True)})
     original_post = client.post
 
     def post(path: str, payload: Mapping[str, object]) -> Any:
@@ -652,7 +670,8 @@ def test_gated_selection_queries_exclude_every_fixed_owner():
     negatives = '-assignee:adtyavrdhn -assignee:DouweM -assignee:dsfaccini -assignee:mpfaffenberger'
     assert _search_queries(client) == [
         f'repo:pydantic/pydantic-ai is:open is:issue label:"p:1-highest","p:2-high" {negatives} sort:created-asc',
-        f'repo:pydantic/pydantic-ai is:open is:pr -draft:true created:>=2026-08-18 {negatives} sort:created-asc',
+        f'repo:pydantic/pydantic-ai is:open is:pr -draft:true label:"p:1-highest","p:2-high" '
+        f'created:>=2026-08-18 {negatives} sort:created-asc',
     ]
 
 


### PR DESCRIPTION
Re-enabling the router after the triage rework pinged three unlabeled pull requests straight to the fallback owner: the priority gate from #7819 covered issues only. Per the ratified policy, pull requests are simply not triaged: a human assigns one when an issue warrants it.

- On `pydantic/pydantic-ai` the router no longer searches, routes, pings, assigns, or emits events for pull requests at all — `decision_for` records them as `pull-request` and stops.
- The path-rule machinery existed only to route PR files, so it is deleted: `Rule` keeps labels, `_route` drops path matching, file-page validation, and the oversized/incomplete-file statuses (net −180 lines).
- Harness keeps blanket-routing to its default owner, but only for items created after the rollout epoch — new intake, not the backlog — and a maintainer-authored pull request is never auto-assigned, not even to its author.
- The community-demand lane is explicitly an issue lane, and it only runs on gated repositories — a hand-applied `community-backed` label can no longer sweep the harness backlog past the new-intake epoch.
- The attention monitor's placeholder assignment is issues-only too: a maintainer already on a PR was a human's choice and owns it; a PR without one stays tracked silently.

Issue routing is unchanged (verified against `main`'s `_route` — the deleted path half was unreachable for issues). The census still counts PR intake in the heartbeat; that is monitoring, not routing.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
