### PR TITLE
Preserve Vercel binary mappings without `data`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -1154,7 +1154,7 @@ def _coerce_js_binary_data(value: Any) -> Any:
     # Gate on `media_type` (the type-specific field a real `BinaryContent` carries) so this matches
     # the core `ToolReturnContent` discriminator: a plain user mapping that merely reuses
     # `kind: 'binary'` stays untouched instead of having its `data` rewritten to bytes.
-    if coerced.get('kind') == 'binary' and 'media_type' in coerced:
+    if coerced.get('kind') == 'binary' and 'media_type' in coerced and 'data' in coerced:
         coerced['data'] = _js_binary_to_bytes(coerced.get('data'))
     return coerced
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -5039,6 +5039,32 @@ async def test_adapter_load_tool_return_non_multimodal_binary_kind_dict_preserve
     assert tool_returns[0].content == snapshot({'kind': 'binary', 'data': {'0': 104, '1': 105}, 'label': 'foo'})
 
 
+async def test_adapter_load_tool_return_binary_mapping_without_data_preserved():
+    """A `kind: 'binary'` user mapping without `data` must not gain a `data: None` key."""
+    output = {'kind': 'binary', 'media_type': 'application/json', 'rows': [1, 2]}
+    ui_messages: list[UIMessage] = [
+        UIMessage(id='m1', role='user', parts=[TextUIPart(text='go')]),
+        UIMessage(
+            id='m2',
+            role='assistant',
+            parts=[
+                ToolOutputAvailablePart(
+                    type='tool-get_rows',
+                    tool_call_id='tc-1',
+                    state='output-available',
+                    input={},
+                    output=output,
+                )
+            ],
+        ),
+    ]
+
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+    tool_returns = list(iter_message_parts(reloaded, ModelRequest, ToolReturnPart))
+    assert len(tool_returns) == 1
+    assert tool_returns[0].content == output
+
+
 async def test_adapter_tool_return_text_only_unchanged():
     """Text-only tool returns serialize as the literal string and round-trip unchanged."""
     messages = [


### PR DESCRIPTION
- Closes #7824

Preserves a user-provided `kind: "binary"` mapping when it has `media_type` but no `data` key. Existing JavaScript `Uint8Array` and Node `Buffer` conversion still applies whenever `data` is present.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

Tests:

- `uv run pytest tests/test_vercel_ai.py::test_adapter_load_tool_return_binary_mapping_without_data_preserved tests/test_vercel_ai.py::test_adapter_load_tool_return_binary_data_from_js_buffer_shape tests/test_vercel_ai.py::test_adapter_load_tool_return_non_multimodal_binary_kind_dict_preserved`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py tests/test_vercel_ai.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

