### PR TITLE
fix(anthropic): omit container_upload from count_tokens

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1181,12 +1181,17 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         revealed_tool_order = _revealed_deferred_tool_order(messages, map_parameters)
         tools, tool_choice = self._prepare_tools_and_tool_choice(model_settings, map_parameters)
         # `count_tokens_parameters` here, not `map_parameters`: the server-side tool definitions are
-        # what the endpoint rejects, so they're the one thing that has to differ from the real request.
+        # what the endpoint rejects, so they have to differ from the real request.
         tools, mcp_servers, native_tool_betas = self._add_native_tools(tools, count_tokens_parameters, model_settings)
         _append_revealed_tool_params(tools, revealed_tool_order)
 
         auto_cache_control, resolved_cache_ttl = self._build_automatic_cache_control(model_settings)
         system_prompt, anthropic_messages = await self._map_message(messages, map_parameters, model_settings)
+        # The endpoint also rejects `container_upload` file sources with a 400. Drop those blocks
+        # on this path only; `_map_message` still injects them on the real request. The omitted
+        # blocks are a handful of tokens each, so the count is a small underestimate rather than
+        # unusable with `CodeExecutionTool(files=...)`.
+        _drop_container_upload_blocks(anthropic_messages)
         self._apply_per_block_caching_fallback(resolved_cache_ttl, anthropic_messages)
         self._apply_explicit_message_caching(model_settings, anthropic_messages)
         self._limit_cache_points(
@@ -3401,6 +3406,25 @@ def _last_message_content(anthropic_messages: list[BetaMessageParam]) -> list[Be
     # Returned as-is, not copied: the caller attaches `cache_control` by mutating the block in place, so
     # it has to be the list the message actually holds.
     return content if isinstance(content, list) else []
+
+
+def _drop_container_upload_blocks(anthropic_messages: list[BetaMessageParam]) -> None:
+    """Drop `container_upload` blocks in place.
+
+    Anthropic's `count_tokens` endpoint rejects file sources with a 400, so these
+    blocks have to come off the count path even though the real request sends them.
+    """
+    for message in anthropic_messages:
+        content = message['content']
+        assert isinstance(content, list)
+        kept: list[BetaContentBlockParam] = []
+        for block in content:
+            # Preserve the union type before `is_str_dict` narrows `block` to `dict[str, Any]`.
+            block_param = block
+            if is_str_dict(block) and block.get('type') == 'container_upload':
+                continue
+            kept.append(block_param)
+        message['content'] = kept
 
 
 def _drop_unpaired_native_tool_calls(anthropic_messages: list[BetaMessageParam]) -> None:  # noqa: C901

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -11621,6 +11621,50 @@ async def test_anthropic_count_tokens_omits_native_tools(allow_model_requests: N
     assert create_kwargs['betas'] == ['context-management-2025-06-27']
 
 
+async def test_anthropic_count_tokens_omits_container_upload(allow_model_requests: None):
+    """`count_tokens` must drop `container_upload` blocks that `_map_message` injects for
+    `CodeExecutionTool(files=...)`. Anthropic's token-counting endpoint 400s on file sources
+    (`File sources are not supported in the token counting endpoint.`), so
+    `UsageLimits(count_tokens_before_request=True)` is otherwise unusable with this feature.
+
+    The omitted blocks are a handful of tokens each; the real `/v1/messages` request still
+    sends them. Not a VCR test: cassette matchers aren't sensitive to `container_upload` in
+    the messages body, so we pin the count vs request payloads on the mock client.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/7867
+    """
+    c = completion_message([BetaTextBlock(text='done', type='text')], BetaUsage(input_tokens=5, output_tokens=10))
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-sonnet-4-6', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    params = ModelRequestParameters(
+        native_tools=[
+            CodeExecutionTool(files=[UploadedFile(file_id='file_anthropic', provider_name='anthropic')]),
+        ]
+    )
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='sum column a')]),
+        ModelResponse(parts=[TextPart(content='42')]),
+        ModelRequest(parts=[UserPromptPart(content='now the mean')]),
+    ]
+
+    await m.count_tokens(messages, None, params)
+    await m.request(messages, None, params)
+
+    count_tokens_kwargs, create_kwargs = get_mock_chat_completion_kwargs(mock_client)
+
+    def container_uploads(kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            block
+            for msg in kwargs['messages']
+            for block in msg['content']
+            if block.get('type') == 'container_upload'
+        ]
+
+    assert container_uploads(count_tokens_kwargs) == []
+    assert container_uploads(create_kwargs) == [{'file_id': 'file_anthropic', 'type': 'container_upload'}]
+
+
 async def test_anthropic_count_tokens_preserves_tool_search_replay(allow_model_requests: None):
     """`count_tokens` renders a tool-search replay turn with the same `tool_reference` wire shape
     as the real `/v1/messages` request, while still omitting the server-side `tool_search_tool_*`


### PR DESCRIPTION
## Summary

Anthropic's `count_tokens` endpoint rejects `container_upload` file sources with a 400. `_messages_count_tokens` was sharing `_map_message` with the real request, so `UsageLimits(count_tokens_before_request=True)` could not be used with `CodeExecutionTool(files=...)`.

Drop `container_upload` blocks on the count path only (same idea as already omitting the `code_execution` tool definition). The real `/v1/messages` request is unchanged. The count is a small underestimate.

Fixes #7867

## Test plan

- [x] `uv run pytest tests/models/test_anthropic.py::test_anthropic_count_tokens_omits_container_upload tests/models/test_anthropic.py::test_anthropic_count_tokens_omits_native_tools -q`
- [x] New regression asserts count payload has no `container_upload` while the create payload still includes it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

