### PR TITLE
Restore raw tool-call IDs when replaying Bedrock Mantle Responses history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2137,6 +2137,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             messages,
             model_settings,
             model_request_parameters,
+            previous_response_id=previous_response_id,
             standing_prompt_retained=False,
         )
         if instructions_override is not None:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3667,7 +3667,11 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         raise _unconverted_speech_part_error()
                     else:
                         assert_never(item)
-                response_id = message.provider_response_id if response_from_same_provider else None
+                response_id = (
+                    message.provider_response_id
+                    if response_scoped_tool_call_ids and response_from_same_provider
+                    else None
+                )
             else:
                 assert_never(message)
         instructions = get_instructions(messages, model_request_parameters) or OMIT

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2614,7 +2614,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
 
         previous_response_id, conversation_id, messages = self._resolve_server_side_state(model_settings, messages)
 
-        instructions, openai_messages = await self._map_messages(messages, model_settings, wire_request_parameters)
+        instructions, openai_messages = await self._map_messages(
+            messages,
+            model_settings,
+            wire_request_parameters,
+            previous_response_id=previous_response_id,
+        )
         reasoning = self._translate_thinking(model_settings, model_request_parameters)
 
         text: responses.ResponseTextConfigParam | Omit = OMIT
@@ -3215,6 +3220,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         model_request_parameters: ModelRequestParameters,
         *,
         standing_prompt_retained: bool = True,
+        previous_response_id: str | None = None,
     ) -> tuple[str | Omit, list[responses.ResponseInputItemParam]]:
         """Maps a `pydantic_ai.Message` to a `openai.types.responses.ResponseInputParam` i.e. the OpenAI Responses API input format.
 
@@ -3232,6 +3238,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         # across a second compaction in probing, so each freshly built window plants it explicitly.
         messages = self._trim_before_compaction(messages, standing_prompt_retained=standing_prompt_retained)
         profile = self.profile
+        response_scoped_tool_call_ids = profile.get('openai_responses_tool_call_ids_are_response_scoped', False)
+        response_id = previous_response_id if response_scoped_tool_call_ids else None
         send_item_ids = model_settings.get(
             'openai_send_reasoning_ids', profile.get('openai_supports_encrypted_reasoning_content', False)
         )
@@ -3280,6 +3288,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     elif isinstance(part, ToolReturnPart):
                         call_id = _guard_tool_call_id(t=part)
                         call_id, _ = _split_combined_tool_call_id(call_id)
+                        call_id = _provider_response_tool_call_id(call_id, response_id)
                         if call_id in client_replay_call_ids and isinstance(part, ToolSearchReturnPart):
                             # Replay the local `search_tools` result as a
                             # `tool_search_output` so the provider rehydrates the
@@ -3322,6 +3331,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         else:
                             call_id = _guard_tool_call_id(t=part)
                             call_id, _ = _split_combined_tool_call_id(call_id)
+                            call_id = _provider_response_tool_call_id(call_id, response_id)
                             item = FunctionCallOutput(
                                 type='function_call_output',
                                 call_id=call_id,
@@ -3334,6 +3344,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     else:
                         assert_never(part)
             elif isinstance(message, ModelResponse):
+                response_from_same_provider = message.provider_name == self.system
                 message_item: responses.ResponseOutputMessageParam | None = None
                 reasoning_item: responses.ResponseReasoningItemParam | None = None
                 web_search_item: responses.ResponseFunctionWebSearchParam | None = None
@@ -3351,6 +3362,10 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     from_same_provider = item.provider_name == self.system or (
                         item.provider_name is None and message.provider_name == self.system
                     )
+                    response_id_from_same_provider = message.provider_name == self.system or (
+                        message.provider_name is None and item.provider_name == self.system
+                    )
+                    response_from_same_provider |= response_id_from_same_provider
                     # Two distinct gates. For native tool items whose state lives server-side
                     # (web search, code interpreter, image generation, MCP), the item ID *is*
                     # the replay payload, so `should_send_item_id` decides whether those items
@@ -3393,6 +3408,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     elif isinstance(item, ToolCallPart):
                         call_id = _guard_tool_call_id(t=item)
                         call_id, id = _split_combined_tool_call_id(call_id)
+                        call_id = _provider_response_tool_call_id(
+                            call_id,
+                            message.provider_response_id
+                            if response_scoped_tool_call_ids and response_id_from_same_provider
+                            else None,
+                        )
                         id = id or item.id
 
                         if client_tool_search_active and item.tool_name == TOOL_SEARCH_FUNCTION_TOOL_NAME:
@@ -3645,6 +3666,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         raise _unconverted_speech_part_error()
                     else:
                         assert_never(item)
+                response_id = message.provider_response_id if response_from_same_provider else None
             else:
                 assert_never(message)
         instructions = get_instructions(messages, model_request_parameters) or OMIT
@@ -5159,6 +5181,13 @@ def _response_tool_call_id(tool_call_id: str, response_id: str | None) -> str:
     ID must be made history-wide unique), or `None` to leave the call ID as-is.
     """
     return f'{response_id}:{tool_call_id}' if response_id is not None else tool_call_id
+
+
+def _provider_response_tool_call_id(tool_call_id: str, response_id: str | None) -> str:
+    """Restore a response-scoped provider tool-call ID from its normalized form."""
+    if response_id is None:
+        return tool_call_id
+    return tool_call_id.removeprefix(f'{response_id}:')
 
 
 def _map_code_interpreter_tool_call(

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -288,8 +288,8 @@ class OpenAIModelProfile(ModelProfile, total=False):
 
     When enabled, response IDs are incorporated into tool call IDs as responses are ingested so
     normalized message history keeps the history-wide uniqueness required by Pydantic AI. The qualified
-    `response_id:tool_call_id` form is replayed unchanged, so the Responses endpoint must accept
-    colon-containing tool call IDs in follow-up requests.
+    `response_id:tool_call_id` form is restored to the original provider tool call ID when history is
+    replayed.
     """
 
     openai_responses_supports_interleaved_function_calls: bool

--- a/tests/models/cassettes/test_openai_responses/test_openai_previous_response_id_seed_auto_chains_through_retries.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_previous_response_id_seed_auto_chains_through_retries.yaml
@@ -4,7 +4,7 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate, br
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
@@ -37,20 +37,20 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-length:
-      - '1467'
+      - '1810'
       content-type:
       - application/json
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '802'
-      openai-project:
-      - proj_dKobscVY9YJxeEaDJen54e3d
+      - '510'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -61,17 +61,18 @@ interactions:
       background: false
       billing:
         payer: developer
-      completed_at: 1776377854
-      created_at: 1776377853
+      completed_at: 1788212248
+      created_at: 1788212248
       error: null
       frequency_penalty: 0.0
-      id: resp_0435eb6c2aa8e9eb0069e15ffdbb848195ab503209f100317f
+      id: resp_089c555e8fb26536006a95f418124487d2925f1494269f7b44
       incomplete_details: null
       instructions: null
       max_output_tokens: null
       max_tool_calls: null
       metadata: {}
       model: gpt-4.1-2025-04-14
+      moderation: null
       object: response
       output:
       - content:
@@ -79,7 +80,7 @@ interactions:
           logprobs: []
           text: Hello
           type: output_text
-        id: msg_0435eb6c2aa8e9eb0069e15ffe56b4819587eaac6a6c786706
+        id: msg_089c555e8fb26536006a95f41866f087d2a6172c992ea4b599
         role: assistant
         status: completed
         type: message
@@ -87,8 +88,9 @@ interactions:
       presence_penalty: 0.0
       previous_response_id: null
       prompt_cache_key: null
-      prompt_cache_retention: null
+      prompt_cache_retention: in_memory
       reasoning:
+        context: null
         effort: null
         summary: null
       safety_identifier: null
@@ -101,9 +103,23 @@ interactions:
           type: text
         verbosity: medium
       tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
       tools:
       - description: null
         name: get_weather
+        output_schema: null
         parameters:
           additionalProperties: false
           properties:
@@ -120,6 +136,7 @@ interactions:
       usage:
         input_tokens: 40
         input_tokens_details:
+          cache_write_tokens: 0
           cached_tokens: 0
         output_tokens: 3
         output_tokens_details:
@@ -134,15 +151,13 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate, br
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
       - '457'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=Wd0GUrhL.mfpt__BYuSnzo6fFLD6I.hXZQKSnQW4ro8-1776377853.6917653-1.0.1.1-VozUb1Q1rGdedibygdT_szkLU9P9RBnCCwFRDbOKAPJpMPQCTax0VN2W0uBN0S2zQG8uZNlyTOaTJ9UqhQwCB7UwHhKfw9upLMHgTMpzUJEokABaq5LHz3b5TNoiSPaC
       host:
       - api.openai.com
     method: POST
@@ -151,7 +166,7 @@ interactions:
       - content: What's the weather in New York?
         role: user
       model: gpt-4.1
-      previous_response_id: resp_0435eb6c2aa8e9eb0069e15ffdbb848195ab503209f100317f
+      previous_response_id: resp_089c555e8fb26536006a95f418124487d2925f1494269f7b44
       store: true
       stream: false
       tool_choice: auto
@@ -171,20 +186,20 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-length:
-      - '1522'
+      - '1865'
       content-type:
       - application/json
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '1205'
-      openai-project:
-      - proj_dKobscVY9YJxeEaDJen54e3d
+      - '1118'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -195,31 +210,33 @@ interactions:
       background: false
       billing:
         payer: developer
-      completed_at: 1776377855
-      created_at: 1776377854
+      completed_at: 1788212249
+      created_at: 1788212248
       error: null
       frequency_penalty: 0.0
-      id: resp_0435eb6c2aa8e9eb0069e15ffeb3fc81959cd2d1e915a8c7ea
+      id: resp_089c555e8fb26536006a95f418e35c87d2b2dd87804a697227
       incomplete_details: null
       instructions: null
       max_output_tokens: null
       max_tool_calls: null
       metadata: {}
       model: gpt-4.1-2025-04-14
+      moderation: null
       object: response
       output:
       - arguments: '{"city":"New York"}'
-        call_id: call_P1vN20XNjvNyIm0VshHYzmSA
-        id: fc_0435eb6c2aa8e9eb0069e15fffae50819597bbbe870015ea70
+        call_id: call_alvVcMLLxsySZfL2LFXRURkk
+        id: fc_089c555e8fb26536006a95f419cee087d2a847d8b5a04ee050
         name: get_weather
         status: completed
         type: function_call
       parallel_tool_calls: true
       presence_penalty: 0.0
-      previous_response_id: resp_0435eb6c2aa8e9eb0069e15ffdbb848195ab503209f100317f
+      previous_response_id: resp_089c555e8fb26536006a95f418124487d2925f1494269f7b44
       prompt_cache_key: null
-      prompt_cache_retention: null
+      prompt_cache_retention: in_memory
       reasoning:
+        context: null
         effort: null
         summary: null
       safety_identifier: null
@@ -232,9 +249,23 @@ interactions:
           type: text
         verbosity: medium
       tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
       tools:
       - description: null
         name: get_weather
+        output_schema: null
         parameters:
           additionalProperties: false
           properties:
@@ -251,6 +282,7 @@ interactions:
       usage:
         input_tokens: 56
         input_tokens_details:
+          cache_write_tokens: 0
           cached_tokens: 0
         output_tokens: 16
         output_tokens_details:
@@ -265,28 +297,26 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate, br
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
       - '621'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=Wd0GUrhL.mfpt__BYuSnzo6fFLD6I.hXZQKSnQW4ro8-1776377853.6917653-1.0.1.1-VozUb1Q1rGdedibygdT_szkLU9P9RBnCCwFRDbOKAPJpMPQCTax0VN2W0uBN0S2zQG8uZNlyTOaTJ9UqhQwCB7UwHhKfw9upLMHgTMpzUJEokABaq5LHz3b5TNoiSPaC
       host:
       - api.openai.com
     method: POST
     parsed_body:
       input:
-      - call_id: call_P1vN20XNjvNyIm0VshHYzmSA
+      - call_id: call_alvVcMLLxsySZfL2LFXRURkk
         output: |-
           Location not recognized. The tool only supports the airport code "NYC". Call again with city="NYC".
 
           Fix the errors and try again.
         type: function_call_output
       model: gpt-4.1
-      previous_response_id: resp_0435eb6c2aa8e9eb0069e15ffeb3fc81959cd2d1e915a8c7ea
+      previous_response_id: resp_089c555e8fb26536006a95f418e35c87d2b2dd87804a697227
       store: true
       stream: false
       tool_choice: auto
@@ -306,20 +336,20 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-length:
-      - '1519'
+      - '1862'
       content-type:
       - application/json
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '1290'
-      openai-project:
-      - proj_dKobscVY9YJxeEaDJen54e3d
+      - '1001'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -330,31 +360,33 @@ interactions:
       background: false
       billing:
         payer: developer
-      completed_at: 1776377857
-      created_at: 1776377856
+      completed_at: 1788212251
+      created_at: 1788212250
       error: null
       frequency_penalty: 0.0
-      id: resp_0435eb6c2aa8e9eb0069e1600000608195818a61245c018620
+      id: resp_089c555e8fb26536006a95f41a624c87d28e4dd4baddfb0bc2
       incomplete_details: null
       instructions: null
       max_output_tokens: null
       max_tool_calls: null
       metadata: {}
       model: gpt-4.1-2025-04-14
+      moderation: null
       object: response
       output:
       - arguments: '{"city":"NYC"}'
-        call_id: call_N2BikjqNxghwNIwHl2XKfb0F
-        id: fc_0435eb6c2aa8e9eb0069e16000fad08195bb4d519c2d62b811
+        call_id: call_NP4ZYWCcjva7uSRchwRbnCyq
+        id: fc_089c555e8fb26536006a95f41b29f487d2b7b97bcfbb6dfaec
         name: get_weather
         status: completed
         type: function_call
       parallel_tool_calls: true
       presence_penalty: 0.0
-      previous_response_id: resp_0435eb6c2aa8e9eb0069e15ffeb3fc81959cd2d1e915a8c7ea
+      previous_response_id: resp_089c555e8fb26536006a95f418e35c87d2b2dd87804a697227
       prompt_cache_key: null
-      prompt_cache_retention: null
+      prompt_cache_retention: in_memory
       reasoning:
+        context: null
         effort: null
         summary: null
       safety_identifier: null
@@ -367,9 +399,23 @@ interactions:
           type: text
         verbosity: medium
       tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
       tools:
       - description: null
         name: get_weather
+        output_schema: null
         parameters:
           additionalProperties: false
           properties:
@@ -386,6 +432,7 @@ interactions:
       usage:
         input_tokens: 110
         input_tokens_details:
+          cache_write_tokens: 0
           cached_tokens: 0
         output_tokens: 16
         output_tokens_details:
@@ -400,25 +447,23 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate, br
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
       - '495'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=Wd0GUrhL.mfpt__BYuSnzo6fFLD6I.hXZQKSnQW4ro8-1776377853.6917653-1.0.1.1-VozUb1Q1rGdedibygdT_szkLU9P9RBnCCwFRDbOKAPJpMPQCTax0VN2W0uBN0S2zQG8uZNlyTOaTJ9UqhQwCB7UwHhKfw9upLMHgTMpzUJEokABaq5LHz3b5TNoiSPaC
       host:
       - api.openai.com
     method: POST
     parsed_body:
       input:
-      - call_id: call_N2BikjqNxghwNIwHl2XKfb0F
+      - call_id: call_NP4ZYWCcjva7uSRchwRbnCyq
         output: Sunny, 72F
         type: function_call_output
       model: gpt-4.1
-      previous_response_id: resp_0435eb6c2aa8e9eb0069e1600000608195818a61245c018620
+      previous_response_id: resp_089c555e8fb26536006a95f41a624c87d28e4dd4baddfb0bc2
       store: true
       stream: false
       tool_choice: auto
@@ -438,20 +483,20 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-length:
-      - '1565'
+      - '1908'
       content-type:
       - application/json
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '2413'
-      openai-project:
-      - proj_dKobscVY9YJxeEaDJen54e3d
+      - '526'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -462,17 +507,18 @@ interactions:
       background: false
       billing:
         payer: developer
-      completed_at: 1776377859
-      created_at: 1776377857
+      completed_at: 1788212251
+      created_at: 1788212251
       error: null
       frequency_penalty: 0.0
-      id: resp_0435eb6c2aa8e9eb0069e160015f14819589a941eb8f14e5a5
+      id: resp_089c555e8fb26536006a95f41b967087d28f5751be0b2b603d
       incomplete_details: null
       instructions: null
       max_output_tokens: null
       max_tool_calls: null
       metadata: {}
       model: gpt-4.1-2025-04-14
+      moderation: null
       object: response
       output:
       - content:
@@ -480,16 +526,17 @@ interactions:
           logprobs: []
           text: The weather in New York is sunny and 72°F.
           type: output_text
-        id: msg_0435eb6c2aa8e9eb0069e16003516081958ff28fb508f53045
+        id: msg_089c555e8fb26536006a95f41bdf3887d2895915f274d262dc
         role: assistant
         status: completed
         type: message
       parallel_tool_calls: true
       presence_penalty: 0.0
-      previous_response_id: resp_0435eb6c2aa8e9eb0069e1600000608195818a61245c018620
+      previous_response_id: resp_089c555e8fb26536006a95f41a624c87d28e4dd4baddfb0bc2
       prompt_cache_key: null
-      prompt_cache_retention: null
+      prompt_cache_retention: in_memory
       reasoning:
+        context: null
         effort: null
         summary: null
       safety_identifier: null
@@ -502,9 +549,23 @@ interactions:
           type: text
         verbosity: medium
       tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
       tools:
       - description: null
         name: get_weather
+        output_schema: null
         parameters:
           additionalProperties: false
           properties:
@@ -521,6 +582,7 @@ interactions:
       usage:
         input_tokens: 139
         input_tokens_details:
+          cache_write_tokens: 0
           cached_tokens: 0
         output_tokens: 14
         output_tokens_details:

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_stream.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_stream.yaml
@@ -4,11 +4,11 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
-      - '348'
+      - '362'
       content-type:
       - application/json
       host:
@@ -18,12 +18,11 @@ interactions:
       input:
       - content: What is the capital of France?
         role: user
-      instructions: ''
       model: gpt-4o
       stream: true
       tool_choice: auto
       tools:
-      - description: ''
+      - description: null
         name: get_capital
         parameters:
           additionalProperties: false
@@ -40,49 +39,51 @@ interactions:
     body:
       string: |+
         event: response.created
-        data: {"type":"response.created","response":{"id":"resp_67e554a155508191900ee113293c4c830794405d35281ae2","object":"response","created_at":1743082657,"status":"in_progress","error":null,"incomplete_details":null,"instructions":"","max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"function","description":null,"name":"get_capital","parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0bf9cabe1554144f006a95f3e5881887d2a1f8be0a9c0dc61e","object":"response","created_at":1788212197,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
         event: response.in_progress
-        data: {"type":"response.in_progress","response":{"id":"resp_67e554a155508191900ee113293c4c830794405d35281ae2","object":"response","created_at":1743082657,"status":"in_progress","error":null,"incomplete_details":null,"instructions":"","max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"function","description":null,"name":"get_capital","parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0bf9cabe1554144f006a95f3e5881887d2a1f8be0a9c0dc61e","object":"response","created_at":1788212197,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
         event: response.output_item.added
-        data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","call_id":"call_kL0PCQV7M2WMoVX8V8OtYSAL","name":"get_capital","arguments":"","status":"in_progress"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","type":"function_call","status":"in_progress","arguments":"","call_id":"call_krMjVWOqLVziwANwnbVZgmqE","name":"get_capital"},"output_index":0,"sequence_number":2}
 
         event: response.function_call_arguments.delta
-        data: {"type":"response.function_call_arguments.delta","item_id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","output_index":0,"delta":"{\""}
+        data: {"type":"response.function_call_arguments.delta","delta":"{\"","item_id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","obfuscation":"AQmWlbLUT0OaTc","output_index":0,"sequence_number":3}
 
         event: response.function_call_arguments.delta
-        data: {"type":"response.function_call_arguments.delta","item_id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","output_index":0,"delta":"country"}
+        data: {"type":"response.function_call_arguments.delta","delta":"country","item_id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","obfuscation":"g3RNlYbVM","output_index":0,"sequence_number":4}
 
         event: response.function_call_arguments.delta
-        data: {"type":"response.function_call_arguments.delta","item_id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","output_index":0,"delta":"\":\""}
+        data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","obfuscation":"Na0MWogLXT6m0","output_index":0,"sequence_number":5}
 
         event: response.function_call_arguments.delta
-        data: {"type":"response.function_call_arguments.delta","item_id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","output_index":0,"delta":"France"}
+        data: {"type":"response.function_call_arguments.delta","delta":"France","item_id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","obfuscation":"RvanY0YzHG","output_index":0,"sequence_number":6}
 
         event: response.function_call_arguments.delta
-        data: {"type":"response.function_call_arguments.delta","item_id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","output_index":0,"delta":"\"}"}
+        data: {"type":"response.function_call_arguments.delta","delta":"\"}","item_id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","obfuscation":"L5lHzcuZ6vLqhh","output_index":0,"sequence_number":7}
 
         event: response.function_call_arguments.done
-        data: {"type":"response.function_call_arguments.done","item_id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","output_index":0,"arguments":"{\"country\":\"France\"}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"country\":\"France\"}","item_id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","output_index":0,"sequence_number":8}
 
         event: response.output_item.done
-        data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","call_id":"call_kL0PCQV7M2WMoVX8V8OtYSAL","name":"get_capital","arguments":"{\"country\":\"France\"}","status":"completed"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","type":"function_call","status":"completed","arguments":"{\"country\":\"France\"}","call_id":"call_krMjVWOqLVziwANwnbVZgmqE","name":"get_capital"},"output_index":0,"sequence_number":9}
 
         event: response.completed
-        data: {"type":"response.completed","response":{"id":"resp_67e554a155508191900ee113293c4c830794405d35281ae2","object":"response","created_at":1743082657,"status":"completed","error":null,"incomplete_details":null,"instructions":"","max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[{"type":"function_call","id":"fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2","call_id":"call_kL0PCQV7M2WMoVX8V8OtYSAL","name":"get_capital","arguments":"{\"country\":\"France\"}","status":"completed"}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"function","description":null,"name":"get_capital","parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":255,"input_tokens_details":{"cached_tokens":0},"output_tokens":16,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":271},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0bf9cabe1554144f006a95f3e5881887d2a1f8be0a9c0dc61e","object":"response","created_at":1788212197,"status":"completed","background":false,"completed_at":1788212198,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","moderation":null,"output":[{"id":"fc_0bf9cabe1554144f006a95f3e6eb9087d2a165a783fac9989d","type":"function_call","status":"completed","arguments":"{\"country\":\"France\"}","call_id":"call_krMjVWOqLVziwANwnbVZgmqE","name":"get_capital"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":39,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":16,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":55},"user":null,"metadata":{}},"sequence_number":10}
 
     headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-type:
       - text/event-stream; charset=utf-8
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '100'
+      - '230'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -97,16 +98,13 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
-      - '610'
+      - '594'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=elE9FknxoKl9hypuWr9U7L0wvq0uECHBbKEn0s4ymsE-1743082657-1.0.1.1-NtLziVJ.95rmB6AWode1f2xyipNMUbu_BKePPZjYQerhr9gRgMHV4iW.0tAhxdVAlgKvQ1BP.yKoSYj9GVD3phMrStrVxclEQ5scgA37Ie0;
-        _cfuvid=jgKaRpCXzc4an8g3tXyrelqdUfEtMZsdBPqFq9LZqR4-1743082657435-0.0.1.1-604800000
       host:
       - api.openai.com
     method: POST
@@ -115,18 +113,17 @@ interactions:
       - content: What is the capital of France?
         role: user
       - arguments: '{"country":"France"}'
-        call_id: fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2
+        call_id: call_krMjVWOqLVziwANwnbVZgmqE
         name: get_capital
         type: function_call
-      - call_id: fc_67e554a1de488191af0831d35cbe082e0794405d35281ae2
+      - call_id: call_krMjVWOqLVziwANwnbVZgmqE
         output: Paris
         type: function_call_output
-      instructions: ''
       model: gpt-4o
       stream: true
       tool_choice: auto
       tools:
-      - description: ''
+      - description: null
         name: get_capital
         parameters:
           additionalProperties: false
@@ -143,61 +140,63 @@ interactions:
     body:
       string: |+
         event: response.created
-        data: {"type":"response.created","response":{"id":"resp_67e554a21aa88191b65876ac5e5bbe0406c52f0e511c76ed","object":"response","created_at":1743082658,"status":"in_progress","error":null,"incomplete_details":null,"instructions":"","max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"function","description":null,"name":"get_capital","parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_003440f5ba4dd7f1006a95f3e7961887d2ae83dcea20d24a32","object":"response","created_at":1788212199,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
         event: response.in_progress
-        data: {"type":"response.in_progress","response":{"id":"resp_67e554a21aa88191b65876ac5e5bbe0406c52f0e511c76ed","object":"response","created_at":1743082658,"status":"in_progress","error":null,"incomplete_details":null,"instructions":"","max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"function","description":null,"name":"get_capital","parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_003440f5ba4dd7f1006a95f3e7961887d2ae83dcea20d24a32","object":"response","created_at":1788212199,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
         event: response.output_item.added
-        data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","status":"in_progress","role":"assistant","content":[]}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
         event: response.content_part.added
-        data: {"type":"response.content_part.added","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":"The"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"QmKIBsg46jlsJ","output_index":0,"sequence_number":4}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":" capital"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" capital","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"FRH2W3Z0","output_index":0,"sequence_number":5}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":" of"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"yDykx37WSQXOj","output_index":0,"sequence_number":6}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":" France"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" France","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"1Ynf9MRQC","output_index":0,"sequence_number":7}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":" is"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"MeVR193bGD2DI","output_index":0,"sequence_number":8}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":" Paris"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Paris","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"XyBNNejQNM","output_index":0,"sequence_number":9}
 
         event: response.output_text.delta
-        data: {"type":"response.output_text.delta","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"delta":"."}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"obfuscation":"qrunM5OkAxCJMTo","output_index":0,"sequence_number":10}
 
         event: response.output_text.done
-        data: {"type":"response.output_text.done","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"text":"The capital of France is Paris."}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","logprobs":[],"output_index":0,"sequence_number":11,"text":"The capital of France is Paris."}
 
         event: response.content_part.done
-        data: {"type":"response.content_part.done","item_id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","output_index":0,"content_index":0,"part":{"type":"output_text","text":"The capital of France is Paris.","annotations":[]}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of France is Paris."},"sequence_number":12}
 
         event: response.output_item.done
-        data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","status":"completed","role":"assistant","content":[{"type":"output_text","text":"The capital of France is Paris.","annotations":[]}]}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of France is Paris."}],"role":"assistant"},"output_index":0,"sequence_number":13}
 
         event: response.completed
-        data: {"type":"response.completed","response":{"id":"resp_67e554a21aa88191b65876ac5e5bbe0406c52f0e511c76ed","object":"response","created_at":1743082658,"status":"completed","error":null,"incomplete_details":null,"instructions":"","max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[{"type":"message","id":"msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed","status":"completed","role":"assistant","content":[{"type":"output_text","text":"The capital of France is Paris.","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[{"type":"function","description":null,"name":"get_capital","parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":278,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":287},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_003440f5ba4dd7f1006a95f3e7961887d2ae83dcea20d24a32","object":"response","created_at":1788212199,"status":"completed","background":false,"completed_at":1788212200,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","moderation":null,"output":[{"id":"msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The capital of France is Paris."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"type":"function","description":null,"name":"get_capital","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"country":{"type":"string"}},"required":["country"],"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":62,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":71},"user":null,"metadata":{}},"sequence_number":14}
 
     headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-type:
       - text/event-stream; charset=utf-8
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '122'
+      - '146'
       openai-version:
       - '2020-10-01'
       strict-transport-security:

--- a/tests/models/test_bedrock_mantle.py
+++ b/tests/models/test_bedrock_mantle.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import os
 from decimal import Decimal
 
+import httpx2
 import pytest
 from inline_snapshot import snapshot
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from pydantic_ai import Agent, BinaryImage, RequestUsage, UserError
 from pydantic_ai.capabilities import NativeTool
@@ -23,6 +24,7 @@ from pydantic_ai.native_tools import WebSearchTool
 from pydantic_ai.output import NativeOutput
 
 from ..conftest import IsDatetime, IsStr, try_import
+from .conftest import RequestCapture
 
 with try_import() as imports_successful:
     from pydantic_ai.providers.bedrock_mantle import BedrockMantleProvider
@@ -34,15 +36,19 @@ pytestmark = [
 ]
 
 
-def _provider() -> BedrockMantleProvider:
-    return BedrockMantleProvider(region_name='us-east-1', api_key=os.getenv('AWS_BEARER_TOKEN_BEDROCK', 'mock-api-key'))
+def _provider(http_client: httpx2.AsyncClient | None = None) -> BedrockMantleProvider:
+    return BedrockMantleProvider(
+        region_name='us-east-1',
+        api_key=os.getenv('AWS_BEARER_TOKEN_BEDROCK', 'mock-api-key'),
+        http_client=http_client,
+    )
 
 
 @pytest.mark.parametrize('stream', [False, True], ids=['request', 'stream'])
 @pytest.mark.moves_cache_prefix(reason='replay uses a fresh agent without the original instructions and tools')
-async def test_reused_tool_call_ids(stream: bool, allow_model_requests: None) -> None:
-    """Mantle GPT-5.6 resets Responses tool-call IDs per response; pydantic-ai must re-qualify them."""
-    model = infer_model('bedrock-mantle:openai.gpt-5.6-luna', lambda _: _provider())
+async def test_reused_tool_call_ids(stream: bool, allow_model_requests: None, request_capture: RequestCapture) -> None:
+    """Mantle IDs stay unique in normalized history and return to their raw form on the wire."""
+    model = infer_model('bedrock-mantle:openai.gpt-5.6-luna', lambda _: _provider(request_capture.client))
     agent = Agent(
         model,
         instructions=(
@@ -218,6 +224,43 @@ Second tool result: `second result`\
         assert all(call.tool_call_id.endswith(':call_0') for _, call in tool_calls)
         replay_result = await Agent(model).run('Reply with exactly OK.', message_history=messages)
         assert replay_result.output == 'OK'
+
+    input_adapter = TypeAdapter(list[dict[str, object]])
+    wire_call_ids: list[tuple[str, str]] = []
+    for body in request_capture.bodies('/responses'):
+        for item in input_adapter.validate_python(body['input']):
+            item_type = item.get('type')
+            call_id = item.get('call_id')
+            if isinstance(item_type, str) and isinstance(call_id, str):
+                wire_call_ids.append((item_type, call_id))
+    expected_wire_call_ids = (
+        snapshot(
+            [
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+                ('function_call', 'call_1'),
+                ('function_call_output', 'call_1'),
+            ]
+        )
+        if stream
+        else snapshot(
+            [
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+                ('function_call', 'call_0'),
+                ('function_call_output', 'call_0'),
+            ]
+        )
+    )
+    assert wire_call_ids == expected_wire_call_ids
 
 
 @pytest.mark.moves_cache_prefix(reason='replay uses a fresh agent without the original instructions and tools')

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -3933,6 +3933,49 @@ async def test_openai_previous_response_id_same_model_history(allow_model_reques
     )
 
 
+async def test_response_scoped_tool_call_id_with_previous_response(allow_model_requests: None) -> None:
+    """The raw provider ID is restored when the qualifying response is held server-side."""
+    response_id = f'resp_{"x" * 83}'
+    qualified_call_id = f'{response_id}:call_0'
+    history: list[ModelRequest | ModelResponse] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name='tool',
+                    args='{}',
+                    tool_call_id=qualified_call_id,
+                    id='fc_1',
+                    provider_name='openai',
+                )
+            ],
+            model_name='gpt-5.6-sol',
+            provider_name='openai',
+            provider_response_id=response_id,
+        ),
+        ModelRequest(parts=[ToolReturnPart(tool_name='tool', content='result', tool_call_id=qualified_call_id)]),
+    ]
+    mock_client = MockOpenAIResponses.create_mock(response_message([]))
+    model = OpenAIResponsesModel(
+        'gpt-5.6-sol',
+        provider=OpenAIProvider(openai_client=mock_client),
+        profile=OpenAIModelProfile(openai_responses_tool_call_ids_are_response_scoped=True),
+    )
+
+    await model.request(
+        history,
+        OpenAIResponsesModelSettings(openai_previous_response_id='auto'),
+        ModelRequestParameters(),
+    )
+
+    request_kwargs = get_mock_responses_kwargs(mock_client)[0]
+    assert (request_kwargs['previous_response_id'], request_kwargs['input']) == snapshot(
+        (
+            'resp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+            [{'type': 'function_call_output', 'call_id': 'call_0', 'output': 'result'}],
+        )
+    )
+
+
 async def test_openai_previous_response_id_concrete_seed_without_history(openai_api_key: str):
     """A concrete seed is used as-is when there is no prior response in the history."""
     history = [ModelRequest(parts=[UserPromptPart(content='Continue')])]

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -1292,12 +1292,12 @@ async def test_openai_responses_stream(allow_model_requests: None, openai_api_ke
                     parts=[
                         TextPart(
                             content='The capital of France is Paris.',
-                            id='msg_67e554a28bec8191b56d3e2331eff88006c52f0e511c76ed',
+                            id='msg_003440f5ba4dd7f1006a95f3e8cd9087d2b399f7145627ec79',
                             provider_name='openai',
                         )
                     ],
                     usage=RequestUsage(
-                        input_tokens=278, output_tokens=9, output_reasoning_tokens=0, details={'reasoning_tokens': 0}
+                        input_tokens=62, output_tokens=9, output_reasoning_tokens=0, details={'reasoning_tokens': 0}
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
@@ -1305,9 +1305,9 @@ async def test_openai_responses_stream(allow_model_requests: None, openai_api_ke
                     provider_url='https://api.openai.com/v1/',
                     provider_details={
                         'finish_reason': 'completed',
-                        'timestamp': datetime(2025, 3, 27, 13, 37, 38, tzinfo=timezone.utc),
+                        'timestamp': IsDatetime(),
                     },
-                    provider_response_id='resp_67e554a21aa88191b65876ac5e5bbe0406c52f0e511c76ed',
+                    provider_response_id='resp_003440f5ba4dd7f1006a95f3e7961887d2ae83dcea20d24a32',
                     finish_reason='stop',
                 )
             )

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -57,7 +57,7 @@ from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.direct import model_request as direct_model_request
 from pydantic_ai.exceptions import ContentFilterError, ModelHTTPError, ModelRetry, SuspendedResponseExpired
 from pydantic_ai.messages import INVALID_JSON_KEY, ToolSearchCallPart, ToolSearchReturnPart, sanitize_messages
-from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAspectRatio, MCPServerTool, WebSearchTool
 from pydantic_ai.native_tools._tool_search import ToolSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
@@ -3969,6 +3969,35 @@ async def test_response_scoped_tool_call_id_with_previous_response(allow_model_r
 
     request_kwargs = get_mock_responses_kwargs(mock_client)[0]
     assert (request_kwargs['previous_response_id'], request_kwargs['input']) == snapshot(
+        (
+            'resp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+            [{'type': 'function_call_output', 'call_id': 'call_0', 'output': 'result'}],
+        )
+    )
+
+    compact_kwargs: dict[str, Any] = {}
+
+    async def fake_compact(**kwargs: Any) -> CompactedResponse:
+        compact_kwargs.update(kwargs)
+        return CompactedResponse(
+            id='resp_compact',
+            created_at=0,
+            object='response.compaction',
+            output=[ResponseCompactionItem(id='comp_1', encrypted_content='encrypted', type='compaction')],
+            usage=ResponseUsage.model_construct(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
+
+    model.client.responses.compact = fake_compact
+    await model.compact_messages(
+        ModelRequestContext(
+            model=model,
+            messages=history,
+            model_settings=OpenAIResponsesModelSettings(openai_previous_response_id='auto'),
+            model_request_parameters=ModelRequestParameters(),
+        )
+    )
+
+    assert (compact_kwargs['previous_response_id'], compact_kwargs['input']) == snapshot(
         (
             'resp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
             [{'type': 'function_call_output', 'call_id': 'call_0', 'output': 'result'}],
@@ -13586,8 +13615,6 @@ async def test_openai_responses_compact_replants_standing_prompt(allow_model_req
         )
 
     model.client.responses.compact = fake_compact
-    from pydantic_ai.models import ModelRequestContext
-
     response = await model.compact_messages(
         ModelRequestContext(
             model=model, messages=messages, model_settings=None, model_request_parameters=ModelRequestParameters()


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Bedrock Mantle now rejects Responses API `call_id` values longer than 64 characters. The response-scoped IDs introduced in #6538 can exceed that limit because Pydantic AI stores them as `<response_id>:<call_id>`.

This keeps the response-qualified form in normalized message history, where it prevents collisions, but restores the provider's raw `call_id` at the outbound OpenAI Responses boundary. It also handles `openai_previous_response_id='auto'`, where the originating response is no longer present in the replayed input.

Relates to #6536 and #6538.

Slack outage report: link to be added by David.

New public surface: none.

Existing users: affected Bedrock Mantle agents can replay tool results without exceeding the provider limit; providers without response-scoped IDs are unchanged.

Regression coverage:

- [`test_reused_tool_call_ids`](https://github.com/pydantic/pydantic-ai/blob/codex/fix-bedrock-mantle-tool-call-id-limit/tests/models/test_bedrock_mantle.py) verifies both request and streaming paths keep qualified history IDs while sending raw IDs.
- [`test_response_scoped_tool_call_id_with_previous_response`](https://github.com/pydantic/pydantic-ai/blob/codex/fix-bedrock-mantle-tool-call-id-limit/tests/models/test_openai_responses.py) verifies the `previous_response_id` and compaction paths.
- Live-recorded `gpt-4o` streaming verifies an ordinary OpenAI profile replays the same raw `call_id` for the function call and output.
- Live-recorded `gpt-4.1` continuation verifies seeded and automatic `previous_response_id` chaining across retries and tool outputs. Both recordings replay offline in CI.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (Not applicable.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
