### PR TITLE
Stop the Temporal test dev server from binding an unprobed UI port

### DIFF
--- a/tests/durable_exec/temporal/conftest.py
+++ b/tests/durable_exec/temporal/conftest.py
@@ -126,9 +126,11 @@ async def temporal_env(temporal_port: int) -> AsyncIterator[WorkflowEnvironment]
     # restricts `Path.home()` access.
     download_dest_dir = Path.home() / '.cache' / 'temporal-dev-server'
     download_dest_dir.mkdir(parents=True, exist_ok=True)
+    # Leave `ui` off (the `start_local` default). With `ui=True` and no explicit `ui_port`, the dev
+    # server binds `port + 1000` without probing it first, and a bind failure there aborts the whole
+    # process — surfacing as `ConnectionRefused` on the healthy gRPC port. No test reads the UI.
     async with await WorkflowEnvironment.start_local(  # pyright: ignore[reportUnknownMemberType]
         port=temporal_port,
-        ui=True,
         dev_server_extra_args=['--dynamic-config-value', 'frontend.enableServerVersionCheck=false'],
         download_dest_dir=str(download_dest_dir),
     ) as env:


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-sonnet-5 on behalf of David.

The `temporal_env` fixture passed `ui=True` to `WorkflowEnvironment.start_local()` without a `ui_port`. The dev server then derives its UI port as `port + 1000` and binds it **without probing it first**. If that port is taken, the dev-server process aborts at startup, and the SDK reports the failure against the freshly-allocated, perfectly healthy gRPC port:

```
RuntimeError: Failed starting Temporal dev server: Failed connecting to test server
after 5 seconds, last error: ... ConnectError("tcp connect error", 127.0.0.1:<grpc port>,
Os { code: 61, kind: ConnectionRefused })
```

Every test sharing that module's dev server then fails, pointing at a port that was never the problem.

#7850 replaced one hardcoded port for the whole suite with a per-module `free_tcp_port_factory()` allocation, so a CI job now runs several dev servers at once — each probing its gRPC port and silently claiming an unprobed `port + 1000` next to it. That's enough for the race to surface: it took down [`test durable-exec on 3.11 (locked)`](https://github.com/pydantic/pydantic-ai/actions/runs/33226355529/job/99030778171) during the v2.36.0 tag run, and a plain re-run passed clean.

Nothing under `tests/durable_exec/` reads the dev server UI, so this drops `ui=True` instead of allocating a second probed port — removing the extra bind rather than narrowing the window on it.

<details>
<summary>Local reproduction</summary>

Squatting on `port + 1000` before calling `start_local()`:

| `ui` | `port + 1000` | result |
|---|---|---|
| `True` | free | starts, and binds `port + 1000` |
| `True` | taken | dev server logs `can't set UI port <n>: listen tcp 127.0.0.1:<n>: bind: address already in use`, then `RuntimeError: ... ConnectionRefused` on the gRPC port |
| `False` | taken | starts fine |

</details>

`tests/durable_exec/temporal`: 283 passed, 2 skipped.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

