### PR TITLE
fix(messages): treat an empty CompactionPart as a non-boundary

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2969,7 +2969,7 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    return not requires_encrypted_content and bool(part.content)
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2865,3 +2865,21 @@ def test_post_compaction_window_accepts_a_minimal_sequence():
     assert len(window) == 2
     assert isinstance(window[0], ModelResponse)
     assert isinstance(window[1], ModelRequest)
+
+
+def test_empty_compaction_part_is_not_a_wire_boundary():
+    """Regression: an empty-string CompactionPart must not count as a wire boundary,
+    matching CompactionPart.has_content() semantics."""
+    from pydantic_ai.messages import _compaction_part_is_wire_boundary
+
+    empty = CompactionPart(content='', provider_name='anthropic')
+    none = CompactionPart(content=None, provider_name='anthropic')
+    real = CompactionPart(content='summary text', provider_name='anthropic')
+
+    assert not empty.has_content()
+    assert not none.has_content()
+    assert real.has_content()
+
+    assert not _compaction_part_is_wire_boundary(empty, 'anthropic')
+    assert not _compaction_part_is_wire_boundary(none, 'anthropic')
+    assert _compaction_part_is_wire_boundary(real, 'anthropic')


### PR DESCRIPTION
Fixes #7773.

An empty-string `CompactionPart` (`content=''`) passes the `is not None` check
in `_compaction_part_is_wire_boundary` and gets treated as a wire boundary. The
downstream effect is that the compaction window splits at an empty summary,
dropping the conversation history after that point.

`CompactionPart.has_content()` already distinguishes empty from non-empty via
truthiness (`return bool(self.content)`), but the boundary check used identity
instead:

```python
# before
return not requires_encrypted_content and part.content is not None

# after
return not requires_encrypted_content and bool(part.content)
```

This aligns the boundary decision with `has_content()` semantics: an empty
string is not a meaningful boundary, just as `None` is not.

### Test

`test_empty_compaction_part_is_not_a_wire_boundary` covers the three cases:
- `content=''` (empty) — not a boundary (was wrongly treated as one)
- `content=None` — not a boundary (already correct)
- `content='summary text'` — boundary (unchanged)

Verified red-first: the test fails with `AssertionError: assert not True` on the
unfixed code and passes after the change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

