### PR TITLE
fix(providers): let GoogleProvider's public overload accept the environment-key call pattern

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -108,7 +108,7 @@ class GoogleProvider(BaseGoogleProvider):
     def __init__(
         self,
         *,
-        api_key: str,
+        api_key: str | None = None,
         http_client: AsyncHTTPClient | None = None,
         base_url: str | None = None,
         retry_options: HttpRetryOptions | None = None,

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -63,7 +63,18 @@ def test_google_provider_without_api_key_raises_error(env: TestEnv):
             r" to use the Gemini API\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
         ),
     ):
-        GoogleProvider()  # pyright: ignore[reportCallIssue]  # deliberately no api_key, to test the missing-key error
+        GoogleProvider()  # deliberately no api_key, to test the missing-key error
+
+
+def test_google_provider_api_key_from_env(env: TestEnv):
+    """The zero-argument call is a supported pattern — it resolves `GOOGLE_API_KEY` (or the legacy
+    `GEMINI_API_KEY`) — so the public overload must accept omitting `api_key`, not just the runtime.
+    """
+    env.set('GOOGLE_API_KEY', 'your-api-key')
+
+    provider = GoogleProvider()
+    assert provider.name == 'google'
+    assert provider.client._api_client.api_key == 'your-api-key'  # pyright: ignore[reportPrivateUsage]
 
 
 def test_google_provider_retry_options(env: TestEnv):


### PR DESCRIPTION
Fixes #7882

## What

`GoogleProvider`'s non-client overload pinned `api_key: str` as required, so the supported zero-argument call pattern — `GoogleProvider()` resolving `GOOGLE_API_KEY` (or the legacy `GEMINI_API_KEY`) — failed type checking even though the runtime `__init__` has accepted it all along (`api_key: str | None = None`). The repo's own missing-key test had to carry a `pyright: ignore[reportCallIssue]` for exactly this call shape.

No runtime behavior changes: the overload now matches the implementation signature, the same shape `OpenAIProvider`'s non-client overload already uses.

## Changes

- `pydantic_ai_slim/pydantic_ai/providers/google.py`: first overload's `api_key: str` → `api_key: str | None = None`.
- `tests/providers/test_google.py`: dropped the now-unneeded pyright suppression on the missing-key test, and added `test_google_provider_api_key_from_env` pinning that the zero-argument call constructs from the environment (mirroring the existing `GoogleCloudProvider` env-key test).

## Verification

- `tests/providers/test_google.py`: 27 passed.
- `ruff check` / `ruff format --check` clean; `pyright` on both files: 0 errors (the removed ignore would have resurfaced as an error if the overload didn't actually accept the call).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

