### PR TITLE
Treat empty `CompactionPart` summary as non-boundary

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2969,7 +2969,7 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    return not requires_encrypted_content and bool(part.content)
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]


### PR DESCRIPTION
Closes #7773

### Problem
`_compaction_part_is_wire_boundary` (pydantic_ai_slim/pydantic_ai/messages.py:2972) ended with:

``python
return not requires_encrypted_content and part.content is not None
``

`content is not None` accepts `''`, so a `CompactionPart` carrying an empty summary is treated as a compaction boundary. `_post_compaction_window_for_response` then discards every message before it � even though an empty summary cannot stand in for the history it replaced.

This contradicts the function's own docstring (\"A part carrying neither payload is a failed compaction, a documented no-op, and a boundary for nobody\") and disagrees with `CompactionPart.has_content()` which uses `bool(self.content)`.

### Change
Use the same non-empty semantics as `has_content()` for the plaintext case:

``python
return not requires_encrypted_content and bool(part.content)
``

Encrypted-content path unaffected (returns earlier). Single-line surgical fix, no API change.

### Checklist
- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] PR title is fit for the release changelog.

### Verification
- Repro from issue: `CompactionPart(content='', provider_name='anthropic')` now returns `False` (was `True`), matching `has_content()==False`
- `uv run pytest tests/test_messages.py -k compaction -q` � 3 passed
- `uv run ruff check` / `pyright` � clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

