### PR TITLE
List `glm-5.3-flash` among the Z.AI thinking models

### DIFF
--- a/docs/models/zai.md
+++ b/docs/models/zai.md
@@ -44,7 +44,7 @@ agent = Agent(model)
 
 ## Thinking mode
 
-Z.AI's `glm-5.3`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-4.7`, `glm-4.6` (hybrid thinking), and `glm-4.5` (interleaved thinking) models support thinking/reasoning mode, where the model produces reasoning content before the final response. This includes the `glm-4.6v` and `glm-4.5v` vision models. Configure this through the unified [`thinking`][pydantic_ai.settings.ModelSettings.thinking] setting:
+Z.AI's `glm-5.3`, `glm-5.3-flash`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-4.7`, `glm-4.6` (hybrid thinking), and `glm-4.5` (interleaved thinking) models support thinking/reasoning mode, where the model produces reasoning content before the final response. This includes the `glm-4.6v` and `glm-4.5v` vision models. Configure this through the unified [`thinking`][pydantic_ai.settings.ModelSettings.thinking] setting:
 
 ```python
 from pydantic_ai import Agent


### PR DESCRIPTION
#7887 added `glm-5.3-flash` to `_known_model_names.py`, but the thinking-mode list in `docs/models/zai.md` still stops at `glm-5.3`, so the new model reads as if it has no thinking support.

It does. `profiles/zai.py` matches on prefixes, not exact ids: `_REASONING_EFFORT_MODEL_PREFIXES = ('glm-5.3', 'glm-5.2')` at `:23`, `_ALWAYS_THINKING_MODEL_PREFIXES = ('glm-5.3',)` at `:31`, and the `startswith('glm-5.3')` branch at `:67`. So `glm-5.3-flash` picks up the whole GLM-5.3 profile, which is what the comment on `tests/models/test_zai.py:340` says too, and #7887 recorded `test_zai_reasoning_effort[glm-5.3-flash].yaml` against it.

The page enumerates specific ids rather than families (it separately calls out the `glm-4.6v` and `glm-4.5v` vision variants), and when #7600 added GLM-5.3 it added `glm-5.3` to this same sentence. This just does the same for the flash variant.

Scope kept to that one list. The paragraph below it already speaks in family terms ("on GLM-5.2 and GLM-5.3"), which covers the flash variant as written, so I left it alone.

Ran `uv run pytest tests/test_examples.py -k zai` (6 passed).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

About me: I'm a freshman in college, so rather than assume the omission was a mistake I checked how the profile actually resolves and how the same list was handled when GLM-5.3 landed. I used Claude Code to double-check the reasoning and read the diff myself. If you would rather the list stay family-level and drop the variants entirely, that is a fair call and I will close this.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

