### PR TITLE
Restrict maintainer-attention Slack pings to P1 and P2 issues

### DIFF
--- a/.github/scripts/issue_pr_attention_monitor.py
+++ b/.github/scripts/issue_pr_attention_monitor.py
@@ -39,13 +39,12 @@ _API = 'https://api.github.com'
 _SLA = dt.timedelta(days=3)
 # Applied only by the community-demand sweep; scripts trust the label.
 COMMUNITY_LABEL = 'community-backed'
-# Assigned priority or community-backed issues are kept in the attention queue
-# by `reconcile`; the owner is pinged once *they* have been inactive past the
-# window. Community chatter neither suppresses nor hastens the reminder.
+# Assigned P1/P2 issues are kept in the attention queue by `reconcile`; the
+# owner is pinged once *they* have been inactive past the window. Community
+# demand may still open the assignment gate, but does not interrupt owners.
 _REMINDER_SLAS = {
     'p:1-highest': dt.timedelta(days=3),
     'p:2-high': dt.timedelta(days=5),
-    COMMUNITY_LABEL: dt.timedelta(days=7),
 }
 _SLA_MARK_LIMIT = 10
 _RESURFACE_AFTER = dt.timedelta(days=7)
@@ -106,7 +105,7 @@ _LABELS = {
     _PINGED_LABEL: ('fbca04', 'The assigned maintainer has received one reminder'),
     _ESCALATED_LABEL: ('d93f0b', 'The maintainer attention request is cooling down after escalation'),
     _DELIVERED_LABEL: ('ededed', 'A delivered channel escalation is waiting for GitHub state cleanup'),
-    COMMUNITY_LABEL: ('0e8a16', 'Real users are asking for this; it routes and reminds like a priority issue'),
+    COMMUNITY_LABEL: ('0e8a16', 'Real users are asking for this; it opens the assignment routing gate'),
 }
 _SLACK_MENTION = re.compile(r'<@[UW][A-Z0-9]+>')
 _SEARCH_SUMMARY_QUERY = """
@@ -1087,6 +1086,9 @@ def _reconcile_item(
         return f'#{number}: completed after the item was closed', None
     if _finish_delivery_receipt(client, repo, number, labels, events, transition):
         return f'#{number}: finished delivered channel escalation', None
+    if current_stage == 1 and not labels.intersection(_REMINDER_SLAS):
+        _complete(client, repo, number, labels)
+        return f'#{number}: completed after losing reminder priority', None
     current_stage_label = _STAGE_LABELS[current_stage - 1] if current_stage else None
     for label in labels.intersection(_STAGE_LABELS):
         if label != current_stage_label:
@@ -1131,11 +1133,9 @@ def _queue_stage_notice(
     if current_stage == 1 and now - transition_at < _sla_for(labels):
         return None
     if current_stage == 0:
-        # Only assigned priority or community-backed issues enter the
-        # interrupt pipeline: anything else the triage agent marks stays
-        # tracked, visible in the Monday digest, and silent. Items already
-        # pinged before the cutover finish their lifecycle rather than
-        # stranding at stage 1.
+        # Only assigned P1/P2 issues enter the interrupt pipeline: anything
+        # else the triage agent marks stays tracked, visible in the Monday
+        # digest, and silent.
         if not labels.intersection(_REMINDER_SLAS):
             return None
         # Items reach stage 0 from several lanes (the reminder sweep, agent
@@ -1245,7 +1245,7 @@ def _owner_quiet_since(timeline: Sequence[dict[str, Any]], owners: Sequence[str]
 def _mark_assigned_reminders(
     client: GitHubClient, repo: str, *, slot: int, now: dt.datetime
 ) -> tuple[list[str], list[str]]:
-    """Keep every assigned priority or community-backed issue inside the attention queue.
+    """Keep every assigned P1/P2 issue inside the attention queue.
 
     An issue is marked once its owner has gone quiet past the label's window
     (`_owner_quiet_since` — the same activity rule acknowledgment uses), so

--- a/.github/scripts/test_issue_pr_attention_monitor.py
+++ b/.github/scripts/test_issue_pr_attention_monitor.py
@@ -983,7 +983,10 @@ def test_reconcile_queues_channel_escalation_without_advancing_before_delivery()
 
 
 def test_reconcile_retries_preexisting_pending_escalation():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, *monitor._STAGE_LABELS])})
+    client = FakeClient(
+        {7: item(7, labels=[monitor._ACTION_LABEL, *monitor._STAGE_LABELS, 'p:1-highest'], assignees=['alice'])}
+    )
+    client.permissions['alice'] = 'write'
     notices: list[monitor.Notice] = []
 
     assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
@@ -1223,9 +1226,10 @@ def test_reconcile_marks_assigned_priority_issues_for_attention():
     assert monitor._ACTION_LABEL not in {label['name'] for label in client.items[8]['labels']}
 
 
-def test_non_priority_attention_items_never_ping():
-    """Only assigned p:1/p:2/community-backed issues may interrupt a maintainer in Slack."""
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL], assignees=['alice'])})
+@pytest.mark.parametrize('extra_labels', [[], [monitor.COMMUNITY_LABEL]])
+def test_non_priority_attention_items_never_ping(extra_labels: list[str]):
+    """Only assigned P1/P2 issues may interrupt a maintainer in Slack."""
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, *extra_labels], assignees=['alice'])})
     client.permissions = {'alice': 'write'}
     notices: list[monitor.Notice] = []
 
@@ -1254,13 +1258,23 @@ def test_priority_reminder_windows_follow_the_label():
         return [notice['number'] for notice in notices]
 
     # The window measures the *owner's* quiet, from their own last comment.
-    # Four days: past the 3-day p:1 window, inside the 5-day p:2 window and
-    # the 7-day community window. A breached item is marked and pinged in the
-    # same pass.
+    # Four days is past the 3-day P1 window and inside the 5-day P2 window. A
+    # breached item is marked and pinged in the same pass.
     assert queued(7, 'p:1-highest', 4) == [7]
     assert queued(9, 'p:2-high', 4) == []
-    assert queued(11, monitor.COMMUNITY_LABEL, 4) == []
-    assert queued(11, monitor.COMMUNITY_LABEL, 8) == [11]
+
+
+def test_non_priority_pinged_item_stands_down_before_escalation():
+    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL], assignees=['alice'])})
+    client.permissions['alice'] = 'write'
+    notices: list[monitor.Notice] = []
+
+    assert monitor.reconcile(client, 'r', now=NOW, notices=notices) == (
+        ['#7: completed after losing reminder priority'],
+        [],
+    )
+    assert notices == []
+    assert {label['name'] for label in client.items[7]['labels']} == set()
 
 
 def test_community_chatter_neither_suppresses_nor_hastens_the_owner_reminder():
@@ -2193,7 +2207,15 @@ def test_recent_activity_delays_the_next_reminder():
 
 
 def test_maintainer_comment_completes_the_request():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
+    client = FakeClient(
+        {
+            7: item(
+                7,
+                labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, 'p:1-highest'],
+                assignees=[monitor._FALLBACK_OWNER],
+            )
+        }
+    )
     client.timelines[7] = [
         {
             'event': 'labeled',
@@ -2557,7 +2579,10 @@ def test_bot_triggered_mention_event_is_not_an_acknowledgement():
 
 
 def test_latest_stage_transition_restarts_the_sla_clock():
-    client = FakeClient({7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL])})
+    client = FakeClient(
+        {7: item(7, labels=[monitor._ACTION_LABEL, monitor._PINGED_LABEL, 'p:1-highest'], assignees=['alice'])}
+    )
+    client.permissions['alice'] = 'write'
     client.timelines[7] = [
         {
             'event': 'labeled',


### PR DESCRIPTION
The reminder pipeline now treats only `p:1-highest` and `p:2-high` as Slack-interrupting priorities. `community-backed` continues to open the assignment-routing gate without pinging an owner.

If an already-pinged item loses P1/P2 before escalation, reconciliation clears its attention lifecycle instead of sending a non-priority escalation.

- Closes #7937

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

