### PR TITLE
fix: bind per-run capability durable operations on callable backends

### DIFF
--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -152,7 +152,7 @@ Toolsets that implement their own tool listing and calling (i.e. [`FunctionTools
 
 ### Capabilities at Runtime
 
-Unlike Temporal and DBOS, Prefect creates a task per call rather than registering its durable units up front, so [capabilities](../capabilities/overview.md) passed to `agent.run(capabilities=[...])` inside a flow are accepted. A capability that contributes an executing toolset is still rejected, by the same guard that rejects `run(toolsets=...)`: the toolset arrives after the agent's toolsets were wrapped. Attach those at agent construction time.
+Unlike Temporal and DBOS, Prefect creates a task per call rather than registering its durable units up front, so [capabilities](../capabilities/overview.md) passed to `agent.run(capabilities=[...])` inside a flow are accepted. That includes [`@durable_operation`][pydantic_ai.capabilities.durable_operation] methods on those capabilities, which Prefect wraps as tasks at call time. A capability that contributes an executing toolset is still rejected, by the same guard that rejects `run(toolsets=...)`: the toolset arrives after the agent's toolsets were wrapped. Attach those at agent construction time.
 
 ### Model Selection at Runtime
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -304,108 +304,135 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         self._bound_capability_operations = {}
         self._capability_declarations = {}
         backend = self.get_durable_operation_backend()
-        durability_ref = ref(self)
         for capability in leaf_capabilities(agent.root_capability):
-            declarations = collect_capability_operations(capability)
-            if not declarations:
+            self._bind_capability_instance_operations(agent, capability, backend)
+
+    def _bind_capability_instance_operations(
+        self,
+        agent: AbstractAgent[AgentDepsT, Any],
+        capability: AbstractCapability[Any],
+        backend: DurableOperationBackend[Any],
+    ) -> None:
+        declarations = collect_capability_operations(capability)
+        if not declarations:
+            return
+        capability_id = capability.id
+        if capability_id is None:
+            raise UserError(
+                f'Capability {type(capability).__name__!r} contributes durable operations and needs an explicit '
+                '`id` because persisted operation identity and worker-side recovery must remain stable. '
+                f"Construct it as `{type(capability).__name__}(id='...')`."
+            )
+        durability_ref = ref(self)
+        for operation_name, declaration in declarations.items():
+            key = (capability_id, operation_name)
+            if key in self._bound_capability_operations:
                 continue
-            capability_id = capability.id
-            if capability_id is None:
-                raise UserError(
-                    f'Capability {type(capability).__name__!r} contributes durable operations and needs an explicit '
-                    '`id` because persisted operation identity and worker-side recovery must remain stable. '
-                    f"Construct it as `{type(capability).__name__}(id='...')`."
-                )
-            for operation_name, declaration in declarations.items():
-                key = (capability_id, operation_name)
 
-                async def handler(
-                    params: CapabilityOperationParams,
-                    *,
-                    declaration: CapabilityMethodDeclaration = declaration,
-                    capability_id: str = capability_id,
-                ) -> Any:
-                    arguments = self.engine_spec.codec.load(
-                        dict[str, Any], self.engine_spec.codec.dump(dict[str, Any], params.arguments)
+            async def handler(
+                params: CapabilityOperationParams,
+                *,
+                declaration: CapabilityMethodDeclaration = declaration,
+                capability_id: str = capability_id,
+            ) -> Any:
+                arguments = self.engine_spec.codec.load(
+                    dict[str, Any], self.engine_spec.codec.dump(dict[str, Any], params.arguments)
+                )
+                validated = cast(dict[str, Any], declaration.schema.validator.validate_python(arguments))
+                semantic_params = CapabilityOperationParams(
+                    run_context=params.run_context, arguments=validated, model_id=params.model_id
+                )
+                recovered = await recover_capability(params.run_context, capability_id=capability_id)
+                if declaration.model_request_parameter is not None:
+                    projection = cast(
+                        ModelRequestContextProjection,
+                        semantic_params.arguments[declaration.model_request_parameter],
                     )
-                    validated = cast(dict[str, Any], declaration.schema.validator.validate_python(arguments))
-                    semantic_params = CapabilityOperationParams(
-                        run_context=params.run_context, arguments=validated, model_id=params.model_id
-                    )
-                    recovered = await recover_capability(params.run_context, capability_id=capability_id)
-                    if declaration.model_request_parameter is not None:
-                        projection = cast(
-                            ModelRequestContextProjection,
-                            semantic_params.arguments[declaration.model_request_parameter],
-                        )
-                        async with self._durable_model_scope(projection.model_id, params.run_context) as (
-                            model,
-                            durable_ctx,
-                        ):
-                            request_context = projection.build_context(model)
-                            usage_before = copy.copy(durable_ctx.usage)
-                            result = await call_declaration(
-                                declaration,
-                                recovered,
-                                params=semantic_params,
-                                model_request_context=request_context,
-                            )
-                            operation_result = ModelRequestContextProjection.from_context(result)
-                            if result.model is not model:
-                                operation_result.model_id = self._find_registered_model_id_for_hook(result.model)
-                        return CapabilityOperationResult(
-                            value=operation_result, usage_delta=durable_ctx.usage - usage_before
-                        )
-                    async with self._durable_model_scope(params.model_id, params.run_context) as (_, durable_ctx):
-                        semantic_params = CapabilityOperationParams(
-                            run_context=durable_ctx,
-                            arguments=semantic_params.arguments,
-                            model_id=params.model_id,
-                        )
+                    async with self._durable_model_scope(projection.model_id, params.run_context) as (
+                        model,
+                        durable_ctx,
+                    ):
+                        request_context = projection.build_context(model)
                         usage_before = copy.copy(durable_ctx.usage)
-                        result = await call_declaration(declaration, recovered, params=semantic_params)
-                    return CapabilityOperationResult(value=result, usage_delta=durable_ctx.usage - usage_before)
-
-                operation = DurableOperation(
-                    operation_id=CapabilityOperationId(capability_id, operation=operation_name),
-                    handler=handler,
-                    parameter_transport=self._capability_operation_parameter_transport(declaration),
-                    cache_identity=CapabilityCacheIdentity(),
-                    result_codec=TypedResultCodec(
-                        capability_operation_result_type(declaration.result_type),
-                        mode='identity' if self.engine_spec.codec is IDENTITY_CODEC else 'json',
-                    ),
-                    config_role='capability',
-                )
-                self._bound_capability_operations[key] = backend.bind(operation)
-                self._capability_declarations[key] = declaration
-
-                async def dispatch_for_run_context(
-                    ctx: RunContext[object],
-                    args: tuple[object, ...],
-                    kwargs: dict[str, object],
-                    _capability: AbstractCapability[Any] = capability,
-                    _operation_name: str = operation_name,
-                ) -> Any:
-                    durability = durability_ref()
-                    if durability is None:  # pragma: no cover
-                        raise RuntimeError('The durability capability bound to this agent is no longer available.')
-                    return await durability._invoke_capability_operation(
-                        _capability,
-                        _operation_name,
-                        ctx=ctx,
-                        args=args,
-                        kwargs=kwargs,
+                        result = await call_declaration(
+                            declaration,
+                            recovered,
+                            params=semantic_params,
+                            model_request_context=request_context,
+                        )
+                        operation_result = ModelRequestContextProjection.from_context(result)
+                        if result.model is not model:
+                            operation_result.model_id = self._find_registered_model_id_for_hook(result.model)
+                    return CapabilityOperationResult(
+                        value=operation_result, usage_delta=durable_ctx.usage - usage_before
                     )
+                async with self._durable_model_scope(params.model_id, params.run_context) as (_, durable_ctx):
+                    semantic_params = CapabilityOperationParams(
+                        run_context=durable_ctx,
+                        arguments=semantic_params.arguments,
+                        model_id=params.model_id,
+                    )
+                    usage_before = copy.copy(durable_ctx.usage)
+                    result = await call_declaration(declaration, recovered, params=semantic_params)
+                return CapabilityOperationResult(value=result, usage_delta=durable_ctx.usage - usage_before)
 
-                bindings = capability._get_durable_operation_bindings()
-                bindings.setdefault(agent)[operation_name] = dispatch_for_run_context
+            operation = DurableOperation(
+                operation_id=CapabilityOperationId(capability_id, operation=operation_name),
+                handler=handler,
+                parameter_transport=self._capability_operation_parameter_transport(declaration),
+                cache_identity=CapabilityCacheIdentity(),
+                result_codec=TypedResultCodec(
+                    capability_operation_result_type(declaration.result_type),
+                    mode='identity' if self.engine_spec.codec is IDENTITY_CODEC else 'json',
+                ),
+                config_role='capability',
+            )
+            self._bound_capability_operations[key] = backend.bind(operation)
+            self._capability_declarations[key] = declaration
+
+            async def dispatch_for_run_context(
+                ctx: RunContext[object],
+                args: tuple[object, ...],
+                kwargs: dict[str, object],
+                _capability: AbstractCapability[Any] = capability,
+                _operation_name: str = operation_name,
+            ) -> Any:
+                durability = durability_ref()
+                if durability is None:  # pragma: no cover
+                    raise RuntimeError('The durability capability bound to this agent is no longer available.')
+                return await durability._invoke_capability_operation(
+                    _capability,
+                    _operation_name,
+                    ctx=ctx,
+                    args=args,
+                    kwargs=kwargs,
+                )
+
+            bindings = capability._get_durable_operation_bindings()
+            bindings.setdefault(agent)[operation_name] = dispatch_for_run_context
+
+    def _bind_run_capability_operations(self, ctx: RunContext[AgentDepsT]) -> None:
+        """Bind `@durable_operation` methods on capabilities added at run time.
+
+        Callable backends create durable units per call, so a capability passed to
+        `agent.run(capabilities=[...])` can still be wrapped. Registered backends reject
+        per-run capabilities before this runs and need the complete set at `for_agent` time.
+        """
+        backend = self.get_durable_operation_backend()
+        if isinstance(backend, RegisteredOperationBackend):
+            return
+        agent = ctx.agent
+        if agent is None:  # pragma: no cover
+            return
+        for capability in (ctx._run_capabilities_by_id or {}).values():  # pyright: ignore[reportPrivateUsage]
+            self._bind_capability_instance_operations(agent, capability, backend)
 
     def _prepare_run_context(self, ctx: RunContext[AgentDepsT]) -> None:
         """Register dispatchers on `RunContext` for worker-side and per-run capability recovery."""
         ctx._durable_operations = {}  # pyright: ignore[reportPrivateUsage]
         if ctx.agent is None:
             return
+        self._bind_run_capability_operations(ctx)
         operations: dict[tuple[str, str], Callable[..., Awaitable[object]]] = {}
         run_capabilities = ctx._run_capabilities_by_id or {}  # pyright: ignore[reportPrivateUsage]
         for capability_id, capability in run_capabilities.items():

--- a/tests/durable_exec/test_capability_durable_operation.py
+++ b/tests/durable_exec/test_capability_durable_operation.py
@@ -667,6 +667,24 @@ async def test_for_run_replacement_dispatches_on_run_instance() -> None:
     assert any(name == 'for_run_operation__capability__per_run_operation.operation' for name, _ in durability.calls)
 
 
+async def test_per_run_capability_durable_operation_dispatches() -> None:
+    """A capability passed to `agent.run(capabilities=[...])` must still dispatch `@durable_operation`.
+
+    Construction-time binding walks `agent.root_capability`, so a run-level instance is never bound.
+    Callable backends create durable units per call and can bind that instance on demand; without
+    that, dispatch falls through to the undecorated method and the operation is not durable.
+    """
+    capability = Operations()
+    agent = Agent(TestModel(), name='per_run_ops', capabilities=[RecordingDurability()])
+
+    await agent.run('test', capabilities=[capability])
+
+    assert capability.result == 2
+    durability = RecordingDurability.from_agent(agent)
+    assert durability is not None
+    assert any(name == 'per_run_ops__capability__operations.calculate' for name, _ in durability.calls)
+
+
 async def test_shared_capability_dispatch_is_scoped_to_each_agent() -> None:
     capability = Operations()
     first_agent = Agent(TestModel(), name='first_agent', capabilities=[capability, RecordingDurability()])

--- a/tests/durable_exec/test_prefect.py
+++ b/tests/durable_exec/test_prefect.py
@@ -3007,6 +3007,38 @@ async def test_prefect_durability_allows_hook_only_per_run_capabilities(blockbus
     assert await run_with_instrumentation() == snapshot('success (no tool calls)')
 
 
+@pytest.mark.parametrize('blockbuster_enabled', [False])
+async def test_prefect_durability_runs_per_run_capability_operation_in_task(blockbuster_enabled: bool) -> None:
+    """A per-run capability's `@durable_operation` must run inside a Prefect task.
+
+    Prefect accepts per-run capabilities because it creates tasks per call. Durable operations
+    still have to be bound for that run-level instance; otherwise dispatch falls through to the
+    undecorated method and the call is not a task.
+    """
+    assert blockbuster_enabled is False
+    ran_in_task: list[bool] = []
+
+    class Audit(AbstractCapability[Any]):
+        id = 'audit'
+
+        async def before_run(self, ctx: RunContext[Any]) -> None:
+            await self.record(ctx, 'hello')
+
+        @durable_operation(name='record')
+        async def record(self, ctx: RunContext[Any], message: str) -> str:
+            ran_in_task.append(TaskRunContext.get() is not None)
+            return message
+
+    agent = Agent(TestModel(), name='durability_per_run_durable_op', capabilities=[PrefectDurability()])
+
+    @flow
+    async def run_with_audit() -> str:
+        return (await agent.run('Hello', capabilities=[Audit()])).output
+
+    assert await run_with_audit() == snapshot('success (no tool calls)')
+    assert ran_in_task == [True]
+
+
 async def test_prefect_durability_rejects_executing_toolset_from_per_run_capability() -> None:
     """A per-run capability contributing an executing toolset is still rejected on Prefect.
 


### PR DESCRIPTION
Prefect (and other callable durability backends) wrap units per call, so a capability passed to `agent.run(capabilities=[...])` is accepted. `@durable_operation` methods on that instance were still only bound by walking `agent.root_capability` at `for_agent` time, so dispatch fell through to the plain method and the call never became a Prefect task.

Bind those operations on demand in `_prepare_run_context` for callable backends. Registered backends still require the full set at agent construction.

Fixes #7973

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

