### PR TITLE
fix(embeddings): sort embedding response by index to preserve input order

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -143,7 +143,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         except APIConnectionError as e:  # pragma: no cover
             raise ModelAPIError(model_name=self.model_name, message=e.message) from e
 
-        embeddings = [item.embedding for item in response.data]
+        embeddings = [item.embedding for item in sorted(response.data, key=lambda e: e.index)]
 
         return EmbeddingResult(
             embeddings=embeddings,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2306,3 +2306,30 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
             }
         ]
     )
+
+
+@pytest.mark.skipif(not openai_imports_successful(), reason='openai not installed')
+async def test_openai_embedding_batch_preserves_input_order():
+    from openai.types import Embedding
+    from openai.types.create_embedding_response import CreateEmbeddingResponse, Usage
+
+    out_of_order_response = CreateEmbeddingResponse(
+        data=[
+            Embedding(embedding=[0.2, 0.2], index=1, object='embedding'),
+            Embedding(embedding=[0.1, 0.1], index=0, object='embedding'),
+        ],
+        model='text-embedding-3-small',
+        object='list',
+        usage=Usage(prompt_tokens=2, total_tokens=2),
+    )
+
+    model = OpenAIEmbeddingModel('text-embedding-3-small', provider=OpenAIProvider(api_key='test-key'))
+
+    with patch(
+        'openai.resources.embeddings.AsyncEmbeddings.create',
+        AsyncMock(return_value=out_of_order_response),
+    ):
+        result = await model.embed(['first', 'second'], input_type='document')
+
+    assert result.embeddings[0] == [0.1, 0.1]
+    assert result.embeddings[1] == [0.2, 0.2]


### PR DESCRIPTION
## Summary

Fixes #7284 — the embedding model's `embed()` method does not sort the response by the per-item `index` field, so when the API returns items out of input order, `embeddings[i]` no longer corresponds to `inputs[i]`.

**Root cause:** The result is built directly from `response.data` in provider order:
```python
embeddings = [item.embedding for item in response.data]
```
The embeddings response schema carries an explicit `index: int` per item precisely because response order is not guaranteed for batch requests.

**Fix:** Sort `response.data` by `index` before extracting embeddings, matching the defensive pattern used by `litellm` and the legacy SDK client.

## Changed files

- `pydantic_ai_slim/pydantic_ai/embeddings/` — sort `response.data` by `index` (1 line)
- `tests/test_embeddings.py` — add regression test with a mocked out-of-order response

## Test plan

- [x] `pytest tests/test_embeddings.py` — 55 passed, 75 skipped
- [x] `ruff check` — all checks passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

