### PR TITLE
Document that a `Case` with `expected_output=None` cannot fail under `EqualsExpected`

### DIFF
--- a/docs/evals/core-concepts.md
+++ b/docs/evals/core-concepts.md
@@ -238,7 +238,7 @@ Case(
 )
 ```
 
-If no `expected_output` is provided, evaluators that require it (like `EqualsExpected`) will skip that case.
+If no `expected_output` is provided, evaluators that require it (like `EqualsExpected`) will skip that case. `None` is how "not provided" is spelled, so a case written as `expected_output=None` is skipped too: to assert that the task returns `None`, use [`Equals(value=None)`][pydantic_evals.evaluators.Equals] instead.
 
 #### Metadata
 Arbitrary data that evaluators can access via [`EvaluatorContext`][pydantic_evals.evaluators.EvaluatorContext]:

--- a/docs/evals/evaluators/built-in.md
+++ b/docs/evals/evaluators/built-in.md
@@ -40,6 +40,9 @@ dataset = Dataset(
 **Notes:**
 
 - Skips evaluation if `expected_output` is `None` (returns empty dict `{}`)
+- Because of that skip, a case whose expected output *is* `None` records no assertion at
+  all, so it passes whatever the task returns. To assert that the output is `None`, use
+  [`Equals(value=None)`](#equals), which takes the value explicitly.
 - Uses Python's `==` operator, so works with any comparable types
 - For structured data, considers nested equality
 


### PR DESCRIPTION
- Closes #7934

Docs only, and it follows from that issue's triage rather than disputing it. The verdict there was right: the skip is documented (`evaluators/built-in.md:42`, `core-concepts.md:241`) and deliberate, so the behaviour is the design and changing it is a maintainer decision, not a PR. The triage also called the ergonomics point genuine — "an eval that cannot fail for None outputs is a real trap" — and named the docs-only remedy as one of the three options. This is that option, and nothing else.

What the docs say today is the mechanism: `EqualsExpected` "skips evaluation if `expected_output` is `None`". What they do not say is its consequence, which is the part a reader gets wrong: a case written as `expected_output=None` — the natural way to assert that a lookup returns nothing, or that a retrieval system abstains — records no assertion and passes whatever the task returns.

Two additions, no behaviour change:

- `evaluators/built-in.md`: one bullet in `EqualsExpected`'s notes, spelling out the consequence and pointing at `Equals(value=None)`, which is documented immediately below it on the same page and does assert the value.
- `core-concepts.md`: one sentence where the skip is already described.

### How it was tested

`pytest tests/test_examples.py -k evals`: 222 passed, 12 skipped. No code blocks were added or changed, so there is nothing new for the example tests to execute.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** — documentation only.
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver — n/a.
- [x] **PR title** is fit for the release changelog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

