### PR TITLE
Align `GoogleProvider` overload with environment API-key fallback

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -108,7 +108,7 @@ class GoogleProvider(BaseGoogleProvider):
     def __init__(
         self,
         *,
-        api_key: str,
+        api_key: str | None = None,
         http_client: AsyncHTTPClient | None = None,
         base_url: str | None = None,
         retry_options: HttpRetryOptions | None = None,

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -63,7 +63,7 @@ def test_google_provider_without_api_key_raises_error(env: TestEnv):
             r" to use the Gemini API\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
         ),
     ):
-        GoogleProvider()  # pyright: ignore[reportCallIssue]  # deliberately no api_key, to test the missing-key error
+        GoogleProvider()
 
 
 def test_google_provider_retry_options(env: TestEnv):


### PR DESCRIPTION
`GoogleProvider()` already resolves `GOOGLE_API_KEY` when `api_key` is omitted. Align the public overload with that existing supported call pattern.

New public surface: none.

Verification: `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/providers/test_google.py`. The existing missing-key test no longer needs a type-ignore.

What changes for existing users: `GoogleProvider()` now type-checks when credentials are supplied through `GOOGLE_API_KEY`.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).