### PR TITLE
fix(models): keep PartEndEvent (index, part) pairs consistent with their starts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -136,15 +136,15 @@ class ModelResponsePartsManager:
         return [p for p in self._parts if not isinstance(p, ToolCallPartDelta)]
 
     def get_part(self, index: int) -> ManagedPart | None:
-        """Return the part at the unfiltered stream ``index``.
+        """Return the part at the unfiltered stream `index`.
 
-        Returns None while the part is still a dangling ``ToolCallPartDelta`` (a tool-call
+        Returns None while the part is still a dangling `ToolCallPartDelta` (a tool-call
         delta that never received a name and so was never promoted to a real part).
 
-        ``PartStartEvent.index`` values come from the unfiltered ``_parts`` space (see
-        :meth:`_append_part`), so a lookup by that index must NOT go through :meth:`get_parts`:
+        `PartStartEvent.index` values come from the unfiltered `_parts` space (see
+        `_append_part`), so a lookup by that index must NOT go through `get_parts`:
         the filtered list is shorter whenever a dangling delta exists, which returns
-        the wrong part for the index or raises ``IndexError`` past the end of the
+        the wrong part for the index or raises `IndexError` past the end of the
         filtered list.
         """
         if index < 0 or index >= len(self._parts):

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -136,14 +136,16 @@ class ModelResponsePartsManager:
         return [p for p in self._parts if not isinstance(p, ToolCallPartDelta)]
 
     def get_part(self, index: int) -> ManagedPart | None:
-        """Return the part at the unfiltered stream ``index``, or None while it is a
-        dangling ``ToolCallPartDelta`` (a tool-call delta that never received a name and so was
-        never promoted to a real part).
+        """Return the part at the unfiltered stream ``index``.
+
+        Returns None while the part is still a dangling ``ToolCallPartDelta`` (a tool-call
+        delta that never received a name and so was never promoted to a real part).
 
         ``PartStartEvent.index`` values come from the unfiltered ``_parts`` space (see
         :meth:`_append_part`), so a lookup by that index must NOT go through :meth:`get_parts`:
-        the filtered list is shorter whenever a dangling delta exists, which returns the wrong
-        part for the index or raises ``IndexError`` past the end of the filtered list.
+        the filtered list is shorter whenever a dangling delta exists, which returns
+        the wrong part for the index or raises ``IndexError`` past the end of the
+        filtered list.
         """
         if index < 0 or index >= len(self._parts):
             return None

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -135,6 +135,24 @@ class ModelResponsePartsManager:
                 self._materialize_and_cache_part(part_index)
         return [p for p in self._parts if not isinstance(p, ToolCallPartDelta)]
 
+    def get_part(self, index: int) -> ManagedPart | None:
+        """Return the part at the unfiltered stream ``index``, or None while it is a
+        dangling ``ToolCallPartDelta`` (a tool-call delta that never received a name and so was
+        never promoted to a real part).
+
+        ``PartStartEvent.index`` values come from the unfiltered ``_parts`` space (see
+        :meth:`_append_part`), so a lookup by that index must NOT go through :meth:`get_parts`:
+        the filtered list is shorter whenever a dangling delta exists, which returns the wrong
+        part for the index or raises ``IndexError`` past the end of the filtered list.
+        """
+        if index < 0 or index >= len(self._parts):
+            return None
+        if index in self._string_buffers and not isinstance(self._parts[index], ToolCallPartDelta):
+            self._materialize_and_cache_part(index)
+        if isinstance(self._parts[index], ToolCallPartDelta):
+            return None
+        return self._parts[index]
+
     def get_part_by_vendor_id(self, vendor_id: VendorId) -> ManagedPart | None:
         """Return a part by its vendor ID.
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1036,9 +1036,14 @@ class StreamedResponse(ABC):
                         return None
 
                     index = last_start_event.index
-                    part = self._parts_manager.get_parts()[index]
-                    if not isinstance(part, TextPart | ThinkingPart | BaseToolCallPart):
-                        # Parts other than these 3 don't have deltas, so don't need an end part.
+                    # `index` is from the unfiltered parts space; `get_part` keeps the
+                    # (index, part) pair consistent with the start event even when dangling
+                    # tool-call deltas shrink the filtered list (`get_parts()[index]` used to
+                    # return the wrong part or raise IndexError at end of stream).
+                    part = self._parts_manager.get_part(index)
+                    if part is None or not isinstance(part, TextPart | ThinkingPart | BaseToolCallPart):
+                        # A dangling delta never became a real part, and parts other than these
+                        # 3 don't have deltas — neither needs an end part.
                         return None
 
                     return PartEndEvent(

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -35,6 +35,7 @@ from pydantic_ai import (
     ModelRetry,
     PartDeltaEvent,
     PartEndEvent,
+    PartStartEvent,
     RetryPromptPart,
     TextContent,
     TextPart,
@@ -6419,3 +6420,81 @@ def test_model_construction_preloads_lazy_dependencies():
     env = {key: value for key, value in os.environ.items() if not key.startswith('COVERAGE_')}
     process = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True, timeout=120, env=env)
     assert process.returncode == 0, f'lazy-dependency preload check failed:\n{process.stderr}'
+
+
+async def test_stream_dangling_tool_call_delta_keeps_part_end_events_consistent(
+    allow_model_requests: None,
+):
+    """Regression: `PartStartEvent.index` comes from the unfiltered parts space, but
+    `part_end_event` used `get_parts()[index]` — the filtered list. A nameless
+    tool-call delta (OpenAI-compatible gateways do send those — the same shape
+    issue #5165 defends against) creates a dangling `ToolCallPartDelta` that
+    shrinks the filtered list, so a later part's end event carried the WRONG
+    part object, and the end-of-stream lookup raised IndexError."""
+    # Tool call 0 arrives complete; tool call 1 never gets a name (dangling
+    # delta at unfiltered index 1); text then lands at unfiltered index 2.
+    first_turn = [
+        chunk(
+            [
+                ChoiceDelta(
+                    tool_calls=[
+                        ChoiceDeltaToolCall(
+                            index=0,
+                            id='call_0',
+                            function=ChoiceDeltaToolCallFunction(name='get_location', arguments='{}'),
+                        )
+                    ]
+                )
+            ]
+        ),
+        chunk(
+            [
+                ChoiceDelta(
+                    tool_calls=[
+                        ChoiceDeltaToolCall(
+                            index=1,
+                            function=ChoiceDeltaToolCallFunction(arguments='{"city"'),
+                        )
+                    ]
+                )
+            ]
+        ),
+        text_chunk('Hello there'),
+        text_chunk('.', finish_reason='tool_calls'),
+    ]
+    second_turn = [text_chunk('done'), text_chunk('.', finish_reason='stop')]
+    mock_client = MockOpenAI.create_mock_stream([first_turn, second_turn])
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    def get_location() -> str:
+        return 'Paris'
+
+    agent = Agent(m, tools=[get_location], output_type=[str])
+
+    turns: list[list[object]] = []
+    async with agent.iter('') as run:
+        async for node in run:
+            if agent.is_model_request_node(node):
+                turn_events: list[object] = []
+                async with node.stream(run.ctx) as stream_events:
+                    async for event in stream_events:
+                        turn_events.append(event)
+                turns.append(turn_events)
+
+    # Each model request numbers its parts from zero; assert per turn.
+    first_turn_events = turns[0]
+    starts = {e.index: e for e in first_turn_events if isinstance(e, PartStartEvent)}
+    ends = [e for e in first_turn_events if isinstance(e, PartEndEvent)]
+    assert 2 in starts and isinstance(starts[2].part, TextPart)
+
+    for end in ends:
+        # Every end event must carry the same part type its start event
+        # announced for that index — no cross-contamination from the dangling
+        # delta shrinking the filtered list.
+        assert type(end.part) is type(starts[end.index].part)
+
+    # The text part (unfiltered index 2, filtered position 1) ends with the
+    # text part itself, not the tool call the off-by-one used to pick, and
+    # the stream completes instead of raising IndexError past the list end.
+    text_end = next(e for e in ends if e.index == 2)
+    assert isinstance(text_end.part, TextPart) and text_end.part.content == 'Hello there.'

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -1141,6 +1141,24 @@ def test_get_part_by_vendor_id():
     assert manager.get_part_by_vendor_id('missing') is None
 
 
+def test_get_part_resolves_in_the_unfiltered_index_space():
+    """`get_part` looks parts up in the same unfiltered space `PartStartEvent.index` comes from."""
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+
+    # A nameless tool-call delta stays a dangling `ToolCallPartDelta` occupying unfiltered index 0.
+    assert manager.handle_tool_call_delta(vendor_part_id='tool', args='{"value":') is None
+    assert manager.get_part(0) is None
+
+    # The next part is indexed past the dangling delta, and resolves to itself.
+    next(manager.handle_text_delta(vendor_part_id='content', content='hello'))
+    assert manager.get_part(1) == TextPart(content='hello', part_kind='text')
+
+    # Out-of-range indexes return None rather than raising IndexError — the filtered
+    # `get_parts()[index]` lookup this method replaced raised at end of stream.
+    assert manager.get_part(-1) is None
+    assert manager.get_part(2) is None
+
+
 def test_apply_event_preserves_stream_part_indexes():
     """Incomplete tool calls do not emit events, but still occupy a stream-part index."""
     manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())


### PR DESCRIPTION
Fixes #7906

## Summary

`PartStartEvent.index` comes from the parts manager's **unfiltered** `_parts` space (`_append_part` returns `len(self._parts)`), but the shared `part_end_event` helper in `models/__init__.py` resolved the part via `get_parts()[index]` — the **filtered** list, which excludes dangling `ToolCallPartDelta`s. One nameless tool-call delta (the shape OpenAI-compatible gateways send; the empty-`choices` twin of this is already defended per #5165) shifts every later index:

- a later part's `PartEndEvent` carried the **wrong part object** (e.g. the text part's end event carried the earlier tool call), corrupting index-merging consumers (`run_stream_events`, AG-UI adapters, event replay);
- at end of stream the lookup raised `IndexError: list index out of range`, aborting the run.

Reachable from the Chat Completions path (args delta before a name arrives), the Responses path (`output_item.added` ordering), and any adapter that permits nameless tool-call deltas. Details and a chunk-by-chunk reproduction in the linked issue.

## Change

`PartsManager.get_part(index)` resolves in the **unfiltered** space (materializing string buffers exactly like `get_parts` does) and returns `None` for indices that are still dangling deltas; `part_end_event` uses it, so every end event carries the same part its start event announced and dangling deltas simply get no end event.

## Tests

Regression test in `tests/models/test_openai.py`: tool call + nameless delta + text + a final turn, asserting per-turn that each end event's part type matches its start's, the text part's end carries the `TextPart` itself, and the stream completes (no `IndexError`). Full affected suites: `test_openai.py` + `test_parts_manager.py` + `test_streaming.py` → 474 passed, 3 xfailed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

