### PR TITLE
Remove the expired Anthropic dependency cutoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,10 +185,6 @@ pydantic-handlebars = false
 genai-prices = false
 logfire = false
 logfire-api = false
-# Anthropic 1.0 is built on HTTPX2 and drops legacy HTTPX entirely.
-# TODO(dsfaccini): Remove after 2026-08-27 19:59 UTC. https://github.com/pydantic/pydantic-ai/issues/7658
-# This admits only the reviewed 1.0.0 artifacts; later Anthropic artifacts remain quarantined.
-anthropic = "2026-08-20T19:58:59Z"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,6 @@ logfire = false
 pydantic-settings = false
 pydantic-handlebars = false
 genai-prices = false
-anthropic = "2026-08-20T19:58:59Z"
 pydantic-extra-types = false
 pydantic-core = false
 pydantic = false


### PR DESCRIPTION
Closes #7658.

## Why we make these changes

The temporary Anthropic cutoff has passed the removal time documented in the issue. The repository's normal rolling dependency policy can now admit the reviewed release without the package-specific override.

This removes the expired entry and regenerates the lock metadata. No resolved package versions changed.

## Verification

- `uv lock --check`
- `git diff --check`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

