### PR TITLE
Track `test-durable-exec` jobs and stop pooling Ubicloud runner sizes in the CI duration report

### DIFF
--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -16,7 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
-SCHEMA_VERSION = 1
+# 2: `runner_class` names the Ubicloud size and `job_family` distinguishes `test-durable-exec`.
+SCHEMA_VERSION = 2
 CI_WORKFLOW_FILE = 'ci.yml'
 REPORT_MARKER = '<!-- ci-duration-report -->'
 REPORT_LABEL = 'trigger:ci-duration-report'
@@ -24,6 +25,8 @@ BASELINE_MAIN_RUN_LIMIT = 30
 BASELINE_PR_RUN_LIMIT = 60
 BASELINE_COLLECTION_MAX_SECONDS = 90
 MIN_BASELINE_SAMPLES = 10
+# Keep above the number of tracked jobs so a full run renders every row.
+REPORT_ROW_LIMIT = 40
 WARNING_MIN_SECONDS = 60
 SLOW_THRESHOLD_MULTIPLIER = 1.25
 FAST_THRESHOLD_MULTIPLIER = 0.75
@@ -434,7 +437,7 @@ def step_to_json(step: StepRecord) -> JsonObject:
 
 
 def parse_job_matrix(job_name: str) -> tuple[str | None, str | None]:
-    match = re.fullmatch(r'test on (?P<python>[^ ]+) \((?P<extra>[^)]+)\)', job_name)
+    match = re.fullmatch(r'test(?: durable-exec)? on (?P<python>[^ ]+) \((?P<extra>[^)]+)\)', job_name)
     if match:
         return match.group('python'), match.group('extra')
     match = re.fullmatch(r'test examples on (?P<python>[^ ]+)', job_name)
@@ -446,22 +449,34 @@ def parse_job_matrix(job_name: str) -> tuple[str | None, str | None]:
 def parse_job_family(job_name: str) -> str:
     if job_name.startswith('test on '):
         return 'test'
+    # Its own family rather than part of `test`: `job_family` keys `is_tracked_test_job`, prefixes
+    # every signature, and is emitted as its own dimension in both the record and Logfire, so
+    # folding a different suite under the `test` label mislabels it in all three.
+    if job_name.startswith('test durable-exec on '):
+        return 'test-durable-exec'
     if job_name.startswith('test examples on '):
         return 'test-examples'
-    if job_name in {'lint', 'mypy', 'docs', 'coverage', 'check'}:
-        return job_name
     return job_name
 
 
 def is_tracked_test_job(job: JobRecord) -> bool:
-    return job.job_family == 'test'
+    return job.job_family in {'test', 'test-durable-exec'}
 
 
 def parse_runner_class(runner_group_name: str | None, runner_name: str | None, labels: list[JsonValue] | None) -> str:
-    label_values = [value for value in labels or [] if isinstance(value, str)]
+    label_values = [value.lower() for value in labels or [] if isinstance(value, str)]
     lower_values = ' '.join([runner_group_name or '', runner_name or '', *label_values]).lower()
     if 'depot' in lower_values:
         return 'depot'
+    # Keep the size in the class: the same job takes materially different times on different
+    # Ubicloud sizes, so a size-blind class pools those durations into one meaningless baseline.
+    # Read it off the labels only -- `runner_name` and `runner_group_name` are vendor-controlled, so
+    # matching the size anywhere in the joined string reads back whatever Ubicloud puts there.
+    # The branches below still match the joined string. They stay size-blind because no `ci.yml`
+    # job asks for more than one size of a GitHub runner, and none asks for a depot runner at all.
+    ubicloud_label = next((label for label in label_values if label.startswith('ubicloud')), None)
+    if ubicloud_label is not None:
+        return ubicloud_label
     if 'ubicloud' in lower_values:
         return 'ubicloud'
     if 'github actions' in lower_values or 'ubuntu' in lower_values:
@@ -563,7 +578,7 @@ def render_report(pr_number: int, head_sha: str, workflow: JsonObject, rows: lis
         '| Job | Duration | Baseline median | p75 | Delta | Status |',
         '|---|---:|---:|---:|---:|---|',
     ]
-    for row in sorted_rows[:20]:
+    for row in sorted_rows[:REPORT_ROW_LIMIT]:
         lines.append(
             '| '
             + ' | '.join(
@@ -578,8 +593,8 @@ def render_report(pr_number: int, head_sha: str, workflow: JsonObject, rows: lis
             )
             + ' |'
         )
-    if len(sorted_rows) > 20:
-        lines.append(f'| ... | {len(sorted_rows) - 20} more jobs omitted |  |  |  |  |')
+    if len(sorted_rows) > REPORT_ROW_LIMIT:
+        lines.append(f'| ... | {len(sorted_rows) - REPORT_ROW_LIMIT} more jobs omitted |  |  |  |  |')
     lines.extend(
         [
             '',
@@ -663,6 +678,7 @@ def emit_logfire(record: JsonObject) -> None:
                 'event': workflow.get('event'),
                 'base_branch': workflow.get('base_branch'),
                 'conclusion': workflow.get('conclusion'),
+                'schema_version': SCHEMA_VERSION,
             }
         ),
     )
@@ -703,6 +719,7 @@ def emit_logfire(record: JsonObject) -> None:
                             'matrix_extra': job_object.get('matrix_extra'),
                             'runner_class': job_object.get('runner_class'),
                             'conclusion': job_object.get('conclusion'),
+                            'schema_version': SCHEMA_VERSION,
                         }
                     ),
                 )

--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -25,7 +25,9 @@ BASELINE_MAIN_RUN_LIMIT = 30
 BASELINE_PR_RUN_LIMIT = 60
 BASELINE_COLLECTION_MAX_SECONDS = 90
 MIN_BASELINE_SAMPLES = 10
-# Keep above the number of tracked jobs so a full run renders every row.
+# Must stay above the number of tracked jobs so a full run renders every row: `no_baseline` sorts
+# into the truncated tail with `normal`, and every newly-minted signature starts there. Today's
+# `ci.yml` matrices give 5 pythons x (4 installs + lowest-versions) + 5 x 2 durable-exec = 35.
 REPORT_ROW_LIMIT = 40
 WARNING_MIN_SECONDS = 60
 SLOW_THRESHOLD_MULTIPLIER = 1.25
@@ -466,14 +468,14 @@ def is_tracked_test_job(job: JobRecord) -> bool:
 def parse_runner_class(runner_group_name: str | None, runner_name: str | None, labels: list[JsonValue] | None) -> str:
     label_values = [value.lower() for value in labels or [] if isinstance(value, str)]
     lower_values = ' '.join([runner_group_name or '', runner_name or '', *label_values]).lower()
+    # Only the Ubicloud class carries a size, because only Ubicloud is requested in two of them:
+    # every GitHub runner in `ci.yml` is `ubuntu-latest`, and no job asks for a depot runner at all.
     if 'depot' in lower_values:
         return 'depot'
     # Keep the size in the class: the same job takes materially different times on different
     # Ubicloud sizes, so a size-blind class pools those durations into one meaningless baseline.
     # Read it off the labels only -- `runner_name` and `runner_group_name` are vendor-controlled, so
     # matching the size anywhere in the joined string reads back whatever Ubicloud puts there.
-    # The branches below still match the joined string. They stay size-blind because no `ci.yml`
-    # job asks for more than one size of a GitHub runner, and none asks for a depot runner at all.
     ubicloud_label = next((label for label in label_values if label.startswith('ubicloud')), None)
     if ubicloud_label is not None:
         return ubicloud_label
@@ -715,6 +717,7 @@ def emit_logfire(record: JsonObject) -> None:
                             'base_branch': workflow.get('base_branch'),
                             'job_name': job_object.get('raw_name'),
                             'job_signature': job_object.get('job_signature'),
+                            'job_family': job_object.get('job_family'),
                             'matrix_python': job_object.get('matrix_python'),
                             'matrix_extra': job_object.get('matrix_extra'),
                             'runner_class': job_object.get('runner_class'),

--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -188,7 +188,7 @@ def test_render_report_uses_sticky_marker_and_threshold_context():
     'row_count,expect_omission',
     [(ci_duration.REPORT_ROW_LIMIT, False), (ci_duration.REPORT_ROW_LIMIT + 1, True)],
 )
-def test_render_report_row_limit_clears_a_full_run(row_count: int, expect_omission: bool):
+def test_render_report_truncates_only_past_the_row_limit(row_count: int, expect_omission: bool):
     workflow: ci_duration.JsonObject = {
         'duration_seconds': 840,
         'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1',

--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -11,15 +11,94 @@ sys.path.insert(0, str(Path(__file__).parent))
 import ci_duration
 
 
-def test_normalize_matrix_job_signature():
-    job = ci_duration.normalize_job(
+@pytest.mark.parametrize(
+    'job,expected',
+    [
+        pytest.param(
+            {
+                'name': 'test on 3.10 (all-extras)',
+                'completed_at': '2026-06-13T17:24:05Z',
+                'runner_name': 'GitHub Actions 1001364942',
+                'runner_group_name': 'GitHub Actions',
+                'labels': ['ubuntu-latest'],
+            },
+            (
+                'test',
+                '3.10',
+                'all-extras',
+                'github-hosted',
+                'job=test / runner=github-hosted / py=3.10 / extra=all-extras',
+                542,
+            ),
+            id='main-matrix',
+        ),
+        pytest.param(
+            {
+                'name': 'test durable-exec on 3.11 (locked)',
+                'completed_at': '2026-06-13T17:21:43Z',
+                'runner_name': 'gr6b98dxdphe5q821s6ezttz97',
+                'runner_group_name': 'Default',
+                'labels': ['ubicloud-premium-4'],
+            },
+            (
+                'test-durable-exec',
+                '3.11',
+                'locked',
+                'ubicloud-premium-4',
+                'job=test-durable-exec / runner=ubicloud-premium-4 / py=3.11 / extra=locked',
+                400,
+            ),
+            id='durable-exec',
+        ),
+    ],
+)
+def test_normalize_tracked_job(job: ci_duration.JsonObject, expected: tuple[str, str, str, str, str, float]):
+    record = ci_duration.normalize_job(
         {
             'id': 123,
-            'name': 'test on 3.10 (all-extras)',
             'status': 'completed',
             'conclusion': 'success',
             'started_at': '2026-06-13T17:15:03Z',
-            'completed_at': '2026-06-13T17:24:05Z',
+            'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
+            'steps': [],
+            **job,
+        }
+    )
+
+    assert (
+        record.job_family,
+        record.matrix_python,
+        record.matrix_extra,
+        record.runner_class,
+        record.job_signature,
+        record.duration_seconds,
+    ) == expected
+    assert ci_duration.is_tracked_test_job(record)
+
+
+# The `main` job names closest to a tracked one, none of which may enter the tracked set.
+@pytest.mark.parametrize(
+    'name',
+    [
+        'quality checks',
+        'mypy',
+        'docs-assets',
+        'coverage',
+        'check',
+        'test examples on 3.13',
+        'test Temporal latest on Python 3.10',
+        'test FastMCP 4 compatibility',
+    ],
+)
+def test_non_test_jobs_are_not_tracked(name: str):
+    job = ci_duration.normalize_job(
+        {
+            'id': 123,
+            'name': name,
+            'status': 'completed',
+            'conclusion': 'success',
+            'started_at': '2026-06-13T17:15:03Z',
+            'completed_at': '2026-06-13T17:16:03Z',
             'runner_name': 'GitHub Actions 1001364942',
             'runner_group_name': 'GitHub Actions',
             'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
@@ -27,35 +106,29 @@ def test_normalize_matrix_job_signature():
         }
     )
 
-    assert job.job_family == 'test'
-    assert job.matrix_python == '3.10'
-    assert job.matrix_extra == 'all-extras'
-    assert job.runner_class == 'github-hosted'
-    assert job.job_signature == 'job=test / runner=github-hosted / py=3.10 / extra=all-extras'
-    assert job.duration_seconds == 542
-    assert ci_duration.is_tracked_test_job(job)
+    assert not ci_duration.is_tracked_test_job(job)
 
 
-def test_non_test_jobs_are_not_tracked():
-    jobs = [
-        ci_duration.normalize_job(
-            {
-                'id': 123,
-                'name': name,
-                'status': 'completed',
-                'conclusion': 'success',
-                'started_at': '2026-06-13T17:15:03Z',
-                'completed_at': '2026-06-13T17:16:03Z',
-                'runner_name': 'GitHub Actions 1001364942',
-                'runner_group_name': 'GitHub Actions',
-                'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
-                'steps': [],
-            }
-        )
-        for name in ['lint', 'test examples on 3.13']
-    ]
-
-    assert [ci_duration.is_tracked_test_job(job) for job in jobs] == [False, False]
+@pytest.mark.parametrize(
+    'runner_group_name,runner_name,labels,expected',
+    [
+        ('Default', 'gr6b98dxdphe5q821s6ezttz97', ['ubicloud-premium-4'], 'ubicloud-premium-4'),
+        ('Default', 'grftmf0e4q520g401db7md40ge', ['ubicloud-premium-8'], 'ubicloud-premium-8'),
+        ('Default', 'gr3re7hexr6y2pfmr2413vkzv9', ['ubicloud'], 'ubicloud'),
+        # `runner_group_name` and `runner_name` are Ubicloud's to change; only the label is ours.
+        ('Ubicloud', 'gr6b98dxdphe5q821s6ezttz97', ['ubicloud-premium-8'], 'ubicloud-premium-8'),
+        ('Default', 'ubicloud-runner-abc123', ['ubicloud-premium-8'], 'ubicloud-premium-8'),
+        ('Ubicloud', 'ubicloud-runner-abc123', [], 'ubicloud'),
+        ('GitHub Actions', 'GitHub Actions 1001364942', ['ubuntu-latest'], 'github-hosted'),
+        ('Default', 'depot-runner', ['depot-ubuntu-24.04'], 'depot'),
+        (None, None, ['self-hosted', 'linux'], 'self-hosted'),
+        (None, None, None, 'unknown'),
+    ],
+)
+def test_parse_runner_class(
+    runner_group_name: str | None, runner_name: str | None, labels: list[ci_duration.JsonValue] | None, expected: str
+):
+    assert ci_duration.parse_runner_class(runner_group_name, runner_name, labels) == expected
 
 
 def test_classify_slow_job_requires_relative_and_absolute_delta():
@@ -111,6 +184,36 @@ def test_render_report_uses_sticky_marker_and_threshold_context():
     assert 'trigger:ci-duration-report' in report
 
 
+@pytest.mark.parametrize(
+    'row_count,expect_omission',
+    [(ci_duration.REPORT_ROW_LIMIT, False), (ci_duration.REPORT_ROW_LIMIT + 1, True)],
+)
+def test_render_report_row_limit_clears_a_full_run(row_count: int, expect_omission: bool):
+    workflow: ci_duration.JsonObject = {
+        'duration_seconds': 840,
+        'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1',
+    }
+    # A freshly-minted signature has no baseline, and `no_baseline` sorts with `normal` into the
+    # truncated tail -- so the limit has to clear the whole tracked matrix, not just the slow rows.
+    rows = [
+        ci_duration.ReportRow(
+            job_name=f'test on 3.10 (extra-{index})',
+            job_signature=f'job=test / runner=github-hosted / py=3.10 / extra=extra-{index}',
+            duration_seconds=600,
+            baseline=None,
+            delta_seconds=None,
+            delta_percent=None,
+            status='no_baseline',
+        )
+        for index in range(row_count)
+    ]
+
+    report = ci_duration.render_report(123, 'abcdef1234567890', workflow, rows)
+
+    assert ('more jobs omitted' in report) == expect_omission
+    assert f'Tracked test jobs: {row_count}' in report
+
+
 def test_collect_baselines_skips_unavailable_historical_run():
     class StubGitHubClient(ci_duration.GitHubClient):
         def request_paginated(self, path: str, *, max_items: int | None = None) -> list[ci_duration.JsonObject]:
@@ -147,6 +250,71 @@ def test_collect_baselines_skips_unavailable_historical_run():
     baselines = ci_duration.collect_baselines(StubGitHubClient('pydantic/pydantic-ai', 'token'), 'current-sha')
 
     assert baselines['job=test / runner=github-hosted / py=3.10 / extra=all-extras'].sample_size == 10
+
+
+def test_collect_baselines_keeps_families_and_runner_sizes_apart():
+    jobs: list[ci_duration.JsonObject] = [
+        {
+            'id': 1,
+            'name': 'test on 3.10 (all-extras)',
+            'completed_at': '2026-06-13T17:25:03Z',
+            'runner_name': 'gregszg8jvj21pxs0s0v75zn66',
+            'labels': ['ubicloud-premium-4'],
+        },
+        {
+            'id': 2,
+            'name': 'test on 3.10 (all-extras)',
+            'completed_at': '2026-06-13T17:20:03Z',
+            'runner_name': 'graj7n4s025a7krr8mmch51ab9',
+            'labels': ['ubicloud-premium-8'],
+        },
+        {
+            'id': 3,
+            'name': 'test durable-exec on 3.10 (locked)',
+            'completed_at': '2026-06-13T17:18:23Z',
+            'runner_name': 'grd4b5dgk1fj4jaf6kk5wsna3t',
+            'labels': ['ubicloud-premium-4'],
+        },
+    ]
+
+    class StubGitHubClient(ci_duration.GitHubClient):
+        def request_paginated(self, path: str, *, max_items: int | None = None) -> list[ci_duration.JsonObject]:
+            if path == 'actions/workflows/ci.yml/runs?branch=main&event=push&status=success':
+                return [
+                    {
+                        'id': run_id,
+                        'run_attempt': 1,
+                        'head_sha': f'baseline-{run_id}',
+                    }
+                    for run_id in range(ci_duration.MIN_BASELINE_SAMPLES)
+                ]
+            if path == 'actions/workflows/ci.yml/runs?event=pull_request&status=success':
+                return []
+            if path.startswith('actions/runs/') and path.endswith('/attempts/1/jobs'):
+                return [
+                    {
+                        **job,
+                        'status': 'completed',
+                        'conclusion': 'success',
+                        'started_at': '2026-06-13T17:15:03Z',
+                        'runner_group_name': 'Default',
+                        'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/1',
+                        'steps': [],
+                    }
+                    for job in jobs
+                ]
+            raise RuntimeError(f'Unexpected path: {path}')
+
+    baselines = ci_duration.collect_baselines(StubGitHubClient('pydantic/pydantic-ai', 'token'), 'current-sha')
+
+    # One bucket per (family, runner size). Pooling any two of these would average a 4-core
+    # sample into an 8-core baseline, or the durable-exec suite into the main matrix.
+    assert {signature: baseline.median_seconds for signature, baseline in baselines.items()} == {
+        'job=test / runner=ubicloud-premium-4 / py=3.10 / extra=all-extras': 600,
+        'job=test / runner=ubicloud-premium-8 / py=3.10 / extra=all-extras': 300,
+        'job=test-durable-exec / runner=ubicloud-premium-4 / py=3.10 / extra=locked': 200,
+    }
+    assert [baseline.sample_size for baseline in baselines.values()] == [ci_duration.MIN_BASELINE_SAMPLES] * 3
 
 
 def test_collect_baselines_stops_after_time_budget(monkeypatch: pytest.MonkeyPatch):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,8 @@ jobs:
       fail-fast: false
       matrix:
         # `latest-versions-canary.yml` runs the endpoints of this list; update it alongside.
+        # Growing any test matrix also grows the tracked-job count that `REPORT_ROW_LIMIT` in
+        # `.github/scripts/ci_duration.py` must stay above, or the duration report truncates.
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         install:
           - name: pydantic-ai-slim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,9 @@ jobs:
       fail-fast: false
       matrix:
         # `latest-versions-canary.yml` runs the endpoints of this list; update it alongside.
-        # Growing any test matrix also grows the tracked-job count that `REPORT_ROW_LIMIT` in
-        # `.github/scripts/ci_duration.py` must stay above, or the duration report truncates.
+        # Growing this or either other test matrix grows the tracked-job count that
+        # `REPORT_ROW_LIMIT` in `.github/scripts/ci_duration.py` must stay above, or the duration
+        # report truncates. That constant's comment enumerates all three.
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         install:
           - name: pydantic-ai-slim


### PR DESCRIPTION
### Why we make these changes

No issue — a maintainer follow-up to #7842, #7843 and #7846, which changed the CI job matrix out from under
`.github/scripts/ci_duration.py`. Two coordinates of its `job family / runner class / python / extra` key went stale:

- **The 10 `test durable-exec on <py> (locked|lowest)` jobs are invisible to it.** `parse_job_matrix` only
  `fullmatch`ed `test on <py> (<extra>)`, `parse_job_family` returned `'test'` only for `test on `-prefixed
  names, and `is_tracked_test_job` required family `'test'`. With `test-lowest-versions` already tracked and
  the 20-job `test` matrix, that is 25 tracked today, 35 once durable-exec joins.
- **Ubicloud sizes pool into one baseline.** `parse_runner_class` mapped both `ubicloud-premium-4` and
  `ubicloud-premium-8` to `'ubicloud'`, so #7843's 4→8 core bump changed what an existing signature *means*
  without changing the signature — 8-core samples average against 4-core medians.

### New public surface

None. `.github/scripts/ci_duration.py` is CI-internal, imported only by its own test.

### User-visible behavior

| Job | Signature before | Signature after |
|---|---|---|
| `test durable-exec on 3.11 (locked)` | *untracked* | `job=test-durable-exec / runner=ubicloud-premium-4 / py=3.11 / extra=locked` |
| `test on 3.13 (all-extras)` (premium-8) | `job=test / runner=ubicloud / py=3.13 / extra=all-extras` | `job=test / runner=ubicloud-premium-8 / py=3.13 / extra=all-extras` |

Baselines are recomputed from the GitHub API on every report run and never persisted, so the new classes re-parse existing
history rather than orphaning stored series: each of the last 12 successful `main` runs already carries a
`ubicloud-premium-4` sample for `test durable-exec on 3.11 (locked)`. The row cap goes 20 → `REPORT_ROW_LIMIT = 40` so the
table lists all 35 tracked jobs — `normal` and `no_baseline` rows sort into the tail the report truncates, so the old cap
would have omitted 15 of them.

<details>
<summary>Why `test-durable-exec` is its own family, and two smaller calls</summary>

- It is its own family rather than a `test` subtype because `job_family` keys the tracking predicate,
  prefixes every signature, and is emitted as its own dimension in the record and in Logfire, so folding a
  different suite under the `test` label mislabels it in all three.
- `SCHEMA_VERSION` 1 → 2, added to both Logfire metric attribute dicts, and `job_family` added to the job
  metric alongside the `runner_class` and `matrix_extra` it already carried. I checked the live
  `pydantic-ai` Logfire project: nothing reads these two metrics — every CI dashboard panel and the one CI
  alert query the `ci.duration.test_run` span and `ci.duration.test_job` log instead. So the bump breaks no
  consumer. What does move is the span and the log: four `CI Duration Dashboard` panels read
  `tracked_test_jobs` / `tracked_test_duration_seconds`, which step 25 → 35, and three panels across both
  CI dashboards group by `job_signature`, so each affected job splits into a pre- and post-change row. The
  span and log already carried `schema_version`; the metric points did not, so only they start carrying it
  now.
- Deleted `if job_name in {'lint', 'mypy', 'docs', 'coverage', 'check'}: return job_name`. It returned
  `job_name`, identical to the fallback on the next line, so it was already a no-op — and two of its five
  names no longer match any job: `lint` became `quality checks` in `722374788`, and the `docs` job left with
  the MkDocs pipeline in #7416. Correcting the names would have been an equally dead no-op.

</details>

<details>
<summary>One thing deliberately left alone</summary>

`parse_job_family` anchors with `startswith` while `parse_job_matrix` uses `fullmatch`, so a name like
`test durable-exec on 3.11 (locked) / retry` would be tracked with no `py=`/`extra=` in its signature,
pooling every python and resolution into one bucket. This pre-exists for the `test` family too and is
unreachable from every job name `ci.yml` produces: none of the three jobs feeding the tracked families is a
reusable-workflow caller, and the one caller `ci.yml` has (`latest-versions-canary`) prefixes its children
with `latest versions canary / `, which matches no tracked family. Fixing it means reworking a shared helper
for a defect that cannot currently occur.

</details>

### Verification

`.github/scripts/test_ci_duration.py` runs in every `test` matrix job via `testpaths`.
`test_collect_baselines_keeps_families_and_runner_sizes_apart` drives the real `collect_baselines` path and asserts
one bucket per (family, runner size) — the invariant both defects broke. `test_parse_runner_class`,
`test_normalize_tracked_job[durable-exec]`, `test_render_report_truncates_only_past_the_row_limit` and a
`test_non_test_jobs_are_not_tracked` parametrized over the job names `main` really produces cover the rest.

### What changes for existing users

Nothing. No package code is touched; the change is confined to the CI duration tracker and its tests.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

