### PR TITLE
Add the Harness Channels guide to `docs/navigation.yml`

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -462,6 +462,13 @@ navigation:
           - page: "Process Event Stream"
             path: "capabilities/process-event-stream.md"
             slug: "capabilities/process-event-stream"
+      - section: "Interfaces"
+        slug: ""
+        contents:
+          - page: "Channels"
+            path: "channels.md"
+            source: "harness"
+            slug: "harness/channels"
       - page: "Examples"
         path: "examples.md"
         source: "harness"


### PR DESCRIPTION
Companion to pydantic/pydantic-ai-harness#794.

Registers the new Harness Channels guide under Interfaces at `/docs/ai/harness/channels/`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


