### PR TITLE
Let the Temporal test dev server allocate its own port

### DIFF
--- a/tests/durable_exec/temporal/conftest.py
+++ b/tests/durable_exec/temporal/conftest.py
@@ -7,7 +7,6 @@ from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 
 import pytest
-from anyio.pytest_plugin import FreePortFactory
 
 from pydantic_ai import (
     Agent,
@@ -109,16 +108,15 @@ def uninstrument_pydantic_ai() -> Iterator[None]:
 
 
 # One dev server (and thus one xdist group) per test module so the four temporal files can
-# run on four xdist workers concurrently instead of forming one serial chain. The port comes
-# from anyio's `free_tcp_port_factory`, so parallel workers (and a previously leaked server)
-# can never collide on a hardcoded port.
+# run on four xdist workers concurrently instead of forming one serial chain. `start_local`
+# picks the port: anyio's `free_tcp_port_factory` only probes and releases, so the port sits
+# unowned for the rest of fixture setup, and its dedup set is per factory instance — one per
+# xdist worker — so two workers can be handed the same port. The Temporal SDK instead allocates
+# immediately before spawning the server, and on Linux holds the port in `TIME_WAIT` so the kernel
+# won't hand it to another process's `bind(0)`:
+# https://github.com/temporalio/sdk-core/blob/5962c094869d691b78b9732f09851a9183173db9/crates/sdk-core/src/ephemeral_server/mod.rs#L548
 @pytest.fixture(scope='module')
-def temporal_port(free_tcp_port_factory: FreePortFactory) -> int:
-    return free_tcp_port_factory()
-
-
-@pytest.fixture(scope='module')
-async def temporal_env(temporal_port: int) -> AsyncIterator[WorkflowEnvironment]:
+async def temporal_env() -> AsyncIterator[WorkflowEnvironment]:
     # `start_local` downloads the dev-server binary to the system temp dir by default, which is empty on
     # every CI run, so a CDN hiccup used to fail the entire suite at setup (#5399). Download to a stable
     # per-user cache dir instead so CI can restore it via `actions/cache` and local runs reuse it across
@@ -130,24 +128,30 @@ async def temporal_env(temporal_port: int) -> AsyncIterator[WorkflowEnvironment]
     # server binds `port + 1000` without probing it first, and a bind failure there aborts the whole
     # process — surfacing as `ConnectionRefused` on the healthy gRPC port. No test reads the UI.
     async with await WorkflowEnvironment.start_local(  # pyright: ignore[reportUnknownMemberType]
-        port=temporal_port,
         dev_server_extra_args=['--dynamic-config-value', 'frontend.enableServerVersionCheck=false'],
         download_dest_dir=str(download_dest_dir),
     ) as env:
         yield env
 
 
+# The `host:port` the dev server actually bound — read back rather than assumed — for tests that
+# need a client of their own rather than `temporal_env.client`.
+@pytest.fixture(scope='module')
+def temporal_target(temporal_env: WorkflowEnvironment) -> str:
+    return temporal_env.client.service_client.config.target_host
+
+
 @pytest.fixture
-async def client(temporal_env: WorkflowEnvironment, temporal_port: int) -> Client:
+async def client(temporal_target: str) -> Client:
     return await Client.connect(
-        f'localhost:{temporal_port}',
+        temporal_target,
         plugins=[PydanticAIPlugin()],
     )
 
 
 @pytest.fixture
-async def client_with_logfire(temporal_env: WorkflowEnvironment, temporal_port: int) -> Client:
+async def client_with_logfire(temporal_target: str) -> Client:
     return await Client.connect(
-        f'localhost:{temporal_port}',
+        temporal_target,
         plugins=[PydanticAIPlugin(), LogfirePlugin()],
     )

--- a/tests/durable_exec/temporal/test_model_and_serialization.py
+++ b/tests/durable_exec/temporal/test_model_and_serialization.py
@@ -79,7 +79,7 @@ try:
         PayloadCodec,
         StorageDriver,
     )
-    from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
+    from temporalio.testing import ActivityEnvironment
     from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
     from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
     from temporalio.workflow import ActivityConfig
@@ -1720,10 +1720,8 @@ def test_pydantic_ai_plugin_passes_pydantic_monty_through_sandbox() -> None:
     assert 'pydantic_monty' in configured_runner.restrictions.passthrough_modules
 
 
-async def test_pydantic_ai_plugin_runs_workflow_in_sandbox(
-    temporal_env: WorkflowEnvironment, temporal_port: int
-) -> None:
-    client = await Client.connect(f'localhost:{temporal_port}')
+async def test_pydantic_ai_plugin_runs_workflow_in_sandbox(temporal_target: str) -> None:
+    client = await Client.connect(temporal_target)
     async with Worker(
         client,
         task_queue=TASK_QUEUE,


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

## Why we make these changes

`temporal_port` handed `WorkflowEnvironment.start_local` a port from anyio's `free_tcp_port_factory`, which binds port 0, reads the number back and **closes the probe socket before returning**. Its dedup set lives on the factory instance, and the fixture is session-scoped — one instance per xdist worker. [#7850](https://github.com/pydantic/pydantic-ai/pull/7850) gave each of the four Temporal test modules its own dev server, so four of those allocations now happen concurrently across workers: nothing owns the port between the probe and the server's own bind, and two workers can be handed the same one. A collision fails a whole module at setup.

`start_local` already picks a port when you don't pass one, and reports back the address it bound. sdk-core's [`get_free_port`](https://github.com/temporalio/sdk-core/blob/5962c094869d691b78b9732f09851a9183173db9/crates/sdk-core/src/ephemeral_server/mod.rs#L548) allocates immediately before spawning the CLI rather than a whole fixture setup earlier, and on Linux it holds the port in `TIME_WAIT` (connect, accept, close from the listening side) so the kernel will not hand it to another process's `bind(0)` — exactly the cross-worker collision anyio's factory cannot prevent. Clients now read the bound `host:port` off the environment through a `temporal_target` fixture instead of assuming it.

Raised on #7850 by [macroscopeapp](https://github.com/pydantic/pydantic-ai/pull/7850#discussion_r3879536832) and [chatgpt-codex-connector](https://github.com/pydantic/pydantic-ai/pull/7850#discussion_r3879553586); [#7876](https://github.com/pydantic/pydantic-ai/pull/7876) fixed the sibling UI-port bind.

## New public surface

none

## Verification

`tests/durable_exec/temporal`: 283 passed, 2 skipped. The configuration in which the four allocations race is `--dist=loadgroup`, which is what the `test durable-exec` CI jobs run (`-n logical --dist=loadgroup`).

No regression test: reproducing the collision deterministically means driving two processes' `bind(0)` calls against the kernel's port allocator. What this PR changes is the removal of the unowned window, which the diff shows directly.

<details>
<summary>Why not a bounded retry</summary>

Squatting on a port and then handing it to `start_local` locally: the dev server logs

```
Error: can't set frontend port 55484: listen tcp 127.0.0.1:55484: bind: address already in use
```

and `start_local` never returns (observed past a 120s timeout) — there is no bind failure surfacing as a catchable error to retry on. A retry would also add a branch that never executes in CI, and `tests/**/*.py` is measured at `fail_under = 100`.

</details>

## What changes for existing users

Nothing — test-only change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


