### PR TITLE
Disable Prefect's task-run recorder in the capability test harness

### DIFF
--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -1218,10 +1218,16 @@ def prefect_test_server() -> Generator[None, None, None]:
     so this module-scoped harness enters and exits before that one starts. Renaming either
     module so this one sorts after test_prefect.py would nest two Prefect harnesses.
     """
+    from prefect.settings import PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_ENABLED, temporary_settings
     from prefect.testing.utilities import prefect_test_harness
 
-    with prefect_test_harness(server_startup_timeout=60):
-        yield
+    # The task-run recorder is a background writer against the same sqlite file the flows write to.
+    # Prefect PRAGMAs a 60s `busy_timeout` onto every connection, and under CI contention the
+    # recorder's bulk inserts exhaust it, failing the flow whose state it was recording. Nothing
+    # here reads what it records: task run states reach the API through the task engine.
+    with temporary_settings({PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_ENABLED: False}):
+        with prefect_test_harness(server_startup_timeout=60):
+            yield
 
 
 @requires_prefect


### PR DESCRIPTION
Follow-up to #7871.

The `prefect_test_server` fixture that #7871 added to `tests/durable_exec/test_capability_durable_operation.py` gives those flow tests an isolated harness server, but it left Prefect's background task-run recorder enabled. That recorder is a second writer against the same sqlite file the flows write to, and under CI contention its bulk inserts can exhaust the 60s `busy_timeout` Prefect PRAGMAs onto every connection, failing the flow whose state it was recording.

`tests/durable_exec/test_prefect.py` already wraps its own harness in `temporary_settings({PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_ENABLED: False})` for exactly this reason. This does the same for the capability module, with the same explanation.

Nothing in these tests reads what the recorder writes: task run states reach the API through the task engine.

Spotted by Macroscope on #7312.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

