### PR TITLE
fix(messages): treat an empty CompactionPart as a non-boundary

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2969,7 +2969,7 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    return not requires_encrypted_content and bool(part.content)
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2865,3 +2865,21 @@ def test_post_compaction_window_accepts_a_minimal_sequence():
     assert len(window) == 2
     assert isinstance(window[0], ModelResponse)
     assert isinstance(window[1], ModelRequest)
+
+
+def test_empty_compaction_part_is_not_a_wire_boundary():
+    """Regression: an empty-string CompactionPart must not count as a wire boundary,
+    matching CompactionPart.has_content() semantics."""
+    from pydantic_ai.messages import _compaction_part_is_wire_boundary
+
+    empty = CompactionPart(content='', provider_name='anthropic')
+    none = CompactionPart(content=None, provider_name='anthropic')
+    real = CompactionPart(content='summary text', provider_name='anthropic')
+
+    assert not empty.has_content()
+    assert not none.has_content()
+    assert real.has_content()
+
+    assert not _compaction_part_is_wire_boundary(empty, 'anthropic')
+    assert not _compaction_part_is_wire_boundary(none, 'anthropic')
+    assert _compaction_part_is_wire_boundary(real, 'anthropic')


### PR DESCRIPTION
## Summary

Fixes #7773 — `_compaction_part_is_wire_boundary` treats an empty-string `CompactionPart` as a valid boundary, discarding the history it cannot replace.

**Root cause:** The boundary check ends with `part.content is not None`, which passes for `content=''`. An empty summary cannot stand in for the history it replaced, so the trimming leaves neither the original messages nor a useful summary in their place.

**Fix:** Use `bool(part.content)` instead of `part.content is not None`, aligning with `CompactionPart.has_content()` which already uses `bool(self.content)`.

## Changed files

- `pydantic_ai_slim/pydantic_ai/messages.py` — change `is not None` to `bool()` in `_compaction_part_is_wire_boundary` (1 line)
- `tests/test_messages.py` — add regression test `test_empty_compaction_part_is_not_a_wire_boundary`

## Test plan

- [x] `pytest tests/test_messages.py -q` — 213 passed
- [x] `ruff check` — all checks passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

