### PR TITLE
Document which docstring sections reach the model

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -264,7 +264,7 @@ Even better, Pydantic AI extracts the docstring from functions and (thanks to [g
 Three parts of the docstring reach the model: the leading description, the parameter descriptions, and the
 first entry of the returns section. Other sections Griffe can parse, such as `Raises`, `Examples`, `Notes`,
 `Warnings` and `Yields`, are dropped rather than sent, so anything the model needs to act on belongs in the
-leading description or a parameter description.
+leading description, a parameter description, or the first returns entry.
 
 To demonstrate a tool's schema, here we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to print the schema a model would receive:
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -263,7 +263,7 @@ Even better, Pydantic AI extracts the docstring from functions and (thanks to [g
 
 Three parts of the docstring reach the model: the leading description, the parameter descriptions, and the
 first entry of the returns section. Other sections Griffe can parse, such as `Raises`, `Examples`, `Notes`,
-`Warnings` and `Yields`, are dropped rather than sent, so anything the model needs to act on belongs in the
+`Warnings` and `Yields`, are dropped, so anything the model needs to act on belongs in the
 leading description, a parameter description, or the first returns entry.
 
 To demonstrate a tool's schema, here we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to print the schema a model would receive:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -261,6 +261,11 @@ Even better, Pydantic AI extracts the docstring from functions and (thanks to [g
 
 [Griffe supports](https://mkdocstrings.github.io/griffe/reference/docstrings/#docstrings) extracting parameter descriptions from `google`, `numpy`, and `sphinx` style docstrings. Pydantic AI will infer the format to use based on the docstring, but you can explicitly set it using [`docstring_format`][pydantic_ai.tools.DocstringFormat]. You can also enforce parameter requirements by setting `require_parameter_descriptions=True`. This will raise a [`UserError`][pydantic_ai.exceptions.UserError] if a parameter description is missing.
 
+Three parts of the docstring reach the model: the leading description, the parameter descriptions, and the
+first entry of the returns section. Other sections Griffe can parse, such as `Raises`, `Examples`, `Notes`,
+`Warnings` and `Yields`, are dropped rather than sent, so anything the model needs to act on belongs in the
+leading description or a parameter description.
+
 To demonstrate a tool's schema, here we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to print the schema a model would receive:
 
 ```python {title="tool_schema.py"}


### PR DESCRIPTION
`docs/tools.md` says Pydantic AI extracts the docstring and the parameter descriptions, which is true but incomplete: several sections Griffe parses never reach the model, and nothing says so.

`_griffe.py` reads the parsed sections and keeps exactly three (`:58-68`): `DocstringSectionKind.text` for the leading description, `.parameters` for the per-parameter descriptions, and `.returns`, of which only `value[0]`, the first entry, is used. Anything else Griffe produced, including `Raises`, `Examples`, `Notes`, `Warnings` and `Yields`, is discarded silently.

That matters because the natural place to write a caveat in a Python docstring is a `Notes` or `Raises` section, and a tool author has no way to tell from the current docs that the model will never see it. This adds four lines saying which parts arrive and where to put anything the model must act on.

Context for #7953, which reported this. **Deliberately not marked as closing it**: that issue asks for the sections to be *preserved*, which is a behavior change and your call, and this only documents what happens today. If you do decide to send more sections through, this paragraph should be updated or dropped rather than kept.

Ran `uv run pytest tests/test_examples.py -k tools` (85 passed, 22 skipped).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

About me: I'm a freshman in college, so I read `_griffe.py` to confirm which section kinds are actually consumed rather than taking the issue's word for it, and I checked that the returns handling really does use only the first entry. I used Claude Code to check my reasoning and read the diff myself. If you would rather wait until you have decided on #7953, closing this is completely fine.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

