### PR TITLE
Let `GoogleProvider()` type-check when `api_key` comes from the environment

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -108,7 +108,7 @@ class GoogleProvider(BaseGoogleProvider):
     def __init__(
         self,
         *,
-        api_key: str,
+        api_key: str | None = None,
         http_client: AsyncHTTPClient | None = None,
         base_url: str | None = None,
         retry_options: HttpRetryOptions | None = None,

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -63,7 +63,22 @@ def test_google_provider_without_api_key_raises_error(env: TestEnv):
             r" to use the Gemini API\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
         ),
     ):
-        GoogleProvider()  # pyright: ignore[reportCallIssue]  # deliberately no api_key, to test the missing-key error
+        GoogleProvider()  # deliberately no api_key, to test the missing-key error
+
+
+@pytest.mark.parametrize('api_key_env_var', ['GOOGLE_API_KEY', 'GEMINI_API_KEY'])
+def test_google_provider_api_key_from_env(env: TestEnv, api_key_env_var: str):
+    """`api_key` can be omitted when the key is in the environment, and the overload has to allow that.
+
+    This is a unit test because the key is resolved during construction, before any request a cassette could record.
+    Pyright covers `tests`, so the bare `GoogleProvider()` call below is what pins the overload.
+    """
+    for name in {'GOOGLE_API_KEY', 'GEMINI_API_KEY'} - {api_key_env_var}:
+        env.remove(name)
+    env.set(api_key_env_var, 'your-api-key')
+
+    provider = GoogleProvider()
+    assert provider.client._api_client.api_key == 'your-api-key'  # pyright: ignore[reportPrivateUsage]
 
 
 def test_google_provider_retry_options(env: TestEnv):


### PR DESCRIPTION
- Closes #7882

`GoogleProvider.__init__` resolves `GOOGLE_API_KEY`, and the legacy `GEMINI_API_KEY`, when `api_key` is omitted. The public overload still declared `api_key` as a required `str`, so the documented call pattern worked at runtime and failed type checking:

```python
import os

from pydantic_ai.providers.google import GoogleProvider

os.environ['GOOGLE_API_KEY'] = '...'
provider = GoogleProvider()
```

```
error: No overloads for "__init__" match the provided arguments
    Argument types: () (reportCallIssue)
```

The overload is now `api_key: str | None = None`. That is how `OpenAIProvider`, `AnthropicProvider`, `GroqProvider` and `MistralProvider` already declare the same parameter, so this brings Google in line with its siblings rather than inventing a shape. Only the overload moved, so runtime behavior is identical and the missing-key `UserError` still raises exactly as before.

One related change comes with it rather than as separate cleanup. `test_google_provider_without_api_key_raises_error` carried a `# pyright: ignore[reportCallIssue]` for the bare `GoogleProvider()` call, which existed only because of this defect. `reportUnnecessaryTypeIgnoreComment` is enabled in `pyproject.toml`, so once the overload accepts the call, leaving that suppression in place fails the type check.

### How I tested it

Added `test_google_provider_api_key_from_env`, parametrized over both environment variables, asserting the key is picked up when `api_key` is omitted. `tests` is inside pyright's `include` list at `strict`, so the bare constructor call is what pins the overload rather than just the runtime fallback.

I checked the test actually guards the regression by reverting only the `google.py` change and re-running pyright against the test file, which then reports two `reportCallIssue` errors and reports none with the fix applied.

- `uv run pytest tests/providers/test_google.py`: 28 passed
- `uv run pyright` on both changed files: 0 errors
- `make lint` and `make format`: clean

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

