### PR TITLE
Copy per-call metadata in `DeferredToolRequests.build_results` and `remaining`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deferred.py
+++ b/pydantic_ai_slim/pydantic_ai/_deferred.py
@@ -83,7 +83,8 @@ class DeferredToolRequests:
             for tool_call_id in approval_ids - set(approvals):
                 approvals[tool_call_id] = ToolApproved()
 
-        return DeferredToolResults(approvals=approvals, calls=calls, metadata=metadata or {})
+        metadata = {k: dict(v) for k, v in metadata.items()} if metadata else {}
+        return DeferredToolResults(approvals=approvals, calls=calls, metadata=metadata)
 
     def remaining(self, results: DeferredToolResults) -> DeferredToolRequests | None:
         """Return unresolved requests after applying results, or `None` if all resolved."""
@@ -94,7 +95,7 @@ class DeferredToolRequests:
         remaining = DeferredToolRequests(
             calls=[c for c in self.calls if c.tool_call_id not in call_result_ids],
             approvals=[c for c in self.approvals if c.tool_call_id not in approval_result_ids],
-            metadata={k: v for k, v in self.metadata.items() if k not in resolved_ids},
+            metadata={k: dict(v) for k, v in self.metadata.items() if k not in resolved_ids},
         )
         return remaining if remaining.calls or remaining.approvals else None
 


### PR DESCRIPTION
Closes #7637

### Problem
`DeferredToolRequests.build_results()` stored the caller's `metadata` dict by reference (`metadata or {}`) while already shallow-copying `approvals` and `calls` at the same boundary, and `remaining()` rebuilt the outer metadata dict but shared each nested per-call mapping by reference. Caller-side mutation after hand-off therefore retroactively changed captured continuation state that flows to `RunContext.tool_call_metadata` and via AG-UI to `Interrupt.metadata`.

Reproduced on `main`:

from pydantic_ai.messages import ToolCallPart
from pydantic_ai.tools import DeferredToolRequests

requests = DeferredToolRequests(calls=[ToolCallPart('tool', {}, tool_call_id='call-1')], metadata={'call-1': {'scope': 'before'}})
caller_metadata = {'call-1': {'scope': 'before'}}
results = requests.build_results(metadata=caller_metadata)
caller_metadata['call-1']['scope'] = 'after-build-results'
remaining = requests.remaining(results)
requests.metadata['call-1']['scope'] = 'after-remaining'
assert results.metadata == {'call-1': {'scope': 'before'}} # failed pre-fix
assert remaining.metadata == {'call-1': {'scope': 'before'}} # failed pre-fix

### Change
Copy each per-call metadata mapping at the two ownership boundaries, mirroring the copy-at-boundary pattern already applied to `approvals`/`calls`:
- `build_results()`: `metadata = {k: dict(v) for k, v in metadata.items()} if metadata else {}`
- `remaining()`: `metadata={k: dict(v) for k, v in self.metadata.items() if k not in resolved_ids}`

Shallow per-call copy only — no deep copy, no API change. Backwards-compatible (dict equality unchanged for non-mutating callers).

### Checklist
- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] PR title is fit for the release changelog.

### Verification
- `uv run pytest tests/test_capabilities.py -k deferred -q` — 8 passed
- `uv run pytest tests/test_tools.py -k 'metadata or approved' -q` — 15 passed
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_deferred.py` — All checks passed
- `uv run pyright pydantic_ai_slim/pydantic_ai/_deferred.py` — 0 errors


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

