### PR TITLE
fix(openai): raise a typed error for empty non-streaming choices

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1194,7 +1194,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         """
         return _map_provider_details(response.choices[0])
 
-    def _require_choice(self, response: chat.ChatCompletion) -> chat.Choice:
+    def _require_choice(self, response: chat.ChatCompletion) -> chat_completion.Choice:
         """Return the single choice of a validated completion.
 
         The SDK type has no min-length constraint on `choices`, and OpenAI-compatible gateways

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1194,6 +1194,19 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         """
         return _map_provider_details(response.choices[0])
 
+    def _require_choice(self, response: chat.ChatCompletion) -> chat.Choice:
+        """Return the single choice of a validated completion.
+
+        The SDK type has no min-length constraint on `choices`, and OpenAI-compatible gateways
+        do return empty arrays (the streaming twin of this is already skipped per #5165) —
+        surface a typed error instead of a bare IndexError.
+        """
+        if not response.choices:
+            raise UnexpectedModelBehavior(
+                f'Invalid response from {self.system} chat completions endpoint: response contains no choices'
+            )
+        return response.choices[0]
+
     def _process_response(self, response: chat.ChatCompletion | str) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""
         # Although the OpenAI SDK claims to return a Pydantic model (`ChatCompletion`) from the chat completions function:
@@ -1218,7 +1231,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         except ValidationError as e:
             raise UnexpectedModelBehavior(f'Invalid response from {self.system} chat completions endpoint: {e}') from e
 
-        choice = response.choices[0]
+        choice = self._require_choice(response)
 
         # Moderation is a top-level field, so it's read here rather than in the choice-scoped
         # `_process_provider_details` hook that subclasses may override.

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -6419,3 +6419,26 @@ def test_model_construction_preloads_lazy_dependencies():
     env = {key: value for key, value in os.environ.items() if not key.startswith('COVERAGE_')}
     process = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True, timeout=120, env=env)
     assert process.returncode == 0, f'lazy-dependency preload check failed:\n{process.stderr}'
+
+
+async def test_empty_choices_non_streaming_raises_typed_error(allow_model_requests: None):
+    """Regression: a schema-valid but empty `choices` array (sent by OpenAI-compatible
+    gateways; the streaming twin is already skipped per #5165) used to escape as a bare
+    `IndexError` instead of the typed `UnexpectedModelBehavior` this file's own contract
+    uses for malformed non-streaming responses."""
+    c = chat.ChatCompletion(
+        id='123',
+        choices=[],
+        created=1704067200,  # 2024-01-01
+        model='gpt-4o-123',
+        object='chat.completion',
+    )
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    with pytest.raises(UnexpectedModelBehavior) as exc_info:
+        await agent.run('What is the capital of France?')
+    assert exc_info.value.message == (
+        'Invalid response from openai chat completions endpoint: response contains no choices'
+    )


### PR DESCRIPTION
Fixes #7909

## Summary

A schema-valid `ChatCompletion` with an empty `choices` array (the openai SDK type has no `min_length` constraint; OpenAI-compatible gateways do return it) escaped `_process_response` as a bare `IndexError: list index out of range`. The file's own contract for malformed non-streaming responses is a typed `UnexpectedModelBehavior` — used for non-JSON bodies and validation failures — and the streaming path already handles its empty-`choices` twin explicitly (#5165). Only this path leaked the bare exception.

## Change

`_require_choice(response)` raises `UnexpectedModelBehavior('Invalid response from openai chat completions endpoint: response contains no choices')` when the array is empty and returns the choice otherwise; extracted as a method so `_process_response`'s complexity stays under the repo's ruff C901 budget.

## Tests

Regression test feeds a mocked `ChatCompletion(choices=[])` through `agent.run` and asserts the exact typed message. Suite: `tests/models/test_openai.py` → 231 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

