### PR TITLE
Allow callback API keys in `OpenAIProvider`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/_openai_compatible.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 
 from openai import AsyncOpenAI
 
@@ -36,7 +36,7 @@ class OpenAICompatibleProvider(Provider[AsyncOpenAI]):
         self,
         *,
         base_url: str | None,
-        api_key: str | None,
+        api_key: str | None | Callable[[], Awaitable[str]],
         http_client: AsyncHTTPClient | None,
         default_headers: Mapping[str, str] | None = None,
     ) -> AsyncOpenAI:

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, overload
 
 from pydantic_ai import ModelProfile
@@ -69,7 +70,7 @@ class OpenAIProvider(_OpenAICompatibleProvider):
     def __init__(
         self,
         base_url: str | None = None,
-        api_key: str | None = None,
+        api_key: str | None | Callable[[], Awaitable[str]] = None,
         openai_client: None = None,
         http_client: _OpenAIHTTPClient | None = None,
     ) -> None: ...
@@ -77,7 +78,7 @@ class OpenAIProvider(_OpenAICompatibleProvider):
     def __init__(
         self,
         base_url: str | None = None,
-        api_key: str | None = None,
+        api_key: str | None | Callable[[], Awaitable[str]] = None,
         openai_client: AsyncOpenAI | None = None,
         http_client: _OpenAIHTTPClient | None = None,
     ) -> None:


### PR DESCRIPTION
Closes #7883

Allow `OpenAIProvider(api_key=...)` to receive the async API-key callback accepted by the OpenAI Python SDK. This makes short-lived credentials usable without supplying a prebuilt `AsyncOpenAI` client.

New public surface: `OpenAIProvider(api_key=Callable[[], Awaitable[str]])`.

User-visible behavior: applications can pass an async credential callback directly to `OpenAIProvider`.

Verification: `git diff --check`. The existing SDK callback path is exercised in `tests/realtime/test_openai.py`; no additional targeted test is included pending maintainer feedback.

What changes for existing users: nothing; existing static keys and prebuilt clients retain their behavior.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).