### PR TITLE
Project a bare `ToolDefinition` into Prefect cache keys

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from pydantic_ai import ToolsetTool
 from pydantic_ai._utils import TOOL_CALL_ID_PREFIX
-from pydantic_ai.tools import RunContext
+from pydantic_ai.tools import RunContext, ToolDefinition
 
 _NON_SERIALIZABLE = '<non-serializable>'
 
@@ -28,6 +28,10 @@ def _is_tuple(obj: Any) -> TypeGuard[tuple[Any, ...]]:
 
 def _is_toolset_tool(obj: Any) -> TypeGuard[ToolsetTool]:
     return isinstance(obj, ToolsetTool)
+
+
+def _is_tool_definition(obj: Any) -> TypeGuard[ToolDefinition]:
+    return isinstance(obj, ToolDefinition)
 
 
 def _is_run_context(obj: Any) -> TypeGuard[RunContext[object]]:
@@ -214,6 +218,11 @@ def _replace_toolset_tools(
     Recurses into containers for the same reason as [`_replace_run_context`][]: the durable base
     passes an operation's logical inputs as one `*args` tuple, so a `ToolsetTool` is not always a
     top-level parameter.
+
+    A dynamic toolset's tool call carries a bare `ToolDefinition` instead of a `ToolsetTool`
+    (`_DynamicCallToolCacheIdentity` projects `params.tool_def`), so those are projected too. Their
+    `metadata` is where per-tool config lives and may hold a live resource, which `hash_objects`
+    cannot serialize at all -- without the sentinel `compute_key` raises rather than degrading.
     """
 
     def project(value: Any) -> Any:
@@ -221,6 +230,8 @@ def _replace_toolset_tools(
             return _map_container(value, project)
         if _is_toolset_tool(value):
             return {'toolset': value.toolset.id, 'tool_def': _cacheable_value(value.tool_def)}
+        if _is_tool_definition(value):
+            return _cacheable_value(value)
         return value
 
     return {key: project(value) for key, value in inputs.items()}

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -2314,6 +2314,38 @@ def test_cache_policy_projects_nested_run_context_and_tool():
     assert key_for('acme', 'tool') != key_for('acme', 'other')
 
 
+
+def test_cache_policy_projects_a_bare_tool_definition_in_the_inputs():
+    """A dynamic tool call's cache identity carries a bare `ToolDefinition`, which also needs projecting.
+
+    `_FunctionCallToolCacheIdentity` projects a `ToolsetTool`, which the policy replaces with its
+    value identity, but `_DynamicCallToolCacheIdentity` carries `params.tool_def` directly. A
+    `ToolDefinition`'s `metadata` is where per-tool config lives, so it can hold a live resource --
+    a `TaskConfig` carrying a `cache_policy`, or anything else a user put there -- and hashing one
+    raw fails outright with `Unable to create hash` instead of falling back to the sentinel.
+    """
+    cache_policy = PrefectAgentInputs()
+    mock_task_ctx = MagicMock()
+
+    def key_for(tool_name: str) -> str | None:
+        ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+        tool_def = ToolDefinition(
+            name=tool_name,
+            metadata={'prefect': TaskConfig(cache_policy=PrefectAgentInputs()), 'live': threading.Lock()},
+        )
+        return cache_policy.compute_key(
+            task_ctx=mock_task_ctx,
+            inputs={'unit_name': 'unit', 'args': (tool_name, {}, ctx, tool_def)},
+            flow_parameters={},
+        )
+
+    # Hashable at all -- this is what regresses when the bare definition isn't projected.
+    assert key_for('tool') is not None
+    assert key_for('tool') == key_for('tool')
+    # And still discriminating: the sentinel replaces only the unhashable parts.
+    assert key_for('tool') != key_for('other')
+
+
 async def test_cache_policy_with_tuples():
     """Test that cache policy handles tuples with timestamps correctly."""
     cache_policy = PrefectAgentInputs()

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -2314,7 +2314,6 @@ def test_cache_policy_projects_nested_run_context_and_tool():
     assert key_for('acme', 'tool') != key_for('acme', 'other')
 
 
-
 def test_cache_policy_projects_a_bare_tool_definition_in_the_inputs():
     """A dynamic tool call's cache identity carries a bare `ToolDefinition`, which also needs projecting.
 


### PR DESCRIPTION
Restores a fix that was verified on #6906 and lost when #6696 absorbed that work.

### The defect

`PrefectAgentInputs` projects a `ToolsetTool` onto its value identity, replacing the live objects
`hash_objects` can't serialize with a stable sentinel. A dynamic toolset's tool call never carries
one: `_DynamicCallToolCacheIdentity.project` returns `params.tool_def`, a bare `ToolDefinition`,
where its `_FunctionCallToolCacheIdentity` sibling returns `params.tool`.

A `ToolDefinition`'s `metadata` is exactly where per-tool durable config lives — `resolve_tool_task_config`
reads `metadata['prefect']` — so it can hold a `TaskConfig` carrying a `cache_policy` instance, or any
other live object a user put there. Hashing one raw doesn't just destabilize the key, it fails outright:

```
prefect.exceptions.HashError: Unable to create hash - objects could not be serialized.
  JSON error: Unable to serialize unknown type: <class '_thread.lock'>
  Pickle error: cannot pickle '_thread.lock' object
```

This is the same class as #6907/#6944, which fixed it for `ToolsetTool` inputs; the dynamic path
never got the same treatment.

### The change

One branch in the existing `project()` closure so a bare `ToolDefinition` goes through
`_cacheable_value` too, plus the `_is_tool_definition` guard next to its siblings. The `ToolsetTool`
branch is untouched, so the static path's key shape is byte-identical and no existing cache entry
is invalidated.

### Tests

`test_cache_policy_projects_a_bare_tool_definition_in_the_inputs` builds the inputs in the shape the
Prefect backend actually passes them (`{'unit_name': ..., 'args': (name, args, ctx, tool_def)}`),
with a `threading.Lock` in the definition's metadata. It fails on `main` with the `HashError` above
and passes with the fix. It also asserts the key still discriminates between tool names, so the
sentinel is replacing only the unhashable parts.

### Provenance

Verified on #6906 in August (there as `_replace_tool_inputs`), including a before/after check that
the regression test failed without the fix. #6906 was closed when #6696 incorporated its work;
#6696 rewrote `_replace_toolset_tools` into the recursive `project()` form and carried over the two
sibling fixes from that PR, but not this one.

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

