### PR TITLE
Render binary output whole in `LLMJudge` prompts instead of one byte value per line

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -229,6 +229,10 @@ def set_default_judge_model(model: models.Model | models.KnownModelName) -> None
 def _stringify(value: Any) -> str:
     if isinstance(value, str):
         return value
+    # `to_json` renders `bytes` and `bytearray` as text whenever they decode, but raises on a
+    # `memoryview`, which would then fall through to `repr` and print its address instead.
+    if isinstance(value, memoryview):
+        value = value.tobytes()
     try:
         # If the value can be serialized to JSON, use that.
         # If that behavior is undesirable, the user could manually call repr on the arguments to the judge_* functions
@@ -248,8 +252,13 @@ def _make_section(content: Any, tag: str) -> list[str | UserContent]:
         list[str | UserContent]: the tagged section as a list of strings or UserContent
     """
     sections: list[str | UserContent] = []
-    items: Sequence[str | UserContent] = (  # pyright: ignore[reportUnknownVariableType]
-        content if isinstance(content, Sequence) and not isinstance(content, str) else [content]
+    # A binary buffer is a `Sequence` too, but iterating one yields ints, not content, so it
+    # is kept whole exactly like a `str` and stringified below. Issue #2089 fixed this for
+    # `BinaryContent`; raw buffers were still being iterated.
+    items: Sequence[Any] = (  # pyright: ignore[reportUnknownVariableType]
+        content
+        if isinstance(content, Sequence) and not isinstance(content, (str, bytes, bytearray, memoryview))
+        else [content]
     )
 
     sections.append(f'<{tag}>')

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -161,6 +161,43 @@ def test_build_prompt_section_order_matches_few_shot_examples(
         assert example_tags[start : start + len(expected_tags)] == expected_tags
 
 
+@pytest.mark.parametrize(
+    'binary',
+    [
+        pytest.param(b'The quick brown fox', id='bytes'),
+        pytest.param(bytearray(b'The quick brown fox'), id='bytearray'),
+        pytest.param(memoryview(b'The quick brown fox'), id='memoryview'),
+    ],
+)
+def test_build_prompt_renders_binary_content_whole(binary: bytes | bytearray | memoryview) -> None:
+    """A binary buffer is one piece of content, not a sequence of byte values.
+
+    `bytes`, `bytearray` and `memoryview` are all `Sequence`s, so iterating one yields
+    ints: the judge used to receive `104\n111\n108\n97` in place of the output and grade
+    that. Same failure as issue #2089, which was fixed for `BinaryContent` only.
+    """
+    prompt = _build_prompt(output=binary, rubric='The output mentions a fox')
+    assert isinstance(prompt, str)
+    assert 'The quick brown fox' in prompt
+    assert '\n113\n' not in prompt  # 'q', had the buffer been iterated
+    # One line of content between the tags, not one line per byte.
+    body = prompt.split('<Output>\n')[1].split('\n</Output>')[0]
+    assert body.count('\n') == 0
+
+
+def test_stringify_normalises_binary_buffers() -> None:
+    """All three binary types read the same to the judge.
+
+    `to_json` renders `bytes` as text when it decodes, but has no encoder for a
+    `bytearray` (falls through to `repr`) or a `memoryview` (renders its address).
+    """
+    assert _stringify(b'hi') == '"hi"'
+    assert _stringify(bytearray(b'hi')) == '"hi"'
+    assert _stringify(memoryview(b'hi')) == '"hi"'
+    # Undecodable bytes have no text form; `repr` is the honest fallback, not an address.
+    assert _stringify(b'\xff\xfe') == repr(b'\xff\xfe')
+
+
 @pytest.mark.anyio
 async def test_judge_output_mock(mocker: MockerFixture):
     """Test judge_output function with mocked agent."""


### PR DESCRIPTION
- Closes #7927

`bytes`, `bytearray` and `memoryview` are all `Sequence`s, so `_make_section` iterated them and the judge received one decimal byte value per line in place of the content. `evaluate()` then returned a plausible score for something the judge never saw — no exception, no warning.

Two changes:

- `_make_section` excludes the three buffer types from its `Sequence` check, the way `str` already was, so a binary buffer is kept whole and stringified.
- `_stringify` normalises a `memoryview` to `bytes` first. `to_json` renders `bytes` and `bytearray` as text whenever they decode, but raises on a `memoryview`, which would otherwise fall through to `repr` and print its address. (Thanks for the correction on the issue — my original report was wrong about `bytearray`.)

Behaviour is unchanged for every input that is not a binary buffer: the same `Sequence` branch, the same `_stringify`. #2089 fixed this class of failure for `BinaryContent`; raw buffers were still being iterated.

### How it was tested

Four tests in `tests/evals/test_llm_as_a_judge.py` — `_build_prompt` parametrized over the three buffer types, plus one pinning `_stringify` so all three read the same to the judge and undecodable bytes still fall back to `repr` rather than an address. All four fail on `main`.

`pytest tests/evals`: 567 passed. `ruff check`, `ruff format --check` and `pyright` clean on both files.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver — n/a, no compatibility impact.
- [x] **PR title** is fit for the release changelog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

