### PR TITLE
fix(responses): map finish_reason on incomplete/failed stream terminals

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -317,6 +317,9 @@ _RESPONSES_FINISH_REASON_MAP: dict[Literal['max_output_tokens', 'content_filter'
     'completed': 'stop',
     'cancelled': 'error',
     'failed': 'error',
+    # A terminal `incomplete` status without `incomplete_details` still means the output
+    # was cut short, just with an unreported reason.
+    'incomplete': 'length',
 }
 
 
@@ -4105,6 +4108,26 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
         background = bool((self.provider_details or {}).get('background'))
         self.state = _response_status_to_state(status, background=background)
 
+    def _record_terminal_finish_reason(self, response: responses.Response) -> None:
+        """Map a terminal response's finish reason, mirroring the non-streaming path.
+
+        Applied to all three terminal events (`completed`, `incomplete`, `failed`):
+        `incomplete_details.reason` takes precedence over the status (e.g.
+        `max_output_tokens` on a `response.incomplete` terminal → `length`), and the
+        refusal case skips the update. Without this, an `incomplete`/`failed` terminal
+        left `finish_reason=None`, silently losing the token-limit and content-filter
+        semantics the non-streaming path reports (and `_agent_graph` branches on).
+        """
+        raw_finish_reason = details.reason if (details := response.incomplete_details) else response.status
+
+        if raw_finish_reason:  # pragma: no branch
+            if not self._has_refusal:
+                self.provider_details = {
+                    **(self.provider_details or {}),
+                    'finish_reason': raw_finish_reason,
+                }
+                self.finish_reason = _RESPONSES_FINISH_REASON_MAP.get(raw_finish_reason)
+
     def _track_background(self, response: responses.Response) -> None:
         """Mark a background job so `cancel_suspended_response` can cancel it server-side.
 
@@ -4184,18 +4207,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
                     self._store_conversation_id(chunk.response)
                     self._set_state(chunk.response.status)
-
-                    raw_finish_reason = (
-                        details.reason if (details := chunk.response.incomplete_details) else chunk.response.status
-                    )
-
-                    if raw_finish_reason:  # pragma: no branch
-                        if not self._has_refusal:
-                            self.provider_details = {
-                                **(self.provider_details or {}),
-                                'finish_reason': raw_finish_reason,
-                            }
-                            self.finish_reason = _RESPONSES_FINISH_REASON_MAP.get(raw_finish_reason)
+                    self._record_terminal_finish_reason(chunk.response)
 
                     if chunk.response.moderation:
                         self.provider_details = {
@@ -4218,6 +4230,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                 elif isinstance(chunk, responses.ResponseFailedEvent):
                     self._usage += self._map_usage(chunk.response)
                     self._set_state(chunk.response.status)
+                    self._record_terminal_finish_reason(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDeltaEvent):
                     maybe_event = self._parts_manager.handle_tool_call_delta(
@@ -4237,6 +4250,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                 elif isinstance(chunk, responses.ResponseIncompleteEvent):
                     self._usage += self._map_usage(chunk.response)
                     self._set_state(chunk.response.status)
+                    self._record_terminal_finish_reason(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseOutputItemAddedEvent):
                     if isinstance(chunk.item, responses.ResponseFunctionToolCall):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -16476,3 +16476,83 @@ async def test_openai_responses_malformed_tool_args_degraded_on_the_wire(allow_m
         }
     )
     assert json.loads(function_call['arguments']) == {INVALID_JSON_KEY: bad_args}
+
+
+async def test_incomplete_terminal_maps_finish_reason_streaming(allow_model_requests: None) -> None:
+    """Regression: `response.incomplete` / `response.failed` terminals used to leave
+    `finish_reason=None`, silently losing the token-limit and content-filter semantics the
+    non-streaming path reports and `_agent_graph` branches on (e.g. the empty-output +
+    `finish_reason='length'` "Model token limit exceeded" error)."""
+    from openai.types.responses.response import IncompleteDetails
+
+    base_response = response_message(
+        [
+            resp.ResponseOutputMessage(
+                id='msg_001',
+                type='message',
+                role='assistant',
+                status='incomplete',
+                content=[resp.ResponseOutputText(text='partial output', type='output_text', annotations=[])],
+            )
+        ]
+    ).model_copy(update={'status': 'incomplete', 'incomplete_details': IncompleteDetails(reason='max_output_tokens')})
+    stream = [
+        resp.ResponseOutputItemAddedEvent(
+            item=base_response.output[0],
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=1,
+        ),
+        resp.ResponseTextDeltaEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            delta='partial output',
+            type='response.output_text.delta',
+            sequence_number=2,
+            logprobs=[],
+        ),
+        resp.ResponseTextDoneEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            text='partial output',
+            type='response.output_text.done',
+            sequence_number=3,
+            logprobs=[],
+        ),
+        resp.ResponseIncompleteEvent(response=base_response, type='response.incomplete', sequence_number=4),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.6-terra', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    async with agent.run_stream_events('') as result:
+        _ = [event async for event in result]
+
+    response = next(m for m in result.all_messages() if isinstance(m, ModelResponse))
+    assert response.finish_reason == 'length'
+    assert response.provider_details['finish_reason'] == 'max_output_tokens'
+
+
+async def test_incomplete_terminal_empty_output_raises_token_limit_error(allow_model_requests: None) -> None:
+    """The downstream semantics the streaming finish_reason feeds: an empty output cut
+    short by the token limit must raise the explicit "Model token limit exceeded" error —
+    before the fix, the streaming path silently returned None output instead."""
+    from openai.types.responses.response import IncompleteDetails
+
+    base_response = response_message([]).model_copy(
+        update={'status': 'incomplete', 'incomplete_details': IncompleteDetails(reason='max_output_tokens')}
+    )
+    stream = [
+        resp.ResponseIncompleteEvent(response=base_response, type='response.incomplete', sequence_number=1),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.6-terra', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    with pytest.raises(UnexpectedModelBehavior, match='Model token limit'):
+        async with agent.run_stream_events('') as events:
+            _ = [event async for event in events]

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -16533,6 +16533,7 @@ async def test_incomplete_terminal_maps_finish_reason_streaming(allow_model_requ
 
     response = next(m for m in result.all_messages() if isinstance(m, ModelResponse))
     assert response.finish_reason == 'length'
+    assert response.provider_details is not None
     assert response.provider_details['finish_reason'] == 'max_output_tokens'
 
 


### PR DESCRIPTION
Fixes #7911

## Summary

The streaming Responses path mapped `finish_reason` only on `response.completed`. Streams ending with `response.incomplete` (max_output_tokens / content_filter) or `response.failed` left `finish_reason=None` — the non-streaming path reports these, and `_agent_graph` branches on them:

- empty output + `length` raises the explicit "Model token limit exceeded" error; with `None` the streaming path silently returned `None` output;
- `content_filter` terminals lost `ContentFilterError` semantics;
- `check_incomplete_tool_call` and the OTel `finish_reason` span attribute never fired.

## Change

- `_record_terminal_finish_reason(response)` extracted from the completed branch and applied to **all three** terminal events (`completed`, `incomplete`, `failed`): `incomplete_details.reason` takes precedence over the status, refusal skips the update — identical to the completed branch's previous behavior and the non-streaming mapping.
- `_RESPONSES_FINISH_REASON_MAP` gains `'incomplete': 'length'` — a terminal incomplete status without `incomplete_details` still means the output was cut short, just with an unreported reason.

## Tests

- Streaming `response.incomplete` with `max_output_tokens` + real output events → `finish_reason == 'length'`, `provider_details['finish_reason'] == 'max_output_tokens'` (matches the non-streaming contract).
- Empty output + incomplete terminal → raises the explicit `UnexpectedModelBehavior('Model token limit …')` — the downstream semantics this feeds, which used to be silently skipped.

Suites: `test_openai_responses.py` + `test_openai.py` → 484 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

