### PR TITLE
fix(realtime): roll back user-turn state when an audio chunk is not bytes-like

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1159,8 +1159,14 @@ class RealtimeSession:
             # boundary later cuts this into that turn's own segment (see `_segment_input_audio`); only the
             # exact split at the boundary is approximate (see `audio_retention`).
             previous_length = len(self._input_audio)
-            self._input_audio.extend(data)
         try:
+            # The extend lives inside the try so a chunk that is not bytes-like (possible since
+            # `send_audio` accepts an async iterable of chunks) rolls the user-turn state back below
+            # instead of leaving `_user_turn_active` set with nothing buffered or sent. A failing
+            # `bytearray.extend` leaves the buffer unchanged, so the length guard in the handler
+            # correctly skips the truncation for that case.
+            if self._retain_input:
+                self._input_audio.extend(data)
             await self._send_frame(BinaryAudio(data=data, media_type='audio/pcm'))
         except BaseException:
             self._user_turn_active = user_turn_was_active

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -6332,5 +6332,3 @@ async def test_send_audio_bad_later_chunk_keeps_earlier_chunks() -> None:
         assert session._user_turn_active is True, 'the first chunk legitimately opened the turn'  # pyright: ignore[reportPrivateUsage]
         assert bytes(session._input_audio) == b'good-bytes'  # pyright: ignore[reportPrivateUsage]
         assert len(conn.sent) == 1
-
-

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -6285,3 +6285,52 @@ async def test_agent_realtime_session_drops_auto_injected_tool_search() -> None:
     async with agent.realtime(model).session() as session:
         _ = [e async for e in session]
     assert model.last_native_tools == []
+
+
+async def test_send_audio_first_chunk_bad_rolls_back_turn_state() -> None:
+    """Regression: a non-bytes chunk from an async iterable raised inside the
+    retention-buffer extend, which sat OUTSIDE the rollback try — leaving
+    `_user_turn_active` set (and a pending turn anchor) with nothing buffered
+    or sent, producing a phantom empty user turn at the next boundary."""
+    conn = FakeRealtimeConnection([])
+    session = RealtimeSession(conn, audio_retention='input_audio')
+
+    async def first_chunk_bad():
+        yield 123  # type: ignore[misc]
+
+    async with session:
+        with pytest.raises(TypeError):
+            await session.send_audio(first_chunk_bad())
+
+        assert session._user_turn_active is False, 'bad chunk must roll the turn state back'
+        assert len(session._input_audio) == 0
+        assert conn.sent == [], 'nothing should have reached the connection'
+
+        # With the state clean, a later (empty) turn boundary must not record
+        # a phantom user turn.
+        await session.commit_audio()
+        _ = await drain_events(session)
+
+    assert session.new_messages() == []
+
+
+async def test_send_audio_bad_later_chunk_keeps_earlier_chunks() -> None:
+    """The chunk that fails rolls back to its own entry snapshot: the turn it
+    found still active stays active, and the chunks that already succeeded
+    remain sent and buffered (nothing is duplicated or dropped)."""
+    conn = FakeRealtimeConnection([])
+    session = RealtimeSession(conn, audio_retention='input_audio')
+
+    async def chunks():
+        yield b'good-bytes'
+        yield 'not-bytes'  # type: ignore[misc]
+
+    async with session:
+        with pytest.raises(TypeError):
+            await session.send_audio(chunks())
+
+        assert session._user_turn_active is True, 'the first chunk legitimately opened the turn'
+        assert bytes(session._input_audio) == b'good-bytes'
+        assert len(conn.sent) == 1
+
+

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -6300,7 +6300,7 @@ async def test_send_audio_first_chunk_bad_rolls_back_turn_state() -> None:
 
     async with session:
         with pytest.raises(TypeError):
-            await session.send_audio(cast('AsyncIterator[bytes]', first_chunk_bad()))
+            await session.send_audio(first_chunk_bad())
 
         assert session._user_turn_active is False, 'bad chunk must roll the turn state back'  # pyright: ignore[reportPrivateUsage]
         assert len(session._input_audio) == 0  # pyright: ignore[reportPrivateUsage]
@@ -6327,7 +6327,7 @@ async def test_send_audio_bad_later_chunk_keeps_earlier_chunks() -> None:
 
     async with session:
         with pytest.raises(TypeError):
-            await session.send_audio(cast('AsyncIterator[bytes]', chunks()))
+            await session.send_audio(chunks())
 
         assert session._user_turn_active is True, 'the first chunk legitimately opened the turn'  # pyright: ignore[reportPrivateUsage]
         assert bytes(session._input_audio) == b'good-bytes'  # pyright: ignore[reportPrivateUsage]

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -6295,15 +6295,15 @@ async def test_send_audio_first_chunk_bad_rolls_back_turn_state() -> None:
     conn = FakeRealtimeConnection([])
     session = RealtimeSession(conn, audio_retention='input_audio')
 
-    async def first_chunk_bad():
+    async def first_chunk_bad() -> AsyncIterator[bytes]:
         yield 123  # type: ignore[misc]
 
     async with session:
         with pytest.raises(TypeError):
-            await session.send_audio(first_chunk_bad())
+            await session.send_audio(cast('AsyncIterator[bytes]', first_chunk_bad()))
 
-        assert session._user_turn_active is False, 'bad chunk must roll the turn state back'
-        assert len(session._input_audio) == 0
+        assert session._user_turn_active is False, 'bad chunk must roll the turn state back'  # pyright: ignore[reportPrivateUsage]
+        assert len(session._input_audio) == 0  # pyright: ignore[reportPrivateUsage]
         assert conn.sent == [], 'nothing should have reached the connection'
 
         # With the state clean, a later (empty) turn boundary must not record
@@ -6321,16 +6321,16 @@ async def test_send_audio_bad_later_chunk_keeps_earlier_chunks() -> None:
     conn = FakeRealtimeConnection([])
     session = RealtimeSession(conn, audio_retention='input_audio')
 
-    async def chunks():
+    async def chunks() -> AsyncIterator[bytes]:
         yield b'good-bytes'
         yield 'not-bytes'  # type: ignore[misc]
 
     async with session:
         with pytest.raises(TypeError):
-            await session.send_audio(chunks())
+            await session.send_audio(cast('AsyncIterator[bytes]', chunks()))
 
-        assert session._user_turn_active is True, 'the first chunk legitimately opened the turn'
-        assert bytes(session._input_audio) == b'good-bytes'
+        assert session._user_turn_active is True, 'the first chunk legitimately opened the turn'  # pyright: ignore[reportPrivateUsage]
+        assert bytes(session._input_audio) == b'good-bytes'  # pyright: ignore[reportPrivateUsage]
         assert len(conn.sent) == 1
 
 


### PR DESCRIPTION
Fixes #7904

## Summary

`RealtimeSession.send_audio` accepts either a `bytes` chunk or an async iterable of chunks (since #7860). With audio retention on (`audio_retention='input_audio'`/`'all'`), the retention-buffer extend ran **outside** the rollback `try`:

```python
previous_length = len(self._input_audio)
self._input_audio.extend(data)   # ← outside
try:
    await self._send_frame(BinaryAudio(...))
except BaseException:
    self._user_turn_active = user_turn_was_active
    ...
```

A chunk that is not bytes-like (an async iterable yielding a `str`/`int` — nothing validates chunk types) raises `TypeError` in `extend`, completely bypassing the rollback: `_user_turn_active` stays set and the pending turn anchor remains, with nothing buffered or sent. The inconsistency is visible in-method: the same bad chunk with retention *off* reaches the `BinaryAudio(...)` validation inside the `try` and rolls back cleanly.

Consequences (traced, first one reproducible directly): the stale flag defeats the `not self._user_turn_active` guard in `_finalize_untranscribed_user`, which can produce an empty phantom user turn at the next boundary; the stale anchor can be claimed by a later transcript item, inserting that turn at a stale history position.

## Change

The extend moves inside the `try`. A failing `bytearray.extend` leaves the buffer unchanged (CPython behavior, verified), so the existing equality guard in the handler correctly skips the truncation for the extend-failure case while keeping it for send failures.

## Tests

- First chunk bad → `TypeError` propagates, `_user_turn_active` stays `False`, buffer empty, nothing reached the connection, and a later empty turn boundary records no phantom user turn.
- Bad later chunk → rolls back to its own entry snapshot: the turn the first chunk legitimately opened stays active, its bytes stay buffered and sent.
- Full `tests/realtime/test_session.py` suite: 271 passed.

One deliberate non-change for the record: `commit_audio`'s unconditional `_user_turn_active = True` looks like it defeats the same guard, but the content-less placeholder turn it produces on an empty commit is an intentional, explicitly tested feature (`test_manual_contentless_user_turn_without_transcription`) — "every turn remains represented in history". Left as is.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

