### PR TITLE
Context-manage models rebuilt inside durable operations

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from abc import abstractmethod
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable, Generator, Mapping
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
 from functools import partial
 from typing import Any, ClassVar, Literal, NamedTuple, Protocol, TypeVar, cast, runtime_checkable
 from weakref import ref
@@ -667,16 +667,22 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         both halves, and the guard is not optional for any of them: the unit's recorded result is
         replayed on recovery or a cache hit without re-running its body, so a `ctx.enqueue()` from
         the model -- or from a `resolve_model_id` capability rebuilding it -- would be dropped.
+        Models rebuilt inside the unit are owned and context-managed here; the agent's default and
+        `models=` registry instances keep their existing external lifecycle owner.
         Pairing the two here means a unit can't get its model without the guard, instead of each
         engine remembering to install it per unit (Temporal has its own chokepoint in
         `deserialize_run_context`, so it doesn't use this).
         """
         with self._durable_run_context_scope(run_context) as ctx:
             model = await self._resolve_model_for_request(model_id, ctx)
-            ctx.model = model
-            if isinstance(ctx, _RestrictedRunContext):
-                ctx._expose_field('model')  # pyright: ignore[reportPrivateUsage]
-            yield model, ctx
+            registered, _ = self._registered_model_id(model)
+            async with AsyncExitStack() as stack:
+                if not registered:
+                    model = await stack.enter_async_context(model)
+                ctx.model = model
+                if isinstance(ctx, _RestrictedRunContext):
+                    ctx._expose_field('model')  # pyright: ignore[reportPrivateUsage]
+                yield model, ctx
 
     def _build_resolve_tool_config(self, base_config: Any) -> Callable[[ToolsetTool[Any] | None, str], ToolConfig]:
         """Build the per-tool config resolver from declarative fields (metadata key + polarity)."""

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from abc import abstractmethod
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable, Generator, Mapping
-from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 from typing import Any, ClassVar, Literal, NamedTuple, Protocol, TypeVar, cast, runtime_checkable
 from weakref import ref
@@ -106,7 +106,7 @@ from ._toolset import (
     validate_dynamic_tool_args,
     wrap_tool_call_result,
 )
-from ._utils import DurableModel, StreamedActivityResult, capture_event_stream, unwrap_model
+from ._utils import DurableModel, StreamedActivityResult, capture_event_stream, managed_model_scope, unwrap_model
 
 _T = TypeVar('_T')
 
@@ -676,13 +676,11 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         with self._durable_run_context_scope(run_context) as ctx:
             model = await self._resolve_model_for_request(model_id, ctx)
             registered, _ = self._registered_model_id(model)
-            async with AsyncExitStack() as stack:
-                if not registered:
-                    model = await stack.enter_async_context(model)
-                ctx.model = model
+            async with managed_model_scope(model, owned=not registered) as active_model:
+                ctx.model = active_model
                 if isinstance(ctx, _RestrictedRunContext):
                     ctx._expose_field('model')  # pyright: ignore[reportPrivateUsage]
-                yield model, ctx
+                yield active_model, ctx
 
     def _build_resolve_tool_config(self, base_config: Any) -> Callable[[ToolsetTool[Any] | None, str], ToolConfig]:
         """Build the per-tool config resolver from declarative fields (metadata key + polarity)."""

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_utils.py
@@ -11,6 +11,7 @@ helpers are reserved for the bundled `temporal`, `dbos`, and `prefect`
 integrations.
 """
 
+import sys
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -30,8 +31,26 @@ __all__ = [
     'StreamedActivityResult',
     'disable_threads',
     'capture_event_stream',
+    'managed_model_scope',
     'unwrap_model',
 ]
+
+
+@asynccontextmanager
+async def managed_model_scope(model: Model, *, owned: bool) -> AsyncGenerator[Model]:
+    """Context-manage a model when the current durable unit owns it."""
+    if not owned:
+        yield model
+        return
+
+    active_model = await model.__aenter__()
+    try:
+        yield active_model
+    except BaseException:
+        await model.__aexit__(*sys.exc_info())
+        raise
+    else:
+        await model.__aexit__(None, None, None)
 
 
 def unwrap_model(model: Model) -> Model:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_utils.py
@@ -38,7 +38,11 @@ __all__ = [
 
 @asynccontextmanager
 async def managed_model_scope(model: Model, *, owned: bool) -> AsyncGenerator[Model]:
-    """Context-manage a model when the current durable unit owns it."""
+    """Context-manage a model when the current durable unit owns it.
+
+    The model's `__aexit__` return value is deliberately discarded, so it cannot
+    suppress an error raised by the durable unit's body.
+    """
     if not owned:
         yield model
         return

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -29,7 +29,7 @@ from pydantic_ai.durable_exec._operation import (
 )
 from pydantic_ai.durable_exec._spec import DurabilityEngineSpec
 from pydantic_ai.durable_exec._toolset import DurableToolsetBase, validation_context_from_agent
-from pydantic_ai.durable_exec._utils import StreamedActivityResult, disable_threads
+from pydantic_ai.durable_exec._utils import StreamedActivityResult, disable_threads, managed_model_scope
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelResponse
 from pydantic_ai.models import CompletedStreamedResponse, Model, ModelRequestParameters, infer_model
@@ -527,10 +527,12 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         self, model_id: str | None, response: ModelResponse
     ) -> None:
         model = self._models_by_id.get(model_id or 'default')
-        if model is None:
+        owned = model is None
+        if owned:
             assert model_id is not None
             model = infer_model(model_id)
-        await model.cancel_suspended_response(response)
+        async with managed_model_scope(model, owned=owned) as active_model:
+            await active_model.cancel_suspended_response(response)
 
     def _validate_model_request_parameters(self, model_request_parameters: ModelRequestParameters) -> None:
         if model_request_parameters.allow_image_output:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -30,6 +30,7 @@ from pydantic_ai.providers import Provider
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, RunContext
 
+from .._utils import managed_model_scope
 from ._activity_execution import execute_activity
 from ._durability import (
     IMAGE_OUTPUT_UNSUPPORTED_MESSAGE,
@@ -103,12 +104,15 @@ class TemporalModel(WrapperModel):
                 self.run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
             )
             model_for_request = self._resolve_model_id(params.model_id, run_context)
-            messages = self._reprepare_messages(params, model_for_request)
-            return await model_for_request.request(
-                messages,
-                cast(ModelSettings | None, params.model_settings),
-                params.model_request_parameters,
-            )
+            async with managed_model_scope(
+                model_for_request, owned=not self._is_registered_model(model_for_request)
+            ) as active_model:
+                messages = self._reprepare_messages(params, active_model)
+                return await active_model.request(
+                    messages,
+                    cast(ModelSettings | None, params.model_settings),
+                    params.model_request_parameters,
+                )
 
         # Set type hint explicitly so that Temporal can take care of serialization and deserialization
         # Union with None for backward compatibility with activity payloads created before deps was added
@@ -123,17 +127,20 @@ class TemporalModel(WrapperModel):
                 self.run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
             )
             model_for_request = self._resolve_model_id(params.model_id, run_context)
-            messages = self._reprepare_messages(params, model_for_request)
-            async with model_for_request.request_stream(
-                messages,
-                cast(ModelSettings | None, params.model_settings),
-                params.model_request_parameters,
-                run_context,
-            ) as streamed_response:
-                await self.event_stream_handler(run_context, streamed_response)
+            async with managed_model_scope(
+                model_for_request, owned=not self._is_registered_model(model_for_request)
+            ) as active_model:
+                messages = self._reprepare_messages(params, active_model)
+                async with active_model.request_stream(
+                    messages,
+                    cast(ModelSettings | None, params.model_settings),
+                    params.model_request_parameters,
+                    run_context,
+                ) as streamed_response:
+                    await self.event_stream_handler(run_context, streamed_response)
 
-                async for _ in streamed_response:
-                    pass
+                    async for _ in streamed_response:
+                        pass
             return streamed_response.get()
 
         # Set type hint explicitly so that Temporal can take care of serialization and deserialization
@@ -166,7 +173,10 @@ class TemporalModel(WrapperModel):
                     agent=self._agent,
                 )
             model_for_request = self._resolve_model_id(params.model_id, run_context)
-            await model_for_request.cancel_suspended_response(params.response)
+            async with managed_model_scope(
+                model_for_request, owned=not self._is_registered_model(model_for_request)
+            ) as active_model:
+                await active_model.cancel_suspended_response(params.response)
 
         self.cancel_suspended_response_activity = activity.defn(
             name=f'{activity_name_prefix}__model_cancel_suspended_response'
@@ -496,6 +506,9 @@ class TemporalModel(WrapperModel):
             return self._models_by_id[model_id]
 
         return self._infer_model(model_id, run_context)  # pragma: lax no cover
+
+    def _is_registered_model(self, model: Model) -> bool:
+        return any(registered is model for registered in self._models_by_id.values())
 
     def _infer_model(self, model_id: str, run_context: RunContext[Any] | None) -> Model:  # pragma: lax no cover
         provider_factory = self._provider_factory

--- a/tests/durable_exec/temporal/test_agent.py
+++ b/tests/durable_exec/temporal/test_agent.py
@@ -85,6 +85,7 @@ from pydantic_ai.usage import UsageLimits
 
 from ..._inline_snapshot import snapshot
 from ...continuation_utils import ScriptedContinuationModel, scripted_response
+from ...model_lifecycle_utils import LifecycleTrackingModel
 
 try:
     from temporalio import activity, workflow
@@ -638,26 +639,28 @@ async def test_temporal_operation_backend_registers_novel_id_generically(
 
 
 async def test_temporal_durability_accepts_legacy_cancel_activity_payload() -> None:
-    """Temporal decodes old cancel payloads and resolves registered and inferred models."""
+    """Temporal decodes old cancel payloads and manages only inferred models."""
     response = ModelResponse(parts=[TextPart(content='cancel')], model_name='test')
     params = TypeAdapter(_CancelParams).validate_python({'response': response, 'model_id': None})
     assert params == _CancelParams(response=response)
     assert params.serialized_run_context is None
 
-    cancelled: list[tuple[str, ModelResponse]] = []
-
-    class RecordingModel(TestModel):
-        def __init__(self, name: str):
-            super().__init__()
+    class RecordingModel(LifecycleTrackingModel):
+        def __init__(self, name: str, events: list[str], *, fail: bool = False):
+            super().__init__(events, fail=fail)
             self.name = name
 
         async def cancel_suspended_response(self, response: ModelResponse) -> None:
-            cancelled.append((self.name, response))
+            self.events.append(f'cancel:{self.name}')
+            if self.fail:
+                raise RuntimeError('cancel failed')
 
-    registered_model = RecordingModel('registered')
-    inferred_model = RecordingModel('inferred')
+    default_events: list[str] = []
+    registered_events: list[str] = []
+    default_model = RecordingModel('default', default_events)
+    registered_model = RecordingModel('registered', registered_events)
     agent = Agent(
-        TestModel(),
+        default_model,
         name='legacy_cancel_payload',
         capabilities=[TemporalDurability(models={'registered': registered_model})],
     )
@@ -667,10 +670,24 @@ async def test_temporal_durability_accepts_legacy_cancel_activity_payload() -> N
     assert signature.parameters['deps'].default is None
 
     await durability.cancel_suspended_response_activity(_CancelParams(response=response, model_id='registered'))
+    await durability.cancel_suspended_response_activity(_CancelParams(response=response))
+    assert registered_events == ['cancel:registered']
+    assert default_events == ['cancel:default']
+
+    inferred_events: list[str] = []
+    inferred_model = RecordingModel('inferred', inferred_events)
     with patch('pydantic_ai.durable_exec.temporal._durability.infer_model', return_value=inferred_model):
         await durability.cancel_suspended_response_activity(_CancelParams(response=response, model_id='unregistered'))
+    assert inferred_events == ['enter', 'cancel:inferred', 'exit:none']
 
-    assert cancelled == [('registered', response), ('inferred', response)]
+    failing_events: list[str] = []
+    failing_model = RecordingModel('failing', failing_events, fail=True)
+    with (
+        patch('pydantic_ai.durable_exec.temporal._durability.infer_model', return_value=failing_model),
+        pytest.raises(RuntimeError, match='cancel failed'),
+    ):
+        await durability.cancel_suspended_response_activity(_CancelParams(response=response, model_id='failing'))
+    assert failing_events == ['enter', 'cancel:failing', 'exit:RuntimeError']
 
 
 async def test_complex_agent_run_in_workflow(

--- a/tests/durable_exec/temporal/test_model_and_serialization.py
+++ b/tests/durable_exec/temporal/test_model_and_serialization.py
@@ -1389,6 +1389,14 @@ async def test_temporal_activity_does_not_manage_registered_models() -> None:
         serialized_run_context=TemporalRunContext.serialize_run_context(ctx),
     )
 
+    # A `model_id` of `None` resolves to the agent default, which is registered too, so it must not
+    # be entered either.
+    await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
+    assert events == ['request']
+
+    events = []
+    default.events = events
+    registered.events = events
     params.model_id = 'registered'
     await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
     assert events == ['request']

--- a/tests/durable_exec/temporal/test_model_and_serialization.py
+++ b/tests/durable_exec/temporal/test_model_and_serialization.py
@@ -64,6 +64,7 @@ from pydantic_ai.profiles import DEFAULT_PROFILE, ModelProfile
 from pydantic_ai.tools import ToolDefinition
 
 from ..._inline_snapshot import snapshot
+from ...model_lifecycle_utils import LifecycleTrackingModel
 
 try:
     import temporalio.api.common.v1
@@ -1293,19 +1294,7 @@ async def test_temporal_model_request_outside_workflow():
 async def test_temporal_activities_manage_inferred_model_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     events: list[str] = []
 
-    class TrackingModel(TestModel):
-        async def __aenter__(self) -> TrackingModel:
-            events.append('enter')
-            return await super().__aenter__()
-
-        async def __aexit__(self, *args: Any) -> bool | None:
-            events.append('exit')
-            return await super().__aexit__(*args)
-
-        async def request(self, *args: Any, **kwargs: Any) -> Any:
-            events.append('request')
-            return await super().request(*args, **kwargs)
-
+    class TrackingModel(LifecycleTrackingModel):
         def request_stream(self, *args: Any, **kwargs: Any) -> Any:
             events.append('stream')
             return super().request_stream(*args, **kwargs)
@@ -1325,7 +1314,7 @@ async def test_temporal_activities_manage_inferred_model_lifecycle(monkeypatch: 
     )
 
     def infer_tracking_model(model_id: str, ctx: RunContext[object] | None) -> TrackingModel:
-        return TrackingModel(custom_output_text='ok')
+        return TrackingModel(events, include_exit_exception=False)
 
     monkeypatch.setattr(temporal_model, '_infer_model', infer_tracking_model)
     deps = object()
@@ -1369,32 +1358,27 @@ async def test_temporal_activities_manage_inferred_model_lifecycle(monkeypatch: 
 
 
 async def test_temporal_activity_does_not_manage_registered_models() -> None:
+    class TrackingModel(LifecycleTrackingModel):
+        def request_stream(self, *args: Any, **kwargs: Any) -> Any:
+            self.events.append('stream')
+            return super().request_stream(*args, **kwargs)
+
+        async def cancel_suspended_response(self, response: ModelResponse) -> None:
+            self.events.append('cancel')
+
+    async def handle_stream(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        pass
+
     events: list[str] = []
-
-    class TrackingModel(TestModel):
-        # These two bodies never running is the assertion: a registered model keeps its external
-        # lifecycle owner, so the activity must not enter it. They record into `events` only so a
-        # regression shows up as a named entry rather than as a bare count.
-        async def __aenter__(self) -> TrackingModel:  # pragma: no cover
-            events.append('enter')
-            return await super().__aenter__()
-
-        async def __aexit__(self, *args: Any) -> bool | None:  # pragma: no cover
-            events.append('exit')
-            return await super().__aexit__(*args)
-
-        async def request(self, *args: Any, **kwargs: Any) -> Any:
-            events.append('request')
-            return await super().request(*args, **kwargs)
-
-    default = TrackingModel(custom_output_text='default')
-    registered = TrackingModel(custom_output_text='registered')
+    default = TrackingModel(events, include_exit_exception=False, custom_output_text='default')
+    registered = TrackingModel(events, include_exit_exception=False, custom_output_text='registered')
     temporal_model = TemporalModel(
         default,
         activity_name_prefix='test__registered_lifecycle',
         activity_config={'start_to_close_timeout': timedelta(seconds=60)},
         deps_type=object,
         models={'registered': registered},
+        event_stream_handler=handle_stream,
     )
     deps = object()
     ctx = RunContext[object](deps=deps, model=default, usage=RunUsage(), run_id='registered-lifecycle')
@@ -1405,11 +1389,31 @@ async def test_temporal_activity_does_not_manage_registered_models() -> None:
         serialized_run_context=TemporalRunContext.serialize_run_context(ctx),
     )
 
-    await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
     params.model_id = 'registered'
     await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
+    assert events == ['request']
 
-    assert events == ['request', 'request']
+    events = []
+    registered.events = events
+    await ActivityEnvironment().run(
+        temporal_model.request_stream_activity,
+        params,
+        deps,  # pyright: ignore[reportArgumentType]
+    )
+    assert events == ['stream']
+
+    events = []
+    registered.events = events
+    await ActivityEnvironment().run(
+        temporal_model.cancel_suspended_response_activity,
+        _ModelCancelParams(
+            response=ModelResponse(parts=[TextPart('paused')], state='suspended'),
+            model_id='registered',
+            serialized_run_context=params.serialized_run_context,
+            deps=deps,
+        ),
+    )
+    assert events == ['cancel']
 
 
 async def test_temporal_model_cancel_suspended_response_outside_workflow():

--- a/tests/durable_exec/temporal/test_model_and_serialization.py
+++ b/tests/durable_exec/temporal/test_model_and_serialization.py
@@ -1290,6 +1290,125 @@ async def test_temporal_model_request_outside_workflow():
     assert any(isinstance(part, TextPart) and part.content == 'Direct model response' for part in response.parts)
 
 
+async def test_temporal_activities_manage_inferred_model_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class TrackingModel(TestModel):
+        async def __aenter__(self) -> TrackingModel:
+            events.append('enter')
+            return await super().__aenter__()
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            events.append('exit')
+            return await super().__aexit__(*args)
+
+        async def request(self, *args: Any, **kwargs: Any) -> Any:
+            events.append('request')
+            return await super().request(*args, **kwargs)
+
+        def request_stream(self, *args: Any, **kwargs: Any) -> Any:
+            events.append('stream')
+            return super().request_stream(*args, **kwargs)
+
+        async def cancel_suspended_response(self, response: ModelResponse) -> None:
+            events.append('cancel')
+
+    async def handle_stream(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        events.append('handler')
+
+    temporal_model = TemporalModel(
+        TestModel(),
+        activity_name_prefix='test__inferred_lifecycle',
+        activity_config={'start_to_close_timeout': timedelta(seconds=60)},
+        deps_type=object,
+        event_stream_handler=handle_stream,
+    )
+
+    def infer_tracking_model(model_id: str, ctx: RunContext[object] | None) -> TrackingModel:
+        return TrackingModel(custom_output_text='ok')
+
+    monkeypatch.setattr(temporal_model, '_infer_model', infer_tracking_model)
+    deps = object()
+    ctx = RunContext[object](deps=deps, model=TestModel(), usage=RunUsage(), run_id='inferred-lifecycle')
+    params = _RequestParams(
+        messages=[ModelRequest.user_text_prompt('hello')],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+        serialized_run_context=TemporalRunContext.serialize_run_context(ctx),
+        model_id='rebuilt',
+    )
+
+    await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
+    await ActivityEnvironment().run(
+        temporal_model.request_stream_activity,
+        params,
+        deps,  # pyright: ignore[reportArgumentType]
+    )
+    await ActivityEnvironment().run(
+        temporal_model.cancel_suspended_response_activity,
+        _ModelCancelParams(
+            response=ModelResponse(parts=[TextPart('paused')], state='suspended'),
+            model_id='rebuilt',
+            serialized_run_context=params.serialized_run_context,
+            deps=deps,
+        ),
+    )
+
+    assert events == [
+        'enter',
+        'request',
+        'exit',
+        'enter',
+        'stream',
+        'handler',
+        'exit',
+        'enter',
+        'cancel',
+        'exit',
+    ]
+
+
+async def test_temporal_activity_does_not_manage_registered_models() -> None:
+    events: list[str] = []
+
+    class TrackingModel(TestModel):
+        async def __aenter__(self) -> TrackingModel:
+            events.append('enter')
+            return await super().__aenter__()
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            events.append('exit')
+            return await super().__aexit__(*args)
+
+        async def request(self, *args: Any, **kwargs: Any) -> Any:
+            events.append('request')
+            return await super().request(*args, **kwargs)
+
+    default = TrackingModel(custom_output_text='default')
+    registered = TrackingModel(custom_output_text='registered')
+    temporal_model = TemporalModel(
+        default,
+        activity_name_prefix='test__registered_lifecycle',
+        activity_config={'start_to_close_timeout': timedelta(seconds=60)},
+        deps_type=object,
+        models={'registered': registered},
+    )
+    deps = object()
+    ctx = RunContext[object](deps=deps, model=default, usage=RunUsage(), run_id='registered-lifecycle')
+    params = _RequestParams(
+        messages=[ModelRequest.user_text_prompt('hello')],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+        serialized_run_context=TemporalRunContext.serialize_run_context(ctx),
+    )
+
+    await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
+    params.model_id = 'registered'
+    await ActivityEnvironment().run(temporal_model.request_activity, params, deps)
+
+    assert events == ['request', 'request']
+
+
 async def test_temporal_model_cancel_suspended_response_outside_workflow():
     """`TemporalModel.cancel_suspended_response()` falls back to the wrapped model outside a workflow.
 

--- a/tests/durable_exec/temporal/test_model_and_serialization.py
+++ b/tests/durable_exec/temporal/test_model_and_serialization.py
@@ -1372,11 +1372,14 @@ async def test_temporal_activity_does_not_manage_registered_models() -> None:
     events: list[str] = []
 
     class TrackingModel(TestModel):
-        async def __aenter__(self) -> TrackingModel:
+        # These two bodies never running is the assertion: a registered model keeps its external
+        # lifecycle owner, so the activity must not enter it. They record into `events` only so a
+        # regression shows up as a named entry rather than as a bare count.
+        async def __aenter__(self) -> TrackingModel:  # pragma: no cover
             events.append('enter')
             return await super().__aenter__()
 
-        async def __aexit__(self, *args: Any) -> bool | None:
+        async def __aexit__(self, *args: Any) -> bool | None:  # pragma: no cover
             events.append('exit')
             return await super().__aexit__(*args)
 

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -5,14 +5,16 @@ import gc
 import re
 import uuid
 import weakref
-from collections.abc import Awaitable, Callable, Generator, Mapping
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Mapping
+from contextlib import asynccontextmanager
 from decimal import Decimal
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
-from pydantic_ai import Agent
-from pydantic_ai.capabilities import AbstractCapability, WrapperCapability, durable_operation
+from pydantic_ai import Agent, ModelMessage, ModelResponse, ModelSettings
+from pydantic_ai.capabilities import AbstractCapability, ResolveModelId, WrapperCapability, durable_operation
 from pydantic_ai.durable_exec import DurabilityEngineSpec
 from pydantic_ai.durable_exec._base import BaseDurabilityCapability
 from pydantic_ai.durable_exec._capability_operation import (
@@ -31,7 +33,12 @@ from pydantic_ai.durable_exec._operation_names import JournalOperationNamer
 from pydantic_ai.durable_exec._toolset import ToolConfig
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelRequest, UserPromptPart
-from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models import (
+    ModelRequestContext,
+    ModelRequestParameters,
+    ModelResolutionContext,
+    StreamedResponse,
+)
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
@@ -152,6 +159,123 @@ class RecordingDurability(BaseDurabilityCapability[Any]):
 
 class ReplayingDurability(RecordingDurability):
     replay_capability_operations = True
+
+
+class LifecycleModel(TestModel):
+    def __init__(self, events: list[str], *, fail: bool = False, model_name: str = 'lifecycle') -> None:
+        super().__init__(custom_output_text='ok', model_name=model_name)
+        self.events = events
+        self.fail = fail
+
+    async def __aenter__(self) -> LifecycleModel:
+        self.events.append('model-enter')
+        return await super().__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        exception_name = exc_type.__name__ if exc_type is not None else 'none'
+        self.events.append(f'model-exit:{exception_name}')
+        return await super().__aexit__(exc_type, exc_val, exc_tb)
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        self.events.append('request')
+        if self.fail:
+            raise RuntimeError('request failed')
+        return await super().request(messages, model_settings, model_request_parameters)
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext[Any] | None = None,
+    ) -> AsyncGenerator[StreamedResponse]:
+        self.events.append('stream-enter')
+        try:
+            async with super().request_stream(
+                messages, model_settings, model_request_parameters, run_context
+            ) as streamed:
+                yield streamed
+        finally:
+            self.events.append('stream-exit')
+
+
+@pytest.mark.parametrize(
+    ('stream', 'fail', 'expected_events'),
+    [
+        (False, False, ['model-enter', 'request', 'model-exit:none']),
+        (True, False, ['model-enter', 'stream-enter', 'stream-exit', 'model-exit:none']),
+        (False, True, ['model-enter', 'request', 'model-exit:RuntimeError']),
+    ],
+)
+async def test_durable_model_scope_manages_rebuilt_model_lifecycle(
+    stream: bool, fail: bool, expected_events: list[str]
+) -> None:
+    """A worker-built model stays entered for its whole operation and exits on failure."""
+    events: list[str] = []
+
+    def resolve_model(_ctx: ModelResolutionContext[Any], _model_id: str) -> LifecycleModel:
+        return LifecycleModel(events, fail=fail)
+
+    agent = Agent(
+        'lifecycle',
+        name=f'rebuilt_model_lifecycle_{stream}_{fail}',
+        capabilities=[ResolveModelId(resolve_model), RecordingDurability()],
+    )
+
+    if fail:
+        with pytest.raises(RuntimeError, match='request failed'):
+            await agent.run('test')
+    elif stream:
+        async with agent.run_stream('test') as result:
+            assert await result.get_output() == 'ok'
+    else:
+        assert (await agent.run('test')).output == 'ok'
+
+    assert events == expected_events
+
+
+async def test_durable_model_scope_does_not_manage_registered_models() -> None:
+    """The agent owner remains responsible for default and `models=` instances."""
+    default_events: list[str] = []
+    registered_events: list[str] = []
+    default = LifecycleModel(default_events, model_name='default')
+    registered = LifecycleModel(registered_events, model_name='registered')
+    agent = Agent(
+        default,
+        name='registered_model_lifecycle',
+        capabilities=[RecordingDurability(models={'registered': registered})],
+    )
+
+    assert (await agent.run('test')).output == 'ok'
+    assert (await agent.run('test', model='registered')).output == 'ok'
+
+    assert default_events == ['request']
+    assert registered_events == ['request']
+
+
+async def test_durable_model_scope_manages_inferred_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model inferred inside the worker has the same owned lifecycle as a resolver-built model."""
+    events: list[str] = []
+
+    def infer_lifecycle_model(_model_id: str) -> LifecycleModel:
+        return LifecycleModel(events)
+
+    monkeypatch.setattr('pydantic_ai.durable_exec._base.infer_model', infer_lifecycle_model)
+    agent = Agent('test', name='inferred_model_lifecycle', capabilities=[RecordingDurability()])
+
+    assert (await agent.run('test')).output == 'ok'
+    assert events == ['model-enter', 'request', 'model-exit:none']
 
 
 class Operations(AbstractCapability[Any]):

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -8,12 +8,11 @@ import weakref
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Mapping
 from contextlib import asynccontextmanager
 from decimal import Decimal
-from types import TracebackType
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
-from pydantic_ai import Agent, ModelMessage, ModelResponse, ModelSettings
+from pydantic_ai import Agent, ModelMessage, ModelSettings
 from pydantic_ai.capabilities import AbstractCapability, ResolveModelId, WrapperCapability, durable_operation
 from pydantic_ai.durable_exec import DurabilityEngineSpec
 from pydantic_ai.durable_exec._base import BaseDurabilityCapability
@@ -42,6 +41,8 @@ from pydantic_ai.models import (
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
+
+from ..model_lifecycle_utils import LifecycleTrackingModel
 
 if TYPE_CHECKING:
     from dbos import DBOS, DBOSConfig, SetWorkflowID
@@ -161,49 +162,9 @@ class ReplayingDurability(RecordingDurability):
     replay_capability_operations = True
 
 
-class LifecycleModel(TestModel):
-    def __init__(
-        self,
-        events: list[str],
-        *,
-        fail: bool = False,
-        fail_exit: bool = False,
-        suppress_exit: bool = False,
-        model_name: str = 'lifecycle',
-    ) -> None:
-        super().__init__(custom_output_text='ok', model_name=model_name)
-        self.events = events
-        self.fail = fail
-        self.fail_exit = fail_exit
-        self.suppress_exit = suppress_exit
-
-    async def __aenter__(self) -> LifecycleModel:
-        self.events.append('model-enter')
-        return await super().__aenter__()
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        exception_name = exc_type.__name__ if exc_type is not None else 'none'
-        self.events.append(f'model-exit:{exception_name}')
-        await super().__aexit__(exc_type, exc_val, exc_tb)
-        if self.fail_exit:
-            raise ValueError('exit failed')
-        return self.suppress_exit
-
-    async def request(
-        self,
-        messages: list[ModelMessage],
-        model_settings: ModelSettings | None,
-        model_request_parameters: ModelRequestParameters,
-    ) -> ModelResponse:
-        self.events.append('request')
-        if self.fail:
-            raise RuntimeError('request failed')
-        return await super().request(messages, model_settings, model_request_parameters)
+class LifecycleModel(LifecycleTrackingModel):
+    def __init__(self, events: list[str], **kwargs: Any) -> None:
+        super().__init__(events, event_prefix='model-', **kwargs)
 
     @asynccontextmanager
     async def request_stream(
@@ -303,8 +264,11 @@ async def test_durable_model_scope_does_not_manage_registered_models() -> None:
     assert (await agent.run('test')).output == 'ok'
     assert (await agent.run('test', model='registered')).output == 'ok'
 
+    async with agent.run_stream('test', model='registered') as result:
+        assert await result.get_output() == 'ok'
+
     assert default_events == ['request']
-    assert registered_events == ['request']
+    assert registered_events == ['request', 'stream-enter', 'stream-exit']
 
 
 async def test_durable_model_scope_manages_inferred_models(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -162,10 +162,20 @@ class ReplayingDurability(RecordingDurability):
 
 
 class LifecycleModel(TestModel):
-    def __init__(self, events: list[str], *, fail: bool = False, model_name: str = 'lifecycle') -> None:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        fail: bool = False,
+        fail_exit: bool = False,
+        suppress_exit: bool = False,
+        model_name: str = 'lifecycle',
+    ) -> None:
         super().__init__(custom_output_text='ok', model_name=model_name)
         self.events = events
         self.fail = fail
+        self.fail_exit = fail_exit
+        self.suppress_exit = suppress_exit
 
     async def __aenter__(self) -> LifecycleModel:
         self.events.append('model-enter')
@@ -179,7 +189,10 @@ class LifecycleModel(TestModel):
     ) -> bool | None:
         exception_name = exc_type.__name__ if exc_type is not None else 'none'
         self.events.append(f'model-exit:{exception_name}')
-        return await super().__aexit__(exc_type, exc_val, exc_tb)
+        await super().__aexit__(exc_type, exc_val, exc_tb)
+        if self.fail_exit:
+            raise ValueError('exit failed')
+        return self.suppress_exit
 
     async def request(
         self,
@@ -243,6 +256,36 @@ async def test_durable_model_scope_manages_rebuilt_model_lifecycle(
         assert (await agent.run('test')).output == 'ok'
 
     assert events == expected_events
+
+
+async def test_durable_model_scope_does_not_suppress_body_error() -> None:
+    events: list[str] = []
+    model = LifecycleModel(events, fail=True, suppress_exit=True)
+    agent = Agent(
+        'lifecycle',
+        name='rebuilt_model_suppressed_exit',
+        capabilities=[ResolveModelId(lambda ctx, model_id: model), RecordingDurability()],
+    )
+
+    with pytest.raises(RuntimeError, match='request failed'):
+        await agent.run('test')
+
+    assert events == ['model-enter', 'request', 'model-exit:RuntimeError']
+
+
+async def test_durable_model_scope_surfaces_teardown_error() -> None:
+    events: list[str] = []
+    model = LifecycleModel(events, fail=True, fail_exit=True)
+    agent = Agent(
+        'lifecycle',
+        name='rebuilt_model_failed_exit',
+        capabilities=[ResolveModelId(lambda ctx, model_id: model), RecordingDurability()],
+    )
+
+    with pytest.raises(ValueError, match='exit failed'):
+        await agent.run('test')
+
+    assert events == ['model-enter', 'request', 'model-exit:RuntimeError']
 
 
 async def test_durable_model_scope_does_not_manage_registered_models() -> None:

--- a/tests/durable_exec/test_dbos.py
+++ b/tests/durable_exec/test_dbos.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
+from types import TracebackType
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
@@ -64,6 +65,7 @@ from pydantic_ai.models import (
     ModelRequestContext,
     ModelRequestParameters,
     ModelResolutionContext,
+    StreamedResponse,
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
@@ -3057,6 +3059,90 @@ def _dbos_alt_model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelRe
 # A module-level function (not a lambda): passing the instance to `agent.run(model=...)`
 # makes it part of the DBOS workflow's pickled arguments.
 _dbos_alt_model = FunctionModel(_dbos_alt_model_fn, model_name='alt')
+
+_dbos_model_lifecycle_events: list[str] = []
+
+
+class _DBOSLifecycleModel(TestModel):
+    def __init__(self) -> None:
+        super().__init__(custom_output_text='ok', model_name='lifecycle')
+
+    async def __aenter__(self) -> _DBOSLifecycleModel:
+        _dbos_model_lifecycle_events.append('model-enter')
+        return await super().__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        exception_name = exc_type.__name__ if exc_type is not None else 'none'
+        _dbos_model_lifecycle_events.append(f'model-exit:{exception_name}')
+        return await super().__aexit__(exc_type, exc_val, exc_tb)
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        _dbos_model_lifecycle_events.append('request')
+        return await super().request(messages, model_settings, model_request_parameters)
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext[Any] | None = None,
+    ) -> AsyncGenerator[StreamedResponse]:
+        _dbos_model_lifecycle_events.append('stream-enter')
+        try:
+            async with super().request_stream(
+                messages, model_settings, model_request_parameters, run_context
+            ) as streamed:
+                yield streamed
+        finally:
+            _dbos_model_lifecycle_events.append('stream-exit')
+
+
+def _resolve_dbos_lifecycle_model(_ctx: ModelResolutionContext[Any], _model_id: str) -> _DBOSLifecycleModel:
+    return _DBOSLifecycleModel()
+
+
+async def test_dbos_durability_context_manages_resolved_models(dbos: DBOS) -> None:
+    """Resolver-created models stay entered through ordinary and streamed DBOS steps."""
+    agent = Agent(
+        'lifecycle',
+        name='durability_resolved_model_lifecycle',
+        capabilities=[ResolveModelId(_resolve_dbos_lifecycle_model), DBOSDurability()],
+    )
+
+    @DBOS.workflow()
+    async def run_agent() -> str:
+        return (await agent.run('hello')).output
+
+    @DBOS.workflow()
+    async def stream_agent() -> str:
+        async with agent.run_stream('hello') as result:
+            return await result.get_output()
+
+    _dbos_model_lifecycle_events.clear()
+    with SetWorkflowID(str(uuid.uuid4())):
+        assert await run_agent() == 'ok'
+    assert _dbos_model_lifecycle_events == ['model-enter', 'request', 'model-exit:none']
+
+    _dbos_model_lifecycle_events.clear()
+    with SetWorkflowID(str(uuid.uuid4())):
+        assert await stream_agent() == 'ok'
+    assert _dbos_model_lifecycle_events == [
+        'model-enter',
+        'stream-enter',
+        'stream-exit',
+        'model-exit:none',
+    ]
 
 
 async def test_dbos_durability_runtime_registered_model(dbos: DBOS) -> None:

--- a/tests/durable_exec/test_dbos.py
+++ b/tests/durable_exec/test_dbos.py
@@ -12,7 +12,6 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
-from types import TracebackType
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
@@ -126,6 +125,7 @@ from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from .._inline_snapshot import snapshot
 from ..continuation_utils import ScriptedContinuationModel, StreamSegment, scripted_response
+from ..model_lifecycle_utils import LifecycleTrackingModel
 
 # `DBOSAgent` is deprecated in favor of `capabilities=[DBOSDurability(...)]`.
 # These tests exercise the wrapper-agent path on purpose; suppress the warning here
@@ -3063,32 +3063,9 @@ _dbos_alt_model = FunctionModel(_dbos_alt_model_fn, model_name='alt')
 _dbos_model_lifecycle_events: list[str] = []
 
 
-class _DBOSLifecycleModel(TestModel):
+class _DBOSLifecycleModel(LifecycleTrackingModel):
     def __init__(self) -> None:
-        super().__init__(custom_output_text='ok', model_name='lifecycle')
-
-    async def __aenter__(self) -> _DBOSLifecycleModel:
-        _dbos_model_lifecycle_events.append('model-enter')
-        return await super().__aenter__()
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        exception_name = exc_type.__name__ if exc_type is not None else 'none'
-        _dbos_model_lifecycle_events.append(f'model-exit:{exception_name}')
-        return await super().__aexit__(exc_type, exc_val, exc_tb)
-
-    async def request(
-        self,
-        messages: list[ModelMessage],
-        model_settings: ModelSettings | None,
-        model_request_parameters: ModelRequestParameters,
-    ) -> ModelResponse:
-        _dbos_model_lifecycle_events.append('request')
-        return await super().request(messages, model_settings, model_request_parameters)
+        super().__init__(_dbos_model_lifecycle_events, event_prefix='model-')
 
     @asynccontextmanager
     async def request_stream(

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -3347,6 +3347,51 @@ async def test_prefect_durability_resolve_model_id_capability_is_deps_aware() ->
     assert await run_agent() == ('tenant:acme', 'tenant:globex', 'success (no tool calls)')
 
 
+@pytest.mark.parametrize('blockbuster_enabled', [False])
+async def test_prefect_durability_manages_resolver_built_model_lifecycle(blockbuster_enabled: bool) -> None:
+    assert blockbuster_enabled is False
+    events: list[str] = []
+
+    class TrackingModel(TestModel):
+        async def __aenter__(self) -> TrackingModel:
+            events.append('enter')
+            return await super().__aenter__()
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            events.append('exit')
+            return await super().__aexit__(*args)
+
+        async def request(self, *args: Any, **kwargs: Any) -> Any:
+            events.append('request')
+            return await super().request(*args, **kwargs)
+
+        @asynccontextmanager
+        async def request_stream(self, *args: Any, **kwargs: Any) -> AsyncGenerator[Any]:
+            events.append('stream')
+            async with super().request_stream(*args, **kwargs) as stream:
+                yield stream
+            events.append('stream_consumed')
+
+    agent = Agent(
+        'rebuilt',
+        name='durability_resolved_model_lifecycle',
+        capabilities=[
+            ResolveModelId(lambda ctx, model_id: TrackingModel(custom_output_text='ok')),
+            PrefectDurability(),
+        ],
+    )
+
+    @flow
+    async def run_agent() -> tuple[str, str]:
+        ordinary = (await agent.run('ordinary')).output
+        async with agent.run_stream('streamed') as result:
+            streamed = await result.get_output()
+        return ordinary, streamed
+
+    assert await run_agent() == ('ok', 'ok')
+    assert events == ['enter', 'request', 'exit', 'enter', 'stream', 'stream_consumed', 'exit']
+
+
 async def test_prefect_durability_alias_default_model() -> None:
     """An agent whose *default* model is an alias only a `ResolveModelId` capability can resolve.
 

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -160,6 +160,7 @@ except ImportError:  # pragma: lax no cover
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsSameStr, IsStr
 from ..continuation_utils import ScriptedContinuationModel, StreamSegment, scripted_response
+from ..model_lifecycle_utils import LifecycleTrackingModel
 
 
 def test_durability_codecs() -> None:
@@ -3352,19 +3353,7 @@ async def test_prefect_durability_manages_resolver_built_model_lifecycle(blockbu
     assert blockbuster_enabled is False
     events: list[str] = []
 
-    class TrackingModel(TestModel):
-        async def __aenter__(self) -> TrackingModel:
-            events.append('enter')
-            return await super().__aenter__()
-
-        async def __aexit__(self, *args: Any) -> bool | None:
-            events.append('exit')
-            return await super().__aexit__(*args)
-
-        async def request(self, *args: Any, **kwargs: Any) -> Any:
-            events.append('request')
-            return await super().request(*args, **kwargs)
-
+    class TrackingModel(LifecycleTrackingModel):
         @asynccontextmanager
         async def request_stream(self, *args: Any, **kwargs: Any) -> AsyncGenerator[Any]:
             events.append('stream')
@@ -3376,7 +3365,7 @@ async def test_prefect_durability_manages_resolver_built_model_lifecycle(blockbu
         'rebuilt',
         name='durability_resolved_model_lifecycle',
         capabilities=[
-            ResolveModelId(lambda ctx, model_id: TrackingModel(custom_output_text='ok')),
+            ResolveModelId(lambda ctx, model_id: TrackingModel(events, include_exit_exception=False)),
             PrefectDurability(),
         ],
     )

--- a/tests/model_lifecycle_utils.py
+++ b/tests/model_lifecycle_utils.py
@@ -1,0 +1,71 @@
+"""Lifecycle-tracking models shared by the durable-execution test suites.
+
+Temporal, DBOS, Prefect, and the common durability capability tests all need to
+prove which durable unit owns a rebuilt model's context-manager lifecycle. This
+module keeps the common tracking and failure behavior in one test double, while
+engine-specific subclasses can add hooks with their existing event vocabulary.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+from pydantic_ai.messages import ModelMessage, ModelResponse
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
+
+
+class LifecycleTrackingModel(TestModel):
+    """Record model lifecycle and request events for durable-execution tests."""
+
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        event_prefix: str = '',
+        include_exit_exception: bool = True,
+        fail: bool = False,
+        fail_exit: bool = False,
+        suppress_exit: bool = False,
+        model_name: str = 'lifecycle',
+        custom_output_text: str = 'ok',
+    ) -> None:
+        super().__init__(custom_output_text=custom_output_text, model_name=model_name)
+        self.events = events
+        self.event_prefix = event_prefix
+        self.include_exit_exception = include_exit_exception
+        self.fail = fail
+        self.fail_exit = fail_exit
+        self.suppress_exit = suppress_exit
+
+    async def __aenter__(self) -> LifecycleTrackingModel:
+        self.events.append(f'{self.event_prefix}enter')
+        return await super().__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        exception_name = exc_type.__name__ if exc_type is not None else 'none'
+        exit_event = f'{self.event_prefix}exit'
+        if self.include_exit_exception:
+            exit_event = f'{exit_event}:{exception_name}'
+        self.events.append(exit_event)
+        await super().__aexit__(exc_type, exc_val, exc_tb)
+        if self.fail_exit:
+            raise ValueError('exit failed')
+        return self.suppress_exit
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        self.events.append('request')
+        if self.fail:
+            raise RuntimeError('request failed')
+        return await super().request(messages, model_settings, model_request_parameters)


### PR DESCRIPTION
> Opened by @dsfaccini, whose commit is the shared-scope half. Taken over by @DouweM, who added the Temporal half; see the discussion on #7944.

## Why we make these changes

A durable model unit rebuilds a string-selected model on the worker, through a `ResolveModelId` capability or the `infer_model` backstop, and then used that model without ever entering its async context. Anything the model owns therefore leaks: an `OpenAIResponsesModel` whose `OpenAIProvider` owns its HTTP client leaves that client open, and an async credential callback holding loop-bound resources never releases them. Reported in #7944 with a self-contained reproduction that counts `__aenter__` / `__aexit__` calls and observes zero of each.

The fix is ownership-aware rather than unconditional. A model the durable unit built is owned by that unit and gets its normal lifecycle. The agent's default model and anything registered through `models=` keep their existing external lifecycle owner and are never entered a second time, including when a resolver chain hands back a registered instance (the capability's own registry acts as the durable backstop, so identity, not code path, decides).

There are three places that rebuild models, not one:

- `BaseDurabilityCapability._durable_model_scope`, which DBOS and Prefect go through.
- `TemporalDurability._cancel_suspended_response_without_run_context` in `durable_exec/temporal/_durability.py`. `_cancel_suspended_response_operation` returns early when `params.run_context is None` and so bypasses the shared scope, and Temporal's override then builds a model with `infer_model` and uses it unentered. That `None` is the backward-compat case for activity payloads recorded before the run context was carried, so this fires when an in-flight workflow from an older deploy retries a suspended-response cancellation. The base class only raises there, so Temporal is the sole engine implementing it and the sole one affected.
- `TemporalModel` in `durable_exec/temporal/_model.py`, which resolves independently in three activity bodies. This one serves only the deprecated `TemporalAgent` (its single construction site is `_agent.py:225`), so it is fixed here but goes away in v3.

Note that `TemporalDurability` inherits all four model operations from `BaseDurabilityCapability` and overrides none of them, so the ordinary Temporal request, streaming, and compaction paths are covered by the shared-scope fix rather than by anything Temporal-specific.

All three are fixed here, through one shared `managed_model_scope()` helper in `durable_exec/_utils.py` so the ownership handling exists once rather than in five places.

## New public surface

None. `managed_model_scope` is internal to `pydantic_ai.durable_exec`.

## User-visible behavior

```diff
Agent.run() / Agent.run_stream()
  └─ durable model unit
     ├─ shared scope (DBOS, Prefect, and Temporal's request/stream/compaction)
     ├─ TemporalDurability cancel-without-run-context (backward-compat payloads)
     └─ TemporalModel activities (deprecated TemporalAgent)
-       └─ rebuild model → request, consume stream, or cancel
+       └─ rebuild model → enter → request, consume stream, or cancel → exit
```

For a streamed request the model stays entered until the stream is fully consumed, and it is exited when the operation body raises.

## Verification

- Ordinary, streamed, and failing requests each record one matching enter and exit, asserted on the exact event order.
- Temporal: the backward-compat cancellation path (registered, default, and inferred, including the exception path), plus all three `TemporalModel` activity bodies for the deprecated `TemporalAgent`.
- DBOS: real SQLite-backed ordinary and streamed workflows.
- Prefect: ordinary and streamed lifecycle.
- Ownership: the agent default and a `models=` registration are never entered by the durable unit.
- Teardown edge cases: a truthy `__aexit__` cannot suppress an error raised by the operation body, and a teardown failure surfaces (chained) rather than vanishing.

On the combined branch: `tests/durable_exec` 696 passed, 2 skipped, 5 failed, where all five are the pre-existing Prefect cache-write failures from BlockBuster rejecting `os.mkdir`; `tests/durable_exec/temporal` 285 passed, 2 skipped; lint clean; per-file pyright clean on every changed file.

## What changes for existing users

A model constructed inside a durable unit now receives its normal async lifecycle, so provider-owned clients are closed instead of leaked. Concrete model instances you pass in or register keep their current lifecycle owner, so nothing changes for them.

Fixes #7944

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (Not applicable.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
