### PR TITLE
Render `pydantic_ai.durable_exec` on its API reference page

### DIFF
--- a/docs/api/durable_exec.md
+++ b/docs/api/durable_exec.md
@@ -1,5 +1,7 @@
 # `pydantic_ai.durable_exec`
 
+::: pydantic_ai.durable_exec
+
 ::: pydantic_ai.durable_exec.temporal
 
 ::: pydantic_ai.durable_exec.dbos


### PR DESCRIPTION
#6696 added 24 public symbols to `pydantic_ai.durable_exec` (`DurableOperationBackend`, `DurabilityCodec`, `RoleBasedOperationConfig`, the operation ids, `IDENTITY_CODEC`/`JSON_CODEC`, and so on) plus a new `docs/durable_execution/backends.md` guide for third-party engines. `docs/api/durable_exec.md` was not updated, and it only renders the three submodules:

```
::: pydantic_ai.durable_exec.temporal
::: pydantic_ai.durable_exec.dbos
::: pydantic_ai.durable_exec.prefect
```

None of those three re-export the new symbols, and every one of them is defined in a private module (`_operation.py`, `_codec.py`, `_operation_backend.py`) and surfaced only through `durable_exec/__init__.py`. So nothing renders them, and the 13 distinct `[...][pydantic_ai.durable_exec.X]` cross-references the new guide uses (17 occurrences in `backends.md`) have no target to resolve to.

This adds `::: pydantic_ai.durable_exec` above the submodules. I checked it does not duplicate anything: the module's `__all__` is exactly those 24 new symbols and shares no names with the temporal, dbos or prefect exports.

Verified after the change that all 13 referenced symbols are in `__all__` and therefore rendered, with none left unresolvable. Ran `uv run pytest tests/test_examples.py -k durable` (18 passed, 23 skipped).

Same shape as #3158, which added the missing Prefect submodule to this page.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

About me: I'm a freshman in college, so I traced where each symbol is defined and which pages render what before concluding the references were dangling, rather than assuming from the missing directive. I used Claude Code to check my reasoning and read the diff myself. If you would rather list the members explicitly, or keep this page submodule-only and document the backend API somewhere else, say which and I will redo it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

