### PR TITLE
Bump `genai-prices` to 0.1.5

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -5012,7 +5012,6 @@ def _map_usage(
         if isinstance(v, int)
     }
     response_data = dict(model=model, usage=usage_data)
-    reasoning_tokens: int | None = None
     if isinstance(response_usage, responses.ResponseUsage):
         api_flavor = 'responses'
         input_tokens_details = usage_data.get('input_tokens_details')
@@ -5027,7 +5026,6 @@ def _map_usage(
 
         if response_usage.completion_tokens_details is not None:
             details.update(response_usage.completion_tokens_details.model_dump(exclude_none=True))
-            reasoning_tokens = response_usage.completion_tokens_details.reasoning_tokens
 
     request_usage = usage.RequestUsage.extract(
         response_data,
@@ -5045,18 +5043,6 @@ def _map_usage(
         cache_write_tokens = input_tokens_details.get('cache_write_tokens')
         if isinstance(cache_write_tokens, int):
             request_usage.cache_write_tokens = cache_write_tokens
-    # genai-prices' `openai` entry maps `completion_tokens_details.reasoning_tokens` to
-    # `output_reasoning_tokens`, but an OpenAI-compatible provider it knows by its own id resolves to that
-    # provider's extractor instead of to the `openai` fallback, and not all of those map it — `zai`'s,
-    # added in genai-prices 0.1.2, doesn't, which silently dropped Z.AI's reasoning-token count. Lift it
-    # for whichever provider matched, from what the SDK reported rather than from `details`, which the
-    # `responses` branch above fills with a synthetic zero. Left unset — not zeroed — when the SDK reports
-    # nothing, so a model that doesn't reason stays distinguishable from one that reasoned for free.
-    # TODO: Remove this block once genai-prices maps reasoning tokens for every OpenAI-compatible provider.
-    # https://github.com/pydantic/genai-prices/pull/580 (merged; not in 0.1.4 — drop once the floor is past the release that includes it).
-    if isinstance(reasoning_tokens, int) and 'output_reasoning_tokens' not in request_usage.__dict__:
-        # Extra field, not a declared `RequestUsage` attribute — `setattr` is how `__init__` sets extras.
-        setattr(request_usage, 'output_reasoning_tokens', reasoning_tokens)
     return request_usage
 
 

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -66,9 +66,9 @@ dependencies = [
     "exceptiongroup>=1.2.2; python_version < '3.11'",
     "opentelemetry-api>=1.28.0",
     "typing-inspection>=0.4.0",
-    # 0.1.4 is the first release that prices `openai.gpt-5.6-luna` on Bedrock Mantle, so below it
-    # `RequestUsage.cost` comes back `None` for a model `tests/models/test_bedrock_mantle.py` pins.
-    "genai-prices>=0.1.4",
+    # 0.1.5 adds GPT-5.6 price reductions, time-dependent DeepSeek V4 pricing, and fixes
+    # reasoning-token extraction for OpenAI-compatible providers.
+    "genai-prices>=0.1.5",
 ]
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncIterator, Callable, Generator, Iterator, Sequen
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal
 from functools import cache, cached_property
 from pathlib import Path
 from types import ModuleType
@@ -66,6 +67,7 @@ T = TypeVar('T')
 
 __all__ = (
     'IsDatetime',
+    'IsDecimal',
     'IsFloat',
     'IsNow',
     'IsStr',
@@ -110,6 +112,7 @@ if TYPE_CHECKING:
 
     def IsInstance(arg: type[T]) -> T: ...
     def IsDatetime(*args: Any, **kwargs: Any) -> datetime: ...
+    def IsDecimal(*args: Any, **kwargs: Any) -> Decimal: ...
     def IsFloat(*args: Any, **kwargs: Any) -> float: ...
     def IsInt(*args: Any, **kwargs: Any) -> int: ...
     def IsNow(*args: Any, **kwargs: Any) -> datetime: ...
@@ -118,7 +121,10 @@ if TYPE_CHECKING:
     def IsBytes(*args: Any, **kwargs: Any) -> bytes: ...
     def IsList(*args: T, **kwargs: Any) -> list[T]: ...
 else:
-    from dirty_equals import IsBytes, IsDatetime, IsFloat, IsInstance, IsInt, IsList, IsNow as _IsNow, IsStr
+    from dirty_equals import IsBytes, IsDatetime, IsFloat, IsInstance, IsInt, IsList, IsNow as _IsNow, IsNumeric, IsStr
+
+    class IsDecimal(IsNumeric[Decimal]):
+        allowed_types = Decimal
 
     def IsNow(*args: Any, **kwargs: Any):
         # Increase the default value of `delta` to 10 to reduce test flakiness on overburdened machines

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -774,6 +774,7 @@ async def test_cohere_model_thinking_part(allow_model_requests: None, co_api_key
         model=co_model,
         message_history=result.all_messages(),
     )
+    # Cohere does not charge per-token API rates for Command A Reasoning, so no cost is calculated.
     assert result.new_messages() == snapshot(
         [
             ModelRequest(
@@ -796,7 +797,6 @@ async def test_cohere_model_thinking_part(allow_model_requests: None, co_api_key
                     input_tokens=2190,
                     output_tokens=1257,
                     details={'input_tokens': 431, 'output_tokens': 661},
-                    cost=Decimal('0.018045'),
                 ),
                 model_name='command-a-reasoning-08-2025',
                 timestamp=IsDatetime(),

--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -21,7 +21,6 @@ import json
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from decimal import Decimal
 from typing import Any
 
 import httpx2
@@ -44,7 +43,7 @@ from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.usage import RequestUsage
 
 from .._inline_snapshot import snapshot
-from ..conftest import IsDatetime, IsStr, try_import
+from ..conftest import IsDatetime, IsDecimal, IsStr, try_import
 
 with try_import() as imports_successful:
     from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
@@ -72,6 +71,8 @@ def get_temperature(city: str) -> float:
     return 21.0
 
 
+# DeepSeek V4 prices vary by request time. These response-shape cases assert that a cost was
+# calculated without duplicating genai-prices' time-dependent pricing tests.
 @dataclass(frozen=True)
 class Case:
     id: str
@@ -119,7 +120,7 @@ CASES = [
                         input_tokens=90,
                         output_reasoning_tokens=7,
                         output_tokens=15,
-                        cost=Decimal('0.0000168'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -176,7 +177,7 @@ CASES = [
                         output_tokens=15,
                         output_reasoning_tokens=7,
                         input_tokens=90,
-                        cost=Decimal('0.0000168'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -237,7 +238,7 @@ CASES = [
                         input_tokens=87,
                         output_reasoning_tokens=6,
                         output_tokens=8,
-                        cost=Decimal('0.00001442'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -279,7 +280,7 @@ CASES = [
                         input_tokens=97,
                         output_reasoning_tokens=56,
                         output_tokens=59,
-                        cost=Decimal('0.00003010'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -358,7 +359,7 @@ CASES = [
                         cache_read_tokens=256,
                         output_reasoning_tokens=18,
                         output_tokens=63,
-                        cost=Decimal('0.0000337568'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -398,7 +399,7 @@ CASES = [
                         cache_read_tokens=384,
                         output_reasoning_tokens=0,
                         output_tokens=14,
-                        cost=Decimal('0.0000133952'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -520,7 +521,7 @@ CASES = [
                         output_reasoning_tokens=14,
                         cache_read_tokens=256,
                         input_tokens=366,
-                        cost=Decimal('0.0000326368'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -560,7 +561,7 @@ CASES = [
                         output_reasoning_tokens=0,
                         cache_read_tokens=384,
                         input_tokens=440,
-                        cost=Decimal('0.0000128352'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -683,7 +684,7 @@ CASES = [
                         cache_read_tokens=256,
                         output_reasoning_tokens=21,
                         output_tokens=81,
-                        cost=Decimal('0.0000401968'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),
@@ -770,7 +771,7 @@ CASES = [
                         input_tokens=91,
                         output_reasoning_tokens=18,
                         output_tokens=20,
-                        cost=Decimal('0.00001834'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),

--- a/tests/models/test_openai_prompt_cache.py
+++ b/tests/models/test_openai_prompt_cache.py
@@ -559,7 +559,7 @@ async def test_openai_chat_stream_maps_cache_write_usage(allow_model_requests: N
         cache_write_tokens=30,
         cache_read_tokens=20,
         output_tokens=10,
-        cost=Decimal('0.0007475'),
+        cost=Decimal('0.000558'),
     )
 
 
@@ -654,7 +654,7 @@ async def test_openai_responses_stream_maps_cache_write_usage(allow_model_reques
         output_tokens=300,
         output_reasoning_tokens=10,
         details={'reasoning_tokens': 10},
-        cost=Decimal('0.01047'),
+        cost=Decimal('0.007176'),
     )
 
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -14732,7 +14732,7 @@ async def test_background_mode_reasoning_vcr(allow_model_requests: None, openai_
                     output_tokens=12,
                     output_reasoning_tokens=0,
                     details={'reasoning_tokens': 0},
-                    cost=Decimal('0.00043'),
+                    cost=Decimal('0.000296'),
                 ),
                 model_name='gpt-5.6-sol',
                 timestamp=IsDatetime(),

--- a/uv.lock
+++ b/uv.lock
@@ -2107,15 +2107,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/e3/23f4be7d5626878a6297c728f5f8db83bd9b135da481935d4c1bb82efc21/genai_prices-0.1.4.tar.gz", hash = "sha256:f3b8a0bf0c21b01f5af3ca42babcab2f17728bf3c602f87f42b72d1d2bf61d98", size = 94678, upload-time = "2026-08-19T23:53:25.527Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/70/76dcc9c76b416d2df9aa4c65553f88b75d2ba4fbfeb5efb137f078844cc3/genai_prices-0.1.5.tar.gz", hash = "sha256:04c2cbf4444a3b2f5d38c3b6ab8385ea28ab924ac6f9202bde9261f599be8b45", size = 109418, upload-time = "2026-08-31T09:36:22.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/54/911961e926a4c4ea30bf1fa0bf9d8ffc5c9ac5ed6a3f77b3d9e0ab5bb9a5/genai_prices-0.1.4-py3-none-any.whl", hash = "sha256:1d1b01cc7ab1adfa17c3a1121f4c13990bd0a4377640ecd37ebfde5836768240", size = 99160, upload-time = "2026-08-19T23:53:24.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/14/28f578fa25391bb8983522f3e365e8735310f4b741e54cfed3a614f50384/genai_prices-0.1.5-py3-none-any.whl", hash = "sha256:5215706950decd833ce3527a9e1e745ad0dbdd35ce1b33ac1f7167699640b82a", size = 116330, upload-time = "2026-08-31T09:36:21.364Z" },
 ]
 
 [[package]]
@@ -5645,7 +5645,7 @@ requires-dist = [
     { name = "fastmcp-slim", extras = ["client"], marker = "extra == 'mcp'", specifier = ">=3.3.0,<5" },
     { name = "fastmcp-slim", extras = ["client"], marker = "extra == 'mcp-tasks'", specifier = ">=4.0.0b1,<5" },
     { name = "fastmcp-tasks", marker = "extra == 'mcp-tasks'", specifier = ">=4.0.0b1,<5" },
-    { name = "genai-prices", specifier = ">=0.1.4" },
+    { name = "genai-prices", specifier = ">=0.1.5" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=2.18.0" },
     { name = "google-genai", marker = "extra == 'google-realtime'", specifier = ">=2.18.0" },
     { name = "griffelib", specifier = ">=2.0" },


### PR DESCRIPTION
Bumps the runtime dependency floor and locked version of `genai-prices` from 0.1.4 to 0.1.5, ensuring users receive the latest pricing data and usage extraction fixes.

The dependency update changes three sets of cost expectations:

- OpenAI reduced GPT-5.6 Sol input pricing from $5 to $4 per million tokens and output pricing from $30 to $20. Exact cost assertions are updated from the official rates, including $0.40 cached input and the 1.25x cache-write multiplier.
- DeepSeek V4 Flash now has time-dependent peak/off-peak prices. The Responses API cases continue to snapshot every token count and assert through the shared `IsInstance(Decimal)` matcher that a cost is calculated, without duplicating the UTC-dependent pricing table as fixed values.
- Cohere Command A Reasoning is free under API rate limits, so `command-a-reasoning-08-2025` no longer incorrectly inherits the per-token Command A price.

Version 0.1.5 also maps reasoning tokens for OpenAI-compatible providers. This removes the temporary fallback in `models/openai.py` exactly as its TODO prescribed; existing Z.AI tests continue to assert the extracted reasoning-token values.

Upstream and provider changes audited:

- https://github.com/pydantic/genai-prices/pull/580
- https://github.com/pydantic/genai-prices/pull/592
- https://github.com/pydantic/genai-prices/pull/604
- https://github.com/pydantic/genai-prices/pull/615
- https://developers.openai.com/api/docs/models/gpt-5.6-sol
- https://api-docs.deepseek.com/quick_start/pricing/
- https://docs.cohere.com/docs/command-a-reasoning

### Checks

- Differential target on `genai-prices==0.1.4`: 9 passed
- Same target on `genai-prices==0.1.5` before expectation updates: 9 failed
- Same target after expectation updates: 9 passed
- `uv run pytest tests/models/test_zai.py tests/models/test_deepseek_responses.py tests/models/test_openai_prompt_cache.py tests/models/test_openai_responses.py tests/models/test_cohere.py` (335 passed)
- `uv run pytest tests/test_cost.py tests/test_usage_limits.py tests/models/test_zai.py` (81 passed)
- Targeted Ruff and Pyright checks
- `uv lock --check`
- pre-commit hooks, including full lint and typecheck
- Prior CI run: every test matrix passed; coverage identified the now-removed obsolete fallback as unreachable

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (N/A)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

