### PR TITLE
[EXPERIMENT — do not merge] Run `test-durable-exec` on `ubicloud-premium-8` instead of `ubicloud-premium-4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
           || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-premium-8'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 15


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

**Do not merge.** This is a measurement run, kept in draft on purpose.

## Purpose

Collect `ubicloud-premium-8` timings for the `test-durable-exec` matrix (10 cells: 5 Python versions x `locked`/`lowest`) so the 4-vs-8 core decision for this job rests on numbers.

[#7843](https://github.com/pydantic/pydantic-ai/pull/7843) moved `test` and `test-lowest-versions` to `ubicloud-premium-8` and left `test-durable-exec` on `ubicloud-premium-4`. That job runs `-n logical --dist=loadgroup` over six xdist groups (four per-module Temporal dev servers, plus DBOS and Prefect) on four workers, so the groups cannot all run concurrently. The hypothesis is that eight vCPUs give eight workers, all six groups run at once, and wall time drops.

## What decides it

Ubicloud bills per vCPU-minute, so premium-8 costs 2x premium-4 for the same wall-clock minute. **Break-even is a 0.5x duration ratio**: the upgrade only pays for itself if premium-8 cells finish in half the time. Anything above 0.5x makes this job more expensive than it is today, and the change should not land.

Flake rate is explicitly *not* what this measures - both recent startup-contention flakes in this job (Prefect harness timeout, Temporal `ConnectionRefused`) are too rare to sample in three runs.

## Method

Three CI runs on this branch against the three-to-five most recent green `main` runs as the premium-4 baseline, comparing per-cell job durations.

## What changes for existing users

Nothing - CI-only, and not intended to merge.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

