### PR TITLE
Left-align `Evaluation Summary` headings in eval docs examples

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -250,7 +250,7 @@ async def guess_city(question: str) -> str:  # (3)!
 report = dataset.evaluate_sync(guess_city)  # (4)!
 report.print(include_input=True, include_output=True, include_durations=False)  # (5)!
 """
-                              Evaluation Summary: guess_city
+Evaluation Summary: guess_city
 ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Case ID     ┃ Inputs                         ┃ Outputs ┃ Scores            ┃ Assertions ┃
 ┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩

--- a/docs/evals/core-concepts.md
+++ b/docs/evals/core-concepts.md
@@ -395,7 +395,7 @@ report = dataset.evaluate_sync(my_task)
 # Print to console
 report.print()
 """
-    Evaluation Summary: my_task
+Evaluation Summary: my_task
 ┏━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID  ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩

--- a/docs/evals/evaluators/llm-judge.md
+++ b/docs/evals/evaluators/llm-judge.md
@@ -360,7 +360,7 @@ recipe_dataset = Dataset[CustomerOrder, Recipe, Any](
 report = recipe_dataset.evaluate_sync(transform_recipe)
 print(report)
 """
-     Evaluation Summary: transform_recipe
+Evaluation Summary: transform_recipe
 ┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID            ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
@@ -592,7 +592,7 @@ dataset = Dataset(
 report = dataset.evaluate_sync(my_task)
 report.print(include_reasons=True)
 """
-     Evaluation Summary: my_task
+Evaluation Summary: my_task
 ┏━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID  ┃ Assertions  ┃ Duration ┃
 ┡━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩

--- a/docs/evals/examples/simple-validation.md
+++ b/docs/evals/examples/simple-validation.md
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     # Print results
     report.print(include_input=True, include_output=True)
 """
-                            Evaluation Summary: to_title_case
+Evaluation Summary: to_title_case
 ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID          ┃ Inputs               ┃ Outputs              ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
@@ -137,7 +137,7 @@ else:
 ## Expected Output
 
 ```
-                        Evaluation Summary: to_title_case
+Evaluation Summary: to_title_case
 ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID           ┃ Inputs               ┃ Outputs               ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩

--- a/docs/evals/quick-start.md
+++ b/docs/evals/quick-start.md
@@ -68,7 +68,7 @@ report = dataset.evaluate_sync(uppercase_text)
 # Print the results
 report.print()
 """
-        Evaluation Summary: uppercase_text
+Evaluation Summary: uppercase_text
 ┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID                ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
@@ -84,7 +84,7 @@ report.print()
 Output:
 
 ```
-                  Evaluation Summary: uppercase_text
+Evaluation Summary: uppercase_text
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID                 ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩

--- a/pydantic_evals/README.md
+++ b/pydantic_evals/README.md
@@ -58,7 +58,7 @@ async def answer_question(question: str) -> str:
 report = dataset.evaluate_sync(answer_question)
 report.print(include_input=True, include_output=True)
 """
-                                    Evaluation Summary: answer_question
+Evaluation Summary: answer_question
 ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ Case ID          ┃ Inputs                         ┃ Outputs ┃ Scores            ┃ Assertions ┃ Duration ┃
 ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩


### PR DESCRIPTION
- Closes #7787

This removes hard-coded leading spaces from the standalone `Evaluation Summary` lines in the affected eval docs examples and README snippets.

Those spaces came from terminal-centered output, but in rendered docs they make the heading look offset from the table and copy awkwardly. Left-aligning the heading keeps the examples easier to read while leaving the table content unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

