### PR TITLE
Let an instruction function declare itself `static`

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1425,6 +1425,27 @@ There are two ways to declare a name, depending on what the part is:
 - **A function** is named where it is registered: [`@agent.instructions(name=...)`][pydantic_ai.agent.Agent.instructions], [`@capability.instructions(name=...)`][pydantic_ai.capabilities.Capability.instructions].
 - **Literal text** carries its name on the text itself, by passing an [`InstructionPart`][pydantic_ai.messages.InstructionPart] anywhere instructions are accepted — `Agent(instructions=...)`, `Capability(instructions=...)`, `FunctionToolset(instructions=...)`, or a `get_instructions()` implementation on a [capability](capabilities/custom.md) or [toolset](toolsets.md#building-a-custom-toolset). The part also decides whether it counts as [`dynamic`][pydantic_ai.messages.InstructionPart.dynamic], which is what keeps it outside the cacheable prefix (see [prompt caching](models/anthropic.md#prompt-caching)), and a part is always kept whole rather than merged with its neighbours.
 
+#### Instructions written as a function, fixed for the run
+
+A part is [`dynamic`][pydantic_ai.messages.InstructionPart.dynamic] when the agent recomputes it per request, and that decides which side of the provider's cache breakpoint it lands on (see [prompt caching](models/anthropic.md#prompt-caching)). An instruction function is dynamic by default, because usually that is what a function is for.
+
+Sometimes it isn't. Reaching for a function to *write* fixed text — composing it from a template, reading it out of a config file, looping over feature flags — pushes that text behind the breakpoint for every request of every run, when nothing about it changes. Pass `static=True` to say so:
+
+```python {title="static_instructions.py"}
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.6-sol', deps_type=str)
+
+
+@agent.instructions(name='style', static=True)
+def style_guide() -> str:
+    return '\n'.join(f'- {rule}' for rule in ('Be concise.', 'Cite sources.'))
+```
+
+The block then sorts into the cacheable prefix, and the function is called **once per run** rather than once per model request — which is what makes the first part honest, since a block that claimed the prefix while being recomputed each step would move the prefix under a static label.
+
+"Fixed for the run" is the whole contract, so a static function may read [`RunContext`][pydantic_ai.tools.RunContext] for anything that does not change mid-run, `deps` above all. Don't reach for it when the text depends on [`run_step`][pydantic_ai.tools.RunContext.run_step], the message history, or the time.
+
 Because a part's id is stable across runs, an application that stores instruction configuration elsewhere (say, a UI where a user edits the instructions an MCP server contributes) can key that configuration on the id instead of on the part's position or wording, both of which change as the agent evolves.
 
 A source key is what everything else is built from, so it keeps its meaning permanently: giving more sources ids later can only add keys, never change what an existing key addresses.

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -64,7 +64,12 @@ def add_user_name(ctx: RunContext[str]) -> str:
 An instructions function is treated as recomputed per request, which keeps its text outside the provider's cacheable prefix. Pass `static=True` when the function only *composes* text that is fixed for the run — from a template, a config file, a loop over feature flags. The block then joins the cacheable prefix and the function is called once per run instead of once per model request. It may still read `RunContext` for anything that does not change mid-run, `deps` above all; do not use it for text that depends on `run_step`, the message history, or the time.
 
 ```python
-@agent.instructions(name='style', static=True)
+from pydantic_ai import Agent
+
+style_agent = Agent('openai:gpt-5.2', name='style_agent')
+
+
+@style_agent.instructions(name='style', static=True)
 def style_guide() -> str:
     return '\n'.join(f'- {rule}' for rule in ('Be concise.', 'Cite sources.'))
 ```

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -61,6 +61,14 @@ def add_user_name(ctx: RunContext[str]) -> str:
     return f"The user's name is {ctx.deps}."
 ```
 
+An instructions function is treated as recomputed per request, which keeps its text outside the provider's cacheable prefix. Pass `static=True` when the function only *composes* text that is fixed for the run — from a template, a config file, a loop over feature flags. The block then joins the cacheable prefix and the function is called once per run instead of once per model request. It may still read `RunContext` for anything that does not change mid-run, `deps` above all; do not use it for text that depends on `run_step`, the message history, or the time.
+
+```python
+@agent.instructions(name='style', static=True)
+def style_guide() -> str:
+    return '\n'.join(f'- {rule}' for rule in ('Be concise.', 'Cite sources.'))
+```
+
 Use `@agent.tool` when the tool needs `RunContext`. Use `@agent.tool_plain` when it does not.
 
 ## Define Agents Declaratively with Specs

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -343,8 +343,10 @@ class GraphAgentState:
     exposed as the private `_mcp_tool_defs_cache` field. Recreated per run and reconstructed
     identically on durable replay/recovery, which is what keeps the Temporal/DBOS MCP wrappers'
     `get_tools` scheduling replay-deterministic."""
-    static_instruction_cache: dict[Any, str | None] = dataclasses.field(default_factory=dict[Any, 'str | None'])
-    """Per-run answers of instruction functions registered with `static=True`, keyed by the function.
+    static_instruction_cache: dict[int, tuple[Any, str | None]] = dataclasses.field(
+        default_factory=dict[int, 'tuple[Any, str | None]']
+    )
+    """Per-run answers of instruction functions registered with `static=True`, keyed by function identity.
 
     Shared by reference into every `RunContext` this run (see `build_run_context`), where it is exposed
     as the private `_static_instruction_cache` field. That reference is what makes "called once per

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -343,6 +343,14 @@ class GraphAgentState:
     exposed as the private `_mcp_tool_defs_cache` field. Recreated per run and reconstructed
     identically on durable replay/recovery, which is what keeps the Temporal/DBOS MCP wrappers'
     `get_tools` scheduling replay-deterministic."""
+    static_instruction_cache: dict[Any, str | None] = dataclasses.field(default_factory=dict[Any, 'str | None'])
+    """Per-run answers of instruction functions registered with `static=True`, keyed by the function.
+
+    Shared by reference into every `RunContext` this run (see `build_run_context`), where it is exposed
+    as the private `_static_instruction_cache` field. That reference is what makes "called once per
+    run" true across the several model requests a run makes; recreating it per run is what keeps a
+    function reading `deps` correct in the next run. Reconstructed identically on durable
+    replay/recovery, so a replayed run calls each static function once, as the original did."""
 
     def check_incomplete_tool_call(self) -> None:
         """Raise `IncompleteToolCall` if the last model response was truncated mid-tool-call."""
@@ -2410,15 +2418,16 @@ def build_run_context(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT
         _cancellation=ctx.deps.cancellation,
         _event_stream_buffer=ctx.state.event_stream_buffer,
         _mcp_tool_defs_cache=ctx.state.mcp_tool_defs_cache,
+        _static_instruction_cache=ctx.state.static_instruction_cache,
     )
     validation_context = build_validation_context(ctx.deps.validation_context, run_context)
     # Only `validation_context` may be passed to `replace`: it shallow-copies, preserving the shared
     # identity of the mutable members passed by reference above — `loaded_capability_ids`,
     # `discovered_tool_names`, `pending_messages`, `_cancellation`, `_event_stream_buffer`,
-    # `_mcp_tool_defs_cache` (see the invariant on `GraphAgentDeps.loaded_capability_ids`). Never
-    # add any of them as a `replace` kwarg — forking the object would silently break in-step
-    # capability loads / tool reveals / message enqueues / cancellation / event delivery /
-    # tool-defs caching.
+    # `_mcp_tool_defs_cache`, `_static_instruction_cache` (see the invariant on
+    # `GraphAgentDeps.loaded_capability_ids`). Never add any of them as a `replace` kwarg — forking
+    # the object would silently break in-step capability loads / tool reveals / message enqueues /
+    # cancellation / event delivery / tool-defs caching / static instruction caching.
     run_context = replace(run_context, validation_context=validation_context)
     return run_context
 

--- a/pydantic_ai_slim/pydantic_ai/_instructions.py
+++ b/pydantic_ai_slim/pydantic_ai/_instructions.py
@@ -122,13 +122,18 @@ async def resolve_sourced_instructions(
             # A function the author declared static is called once for the run and its answer reused,
             # because a block that sorts into the cacheable prefix while being recomputed every request
             # is a cache trap rather than a cache win.
+            #
+            # Keyed by identity rather than by the function itself: an instruction is any callable, and
+            # a plain `@dataclass` with `__call__` is unhashable. The entry keeps the callable alive so
+            # its id cannot be handed to a different object while the answer is still cached.
             cache = run_context._static_instruction_cache  # pyright: ignore[reportPrivateUsage]
-            if sourced.dynamic or instruction not in cache:
+            key = id(instruction)
+            if not sourced.dynamic and (cached := cache.get(key)) is not None:
+                _, content = cached
+            else:
                 content = await _system_prompt.SystemPromptRunner[AgentDepsT](instruction).run(run_context)
                 if not sourced.dynamic:
-                    cache[instruction] = content
-            else:
-                content = cache[instruction]
+                    cache[key] = (instruction, content)
             if content:
                 part = InstructionPart(content=content, name=sourced.name, id=sourced.id, dynamic=sourced.dynamic)
                 if group:

--- a/pydantic_ai_slim/pydantic_ai/_instructions.py
+++ b/pydantic_ai_slim/pydantic_ai/_instructions.py
@@ -119,7 +119,17 @@ async def resolve_sourced_instructions(
             group_key = sourced.id
             group.append(InstructionPart(content=content, id=sourced.id))
         else:
-            if content := await _system_prompt.SystemPromptRunner[AgentDepsT](instruction).run(run_context):
+            # A function the author declared static is called once for the run and its answer reused,
+            # because a block that sorts into the cacheable prefix while being recomputed every request
+            # is a cache trap rather than a cache win.
+            cache = run_context._static_instruction_cache  # pyright: ignore[reportPrivateUsage]
+            if sourced.dynamic or instruction not in cache:
+                content = await _system_prompt.SystemPromptRunner[AgentDepsT](instruction).run(run_context)
+                if not sourced.dynamic:
+                    cache[instruction] = content
+            else:
+                content = cache[instruction]
+            if content:
                 part = InstructionPart(content=content, name=sourced.name, id=sourced.id, dynamic=sourced.dynamic)
                 if group:
                     pending_parts.append(part)

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -169,6 +169,14 @@ class RunContext(Generic[RunContextAgentDepsT]):
     (e.g. inside a Temporal activity).
     """
 
+    _static_instruction_cache: dict[Any, str | None] = field(default_factory=dict[Any, 'str | None'], repr=False)
+    """Private implementation detail — not part of the public API; do not read or write.
+
+    What each instruction function registered with `static=True` returned, so it is called once for
+    the run rather than once per model request. Shared by reference through the `replace()` copies
+    each step makes, the same way `retries` is, which is what makes "once per run" hold.
+    """
+
     _event_stream_buffer: list[_messages.AgentStreamEvent] | None = field(default=None, repr=False)
     """Private implementation detail — not part of the public API; do not read or write.
 

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -169,12 +169,15 @@ class RunContext(Generic[RunContextAgentDepsT]):
     (e.g. inside a Temporal activity).
     """
 
-    _static_instruction_cache: dict[Any, str | None] = field(default_factory=dict[Any, 'str | None'], repr=False)
+    _static_instruction_cache: dict[int, tuple[Any, str | None]] = field(
+        default_factory=dict[int, 'tuple[Any, str | None]'], repr=False
+    )
     """Private implementation detail — not part of the public API; do not read or write.
 
     What each instruction function registered with `static=True` returned, so it is called once for
-    the run rather than once per model request. Shared by reference through the `replace()` copies
-    each step makes, the same way `retries` is, which is what makes "once per run" hold.
+    the run rather than once per model request. Keyed by the function's `id()`, with the function
+    itself kept in the entry so that id stays its own. Shared by reference through the `replace()`
+    copies each step makes, the same way `retries` is, which is what makes "once per run" hold.
     """
 
     _event_stream_buffer: list[_messages.AgentStreamEvent] | None = field(default=None, repr=False)

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2192,7 +2192,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
     @overload
     def instructions(
-        self, /, *, name: str | None = None
+        self, /, *, name: str | None = None, static: bool = False
     ) -> Callable[[SystemPromptFunc[AgentDepsT]], SystemPromptFunc[AgentDepsT]]: ...
 
     def instructions(
@@ -2201,6 +2201,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         /,
         *,
         name: str | None = None,
+        static: bool = False,
     ) -> Callable[[SystemPromptFunc[AgentDepsT]], SystemPromptFunc[AgentDepsT]] | SystemPromptFunc[AgentDepsT]:
         """Decorator to register an instructions function.
 
@@ -2233,6 +2234,14 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 `'agent:<name>'` on [`InstructionPart.id`][pydantic_ai.messages.InstructionPart.id] so an
                 application can address this part specifically, where the bare `'agent'` key addresses
                 the agent's literal instructions. See [instruction parts](../agent.md#instruction-parts).
+            static: Whether the text this function returns is fixed for a run. A function is treated as
+                [`dynamic`][pydantic_ai.messages.InstructionPart.dynamic] by default, which sorts its
+                block after the provider's cache breakpoint. Pass `static=True` when you reach for a
+                function to *write* fixed text — building it from a template, a config file, a loop over
+                feature flags — rather than to recompute it: the block then sorts into the cacheable
+                prefix, and the function is called once for the run instead of once per model request.
+                Do not pass it for text that depends on anything that changes mid-run, such as
+                [`ctx.run_step`][pydantic_ai.tools.RunContext.run_step] or the time.
         """
         if name is not None:
             _instructions.validate_instruction_name(name)
@@ -2244,7 +2253,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             func_: SystemPromptFunc[AgentDepsT],
         ) -> SystemPromptFunc[AgentDepsT]:
             self._instructions.append(
-                _instructions.SourcedInstruction(func_, name=name, id=instruction_id, dynamic=True)
+                _instructions.SourcedInstruction(func_, name=name, id=instruction_id, dynamic=not static)
             )
             return func_
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/capability.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/capability.py
@@ -309,7 +309,7 @@ class Capability(AbstractCapability[AgentDepsT]):
 
     @overload
     def instructions(
-        self, /, *, name: str | None = None
+        self, /, *, name: str | None = None, static: bool = False
     ) -> Callable[[SystemPromptFunc[AgentDepsT]], SystemPromptFunc[AgentDepsT]]: ...
 
     def instructions(
@@ -318,6 +318,7 @@ class Capability(AbstractCapability[AgentDepsT]):
         /,
         *,
         name: str | None = None,
+        static: bool = False,
     ) -> Callable[[SystemPromptFunc[AgentDepsT]], SystemPromptFunc[AgentDepsT]] | SystemPromptFunc[AgentDepsT]:
         """Decorator to register an instructions function on this capability.
 
@@ -347,6 +348,10 @@ class Capability(AbstractCapability[AgentDepsT]):
                 [`id`][pydantic_ai.capabilities.AbstractCapability.id] — without one there is no source
                 key to qualify the name against, so the part stays unaddressable. See
                 [instruction parts](../agent.md#instruction-parts).
+            static: Whether the text this function returns is fixed for a run. See
+                [`Agent.instructions`][pydantic_ai.Agent.instructions]: the block sorts into the
+                provider's cacheable prefix and the function is called once for the run rather than
+                once per model request.
         """
         if name is not None:
             validate_instruction_name(name)
@@ -360,7 +365,7 @@ class Capability(AbstractCapability[AgentDepsT]):
                     func_,
                     name=name,
                     id=InstructionId(source, name=name) if source is not None else None,
-                    dynamic=True,
+                    dynamic=not static,
                 )
             )
             return func_

--- a/tests/durable_exec/temporal/test_model_and_serialization.py
+++ b/tests/durable_exec/temporal/test_model_and_serialization.py
@@ -758,6 +758,7 @@ def test_temporal_run_context_serialization_is_exhaustive():
         'validation_context',  # arbitrary user object with no serialization contract
         'model_settings',  # only set for model requests, which receive it as their own typed activity param
         '_mcp_tool_defs_cache',  # run-local cache read/written in workflow code; never needed inside an activity
+        '_static_instruction_cache',  # run-local cache of static instruction answers, resolved in workflow code; never needed inside an activity
         '_event_stream_buffer',  # run-local event buffer drained in workflow code; a public emit surface for activities is a follow-up
         'realtime_session',  # live RealtimeSession, not serializable; realtime sessions don't run inside Temporal activities
         '_cancellation',  # runtime-only controller holding a live asyncio task reference; cannot cross the activity boundary

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -2430,6 +2430,7 @@ def test_cache_key_run_context_projection_is_exhaustive():
         'conversation_id',  # per-conversation id; same rationale as run_id
         'capability_active',  # derived from loaded_capability_ids plus the static capability set, which are projected
         '_mcp_tool_defs_cache',  # live per-run memo of MCP tool defs, reconstructed from messages
+        '_static_instruction_cache',  # live per-run memo of static instruction answers, whose text only ever reaches a model request and so cannot change what a tool call does
         '_event_stream_buffer',  # live per-run event buffer drained in flow code, not a task input
         'realtime_session',  # live RealtimeSession, not hashable run state; sessions don't run inside Prefect tasks
         '_cancellation',  # runtime-only cancellation controller; carries no run inputs and must not fork the cache key

--- a/tests/test_static_instructions.py
+++ b/tests/test_static_instructions.py
@@ -14,6 +14,8 @@ every request would move the prefix under a static label — a cache trap rather
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import pytest
 from inline_snapshot import snapshot
 
@@ -222,3 +224,32 @@ async def test_static_functions_may_read_the_run_context() -> None:
 
     await agent.run('Hello', deps='ACME')
     assert [part.content for part in captured[1]] == ['You serve ACME.']
+
+
+async def test_a_static_callable_object_need_not_be_hashable() -> None:
+    # An instruction may be any callable, and a plain `@dataclass` with `__call__` is unhashable, so
+    # the per-run answers are keyed by identity. Composing the text from an object's own state is
+    # exactly the shape this flag is for, and it would be a poor payoff if declaring it static were
+    # what made the agent fail to run.
+    @dataclass
+    class Composer:
+        rules: list[str]
+        calls: int = 0
+
+        def __call__(self) -> str:
+            self.calls += 1
+            return '\n'.join(self.rules)
+
+    captured: list[list[InstructionPart]] = []
+    agent = Agent(two_step_model(captured))
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    composer = Composer(['Be concise.', 'Cite sources.'])
+    agent.instructions(static=True)(composer)
+
+    await agent.run('Hello')
+    assert composer.calls == 1
+    assert [part.content for part in captured[1]] == ['Be concise.\nCite sources.']

--- a/tests/test_static_instructions.py
+++ b/tests/test_static_instructions.py
@@ -1,0 +1,224 @@
+"""Tests for `static=True` on the instruction decorators.
+
+Whether an instruction block is [`dynamic`][pydantic_ai.messages.InstructionPart.dynamic] decides
+which side of a provider's cache breakpoint it sits on, and it used to be inferred from the shape the
+author reached for: literal text was static, a decorated function was always dynamic. An author who
+writes a function purely because it is a nicer way to *produce* fixed text — from a template, a config
+file, a loop over feature flags — was pushed outside the cacheable prefix for it.
+
+`static=True` lets them say what they meant. It does two things, and the second is what makes the
+first honest: the block sorts into the static group, *and* the function is called once for the run
+rather than once per model request. A block that claims the cacheable prefix while being recomputed
+every request would move the prefix under a static label — a cache trap rather than a cache fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import Capability
+from pydantic_ai.messages import (
+    InstructionPart,
+    ModelMessage,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+pytestmark = pytest.mark.anyio
+
+
+def two_step_model(captured: list[list[InstructionPart]]) -> FunctionModel:
+    """A model that records the blocks of each request, calls a tool once, then finishes.
+
+    Two model requests in one run is the whole point: it is the only way to tell "once per run" from
+    "once per request".
+    """
+    calls = 0
+
+    def model_fn(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        captured.append(list(info.model_request_parameters.instruction_parts or []))
+        if calls == 1:
+            return ModelResponse(parts=[ToolCallPart('ping', {}, tool_call_id='call')])
+        return ModelResponse(parts=[TextPart('done')])
+
+    return FunctionModel(model_fn)
+
+
+def build_agent(static: bool) -> tuple[Agent[None, str], list[int], list[list[InstructionPart]]]:
+    """An agent whose one decorated instruction counts how often it is called."""
+    calls: list[int] = []
+    captured: list[list[InstructionPart]] = []
+    agent = Agent(two_step_model(captured), instructions='Literal instructions.')
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    @agent.instructions(name='fixed', static=static)
+    def fixed() -> str:
+        calls.append(1)
+        return 'Composed once.'
+
+    return agent, calls, captured
+
+
+async def test_static_function_is_called_once_per_run() -> None:
+    agent, calls, captured = build_agent(static=True)
+    await agent.run('Hello')
+
+    assert len(captured) == 2, 'the run should make two model requests'
+    assert len(calls) == 1
+    # Same text on both requests, which is what the cacheable prefix depends on.
+    assert [[part.content for part in request] for request in captured] == snapshot(
+        [
+            ['Literal instructions.', 'Composed once.'],
+            ['Literal instructions.', 'Composed once.'],
+        ]
+    )
+
+
+async def test_a_dynamic_function_is_still_called_every_request() -> None:
+    agent, calls, captured = build_agent(static=False)
+    await agent.run('Hello')
+
+    assert len(captured) == 2
+    assert len(calls) == 2
+
+
+async def test_the_answer_is_not_reused_across_runs() -> None:
+    # Cached on the run, not on the agent: a second run computes its own value, so a function reading
+    # anything that changes between runs is still correct, just fixed within each one.
+    agent, calls, _ = build_agent(static=True)
+    await agent.run('Hello')
+    await agent.run('Hello again')
+    assert len(calls) == 2
+
+
+async def test_static_sorts_into_the_cacheable_prefix() -> None:
+    # `dynamic` is what puts a block behind the provider's cache breakpoint. Declared static, a
+    # function's block keeps its place among the literal text; the dynamic one still sorts last, which
+    # is what makes the ordering visible rather than incidental.
+    captured: list[list[InstructionPart]] = []
+    agent = Agent(two_step_model(captured), instructions='Literal instructions.')
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    @agent.instructions(name='recomputed')
+    def recomputed() -> str:
+        return 'Recomputed.'
+
+    @agent.instructions(name='fixed', static=True)
+    def fixed() -> str:
+        return 'Composed once.'
+
+    await agent.run('Hello')
+    assert [(part.content, str(part.id), part.dynamic) for part in captured[0]] == snapshot(
+        [
+            ('Literal instructions.', 'agent', False),
+            ('Composed once.', 'agent:fixed', False),
+            ('Recomputed.', 'agent:recomputed', True),
+        ]
+    )
+
+
+async def test_a_static_block_stays_addressable_by_its_name() -> None:
+    agent, _, captured = build_agent(static=True)
+    await agent.run('Hello')
+    named = captured[0][-1]
+    assert named.name == 'fixed'
+    assert str(named.id) == 'agent:fixed'
+    assert named.dynamic is False
+
+
+async def test_capability_instructions_take_the_same_flag() -> None:
+    calls: list[int] = []
+    captured: list[list[InstructionPart]] = []
+    capability = Capability[object](id='style')
+
+    @capability.instructions(name='tone', static=True)
+    def tone(_ctx: RunContext[object]) -> str:
+        calls.append(1)
+        return 'Be concise.'
+
+    agent = Agent(two_step_model(captured), capabilities=[capability])
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    await agent.run('Hello')
+
+    assert len(captured) == 2
+    assert len(calls) == 1
+    part = captured[0][-1]
+    assert (str(part.id), part.dynamic) == ('capability:style:tone', False)
+
+
+async def test_two_static_functions_are_cached_apart() -> None:
+    captured: list[list[InstructionPart]] = []
+    agent = Agent(two_step_model(captured))
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    @agent.instructions(name='first', static=True)
+    def first() -> str:
+        return 'First.'
+
+    @agent.instructions(name='second', static=True)
+    def second() -> str:
+        return 'Second.'
+
+    await agent.run('Hello')
+    assert [part.content for part in captured[1]] == ['First.', 'Second.']
+
+
+async def test_a_static_function_returning_nothing_contributes_nothing() -> None:
+    captured: list[list[InstructionPart]] = []
+    calls: list[int] = []
+    agent = Agent(two_step_model(captured), instructions='Literal instructions.')
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    @agent.instructions(static=True)
+    def nothing() -> str | None:
+        calls.append(1)
+        return None
+
+    await agent.run('Hello')
+    # `None` is cached like any other answer, so the second request does not call the function again
+    # just because there was nothing to show for the first.
+    assert len(calls) == 1
+    assert [[part.content for part in request] for request in captured] == [
+        ['Literal instructions.'],
+        ['Literal instructions.'],
+    ]
+
+
+async def test_static_functions_may_read_the_run_context() -> None:
+    # Fixed *for the run*, not independent of it: `deps` do not change mid-run, so reading them is
+    # exactly the case this is for.
+    captured: list[list[InstructionPart]] = []
+    agent = Agent[str, str](two_step_model(captured), deps_type=str)
+
+    @agent.tool_plain
+    def ping() -> str:
+        return 'pong'
+
+    @agent.instructions(static=True)
+    def tenant(ctx: RunContext[str]) -> str:
+        return f'You serve {ctx.deps}.'
+
+    await agent.run('Hello', deps='ACME')
+    assert [part.content for part in captured[1]] == ['You serve ACME.']


### PR DESCRIPTION
Whether an instruction block is [`dynamic`](https://ai.pydantic.dev/api/messages/#pydantic_ai.messages.InstructionPart.dynamic) decides which side of a provider's cache breakpoint it sits on, and it was inferred from the shape the author reached for, not from what they meant:

| How the block is written | `dynamic` |
|---|---|
| `Agent(instructions='...')`, `Capability(instructions='...')` | `False` |
| `InstructionPart(content='...', dynamic=...)` | author's choice |
| `@agent.instructions` / `@capability.instructions` | **always `True`** |

So an author who reaches for a function purely because it is a nicer way to *write* fixed text -- composing it from a template, reading it out of a config file, looping over feature flags -- was pushed outside the cacheable prefix for it, on every request of every run. The workaround was to call the function yourself and pass the string, giving up the decorator's `name=` and its registration site.

`static=True` on both decorators lets them say what they meant:

```python
@agent.instructions(name='style', static=True)
def style_guide() -> str:
    return '\n'.join(f'- {rule}' for rule in ('Be concise.', 'Cite sources.'))
```

It does two things, and the second is what makes the first honest:

1. The resulting part is `dynamic=False`, so it sorts into the static group and inside the cache breakpoint.
2. **The function is called once per run rather than once per model request.** A block claiming the cacheable prefix while being recomputed every step would move the prefix under a static label -- a cache trap rather than a cache fix.

### Once per run, including under replay

The cache is a `dict` on `GraphAgentState`, shared by reference into every `RunContext` the run builds -- exactly the existing `mcp_tool_defs_cache` pattern, and for the same reason: `build_run_context` constructs a fresh `RunContext` each step, so run-scoped state has to be threaded from the graph state rather than carried on the context.

That also settles the durable-execution half of the issue. The cache is recreated per run and reconstructed identically on replay/recovery, so a replayed run calls each static function once, as the original did.

### Scope of the contract

"Fixed for the run" is what is promised, not "independent of the run": a static function may read `RunContext` for anything that does not change mid-run -- `deps` above all -- and there is a test for that. The docs say plainly not to reach for it when the text depends on `run_step`, the message history, or the time.

`static` rather than `dynamic=False`: it reads better at the call site, and it avoids reading like `@agent.system_prompt(dynamic=True)`, which is a different axis entirely ("re-evaluate even when `message_history` is provided").

Docs in `docs/agent.md`, plus the `building-pydantic-ai-agents` skill. Nine tests in `tests/test_static_instructions.py` covering the flag, once-per-run across a two-request run, that a dynamic function still runs every request, that the answer is not reused across runs, capability parity, `None` answers, and reading `deps`.

- Closes #7391

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

