### PR TITLE
Require an explicit operation name on `@durable_operation`

### DIFF
--- a/docs/capabilities/custom.md
+++ b/docs/capabilities/custom.md
@@ -861,7 +861,7 @@ class Summaries(AbstractCapability[None]):
 agent = Agent(TestModel(), capabilities=[Summaries()])
 ```
 
-Mark each operation method with `@durable_operation`. When a durability capability is bound, calling the method during a run dispatches it through that engine. Without durability, the same call awaits the original method directly.
+Mark each operation method with `@durable_operation(name='...')`. The required name becomes part of persisted durable-unit names and must remain stable, while the Python method can be freely renamed. When a durability capability is bound, calling the method during a run dispatches it through that engine. Without durability, the same call awaits the original method directly.
 
 Arguments and results must follow the same serialization rules as durable tools. Temporal sends them through its data converter; JSON-journal engines require JSON-compatible values. Operation names are scoped by capability ID. Changing either identity creates a different persisted operation, and on Prefect it also creates a different cache key.
 

--- a/docs/durable_execution/backends.md
+++ b/docs/durable_execution/backends.md
@@ -137,8 +137,11 @@ The backend config object implements the backend configuration protocol. Its pub
 [`OperationConfigRole`][pydantic_ai.durable_exec.OperationConfigRole] and a
 [`DurableOperationId`][pydantic_ai.durable_exec.DurableOperationId]. Match the concrete ID variants
 when config differs by model, toolset, or operation. The role is a coarse config bucket: `'model'`,
-`'event'`, `'tool'`, or `'capability'`. The operation ID carries the fine-grained identity. The ID
-union represents the IDs available in the installed Pydantic AI version. Per-tool config can return
+`'event'`, `'tool'`, or `'capability'`. The operation ID carries the fine-grained identity. A
+capability operation ID includes the explicit name from `@durable_operation(name='...')`. That name
+is required because it becomes persisted compatibility data and must remain stable if the Python
+method is renamed. The ID union represents the IDs available in the installed Pydantic AI version.
+Per-tool config can return
 `False` to opt a function or dynamic tool out of a durable unit.
 MCP tools perform I/O and always run in their durable unit, so returning `False` for one raises a
 [`UserError`][pydantic_ai.exceptions.UserError].

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -194,7 +194,7 @@ async def log_request(ctx: RunContext, request_context: ModelRequestContext) -> 
 agent = Agent('openai:gpt-5.2', name='hooks_agent', capabilities=[hooks])
 ```
 
-For a custom capability hook that performs I/O under Temporal, DBOS, or Prefect, mark a fixed method with `@durable_operation`. For dynamically contributed handlers, return them from `get_durable_operations()` and invoke a typed handle with `ctx.durable_operation(self, name, handler)`. Always set a stable capability `id`; without a durability capability both forms call the original async handler directly. Arguments and results must be serializable like durable tool inputs and outputs.
+For a custom capability hook that performs I/O under Temporal, DBOS, or Prefect, mark a fixed method with `@durable_operation(name='...')`. The required name becomes part of persisted durable-unit names, so keep it stable even if the Python method is renamed. For dynamically contributed handlers, return them from `get_durable_operations()` and invoke a typed handle with `ctx.durable_operation(self, name, handler)`. Always set a stable capability `id`; without a durability capability both forms call the original async handler directly. Arguments and results must be serializable like durable tool inputs and outputs.
 
 ### Define Agent from YAML Spec
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_capability_operation.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_capability_operation.py
@@ -4,7 +4,7 @@ import inspect
 from collections.abc import Awaitable, Callable
 from dataclasses import KW_ONLY, dataclass
 from functools import update_wrapper, wraps
-from typing import Any, Generic, ParamSpec, TypeVar, cast, get_type_hints, overload
+from typing import Any, Generic, ParamSpec, TypeVar, cast, get_type_hints
 
 from pydantic_ai._function_schema import (
     FunctionSchema,
@@ -185,25 +185,22 @@ def set_durable_operation_marker(obj: object, marker: Marker) -> None:
     setattr(obj, _MARKER_ATTRIBUTE, marker)
 
 
-def _operation_name(function: Callable[..., Any], name: str | None) -> str:
-    return name or function.__name__.removeprefix('_')
+def _validate_operation_name(name: object) -> str:
+    if not isinstance(name, str):
+        raise TypeError(f'`durable_operation` name must be a string, got {type(name).__name__}')
+    if not name:
+        raise ValueError('`durable_operation` name must not be empty')
+    return name
 
 
-@overload
-def durable_operation(function: Callable[P, A], /) -> Callable[P, A]: ...
-
-
-@overload
-def durable_operation(*, name: str | None = None) -> Callable[[Callable[P, A]], Callable[P, A]]: ...
-
-
-def durable_operation(function: Any = None, /, *, name: str | None = None) -> Any:
+def durable_operation(name: str) -> Callable[[Callable[P, A]], Callable[P, A]]:
     """Declare an async capability method as a durable operation.
 
     The method keeps its original signature. During a run with a durability capability, calls
     dispatch through that engine's activity, step, or task. Without durability, calls await the
-    original method directly. The optional `name` is the stable operation name within the
-    capability's required stable `id`.
+    original method directly. The required `name` becomes part of persisted durable-unit names
+    within the capability's required stable `id`, so it must essentially never change. The Python
+    method itself can be renamed freely as long as `name` stays the same.
 
     ```python
     from pydantic_ai.capabilities import AbstractCapability, durable_operation
@@ -213,38 +210,44 @@ def durable_operation(function: Any = None, /, *, name: str | None = None) -> An
     class Audit(AbstractCapability[None]):
         id = 'audit'
 
-        @durable_operation
+        @durable_operation(name='record')
         async def record(self, ctx: RunContext[None], message: str) -> bool:
             return bool(message)
     ```
 
     Args:
-        function: The async capability method when used as `@durable_operation`.
-        name: An explicit stable name when used as `@durable_operation(name='...')`.
+        name: The stable operation name. This can be passed positionally or by keyword.
 
     Returns:
         The marked method with its parameter and return types preserved.
 
     Raises:
-        TypeError: If the decorated method is synchronous.
+        TypeError: If used without an explicit name or if the decorated method is synchronous.
+        ValueError: If `name` is empty.
     """
+    if callable(name):
+        raise TypeError(
+            '`durable_operation` requires an explicit operation name because it becomes persisted compatibility data '
+            "and must not change when the function is renamed. Use `@durable_operation(name='operation_name')`."
+        )
+    name = _validate_operation_name(name)
 
-    def decorate(target: Callable[..., Awaitable[ResultT]]) -> Callable[..., Awaitable[ResultT]]:
+    def decorate(target: Callable[P, A]) -> Callable[P, A]:
         if not inspect.iscoroutinefunction(target):
             if target.__name__ in _SYNC_NEVER_DURABLE_HOOKS:
                 set_durable_operation_marker(
                     target,
                     Marker(
-                        name=_operation_name(target, name),
+                        name=name,
                         function=cast(Callable[..., Awaitable[Any]], target),
                     ),
                 )
                 return target
             raise TypeError('`durable_operation` can only decorate async methods')
-        marker = Marker(name=_operation_name(target, name), function=target)
+        marker = Marker(name=name, function=cast(Callable[..., Awaitable[Any]], target))
 
         @wraps(target)
-        async def decorated(self: AbstractCapability[Any], *args: Any, **kwargs: Any) -> ResultT:
+        async def decorated(self: AbstractCapability[Any], *args: Any, **kwargs: Any) -> Any:
             # Bind the call so context parameters are visible regardless of calling style.
             bound = inspect.signature(target).bind(self, *args, **kwargs)
 
@@ -257,7 +260,7 @@ def durable_operation(function: Any = None, /, *, name: str | None = None) -> An
             if ctx is None:
                 # Agent runs and durable scopes set the ambient context. Calls outside either scope
                 # deliberately pass through to the undecorated method.
-                return await target(self, *args, **kwargs)
+                return await cast(Callable[..., Awaitable[Any]], target)(self, *args, **kwargs)
 
             # Project live model-request context before it crosses a durable boundary.
             request_context = next(
@@ -299,26 +302,33 @@ def durable_operation(function: Any = None, /, *, name: str | None = None) -> An
             # Apply worker-side model-request mutations back to the live context.
             if request_context is not None and isinstance(result, _ResolvedModelRequestContext):
                 result.projection.apply(request_context, result.model)
-                return cast(ResultT, request_context)
-            return cast(ResultT, result)
+                return request_context
+            return result
 
         set_durable_operation_marker(decorated, marker)
-        return decorated
+        return cast(Callable[P, A], decorated)
 
-    return decorate(function) if function is not None else decorate
+    return decorate
 
 
-def base_hook_durable_operation(function: Callable[..., Awaitable[ResultT]]) -> Callable[..., Awaitable[ResultT]]:
+def base_hook_durable_operation(
+    name: str,
+) -> Callable[[Callable[..., Awaitable[ResultT]]], Callable[..., Awaitable[ResultT]]]:
     """Mark a base hook so every override inherits durable execution automatically."""
-    set_durable_operation_marker(
-        function,
-        Marker(
-            name=_operation_name(function, None),
-            function=cast(Callable[..., Awaitable[Any]], function),
-            base_hook=True,
-        ),
-    )
-    return function
+    name = _validate_operation_name(name)
+
+    def decorate(function: Callable[..., Awaitable[ResultT]]) -> Callable[..., Awaitable[ResultT]]:
+        set_durable_operation_marker(
+            function,
+            Marker(
+                name=name,
+                function=cast(Callable[..., Awaitable[Any]], function),
+                base_hook=True,
+            ),
+        )
+        return function
+
+    return decorate
 
 
 def collect_capability_operations(

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import gc
+import re
 import uuid
 import weakref
 from collections.abc import Awaitable, Callable, Generator, Mapping
@@ -164,7 +165,7 @@ class Operations(AbstractCapability[Any]):
     async def before_run(self, ctx: RunContext[Any]) -> None:
         self.result = await self._calculate(ctx, *self.arguments[0], **self.arguments[1])
 
-    @durable_operation
+    @durable_operation('calculate')
     async def _calculate(
         self,
         ctx: RunContext[Any],
@@ -181,7 +182,7 @@ class Operations(AbstractCapability[Any]):
 class DurableBeforeModelRequest(AbstractCapability[Any]):
     id = 'before_model'
 
-    @durable_operation
+    @durable_operation('before_model_request')
     async def before_model_request(
         self, ctx: RunContext[Any], request_context: ModelRequestContext
     ) -> ModelRequestContext:
@@ -197,7 +198,7 @@ class CustomModelRequestOperation(AbstractCapability[Any]):
     ) -> ModelRequestContext:
         return await self.rewrite_request(ctx, request_context)
 
-    @durable_operation
+    @durable_operation('rewrite_request')
     async def rewrite_request(self, ctx: RunContext[Any], request: ModelRequestContext) -> ModelRequestContext:
         request.messages = [ModelRequest(parts=[UserPromptPart('custom replacement')])]
         return request
@@ -210,7 +211,7 @@ class ModelReplacingBeforeModelRequest(AbstractCapability[Any]):
         self.model = model
         self.model_id = model_id
 
-    @durable_operation
+    @durable_operation('before_model_request')
     async def before_model_request(
         self, ctx: RunContext[Any], request_context: ModelRequestContext
     ) -> ModelRequestContext:
@@ -223,7 +224,7 @@ class RenamedContextBeforeModelRequest(AbstractCapability[Any]):
     id = 'renamed_before_model'
 
     # Only the declared context parameter name is inspected; dispatch would duplicate other hook tests.
-    @durable_operation
+    @durable_operation('before_model_request')
     async def before_model_request(  # pyright: ignore[reportIncompatibleMethodOverride] # pragma: no cover
         self, run_context: RunContext[Any], request_context: ModelRequestContext
     ) -> ModelRequestContext: ...
@@ -244,23 +245,23 @@ class ContextPositions(AbstractCapability[Any]):
             await self._summarize(['one', 'two'], ctx, previous_summary='previous'),
         ]
 
-    @durable_operation
+    @durable_operation('ctx_first')
     async def ctx_first(self, ctx: RunContext[Any], value: str) -> str:
         return f'{value}:{ctx.model.model_name}'
 
-    @durable_operation
+    @durable_operation('ctx_last')
     async def ctx_last(self, value: str, ctx: RunContext[Any]) -> str:
         return f'{value}:{ctx.model.model_name}'
 
-    @durable_operation
+    @durable_operation('ctx_keyword_only')
     async def ctx_keyword_only(self, value: str, *, ctx: RunContext[Any]) -> str:
         return f'{value}:{ctx.model.model_name}'
 
-    @durable_operation
+    @durable_operation('no_ctx')
     async def no_ctx(self, value: str) -> str:
         return value
 
-    @durable_operation
+    @durable_operation('summarize')
     async def _summarize(
         self, messages: list[str], ctx: RunContext[Any], *, previous_summary: str | None = None
     ) -> str:
@@ -282,7 +283,7 @@ class PerRunOperation(AbstractCapability[Any]):
     async def before_run(self, ctx: RunContext[Any]) -> None:
         await self.operation(ctx)
 
-    @durable_operation
+    @durable_operation('operation')
     async def operation(self, ctx: RunContext[Any]) -> None:
         self.calls += 1
 
@@ -300,7 +301,7 @@ class TenantScopedOperation(AbstractCapability[str]):
     async def before_run(self, ctx: RunContext[str]) -> None:
         self.observations.append(await self.read_tenant(ctx))
 
-    @durable_operation
+    @durable_operation('read_tenant')
     async def read_tenant(self, ctx: RunContext[str]) -> str:
         return self.tenant
 
@@ -315,7 +316,7 @@ class ModelReadingOperation(AbstractCapability[Any]):
     async def before_run(self, ctx: RunContext[Any]) -> None:
         self.result = await self.read_model(ctx)
 
-    @durable_operation
+    @durable_operation('read_model')
     async def read_model(self, ctx: RunContext[Any]) -> bool:
         return ctx.model is self.expected
 
@@ -329,7 +330,7 @@ class UsageOperation(AbstractCapability[Any]):
     async def before_run(self, ctx: RunContext[Any]) -> None:
         await self.record_nested_usage(ctx)
 
-    @durable_operation
+    @durable_operation('record_nested_usage')
     async def record_nested_usage(self, ctx: RunContext[Any]) -> None:
         self.calls += 1
         await Agent(TestModel(custom_output_text='summary')).run('summarize', usage=ctx.usage)
@@ -454,7 +455,7 @@ async def test_recorded_usage_delta_is_applied_once_per_replayed_run() -> None:
 
 def test_decorated_capability_requires_explicit_stable_id() -> None:
     class MissingId(AbstractCapability[Any]):
-        @durable_operation
+        @durable_operation('operation')
         async def operation(self, ctx: RunContext[Any]) -> None:
             pass
 
@@ -509,7 +510,7 @@ def test_never_durable_hooks_fail_at_bind(hook: str) -> None:
 
     invalid.__name__ = hook
 
-    decorated = durable_operation(invalid)
+    decorated = durable_operation(hook)(invalid)
     capability_type = type('Invalid', (AbstractCapability,), {'id': 'invalid', hook: decorated})
     with pytest.raises(UserError, match=f'`{hook}`'):
         Agent(TestModel(), name='invalid', capabilities=[capability_type(), RecordingDurability()])
@@ -518,7 +519,7 @@ def test_never_durable_hooks_fail_at_bind(hook: str) -> None:
 def test_base_hook_override_is_automatically_registered() -> None:
     class TierOneBase(AbstractCapability[Any]):
         # Registration, not execution, is the behavior under test.
-        @base_hook_durable_operation
+        @base_hook_durable_operation('provision')
         async def provision(self, ctx: RunContext[Any]) -> str: ...  # pragma: no branch
 
     class TierOne(TierOneBase):
@@ -538,7 +539,7 @@ async def test_inherited_base_hook_hook_is_not_registered_or_dispatched() -> Non
         def __init__(self) -> None:
             self.provisioned = False
 
-        @base_hook_durable_operation
+        @base_hook_durable_operation('provision')
         async def provision(self, ctx: RunContext[Any]) -> None:
             self.provisioned = True
 
@@ -582,7 +583,7 @@ def test_unannotated_parameter_is_rejected_at_bind() -> None:
         id = 'unannotated'
 
         # Binding rejects the missing annotation before this handler can be dispatched.
-        @durable_operation  # pyright: ignore[reportUnknownArgumentType]
+        @durable_operation('operation')
         async def operation(  # pragma: no cover
             self,
             ctx: RunContext[Any],
@@ -738,18 +739,58 @@ async def test_registered_model_replacement_is_stable_on_journal_replay() -> Non
     assert [result.output for result in results] == ['restricted', 'restricted']
 
 
+def test_durable_operation_requires_explicit_name() -> None:
+    async def operation() -> None:
+        pass
+
+    message = (
+        '`durable_operation` requires an explicit operation name because it becomes persisted compatibility data '
+        "and must not change when the function is renamed. Use `@durable_operation(name='operation_name')`."
+    )
+    with pytest.raises(TypeError, match='^' + re.escape(message) + '$'):
+        durable_operation(operation)  # pyright: ignore[reportArgumentType]
+
+
+@pytest.mark.parametrize('name', ['', None])
+def test_durable_operation_rejects_invalid_name(name: Any) -> None:
+    if name == '':
+        with pytest.raises(ValueError, match=re.escape('`durable_operation` name must not be empty')):
+            durable_operation(name)
+    else:
+        with pytest.raises(TypeError, match=re.escape('`durable_operation` name must be a string, got NoneType')):
+            durable_operation(name)
+
+
+def test_durable_operation_name_is_independent_of_function_name() -> None:
+    class Renamed(AbstractCapability[Any]):
+        id = 'renamed'
+
+        @durable_operation(name='operation')
+        async def renamed_function(self, ctx: RunContext[Any]) -> None:
+            pass
+
+    declarations = collect_capability_operations(Renamed())
+    assert set(declarations) == {'operation'}
+    assert (
+        JournalOperationNamer('agent').operation_name(
+            CapabilityOperationId('renamed', operation=next(iter(declarations)))
+        )
+        == 'agent__capability__renamed.operation'
+    )
+
+
 def test_sync_non_hook_operation_is_rejected_by_decorator() -> None:
     def operation() -> None:
         pass
 
     with pytest.raises(TypeError, match='can only decorate async methods'):
-        durable_operation(operation)  # pyright: ignore[reportArgumentType]
+        durable_operation('operation')(operation)  # pyright: ignore[reportArgumentType]
 
 
 def test_base_hook_base_and_duplicate_override_paths() -> None:
     class Base(AbstractCapability[Any]):
         # Collection behavior is tested without dispatching any of these declarations.
-        @base_hook_durable_operation
+        @base_hook_durable_operation('operation')
         async def operation(self, ctx: RunContext[Any]) -> str: ...  # pragma: no branch
 
         sentinel = True
@@ -809,7 +850,7 @@ def test_two_run_context_parameters_are_rejected_at_bind() -> None:
     class DuplicateContext(AbstractCapability[Any]):
         id = 'duplicate_context'
 
-        @durable_operation
+        @durable_operation('operation')
         async def operation(self, first: RunContext[Any], second: RunContext[Any]) -> None:
             pass
 
@@ -824,7 +865,7 @@ async def test_two_model_request_context_parameters_are_rejected_at_bind() -> No
     class DuplicateModelRequestContext(AbstractCapability[Any]):
         id = 'duplicate_model_request_context'
 
-        @durable_operation
+        @durable_operation('operation')
         async def operation(self, first: ModelRequestContext, second: ModelRequestContext) -> ModelRequestContext:
             return first
 
@@ -849,7 +890,7 @@ def test_variadic_run_context_is_rejected_for_durable_operation() -> None:
     class VariadicContext(AbstractCapability[Any]):
         id = 'variadic_context'
 
-        @durable_operation
+        @durable_operation('operation')
         async def operation(self, *ctx: RunContext[Any]) -> None:
             pass
 
@@ -861,7 +902,7 @@ async def test_variadic_model_request_context_is_rejected_for_durable_operation(
     class VariadicModelRequestContext(AbstractCapability[Any]):
         id = 'variadic_model_request_context'
 
-        @durable_operation
+        @durable_operation('operation')
         async def operation(self, *request_context: ModelRequestContext) -> ModelRequestContext:
             return request_context[0]
 
@@ -1189,7 +1230,7 @@ async def test_prefect_capability_operation_cache_identity_includes_context_and_
         async def before_run(self, ctx: RunContext[str]) -> None:
             await self.read_context(ctx, 1)
 
-        @durable_operation
+        @durable_operation('read_context')
         async def read_context(self, ctx: RunContext[str], value: int) -> None:
             self.calls.append((ctx.deps, ctx.model.model_name))
 

--- a/tests/durable_exec/test_durable_exec_compat.py
+++ b/tests/durable_exec/test_durable_exec_compat.py
@@ -196,7 +196,7 @@ def _operation_label(operation_id: DurableOperationId) -> str | None:
 class CompatCapability(AbstractCapability[Any]):
     id = 'compat'
 
-    @durable_operation
+    @durable_operation('operation')
     async def operation(self, ctx: RunContext[Any]) -> None:
         pass
 

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -3624,7 +3624,7 @@ async def test_prefect_durability_identical_capability_operations_execute_twice_
             await self.record(ctx, 'same')
             await self.record(ctx, 'same')
 
-        @durable_operation
+        @durable_operation('record')
         async def record(self, ctx: RunContext[object], value: str) -> None:
             nonlocal calls
             calls += 1


### PR DESCRIPTION
## What

`@durable_operation` now requires an explicit operation name: `@durable_operation('calculate')`. Bare `@durable_operation` raises an actionable `TypeError` at class-definition time; non-string names raise `TypeError`, empty names raise `ValueError`.

## Why

The operation name feeds persisted durable-unit names, which are permanent compatibility data (pinned by `tests/durable_exec/test_durable_exec_compat.py`). With the previous default (the wrapped function's `__name__`), renaming a method silently changed persisted names and stranded recorded runs; nothing at the call site hinted at that coupling. Requiring the name makes the persistence contract visible where it is entered into, and makes function renames safe.

This intentionally lands before the first release containing #6696, so the implicit-name form is never in a released version.

## Changes

- Decorator signature: `durable_operation(name: str)`; the internal base-hook marking decorator gets the same treatment.
- Every in-tree decoration site passes its previously implicit name explicitly, so no persisted name changes (compat rows untouched).
- Docs updated (`docs/capabilities/custom.md`, `docs/durable_execution/backends.md`, agent skill) so all examples pass a name and explain why it is required.
- No character restrictions beyond non-empty: custom backend namers support unrestricted names.

## Verification

Full durable suite on this branch: 400 passed, 1 skipped, 0 failed. Lint clean. Downstream decoration sites (harness #707/#710, the #6492 sandbox conversion) will add their names in a small follow-up after this merges; their current git pins predate this change, so nothing breaks in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

