### PR TITLE
Trim measured test-suite hot spots

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -800,6 +800,32 @@ _HttpClient: TypeAlias = 'httpx.AsyncClient | httpx2.AsyncClient'
 _HttpClientCache: TypeAlias = 'dict[tuple[str, int, int], _HttpClient]'
 
 
+# Which loaded modules hold a reference to an HTTP client factory, keyed by module name and
+# invalidated on module identity change. Scanning all of `sys.modules` (thousands of entries)
+# on every test is the single largest per-test fixture cost, and the answer only changes when
+# a module is imported or reloaded, so `track_httpx_clients` only scans what it hasn't seen.
+_factory_holding_modules: dict[str, tuple[Any, bool, bool]] = {}
+
+
+def _modules_holding_http_factories(original_httpx: Any, original_httpx2: Any) -> Iterator[tuple[Any, bool, bool]]:
+    for name, mod in list(sys.modules.items()):
+        cached = _factory_holding_modules.get(name)
+        if cached is None or cached[0] is not mod:
+            # Read the module's own namespace via `__dict__` rather than `getattr`: some
+            # modules (e.g. `transformers` submodules) define a lazy PEP 562 `__getattr__`
+            # that imports submodules on attribute access, and probing every loaded module
+            # with `getattr` would trigger those unrelated (and possibly failing) imports.
+            mod_dict: dict[str, object] = getattr(mod, '__dict__', None) or {}
+            cached = (
+                mod,
+                mod_dict.get('create_async_http_client', None) is original_httpx,
+                mod_dict.get('create_async_httpx2_client', None) is original_httpx2,
+            )
+            _factory_holding_modules[name] = cached
+        if cached[1] or cached[2]:
+            yield cached
+
+
 @pytest.fixture(autouse=True)
 def track_httpx_clients(monkeypatch: pytest.MonkeyPatch) -> Iterator[_HttpClientCache]:
     """Monkeypatch the HTTP client factories in all loaded modules and track created clients.
@@ -830,15 +856,10 @@ def track_httpx_clients(monkeypatch: pytest.MonkeyPatch) -> Iterator[_HttpClient
     cached_per_test = make_cached('httpx', original_httpx, httpx.AsyncClient)
     cached_httpx2_per_test = make_cached('httpx2', original_httpx2, httpx2.AsyncClient)
 
-    for mod in list(sys.modules.values()):
-        # Read the module's own namespace via `__dict__` rather than `getattr`: some
-        # modules (e.g. `transformers` submodules) define a lazy PEP 562 `__getattr__`
-        # that imports submodules on attribute access, and probing every loaded module
-        # with `getattr` would trigger those unrelated (and possibly failing) imports.
-        mod_dict: dict[str, object] = getattr(mod, '__dict__', None) or {}
-        if mod_dict.get('create_async_http_client', None) is original_httpx:
+    for mod, holds_httpx, holds_httpx2 in _modules_holding_http_factories(original_httpx, original_httpx2):
+        if holds_httpx:
             monkeypatch.setattr(mod, 'create_async_http_client', cached_per_test)
-        if mod_dict.get('create_async_httpx2_client', None) is original_httpx2:
+        if holds_httpx2:
             monkeypatch.setattr(mod, 'create_async_httpx2_client', cached_httpx2_per_test)
 
     yield cache

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1901,6 +1901,7 @@ class TestGoogle:
 
 
 @pytest.mark.skipif(not sentence_transformers_imports_successful(), reason='SentenceTransformers not installed')
+@pytest.mark.xdist_group(name='sentence_transformers')
 class TestSentenceTransformers:
     def _load_stsb_bert_tiny_model(self):
         # The pinned commit revision lets huggingface_hub serve every model file

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -241,6 +241,7 @@ def test_docs_examples(
     mocker.patch('pydantic_ai.agent.models.infer_model', side_effect=mock_infer_model)
     mocker.patch('pydantic_ai.embeddings.infer_embedding_model', side_effect=mock_infer_embedding_model)
     mocker.patch('pydantic_ai._utils.group_by_temporal', side_effect=mock_group_by_temporal)
+    mocker.patch('asyncio.sleep', side_effect=fast_asyncio_sleep)
     mocker.patch('pydantic_evals.reporting.render_numbers._render_duration', side_effect=mock_render_duration)
 
     mocker.patch('httpx.Client.get', side_effect=http_request)
@@ -1330,6 +1331,18 @@ def mock_infer_model(model: Model | KnownModelName) -> Model:
             model_name=model_name,
             profile=model.profile if isinstance(model, Model) else None,
         )
+
+
+_real_asyncio_sleep = asyncio.sleep
+
+
+async def fast_asyncio_sleep(delay: float, result: Any = None) -> Any:
+    """Scale down example sleeps so illustrative delays don't burn real CI time.
+
+    Division rather than zeroing preserves the relative ordering that concurrency
+    examples (joins, toolset logging) rely on for deterministic output.
+    """
+    return await _real_asyncio_sleep(delay / 100, result)
 
 
 def mock_group_by_temporal(aiter: Any, soft_max_interval: float | None) -> Any:


### PR DESCRIPTION
## Why we make these changes

Profiling the full suite (`--durations`) surfaced a handful of tests that dominate per-cell CPU on CI, all self-inflicted rather than inherent:

- `docs/agent.md` cancellation examples each contain a real `await asyncio.sleep(10)` that runs to completion on the resumed history (~21s per matrix cell); `docs/evals/how-to/concurrency.md` adds ~7s of illustrative sleeps.
- `TestSentenceTransformers` loaded the model through a session fixture but xdist spreads its tests over workers, each paying the ~2.5-4s load (~14s total).
- `track_httpx_clients` (autouse) scanned all of `sys.modules` (thousands of entries) on every one of ~11.5k tests, ~0.6ms each.

Changes, in the same order:

- `test_examples.py` patches `asyncio.sleep` to divide delays by 100. Division rather than zeroing preserves the relative ordering that the joins and toolset-logging examples depend on for deterministic output.
- `TestSentenceTransformers` gets `xdist_group('sentence_transformers')` so one worker loads the model once.
- The factory-module scan is cached in a module-level map keyed by module name and identity, so each test only scans modules imported since the last scan.

## New public surface

none

## Verification

Full suite locally: 11537 passed, wall 2m18s -> 1m48s (`-n logical`, same machine, same flags). `test_examples.py` alone: the two `agent.md` cancel examples drop from ~10.5s each to ~0.4s, `concurrency_example.py` from 7.3s to ~0.2s, outputs unchanged.

## What changes for existing users

Nothing - test infrastructure only.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

