### PR TITLE
fix(openai): keep the cumulative usage snapshot across usage-less chunks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3842,6 +3842,22 @@ class OpenAIStreamedResponse(StreamedResponse):
     async def close_stream(self) -> None:
         await self._response.source.close()
 
+    def _update_usage(self, chunk: ChatCompletionChunk) -> None:
+        """Fold a chunk's usage into the running total.
+
+        With `openai_continuous_usage_stats` each chunk carries cumulative usage, so it
+        replaces rather than increments to avoid double-counting — but chunks without usage
+        map to all zeros, and replacing on those would wipe the running cumulative snapshot:
+        an interrupted stream (error/cancel before the final chunk) would then commit a zero
+        partial usage instead of the tokens actually consumed so far.
+        """
+        chunk_usage = self._map_usage(chunk)
+        if self._model_settings and self._model_settings.get('openai_continuous_usage_stats'):
+            if chunk.usage is not None:
+                self._usage = chunk_usage
+        else:
+            self._usage += chunk_usage
+
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         with _map_api_errors(self._model_name, self._model_id_namespace):
             async for chunk in self._validate_response():
@@ -3852,13 +3868,7 @@ class OpenAIStreamedResponse(StreamedResponse):
                         'timestamp': self._provider_timestamp,
                     }
 
-                chunk_usage = self._map_usage(chunk)
-                if self._model_settings and self._model_settings.get('openai_continuous_usage_stats'):
-                    # When continuous_usage_stats is enabled, each chunk contains cumulative usage,
-                    # so we replace rather than increment to avoid double-counting.
-                    self._usage = chunk_usage
-                else:
-                    self._usage += chunk_usage
+                self._update_usage(chunk)
 
                 if chunk.id:  # pragma: no branch
                     self.provider_response_id = chunk.id

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -6419,3 +6419,45 @@ def test_model_construction_preloads_lazy_dependencies():
     env = {key: value for key, value in os.environ.items() if not key.startswith('COVERAGE_')}
     process = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True, timeout=120, env=env)
     assert process.returncode == 0, f'lazy-dependency preload check failed:\n{process.stderr}'
+
+
+async def test_stream_continuous_usage_stats_no_usage_chunk_keeps_cumulative(allow_model_requests: None):
+    """Regression: with continuous_usage_stats=True, a chunk carrying no usage maps to
+    all-zero RequestUsage — replacing on it wiped the running cumulative snapshot, so a
+    stream interrupted before the final chunk committed a zero partial usage instead of
+    the tokens actually consumed so far."""
+    stream = [
+        chunk_with_usage(
+            [ChoiceDelta(content='hello ', role='assistant')],
+            completion_tokens=5,
+            prompt_tokens=10,
+            total_tokens=15,
+        ),
+        # No usage on this chunk: the first chunk of some streams, moderation chunks, and
+        # gateways that only implement include_usage send these. (The `chunk()` helper
+        # defaults to a non-null usage, so this has to be stripped explicitly.)
+        text_chunk('world').model_copy(update={'usage': None}),
+        chunk_with_usage([ChoiceDelta(content='!')], completion_tokens=10, prompt_tokens=10, total_tokens=20),
+        chunk_with_usage([], finish_reason='stop', completion_tokens=10, prompt_tokens=10, total_tokens=20),
+    ]
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    settings = cast(OpenAIChatModelSettings, {'openai_continuous_usage_stats': True})
+    async with agent.run_stream('', model_settings=settings) as result:
+        usage_at_each_step: list[RequestUsage] = []
+        async for response in result.stream_response(debounce_by=None):
+            usage_at_each_step.append(response.usage)
+
+    # The usage-less chunk must leave the previous cumulative snapshot (10/5) in place —
+    # never zero — until the next cumulative chunk (10/10) replaces it.
+    assert usage_at_each_step == snapshot(
+        [
+            RequestUsage(input_tokens=10, output_tokens=5),
+            RequestUsage(input_tokens=10, output_tokens=5),
+            RequestUsage(input_tokens=10, output_tokens=10),
+            RequestUsage(input_tokens=10, output_tokens=10),
+            RequestUsage(input_tokens=10, output_tokens=10),
+        ]
+    )


### PR DESCRIPTION
Fixes #7913

## Summary

With `openai_continuous_usage_stats=True`, each chunk's cumulative usage *replaces* the running total — but a chunk with `usage=None` maps to an all-zero `RequestUsage`, and the replacement was unconditional, wiping the snapshot. Usage-less chunks are normal (first chunk, moderation chunks, gateways that only implement `include_usage`), and the zeroing surfaces whenever a stream is interrupted before the final chunk (error/cancellation): `partial_response.usage` then reports 0/0 instead of the tokens consumed so far.

## Change

The fold now replaces only when the chunk actually carries usage (`chunk.usage is not None`); usage-less chunks leave the snapshot untouched. Extracted into `_update_usage(chunk)` so `_get_event_iterator` stays under the repo's ruff C901 budget. The default (non-continuous) path is unchanged — adding a zero there was already a no-op.

## Tests

Regression test with a usage-less chunk between two cumulative chunks: the per-step usage snapshot shows the 10/5 cumulative value held across the usage-less chunk (never zero) until the next cumulative chunk replaces it. Suite: `tests/models/test_openai.py` → 231 passed.
