### PR TITLE
Add the Trajectory Judge harness page to `docs/navigation.yml`

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -401,6 +401,10 @@ navigation:
             path: "system-reminders.md"
             source: "harness"
             slug: "harness/system-reminders"
+          - page: "Trajectory Judge"
+            path: "trajectory-judge.md"
+            source: "harness"
+            slug: "harness/trajectory-judge"
       - section: "Self-Extension"
         slug: ""
         contents:


### PR DESCRIPTION
Companion to pydantic/pydantic-ai-harness#724, which adds the `TrajectoryJudge` capability and its `docs/trajectory-judge.md` page. The docs site navigation is owned here, so this adds the page entry under Control & Safety, next to System Reminders (its rule-based sibling, cross-linked from the new page).

Should merge together with (or right after) the harness PR so the nav entry never points at a missing page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

