### PR TITLE
Tie the DBOS warning filter to the supported `dbos` floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -420,8 +420,8 @@ filterwarnings = [
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
     # DBOS logs through the `LoggingHandler` that OpenTelemetry SDK 1.40 deprecated, reached whenever
     # `enable_otlp` is set as `tests/durable_exec/test_dbos.py` does.
-    # TODO(dsfaccini): Drop this once DBOS moves to the `opentelemetry-instrumentation-logging`
-    # handler. https://github.com/dbos-inc/dbos-transact-py/issues/821
+    # TODO(dsfaccini): Drop this once `dbos>=2.31.0` is our minimum supported version.
+    # https://github.com/dbos-inc/dbos-transact-py/pull/822
     "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.
     # Fixed upstream in 0.4.0: https://github.com/voyage-ai/voyageai-python/pull/60 — drop when we bump past 0.3.7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -420,7 +420,7 @@ filterwarnings = [
     "ignore: '_UnionGenericAlias' is deprecated and slated for removal:DeprecationWarning:google.genai",
     # DBOS logs through the `LoggingHandler` that OpenTelemetry SDK 1.40 deprecated, reached whenever
     # `enable_otlp` is set as `tests/durable_exec/test_dbos.py` does.
-    # TODO(dsfaccini): Drop this once `dbos>=2.31.0` is our minimum supported version.
+    # TODO(v3): Require `dbos>=2.31.0` and drop this filter.
     # https://github.com/dbos-inc/dbos-transact-py/pull/822
     "ignore:`LoggingHandler` in `opentelemetry-sdk` is deprecated:DeprecationWarning:opentelemetry.sdk._logs",
     # TODO(Marcelo): Drop this once voyageai stops using Pydantic V1 functionality.


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

The `LoggingHandler` warning filter still protects supported DBOS 2.10–2.30 installs, but its TODO points at the closed upstream issue and implies the handler fix alone permits removal.

Schedule the cleanup for v3: require `dbos>=2.31.0`, then drop the filter. Link the upstream fix that established that boundary. This changes no behavior or dependency constraints today.

### Verification

- `make format`
- `make lint`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
