### PR TITLE
Honor `anthropic_disallows_sampling_settings` on `BedrockConverseModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -76,7 +76,11 @@ from pydantic_ai.models import (
 from pydantic_ai.models._tool_choice import ResolvedToolChoice, resolve_tool_choice
 from pydantic_ai.native_tools import AbstractNativeTool, CodeExecutionTool
 from pydantic_ai.profiles import DEFAULT_THINKING_TAGS
-from pydantic_ai.profiles.anthropic import ANTHROPIC_THINKING_BUDGET_MAP, resolve_anthropic_effort
+from pydantic_ai.profiles.anthropic import (
+    ANTHROPIC_SAMPLING_PARAMS,
+    ANTHROPIC_THINKING_BUDGET_MAP,
+    resolve_anthropic_effort,
+)
 from pydantic_ai.profiles.openai import OPENAI_REASONING_EFFORT_MAP
 from pydantic_ai.providers import Provider, infer_provider
 from pydantic_ai.providers.bedrock import BedrockModelProfile, remove_bedrock_geo_prefix
@@ -786,6 +790,8 @@ class BedrockConverseModel(Model[BaseClient]):
         check_allow_model_requests()
         model_settings, model_request_parameters = self.prepare_request(model_settings, model_request_parameters)
         settings = cast(BedrockModelSettings, model_settings or {})
+        if self.profile.get('anthropic_disallows_sampling_settings', False):
+            settings = self._drop_disallowed_sampling_settings(settings)
         system_prompt, bedrock_messages = await self._map_messages(messages, model_request_parameters, settings)
         converse: ConverseTokensRequestTypeDef = {
             'messages': bedrock_messages,
@@ -1003,6 +1009,8 @@ class BedrockConverseModel(Model[BaseClient]):
         model_request_parameters: ModelRequestParameters,
     ) -> ConverseResponseTypeDef | ConverseStreamResponseTypeDef:
         settings = model_settings or BedrockModelSettings()
+        if self.profile.get('anthropic_disallows_sampling_settings', False):
+            settings = self._drop_disallowed_sampling_settings(settings)
         system_prompt, bedrock_messages = await self._map_messages(messages, model_request_parameters, settings)
         inference_config = self._map_inference_config(settings)
 
@@ -1057,6 +1065,26 @@ class BedrockConverseModel(Model[BaseClient]):
             else:
                 model_response = await _call_bedrock(client, client.converse, params, settings.get('extra_headers'))
         return model_response
+
+    def _drop_disallowed_sampling_settings(self, model_settings: BedrockModelSettings) -> BedrockModelSettings:
+        """Return a copy of `model_settings` without sampling settings the model rejects.
+
+        Claude 5-class models served through Bedrock return a 400 for `temperature`, `top_p`, and
+        `top_k` (`anthropic_disallows_sampling_settings`), instead of ignoring them like the direct
+        Anthropic API's deprecated-field behavior. `top_k` is also dropped so it does not ride in
+        `additionalModelRequestFields` via the `anthropic` top-K variant.
+        """
+        dropped = [setting for setting in ANTHROPIC_SAMPLING_PARAMS if model_settings.get(setting) is not None]
+        filtered: BedrockModelSettings = {**model_settings}
+        for setting in dropped:
+            filtered.pop(setting)
+        if dropped:
+            warnings.warn(
+                f'Sampling parameters {dropped} are not supported by {self.model_name!r}. These settings will be ignored.',
+                UserWarning,
+                stacklevel=2,
+            )
+        return filtered
 
     @staticmethod
     def _map_inference_config(

--- a/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
@@ -35,6 +35,13 @@ _ANTHROPIC_CODE_EXECUTION_20260120_MODEL_PREFIXES = (
     'claude-sonnet-5',
 )
 
+ANTHROPIC_SAMPLING_PARAMS: tuple[str, ...] = ('temperature', 'top_p', 'top_k')
+"""The unified sampling settings governed by `anthropic_disallows_sampling_settings`.
+
+Models whose profile sets that flag reject these settings outright (HTTP 400), so providers
+serving them — including over Bedrock — must drop and warn instead of forwarding them.
+"""
+
 
 class AnthropicModelProfile(ModelProfile, total=False):
     """Profile for models used with `AnthropicModel`.

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import json
 import os
+import warnings
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
@@ -3757,6 +3758,66 @@ async def test_bedrock_top_k_nova_variant(
     sent = single_request_body(vcr)
     assert sent['additionalModelRequestFields'] == {'inferenceConfig': {'topK': 20}}
     assert result.output == IsStr()
+
+
+async def test_bedrock_anthropic_disallows_sampling_settings(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """Claude 5-class models on Bedrock reject sampling settings with a 400, so they are dropped with a warning.
+
+    Unified `temperature`, `top_p`, and `top_k` (the latter would ride in `additionalModelRequestFields`)
+    never reach the request, while non-sampling settings are preserved. Mirrors the `AnthropicModel`
+    warn-and-drop behavior for the same `anthropic_disallows_sampling_settings` profile flag (#7791).
+    """
+    model = BedrockConverseModel('us.anthropic.claude-opus-5', provider=bedrock_provider)
+    assert model.profile.get('anthropic_disallows_sampling_settings') is True
+
+    model_settings = ModelSettings(temperature=0.5, top_p=0.9, top_k=20, max_tokens=100)
+    agent = Agent(model, model_settings=model_settings)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    with pytest.warns(UserWarning, match='Sampling parameters'):
+        await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert kwargs['inferenceConfig'] == {'maxTokens': 100}
+    assert 'additionalModelRequestFields' not in kwargs
+    # The original settings dict is preserved — filtering happens on a copy.
+    assert model_settings == ModelSettings(temperature=0.5, top_p=0.9, top_k=20, max_tokens=100)
+
+
+async def test_bedrock_sampling_settings_kept_when_profile_allows(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """Models whose profile does not set `anthropic_disallows_sampling_settings` keep their sampling settings."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    assert model.profile.get('anthropic_disallows_sampling_settings') is not True
+
+    agent = Agent(model, model_settings=ModelSettings(temperature=0.5, top_p=0.9, top_k=20))
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter('always')
+        await agent.run('What is the capital of France?')
+
+    assert not [w for w in recorded if 'Sampling parameters' in str(w.message)]
+    _, kwargs = mock_converse.call_args
+    assert kwargs['inferenceConfig'] == {'temperature': 0.5, 'topP': 0.9}
+    assert kwargs['additionalModelRequestFields'] == {'top_k': 20}
 
 
 async def test_bedrock_top_k_user_field_takes_precedence(


### PR DESCRIPTION
- Closes #7791

## Problem

Shared `model_settings` that work on the direct Anthropic API hard-fail with a 400 the moment the model is switched to Claude Opus 5 / Sonnet 5 on Bedrock:

```
ModelHTTPError: status_code: 400, model_name: eu.anthropic.claude-opus-5,
body: {'Error': {'Message': '`temperature` is deprecated for this model.', ...}}
```

`AnthropicModel` already honors `anthropic_disallows_sampling_settings` (warn and drop `temperature`/`top_p`/`top_k`), but `BedrockConverseModel` never reads the flag, even though `BedrockProvider.model_profile()` correctly merges it from the downstream Anthropic profile for these models.

## Fix

Mirror the `AnthropicModel` behavior in `BedrockConverseModel`:

- When the profile sets `anthropic_disallows_sampling_settings`, drop `temperature`, `top_p`, and `top_k` from the settings with a `UserWarning` using the same message shape as `AnthropicModel`, on both the Converse and the count-tokens request paths.
- Unified `top_k` is dropped too, so it is not injected into `additionalModelRequestFields` via the `anthropic` top-K variant — the live probe matrix in #7791 shows the same 400 for that path.
- Filtering works on a copy, so the caller's settings dict is not mutated.
- Explicit user-supplied `bedrock_additional_model_requests_fields` are left untouched; those are a deliberate raw-field escape hatch rather than the unified settings surface.

The shared `ANTHROPIC_SAMPLING_PARAMS` tuple now lives in `profiles/anthropic.py` next to the flag it enforces, so the profile contract and its enforcement set stay documented together.

## Verification

- `uv run pytest tests/models/test_bedrock.py tests/profiles/` — 470 passed (includes two new tests: Claude Opus 5 on Bedrock warns and sends no sampling settings, with `max_tokens` preserved and no `additionalModelRequestFields`; Sonnet 4.5, which does not set the flag, keeps all sampling settings).
- `uv run pytest tests/models/test_anthropic.py` — 313 passed (no behavior change on the direct API).
- `uv run pyright pydantic_ai_slim/pydantic_ai/models/bedrock.py pydantic_ai_slim/pydantic_ai/profiles/anthropic.py tests/models/test_bedrock.py` — 0 errors (strict).
- `uv run ruff check` / `ruff format --check` — clean.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


