### PR TITLE
fix(bedrock): omit, don't rewrite, an unsigned trailing thinking block on Anthropic

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1160,6 +1160,19 @@ class BedrockConverseModel(Model[BaseClient]):
         # Most families accept a `status` field on `toolResult` blocks; Writer Palmyra rejects it.
         supports_tool_result_status = profile.get('bedrock_supports_tool_result_status', True)
 
+        # Whether this model's reasoning blocks round-trip: for these families (Anthropic, DeepSeek R1)
+        # thinking parts are re-sent as `reasoningContent`. Anthropic additionally signs every thinking
+        # block and enforces that the latest assistant message re-sends them unmodified — so there a
+        # block whose signature never arrived (the shape Bedrock's response/stream mapping leaves on a
+        # `ThinkingPart` when the signature is missing, i.e. `provider_name=None`) has no survivable wire
+        # form and is omitted instead of rewritten (see the `ThinkingPart` mapping below). DeepSeek R1's
+        # and Nova's reasoning is unsigned, so their tagged-text rewrite is accepted as-is.
+        send_back_thinking = profile.get('bedrock_send_back_thinking_parts', False)
+        enforces_thinking_integrity = profile.get('bedrock_thinking_variant', None) == 'anthropic'
+        last_model_response_index = max(
+            (i for i, message in enumerate(messages) if isinstance(message, ModelResponse)), default=None
+        )
+
         # Media returned from a tool that can't live inside a `toolResult` block (see
         # `bedrock_supported_media_kinds_in_tool_returns`) is emitted as a sibling block. Models like
         # Mistral and Llama require every `toolResult` for a tool-use turn to sit together in the message
@@ -1175,7 +1188,7 @@ class BedrockConverseModel(Model[BaseClient]):
                 bedrock_messages.append({'role': 'user', 'content': [*deferred_media_content]})
                 deferred_media_content.clear()
 
-        for message in messages:
+        for index, message in enumerate(messages):
             if isinstance(message, ModelRequest):
                 for part in message.parts:
                     if isinstance(part, SystemPromptPart):
@@ -1300,15 +1313,12 @@ class BedrockConverseModel(Model[BaseClient]):
             elif isinstance(message, ModelResponse):
                 flush_deferred_media()
                 content: list[ContentBlockOutputTypeDef] = []
+                is_latest_model_response = index == last_model_response_index
                 for item in message.parts:
                     if isinstance(item, TextPart):
                         content.append({'text': item.content})
                     elif isinstance(item, ThinkingPart):
-                        if (
-                            item.provider_name == self.system
-                            and item.signature
-                            and profile.get('bedrock_send_back_thinking_parts', False)
-                        ):
+                        if item.provider_name == self.system and item.signature and send_back_thinking:
                             reasoning_content: ReasoningContentBlockOutputTypeDef
                             if item.id == 'redacted_content':
                                 reasoning_content = {
@@ -1322,6 +1332,22 @@ class BedrockConverseModel(Model[BaseClient]):
                                     }
                                 }
                             content.append({'reasoningContent': reasoning_content})
+                        elif is_latest_model_response and enforces_thinking_integrity and not item.provider_name:
+                            # An Anthropic thinking block whose signature never arrived has no survivable
+                            # wire form: the API rejects any modified thinking in the latest assistant
+                            # message, and without the signature the block can't be re-sent verbatim. The
+                            # tagged-text rewrite used for older history below is exactly the modification
+                            # that turns a recoverable retry into a permanent 400, so omit the block (a
+                            # turn left empty by this is dropped below) and make the omission observable.
+                            # See https://github.com/pydantic/pydantic-ai/issues/7908.
+                            warnings.warn(
+                                'Omitting a thinking block with no signature from the latest assistant message: '
+                                'this model requires thinking blocks in the latest assistant message to be re-sent '
+                                'unmodified, so sending the unsigned block in any form would be rejected. The '
+                                'request proceeds without it, and if this leaves that message empty it is dropped '
+                                'entirely. See https://github.com/pydantic/pydantic-ai/issues/7908',
+                                UserWarning,
+                            )
                         else:
                             start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                             content.append({'text': '\n'.join([start_tag, item.content, end_tag])})

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import json
 import os
+import warnings
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
@@ -3566,6 +3567,331 @@ async def test_bedrock_tool_results_lead_multi_reveal_turn(
     *_, last_message = mock_converse.call_args.kwargs['messages']
     assert [next(iter(block)) for block in last_message['content']] == ['toolResult', 'toolResult', 'text', 'text']
     assert [block['toolResult']['toolUseId'] for block in last_message['content'][:2]] == ['tooluse_1', 'tooluse_2']
+
+
+ANTHROPIC_THINKING_MODEL = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+
+async def test_bedrock_unsigned_trailing_thinking_part_omitted(bedrock_provider: BedrockProvider):
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/7908.
+
+    A thinking-only response whose signature delta never arrives (streaming leaves
+    `provider_name=None`) used to be re-sent on the output-validation retry rewritten as
+    `<thinking>` text — the one modification of the latest assistant message's thinking blocks
+    that Anthropic-on-Bedrock rejects with a deterministic 400, killing the run with no output.
+    The block is now omitted; the turn it empties is dropped, so the retry re-asks the original
+    prompt (the two user turns merge) instead of sending a payload the API can never accept.
+    """
+    model = BedrockConverseModel(ANTHROPIC_THINKING_MODEL, provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(parts=[ThinkingPart(content='weighing it up')], timestamp=IsDatetime()),
+        ModelRequest(parts=[RetryPromptPart(content='Please return text.')], timestamp=IsDatetime()),
+    ]
+
+    with pytest.warns(UserWarning, match='thinking block with no signature'):
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'hi'},
+                    {
+                        'text': """\
+Validation feedback:
+Please return text.
+
+Fix the errors and try again.\
+"""
+                    },
+                ],
+            }
+        ]
+    )
+
+
+async def test_bedrock_unsigned_trailing_thinking_part_kept_beside_other_parts(bedrock_provider: BedrockProvider):
+    """A latest assistant message with real output alongside the unsigned thinking keeps that output.
+
+    The turn is no longer content-less, so it stays on the wire minus the block that cannot be
+    re-sent — the omission warning still fires.
+    """
+    model = BedrockConverseModel(ANTHROPIC_THINKING_MODEL, provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='weighing it up'),
+                ToolCallPart(tool_name='get_location', args={}, tool_call_id='tooluse_1'),
+            ],
+            timestamp=IsDatetime(),
+        ),
+        ModelRequest(
+            parts=[RetryPromptPart(content='Please return text.')],
+            timestamp=IsDatetime(),
+        ),
+    ]
+
+    with pytest.warns(UserWarning, match='thinking block with no signature'):
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'hi'}]},
+            {
+                'role': 'assistant',
+                'content': [{'toolUse': {'toolUseId': 'tooluse_1', 'name': 'get_location', 'input': {}}}],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': """\
+Validation feedback:
+Please return text.
+
+Fix the errors and try again.\
+"""
+                    }
+                ],
+            },
+        ]
+    )
+
+
+async def test_bedrock_unsigned_older_thinking_part_still_rewritten_as_text(bedrock_provider: BedrockProvider):
+    """Older-history thinking keeps the tagged-text fallback: the API only protects the *latest* assistant message."""
+    model = BedrockConverseModel(ANTHROPIC_THINKING_MODEL, provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(parts=[ThinkingPart(content='weighing it up')], timestamp=IsDatetime()),
+        ModelRequest(parts=[UserPromptPart(content='and then?')], timestamp=IsDatetime()),
+        ModelResponse(parts=[TextPart(content='done')], timestamp=IsDatetime()),
+    ]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')  # the rewrite of older history is not an omission
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'hi'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'text': """\
+<thinking>
+weighing it up
+</thinking>\
+"""
+                    }
+                ],
+            },
+            {'role': 'user', 'content': [{'text': 'and then?'}]},
+            {'role': 'assistant', 'content': [{'text': 'done'}]},
+        ]
+    )
+
+
+async def test_bedrock_signed_trailing_thinking_part_sent_verbatim(bedrock_provider: BedrockProvider):
+    """A signed block from this provider is re-sent unmodified as `reasoningContent` — no warning."""
+    model = BedrockConverseModel(ANTHROPIC_THINKING_MODEL, provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='weighing it up', signature='ErUBCkYIBRgCKkD1qX9m', provider_name=model.system)
+            ],
+            timestamp=IsDatetime(),
+        ),
+        ModelRequest(parts=[RetryPromptPart(content='Please return text.')], timestamp=IsDatetime()),
+    ]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'hi'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'reasoningContent': {
+                            'reasoningText': {'text': 'weighing it up', 'signature': 'ErUBCkYIBRgCKkD1qX9m'}
+                        }
+                    }
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': """\
+Validation feedback:
+Please return text.
+
+Fix the errors and try again.\
+"""
+                    }
+                ],
+            },
+        ]
+    )
+
+
+async def test_bedrock_foreign_trailing_thinking_part_still_rewritten_as_text(bedrock_provider: BedrockProvider):
+    """A thinking part from another provider never reached this API, so its trailing rewrite is safe."""
+    model = BedrockConverseModel(ANTHROPIC_THINKING_MODEL, provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(
+            parts=[ThinkingPart(content='foreign reasoning', provider_name='openai')],
+            timestamp=IsDatetime(),
+        ),
+        ModelRequest(parts=[RetryPromptPart(content='Please return text.')], timestamp=IsDatetime()),
+    ]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'hi'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'text': """\
+<thinking>
+foreign reasoning
+</thinking>\
+"""
+                    }
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': """\
+Validation feedback:
+Please return text.
+
+Fix the errors and try again.\
+"""
+                    }
+                ],
+            },
+        ]
+    )
+
+
+async def test_bedrock_unsigned_trailing_thinking_part_rewritten_for_models_that_dont_send_back(
+    bedrock_provider: BedrockProvider,
+):
+    """Families that never re-send `reasoningContent` (Nova) have no integrity check to violate.
+
+    The unsigned trailing block keeps the tagged-text rewrite there — it is that family's only
+    transport back, not a modification the API will reject.
+    """
+    model = BedrockConverseModel('us.amazon.nova-pro-v1:0', provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(parts=[ThinkingPart(content='weighing it up')], timestamp=IsDatetime()),
+        ModelRequest(parts=[RetryPromptPart(content='Please return text.')], timestamp=IsDatetime()),
+    ]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'hi'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'text': """\
+<think>
+weighing it up
+</think>\
+"""
+                    }
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': """\
+Validation feedback:
+Please return text.
+
+Fix the errors and try again.\
+"""
+                    }
+                ],
+            },
+        ]
+    )
+
+
+async def test_bedrock_unsigned_trailing_thinking_part_rewritten_for_deepseek(
+    bedrock_provider: BedrockProvider,
+):
+    """DeepSeek R1 thinking arrives unsigned even though the model re-sends reasoning blocks.
+
+    An unsigned trailing block is therefore normal history for it — the tagged-text rewrite is
+    accepted, and the Anthropic-integrity omission must not fire.
+    """
+    model = BedrockConverseModel('us.deepseek.r1-v1:0', provider=bedrock_provider)
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='hi')], timestamp=IsDatetime()),
+        ModelResponse(parts=[ThinkingPart(content='weighing it up')], timestamp=IsDatetime()),
+        ModelRequest(parts=[RetryPromptPart(content='Please return text.')], timestamp=IsDatetime()),
+    ]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        _, bedrock_messages = await model._map_messages(history, ModelRequestParameters(), None)  # type: ignore[reportPrivateUsage]
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'hi'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'text': """\
+<think>
+weighing it up
+</think>\
+"""
+                    }
+                ],
+            },
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': """\
+Validation feedback:
+Please return text.
+
+Fix the errors and try again.\
+"""
+                    }
+                ],
+            },
+        ]
+    )
 
 
 async def test_bedrock_sanitize_tool_name_in_history(bedrock_provider: BedrockProvider):


### PR DESCRIPTION
Fixes #7908

## What

On Anthropic-via-Bedrock with extended thinking, a thinking-only response whose thinking block lost its signature in streaming (the signature delta never arrives; `_process_response`/streaming leave `provider_name=None`) used to be re-sent on the output-validation retry rewritten as `<thinking>` text — the one payload modification the API deterministically rejects with a 400, killing the run with no output, one request later, silently.

## Change

In `BedrockConverseModel._map_messages`, for the **latest** assistant message on the Anthropic thinking variant, a thinking block with no provider attribution is now **omitted with a `UserWarning`** instead of rewritten:

- a turn the omission empties is dropped entirely (the existing `if content:` guard), so the retry re-asks the original prompt — the two user turns are folded by the existing merge pass — instead of sending a payload the API can never accept;
- **older-history** thinking keeps the tagged-text rewrite (the API only protects the latest assistant message — pinned by a new test);
- **unsigned-reasoning families** (DeepSeek R1, Nova) are untouched: their rewrite was never a modification any API checks, so the omission is gated on `bedrock_thinking_variant == 'anthropic'`, not on `bedrock_send_back_thinking_parts` (DeepSeek R1 sets the latter but its thinking arrives unsigned by design — pinned by new tests);
- foreign-provider thinking parts (`provider_name` set) still take the rewrite even in the trailing position — the API never saw them.

This is the adapter-level boundary from the triage comment: the graph keeps the response + retry; the adapter owes a survivable payload (same invariant as #6139 for OpenAI chat histories), and the omission is now observable, as the issue's direction 3 asked.

## Tests

Seven new `_map_messages` unit tests in `tests/models/test_bedrock.py` assert the exact wire form: the issue's scenario (assistant turn absent, warning raised, user turns merged), unsigned-trailing-beside-a-tool-call (turn kept minus the block), older-history rewrite, signed trailing sent verbatim as `reasoningContent`, foreign trailing rewrite, Nova rewrite, DeepSeek R1 rewrite. Full `tests/models/test_bedrock.py`: 200 passed (the pre-existing DeepSeek VCR test covers the unsigned-reasoning boundary end-to-end as well). `ruff check`/`format` and `pyright` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

