### PR TITLE
Stop rebuilding unmanaged models in durable capability operations

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaita
 from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 from typing import Any, ClassVar, Literal, NamedTuple, Protocol, TypeVar, cast, runtime_checkable
-from weakref import ref
+from weakref import ReferenceType, ref
 
 from pydantic_core import PydanticSerializationError
 from typing_extensions import Self
@@ -124,6 +124,12 @@ class _BoundModelOperations(NamedTuple):
     request_stream: BoundDurableOperation[ModelRequestParams, Any, StreamedActivityResult]
     compact_messages: BoundDurableOperation[ModelCompactMessagesParams, Any, ModelResponse]
     cancel_suspended_response: BoundDurableOperation[ModelCancelSuspendedResponseParams, Any, None]
+
+
+class _ResolvedRequestModel(NamedTuple):
+    model_ref: ReferenceType[Model]
+    model_id: str | None
+    registered: bool
 
 
 class _ModelRequestCacheIdentity(CacheIdentity[ModelRequestParams]):
@@ -253,6 +259,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         self._bound_event_operation: BoundDurableOperation[EventStreamHandlerParams, Any, None] | None = None
         self._bound_capability_operations: dict[tuple[str, str], CapabilityBoundOperation] = {}
         self._capability_declarations: dict[tuple[str, str], CapabilityMethodDeclaration] = {}
+        self._resolved_request_models: dict[int, _ResolvedRequestModel] = {}
 
     def for_agent(self, agent: AbstractAgent[AgentDepsT, Any]) -> Self:
         """Bind to the agent and register this engine's durable units on a new copy."""
@@ -266,6 +273,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         bound = copy.copy(self)
         bound.name = self.name or agent.name or ''
         bound._agent = agent
+        bound._resolved_request_models = {}
         bound._bind_models(agent)
         bound._toolsets_by_id = {}
         bound._bind_to_agent(agent)
@@ -452,6 +460,8 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             resolved_model = None
             if projection.model_id != inbound.model_id:
                 resolved_model = await self._resolve_model_for_request(projection.model_id, ctx)
+                registered, _ = self._registered_model_id(resolved_model)
+                self._record_resolved_request_model(resolved_model, projection.model_id, registered=registered)
             value: Any = _ResolvedModelRequestContext(projection=projection, model=resolved_model)
         else:
             value = result.value
@@ -1248,62 +1258,66 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         if not self.in_durable_context:
             return await handler(request_context)
 
-        self._validate_model_request_parameters(request_context.model_request_parameters)
+        resolved = self._resolved_request_model(request_context.model)
+        owned = resolved is not None and not resolved.registered
         model_id = self._model_id_for_request(ctx, request_context)
-        model_name = request_context.model.model_name
-        backend = self.get_durable_operation_backend()
-        operations = self._bound_model_operations or self._bind_model_operations(
-            backend, model_id=model_id, model_name=model_name
-        )
+        async with managed_model_scope(request_context.model, owned=owned) as active_model:
+            request_context.model = active_model
+            self._validate_model_request_parameters(request_context.model_request_parameters)
+            model_name = request_context.model.model_name
+            backend = self.get_durable_operation_backend()
+            operations = self._bound_model_operations or self._bind_model_operations(
+                backend, model_id=model_id, model_name=model_name
+            )
 
-        async def request_segment(request: ModelRequestContext) -> ModelResponse:
-            return await operations.request(
-                ModelRequestParams(
-                    model_id,
-                    messages=request.messages,
-                    model_settings=request.model_settings,
-                    model_request_parameters=request.model_request_parameters,
-                    run_context=ctx,
+            async def request_segment(request: ModelRequestContext) -> ModelResponse:
+                return await operations.request(
+                    ModelRequestParams(
+                        model_id,
+                        messages=request.messages,
+                        model_settings=request.model_settings,
+                        model_request_parameters=request.model_request_parameters,
+                        run_context=ctx,
+                    )
                 )
-            )
 
-        async def request_stream_segment(request: ModelRequestContext) -> StreamedActivityResult:
-            result = await operations.request_stream(
-                ModelRequestParams(
-                    model_id,
-                    messages=request.messages,
-                    model_settings=request.model_settings,
-                    model_request_parameters=request.model_request_parameters,
-                    run_context=ctx,
+            async def request_stream_segment(request: ModelRequestContext) -> StreamedActivityResult:
+                result = await operations.request_stream(
+                    ModelRequestParams(
+                        model_id,
+                        messages=request.messages,
+                        model_settings=request.model_settings,
+                        model_request_parameters=request.model_request_parameters,
+                        run_context=ctx,
+                    )
                 )
-            )
-            return await self._load_streamed_activity_result(result, request.model_request_parameters)
+                return await self._load_streamed_activity_result(result, request.model_request_parameters)
 
-        async def cancel_suspended_response_segment(response: ModelResponse) -> None:
-            await operations.cancel_suspended_response(
-                ModelCancelSuspendedResponseParams(model_id, response=response, run_context=ctx)
-            )
-
-        async def compact_messages_segment(
-            compact_context: ModelRequestContext, instructions: str | None
-        ) -> ModelResponse:
-            return await operations.compact_messages(
-                ModelCompactMessagesParams(
-                    model_id,
-                    request_context=compact_context,
-                    instructions=instructions,
-                    run_context=ctx,
+            async def cancel_suspended_response_segment(response: ModelResponse) -> None:
+                await operations.cancel_suspended_response(
+                    ModelCancelSuspendedResponseParams(model_id, response=response, run_context=ctx)
                 )
-            )
 
-        request_context.model = DurableModel(
-            request_context.model,
-            request_segment=request_segment,
-            request_stream_segment=request_stream_segment,
-            compact_messages_segment=compact_messages_segment,
-            cancel_suspended_response_segment=cancel_suspended_response_segment,
-        )
-        return await handler(request_context)
+            async def compact_messages_segment(
+                compact_context: ModelRequestContext, instructions: str | None
+            ) -> ModelResponse:
+                return await operations.compact_messages(
+                    ModelCompactMessagesParams(
+                        model_id,
+                        request_context=compact_context,
+                        instructions=instructions,
+                        run_context=ctx,
+                    )
+                )
+
+            request_context.model = DurableModel(
+                request_context.model,
+                request_segment=request_segment,
+                request_stream_segment=request_stream_segment,
+                compact_messages_segment=compact_messages_segment,
+                cancel_suspended_response_segment=cancel_suspended_response_segment,
+            )
+            return await handler(request_context)
 
     async def _load_streamed_activity_result(
         self, result: object, model_request_parameters: ModelRequestParameters
@@ -1558,7 +1572,24 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             and unwrap_model(request_context.model) is unwrap_model(cast('Model[Any]', run_model))
         ):
             return provenance
+        resolved = self._resolved_request_model(request_context.model)
+        if resolved is not None:
+            return resolved.model_id
         return self._find_model_id(request_context.model)
+
+    def _record_resolved_request_model(self, model: Model, model_id: str | None, *, registered: bool) -> None:
+        model_key = id(model)
+
+        def discard(_model_ref: ReferenceType[Model]) -> None:
+            self._resolved_request_models.pop(model_key, None)
+
+        self._resolved_request_models[model_key] = _ResolvedRequestModel(ref(model, discard), model_id, registered)
+
+    def _resolved_request_model(self, model: Model) -> _ResolvedRequestModel | None:
+        resolved = self._resolved_request_models.get(id(model))
+        if resolved is not None and resolved.model_ref() is model:
+            return resolved
+        return None
 
     def _find_model_id(self, model: Model) -> str | None:
         """Find the cross-boundary identifier for a registered `Model` instance.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -413,12 +413,27 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
-        """Dispatch through serialized context so per-run capability instances recover worker-side."""
+        """Dispatch through serialized context so per-run capability instances recover worker-side.
+
+        Outside a durable container, calling the original operation preserves live context mutations
+        without rebuilding resources solely to round-trip them through the durable projection.
+        """
         capability_id = capability.id
         if capability_id is None:
             raise RuntimeError('A durable operation capability must have an explicit `id`.')
         key = (capability_id, operation)
         declaration = self._capability_declarations[key]
+        if not self.in_durable_context:
+            bound = declaration.function.__get__(capability, type(capability))
+            return await bound(*args, **kwargs)
+
+        request_context = next(
+            (value for value in (*args, *kwargs.values()) if isinstance(value, ModelRequestContext)), None
+        )
+        if request_context is not None:
+            projection = ModelRequestContextProjection.from_context(request_context)
+            args = tuple(projection if value is request_context else value for value in args)
+            kwargs = {key: projection if value is request_context else value for key, value in kwargs.items()}
         arguments = bind_arguments(declaration, ctx=ctx, args=args, kwargs=kwargs)
         model = ctx.model
         if not isinstance(model, Model):

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_capability_operation.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_capability_operation.py
@@ -262,19 +262,9 @@ def durable_operation(name: str) -> Callable[[Callable[P, A]], Callable[P, A]]:
                 # deliberately pass through to the undecorated method.
                 return await cast(Callable[..., Awaitable[Any]], target)(self, *args, **kwargs)
 
-            # Project live model-request context before it crosses a durable boundary.
             request_context = next(
                 (value for value in bound.arguments.values() if isinstance(value, ModelRequestContext)), None
             )
-            if isinstance(request_context, ModelRequestContext):
-                projection = ModelRequestContextProjection.from_context(request_context)
-                dispatch_args = tuple(projection if value is request_context else value for value in args)
-                dispatch_kwargs = {
-                    key: projection if value is request_context else value for key, value in kwargs.items()
-                }
-            else:
-                dispatch_args = args
-                dispatch_kwargs = kwargs
 
             # Resolve the per-run operation first, then the agent-bound fallback.
             handler = target.__get__(self, type(self))
@@ -283,7 +273,7 @@ def durable_operation(name: str) -> Callable[[Callable[P, A]], Callable[P, A]]:
                 operations.get((self.id, marker.name)) if operations is not None and self.id is not None else None
             )
             if operation is not None:
-                result = await operation(*dispatch_args, **dispatch_kwargs)
+                result = await operation(*args, **kwargs)
             else:
                 dispatcher = (
                     self._get_durable_operation_bindings().get(ctx.agent, {}).get(marker.name)  # pyright: ignore[reportPrivateUsage]
@@ -291,12 +281,12 @@ def durable_operation(name: str) -> Callable[[Callable[P, A]], Callable[P, A]]:
                     else None
                 )
                 if dispatcher is None:
-                    result = await handler(*dispatch_args, **dispatch_kwargs)
+                    result = await handler(*args, **kwargs)
                 else:
                     result = await dispatcher(
                         ctx,
-                        cast(tuple[object, ...], dispatch_args),
-                        cast(dict[str, object], dispatch_kwargs),
+                        cast(tuple[object, ...], args),
+                        cast(dict[str, object], kwargs),
                     )
 
             # Apply worker-side model-request mutations back to the live context.

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -212,16 +212,37 @@ class RepeatingLifecycleModel(LifecycleTrackingModel):
         return ModelResponse(parts=[TextPart('from-tracked')])
 
 
+def _tracked_model_resolver(
+    built: list[LifecycleTrackingModel],
+    *,
+    events: list[str] | None = None,
+    event_prefix: str = '',
+    model_type: type[LifecycleTrackingModel] = LifecycleTrackingModel,
+) -> Callable[[ModelResolutionContext[Any], str], LifecycleTrackingModel]:
+    """Build a fresh model for the one id these tests swap to, recording every instance.
+
+    Shared across the tests below rather than repeated inside each: the outside-a-container test
+    asserts this is never consulted, so a resolver of its own would leave a body nothing executes.
+    Each call gets its own event list unless the caller supplies one to share.
+    """
+
+    def resolve(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel:
+        del model_id
+        model = model_type(
+            events if events is not None else [],
+            event_prefix=event_prefix,
+            custom_output_text='from-tracked',
+        )
+        built.append(model)
+        return model
+
+    return resolve
+
+
 async def test_capability_operation_is_direct_outside_durable_context() -> None:
     events: list[str] = []
     built_models: list[LifecycleTrackingModel] = []
-
-    def resolve_model(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel | None:
-        if model_id != 'tracked':
-            return None
-        model = LifecycleTrackingModel(events, event_prefix='tracked-', custom_output_text='from-tracked')
-        built_models.append(model)
-        return model
+    resolve_model = _tracked_model_resolver(built_models, events=events, event_prefix='tracked-')
 
     durability = TransparentDurability()
     agent = Agent(
@@ -239,13 +260,7 @@ async def test_capability_operation_is_direct_outside_durable_context() -> None:
 async def test_capability_operation_model_id_swap_resolves_and_manages_model() -> None:
     events: list[str] = []
     built_models: list[LifecycleTrackingModel] = []
-
-    def resolve_model(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel | None:
-        if model_id != 'tracked':
-            return None
-        model = LifecycleTrackingModel(events, event_prefix='tracked-', custom_output_text='from-tracked')
-        built_models.append(model)
-        return model
+    resolve_model = _tracked_model_resolver(built_models, events=events, event_prefix='tracked-')
 
     durability = RecordingDurability()
     agent = Agent(
@@ -282,14 +297,8 @@ async def test_capability_operation_registered_model_id_swap_does_not_manage_mod
 
 
 async def test_repeated_capability_operation_model_id_swaps_close_each_model() -> None:
-    model_events: list[list[str]] = []
-
-    def resolve_model(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel | None:
-        if model_id != 'tracked':
-            return None
-        events: list[str] = []
-        model_events.append(events)
-        return RepeatingLifecycleModel(events, custom_output_text='from-tracked')
+    built_models: list[LifecycleTrackingModel] = []
+    resolve_model = _tracked_model_resolver(built_models, model_type=RepeatingLifecycleModel)
 
     agent = Agent(
         TestModel(custom_output_text='original'),
@@ -308,7 +317,7 @@ async def test_repeated_capability_operation_model_id_swaps_close_each_model() -
         return output
 
     assert (await agent.run('test')).output == 'from-tracked'
-    assert model_events == [
+    assert [model.events for model in built_models] == [
         ['enter', 'exit:none'],
         ['enter', 'request', 'exit:none'],
         ['enter', 'exit:none'],

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -30,8 +30,8 @@ from pydantic_ai.durable_exec._operation import CapabilityOperationId, DurableOp
 from pydantic_ai.durable_exec._operation_backend import CallableOperationBackend
 from pydantic_ai.durable_exec._operation_names import JournalOperationNamer
 from pydantic_ai.durable_exec._toolset import ToolConfig
-from pydantic_ai.exceptions import UserError
-from pydantic_ai.messages import ModelRequest, UserPromptPart
+from pydantic_ai.exceptions import ModelRetry, UserError
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
 from pydantic_ai.models import (
     ModelRequestContext,
     ModelRequestParameters,
@@ -201,6 +201,17 @@ class LifecycleModel(LifecycleTrackingModel):
             self.events.append('stream-exit')
 
 
+class RepeatingLifecycleModel(LifecycleTrackingModel):
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        self.events.append('request')
+        return ModelResponse(parts=[TextPart('from-tracked')])
+
+
 async def test_capability_operation_is_direct_outside_durable_context() -> None:
     events: list[str] = []
     built_models: list[LifecycleTrackingModel] = []
@@ -225,7 +236,7 @@ async def test_capability_operation_is_direct_outside_durable_context() -> None:
     assert not any('__capability__' in name for name, _ in durability.calls)
 
 
-async def test_capability_operation_dispatch_is_unchanged_inside_durable_context() -> None:
+async def test_capability_operation_model_id_swap_resolves_and_manages_model() -> None:
     events: list[str] = []
     built_models: list[LifecycleTrackingModel] = []
 
@@ -243,12 +254,66 @@ async def test_capability_operation_dispatch_is_unchanged_inside_durable_context
         capabilities=[ModelIdReplacingBeforeModelRequest(), ResolveModelId(resolve_model), durability],
     )
 
-    with pytest.raises(UserError, match='was not registered with `RecordingDurability`'):
-        await agent.run('test')
+    assert (await agent.run('test')).output == 'from-tracked'
 
-    assert events == []
-    assert len(built_models) == 1
+    assert events == [
+        'tracked-enter',
+        'tracked-enter',
+        'request',
+        'tracked-exit:none',
+        'tracked-exit:none',
+    ]
+    assert len(built_models) == 2
     assert any('__capability__' in name for name, _ in durability.calls)
+
+
+async def test_capability_operation_registered_model_id_swap_does_not_manage_model() -> None:
+    events: list[str] = []
+    registered = LifecycleTrackingModel(events, event_prefix='registered-', custom_output_text='from-registered')
+    durability = RecordingDurability(models={'tracked': registered})
+    agent = Agent(
+        TestModel(custom_output_text='original'),
+        name='registered_capability_operation_model',
+        capabilities=[ModelIdReplacingBeforeModelRequest(), durability],
+    )
+
+    assert (await agent.run('test')).output == 'from-registered'
+    assert events == ['request']
+
+
+async def test_repeated_capability_operation_model_id_swaps_close_each_model() -> None:
+    model_events: list[list[str]] = []
+
+    def resolve_model(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel | None:
+        if model_id != 'tracked':
+            return None
+        events: list[str] = []
+        model_events.append(events)
+        return RepeatingLifecycleModel(events, custom_output_text='from-tracked')
+
+    agent = Agent(
+        TestModel(custom_output_text='original'),
+        name='repeated_capability_operation_model',
+        capabilities=[ModelIdReplacingBeforeModelRequest(), ResolveModelId(resolve_model), RecordingDurability()],
+    )
+
+    attempts = 0
+
+    @agent.output_validator
+    def retry_once(output: str) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ModelRetry('retry once')
+        return output
+
+    assert (await agent.run('test')).output == 'from-tracked'
+    assert model_events == [
+        ['enter', 'exit:none'],
+        ['enter', 'request', 'exit:none'],
+        ['enter', 'exit:none'],
+        ['enter', 'request', 'exit:none'],
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -296,6 +296,34 @@ async def test_capability_operation_registered_model_id_swap_does_not_manage_mod
     assert events == ['request']
 
 
+async def test_resolved_request_model_records_are_released_with_their_models() -> None:
+    built_models: list[LifecycleTrackingModel] = []
+    durability = RecordingDurability()
+    agent = Agent(
+        TestModel(custom_output_text='original'),
+        name='released_capability_operation_model',
+        capabilities=[
+            ModelIdReplacingBeforeModelRequest(),
+            ResolveModelId(_tracked_model_resolver(built_models)),
+            durability,
+        ],
+    )
+
+    await agent.run('test')
+
+    bound = RecordingDurability.from_agent(agent)
+    assert bound is not None
+    records = bound._resolved_request_models  # pyright: ignore[reportPrivateUsage]
+    assert records
+
+    # The record outlives the request it was made for, so it has to be released with its model
+    # rather than accumulating one entry per swapped request for the life of the agent.
+    built_models.clear()
+    gc.collect()
+
+    assert records == {}
+
+
 async def test_repeated_capability_operation_model_id_swaps_close_each_model() -> None:
     built_models: list[LifecycleTrackingModel] = []
     resolve_model = _tracked_model_resolver(built_models, model_type=RepeatingLifecycleModel)

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -162,6 +162,23 @@ class ReplayingDurability(RecordingDurability):
     replay_capability_operations = True
 
 
+class TransparentDurability(RecordingDurability):
+    @property
+    def in_durable_context(self) -> bool:
+        return False
+
+
+class ModelIdReplacingBeforeModelRequest(AbstractCapability[Any]):
+    id = 'model_id_replacing_before_model'
+
+    @durable_operation('before_model_request')
+    async def before_model_request(
+        self, ctx: RunContext[Any], request_context: ModelRequestContext
+    ) -> ModelRequestContext:
+        request_context.model_id = 'tracked'
+        return request_context
+
+
 class LifecycleModel(LifecycleTrackingModel):
     def __init__(self, events: list[str], **kwargs: Any) -> None:
         super().__init__(events, event_prefix='model-', **kwargs)
@@ -182,6 +199,56 @@ class LifecycleModel(LifecycleTrackingModel):
                 yield streamed
         finally:
             self.events.append('stream-exit')
+
+
+async def test_capability_operation_is_direct_outside_durable_context() -> None:
+    events: list[str] = []
+    built_models: list[LifecycleTrackingModel] = []
+
+    def resolve_model(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel | None:
+        if model_id != 'tracked':
+            return None
+        model = LifecycleTrackingModel(events, event_prefix='tracked-', custom_output_text='from-tracked')
+        built_models.append(model)
+        return model
+
+    durability = TransparentDurability()
+    agent = Agent(
+        TestModel(custom_output_text='original'),
+        name='direct_capability_operation',
+        capabilities=[ModelIdReplacingBeforeModelRequest(), ResolveModelId(resolve_model), durability],
+    )
+
+    assert (await agent.run('test')).output == 'original'
+    assert events == []
+    assert built_models == []
+    assert not any('__capability__' in name for name, _ in durability.calls)
+
+
+async def test_capability_operation_dispatch_is_unchanged_inside_durable_context() -> None:
+    events: list[str] = []
+    built_models: list[LifecycleTrackingModel] = []
+
+    def resolve_model(_ctx: ModelResolutionContext[Any], model_id: str) -> LifecycleTrackingModel | None:
+        if model_id != 'tracked':
+            return None
+        model = LifecycleTrackingModel(events, event_prefix='tracked-', custom_output_text='from-tracked')
+        built_models.append(model)
+        return model
+
+    durability = RecordingDurability()
+    agent = Agent(
+        TestModel(custom_output_text='original'),
+        name='durable_capability_operation',
+        capabilities=[ModelIdReplacingBeforeModelRequest(), ResolveModelId(resolve_model), durability],
+    )
+
+    with pytest.raises(UserError, match='was not registered with `RecordingDurability`'):
+        await agent.run('test')
+
+    assert events == []
+    assert len(built_models) == 1
+    assert any('__capability__' in name for name, _ in durability.calls)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #7969, both parts.

`BaseDurabilityCapability._invoke_capability_operation` rebuilt a `Model` when a `@durable_operation`-decorated `before_model_request` hook swapped `request_context.model_id`, and nothing ever entered that instance. An unentered model is exactly as leaky as one entered and never exited: a provider builds `_own_http_client` eagerly in `__init__` and only closes it from `Provider.__aexit__`, which no-ops at `_entered_count == 0`.

The two halves have to land together. Fixing the provenance alone would have made the leak live, because the rejection described below is currently the only thing preventing it.

## 1. The dispatch had no `in_durable_context` gate

`_invoke_capability_operation` was the only member of its family without one. Its siblings have it at `_base.py:492`, `:531`, `:559`, `:728`, and `:1233`. Outside a durable container there is no boundary to serialize across, the hook has already mutated the live `ModelRequestContext` in place, and `wrap_model_request` early-returns anyway, so the whole projection round-trip was pointless work that also rebuilt a model nobody owned.

The projection moved out of the `durable_operation` decorator and into `_invoke_capability_operation`, behind the gate. Outside a container the undecorated operation now runs directly, which is exactly what the same capability does with no durability attached.

Reproducer before, with a durability capability attached but executing outside its container (a supported mode: `tests/durable_exec/test_dbos.py:3004`, "DBOSDurability is transparent outside a DBOS workflow"):

```
OUTPUT: from-tracked
EVENTS: ['request']
MODELS BUILT: 1
```

After:

```
OUTPUT: original
EVENTS: []
MODELS BUILT: 0
```

## 2. Inside a container, the sanctioned `ResolveModelId` escape hatch was rejected

The same swap inside a durable container raised instead:

> The model instance 'test:lifecycle' was not registered with `RecordingDurability` [...] or pass a model-name string and build the instance from it with a `ResolveModelId` capability.

The reproducer already used a `ResolveModelId` capability. `_model_id_for_request` drops the provenance whenever the request's model is not the run's model. That identity check exists so an instance swapped in by an *outer* capability cannot inherit a stale `model_id`, but it cannot distinguish that from "the durable layer itself just built this instance from `projection.model_id`", where the provenance is correct by construction. So the layer resolved a model through the sanctioned chain and then rejected its own resolution three lines later.

Net effect: swapping `model_id` from a durable hook worked when the target was registered in `models=`, and failed when a resolver built it, even though `_resolve_model_for_request` consults that chain first.

The resolution site now records the pairing from the resolved instance to the `model_id` it came from, plus whether it is registered. `_model_id_for_request` consults that record after the existing identity check, so an outer-capability swap still invalidates the provenance exactly as before. `wrap_model_request` context-manages the model through `managed_model_scope` when it is one this layer resolved and is not registered; registered instances keep their existing external owner and are still not entered.

## Notes from building it

**The obvious fix is wrong.** Skipping the resolution and carrying only `projection.model_id` forward would delete the construction site entirely, and naming is not an obstacle (`ModelRequestId.model_name` never reaches the persisted operation name, and Temporal prefers `params.model_id` over it). But `DurableModel` delegates `profile`, `settings`, and `continuation_delay` to its wrapped model workflow-side, so leaving the previous model wrapped would customize request parameters with the wrong profile. The layer genuinely needs a live instance.

**`WeakKeyDictionary` does not work here**, because `Model` instances are unhashable. The record is keyed on `id(model)` with a weak reference and a collection callback, and every lookup verifies the referent is still the same object, so a recycled id fails safe to `_find_model_id` rather than answering wrongly.

**Two models per swapped request is expected, not a leak.** One is built workflow-side to answer `profile` and `settings`, one worker-side inside `_durable_model_scope`. In a real deployment those are separate processes. `test_repeated_capability_operation_model_id_swaps_close_each_model` pins the full sequence across two requests and asserts each of the four is entered and exited exactly once, so nothing accumulates.

## Tests

- Outside a container: no model is built and no lifecycle event fires.
- Inside a container: the swap now succeeds, with symmetric enter/exit on both instances.
- A registered-model swap is *not* entered by this layer, since it keeps its external owner.
- Repeated requests in one run close every model they open.
- `test_decorated_model_request_hook_rejects_unregistered_model_replacement` still passes unchanged: a genuine outer-capability swap to an unregistered instance is still rejected.

Durable suite 705 passed / 2 skipped, `tests/test_agent.py` 434 passed, lint and pyright clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

