### PR TITLE
Reduce CI for documentation-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,61 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  classify:
+    name: classify changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Detect documentation-only pull requests
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          total=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
+          gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' > "$RUNNER_TEMP/changed-files.txt"
+
+          mapfile -t changed_files < "$RUNNER_TEMP/changed-files.txt"
+          if [ "$total" -eq 0 ] || [ "${#changed_files[@]}" -ne "$total" ]; then
+            echo "::error::Expected $total changed files, received ${#changed_files[@]}."
+            exit 1
+          fi
+
+          is_docs_markdown() {
+            case "$1" in
+              README.md|docs/*.md|examples/*.md) ;;
+              *) return 1 ;;
+            esac
+            case "$1" in
+              AGENTS.md|CLAUDE.md|*/AGENTS.md|*/CLAUDE.md) return 1 ;;
+            esac
+          }
+
+          docs_only=true
+          for changed_file in "${changed_files[@]}"; do
+            IFS=$'\t' read -r filename previous_filename <<< "$changed_file"
+            if ! is_docs_markdown "$filename" || \
+              { [ -n "$previous_filename" ] && ! is_docs_markdown "$previous_filename"; }; then
+              docs_only=false
+              break
+            fi
+          done
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
   quality:
     name: quality checks
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     # `pull-requests: read` is for the lock-regeneration guard's PR file listing. Reading
     # it works today on `contents: read` alone only because this repo is public; declaring
@@ -170,6 +223,8 @@ jobs:
 
   # mypy and quality checks are a bit slower than other jobs, so we run them separately
   mypy:
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -212,8 +267,49 @@ jobs:
           args: --no-progress --offline --include-fragments --config .github/workflows/lychee.toml './docs/**/*.md' './*.md' './examples/**/*.md'
           fail: true
 
+  # Documentation examples are runtime-checked on one representative Python version. A
+  # version-specific miss is low-impact and easy to repair, while multiplying this job across
+  # the support matrix would recreate much of the CI cost this reduced path avoids.
+  docs-only:
+    name: docs-only checks on Python 3.13
+    needs: classify
+    if: needs.classify.outputs.docs_only == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CI: true
+      # Match the all-extras cells in the full matrix: optional SDKs make blocking-call
+      # detection noisy, while the dedicated 3.13 non-all-extras cells still cover it.
+      BLOCKBUSTER_ENABLED: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-suffix: docs-only
+
+      - name: Install documentation test dependencies
+        run: uv sync --all-extras --no-extra mcp-tasks --all-packages
+
+      - name: Check Markdown files
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: --all-files --verbose
+        env:
+          SKIP: no-commit-to-branch,format,lint,typecheck,check-cassettes
+          UV_NO_SYNC: "1"
+
+      - name: Test documentation snippets
+        run: uv run --no-sync pytest tests/test_examples.py -n logical --dist=loadgroup
+
   test:
     name: test on ${{ matrix.python-version }} (${{ matrix.install.name }})
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     # Route the all-extras cells to Ubicloud 8-core runners on same-repo PRs and pushes, or when
     # opted in via the 'ci:fast' label; the other install variants stay on `ubuntu-latest`.
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
@@ -383,6 +479,8 @@ jobs:
   # (`temporalio`, `dbos`, `prefect`) are proven: `test-lowest-versions` skips this directory.
   test-durable-exec:
     name: test durable-exec on ${{ matrix.python-version }} (${{ matrix.resolution }})
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     # Ubicloud 4-core runners, gated like the `test` job above minus its all-extras clause:
     # same-repo PRs, pushes, or the 'ci:fast' label, with 'ci:slow' forcing GitHub runners.
     runs-on: >-
@@ -489,6 +587,8 @@ jobs:
 
   test-lowest-versions:
     name: test on ${{ matrix.python-version }} (lowest-versions)
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     # Use Ubicloud 8-core runners on same-repo PRs and pushes, or opted in via 'ci:fast' label
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
     # See the note on the `test` job for why push/tag runs need their own clause.
@@ -604,6 +704,8 @@ jobs:
 
   test-temporal-latest:
     name: test Temporal latest on Python 3.10
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -628,6 +730,8 @@ jobs:
 
   test-examples:
     name: test examples on ${{ matrix.python-version }}
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -651,6 +755,8 @@ jobs:
 
   test-fastmcp-4:
     name: test FastMCP 4 compatibility
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -721,7 +827,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    needs: [test, test-durable-exec, test-lowest-versions, test-fastmcp-4]
+    needs: [classify, test, test-durable-exec, test-lowest-versions, test-fastmcp-4]
+    if: needs.classify.outputs.docs_only != 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -751,9 +858,11 @@ jobs:
   check:
     if: always()
     needs:
+      - classify
       - quality
       - mypy
       - docs-assets
+      - docs-only
       - test
       - test-durable-exec
       - test-lowest-versions
@@ -768,10 +877,14 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          # The canary runs on tag refs only, so it is skipped on every PR and `main` push.
-          # Allowing the skip keeps this branch-protection check green there; a skip is all
-          # that's forgiven, so on a tag the canary still has to pass.
-          allowed-skips: latest-versions-canary
+          # The canary runs on tag refs only, and `docs-only` runs only for Markdown-only PRs.
+          # Full CI jobs may skip only when the classifier selected that reduced PR path.
+          allowed-skips: >-
+            ${{
+              needs.classify.outputs.docs_only == 'true'
+              && 'quality,mypy,test,test-durable-exec,test-lowest-versions,test-temporal-latest,test-examples,test-fastmcp-4,latest-versions-canary,coverage'
+              || 'docs-only,latest-versions-canary'
+            }}
           jobs: ${{ toJSON(needs) }}
 
   # Note: this should match the `deploy-docs-manual` job in manually-deploy-docs.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
 
           mapfile -t changed_files < "$RUNNER_TEMP/changed-files.txt"
           if [ "$total" -eq 0 ] || [ "${#changed_files[@]}" -ne "$total" ]; then
-            echo "::error::Expected $total changed files, received ${#changed_files[@]}."
-            exit 1
+            echo "::warning::Expected $total changed files, received ${#changed_files[@]}; running full CI."
+            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           is_docs_markdown() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,17 @@ jobs:
             exit 0
           fi
 
-          total=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
-          gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
-            --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' > "$RUNNER_TEMP/changed-files.txt"
+          if ! total=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files'); then
+            echo '::warning::Could not read the PR changed-file count; running full CI.'
+            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' > "$RUNNER_TEMP/changed-files.txt"; then
+            echo '::warning::Could not list the PR changed files; running full CI.'
+            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           mapfile -t changed_files < "$RUNNER_TEMP/changed-files.txt"
           if [ "$total" -eq 0 ] || [ "${#changed_files[@]}" -ne "$total" ]; then


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

A five-line Markdown-only update in [#7959](https://github.com/pydantic/pydantic-ai/pull/7959) launched 45 CI jobs, including the complete runtime, provider, compatibility, durable-execution, and coverage matrices. Those checks cannot gain useful signal from published documentation changes.

This adds a fail-closed classifier for pull requests changing only `README.md`, Markdown under `docs/`, or Markdown under `examples/`. Mixed changes, instruction files, cross-extension renames, pushes, tags, and failed or incomplete classification retain the full CI path.

## New public surface

None.

## User-visible behavior

Before: a Markdown-only pull request ran the full runtime, provider, compatibility, durable-execution, and coverage matrices.

After: it runs documentation assets, Markdown-relevant pre-commit hooks, and `tests/test_examples.py` with all extras on Python 3.13. The aggregate `check` accepts skipped full-CI jobs only when the classifier selects this path.

The snippet suite deliberately runs on one representative Python version. A version-specific snippet failure reaching `main` is unlikely, has low impact, and is easy to repair; multiplying this check across the support matrix would recreate much of the cost this path removes, so we accept that risk.

## Verification

- `make format && make lint`
- `CI=true BLOCKBUSTER_ENABLED=false uv run --no-sync pytest tests/test_examples.py -n logical --dist=loadgroup` (921 passed, 187 skipped)
- `check-yaml` and `zizmor` for `.github/workflows/ci.yml`
- Current-head full CI, 100% coverage, and aggregate `check`

## What changes for existing users

Nothing for library users; contributors with Markdown-only pull requests receive faster, targeted CI.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
