### PR TITLE
Skip Pyright for unrelated pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,34 +34,40 @@ jobs:
       pull-requests: read
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      pyright_changed: ${{ steps.classify.outputs.pyright_changed }}
     steps:
-      - name: Detect documentation-only pull requests
+      - name: Classify pull request changes
         id: classify
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          run_all_checks() {
             echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            echo 'pyright_changed=true' >> "$GITHUB_OUTPUT"
+          }
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            run_all_checks
             exit 0
           fi
 
           if ! total=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files'); then
             echo '::warning::Could not read the PR changed-file count; running full CI.'
-            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            run_all_checks
             exit 0
           fi
           if ! gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
             --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' > "$RUNNER_TEMP/changed-files.txt"; then
             echo '::warning::Could not list the PR changed files; running full CI.'
-            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            run_all_checks
             exit 0
           fi
 
           mapfile -t changed_files < "$RUNNER_TEMP/changed-files.txt"
           if [ "$total" -eq 0 ] || [ "${#changed_files[@]}" -ne "$total" ]; then
             echo "::warning::Expected $total changed files, received ${#changed_files[@]}; running full CI."
-            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+            run_all_checks
             exit 0
           fi
 
@@ -75,16 +81,30 @@ jobs:
             esac
           }
 
+          is_pyright_input() {
+            # All Python/stub files conservatively cover Pyright's include and import graph;
+            # the remaining paths change its command, configuration, dependencies, or this gate.
+            case "$1" in
+              *.py|*.pyi|*/py.typed|py.typed|pyproject.toml|*/pyproject.toml|uv.lock|uv.toml|*/uv.toml|pyrightconfig*.json|Makefile|.pre-commit-config.yaml|.github/workflows/ci.yml) ;;
+              *) return 1 ;;
+            esac
+          }
+
           docs_only=true
+          pyright_changed=false
           for changed_file in "${changed_files[@]}"; do
             IFS=$'\t' read -r filename previous_filename <<< "$changed_file"
             if ! is_docs_markdown "$filename" || \
               { [ -n "$previous_filename" ] && ! is_docs_markdown "$previous_filename"; }; then
               docs_only=false
-              break
+            fi
+            if is_pyright_input "$filename" || \
+              { [ -n "$previous_filename" ] && is_pyright_input "$previous_filename"; }; then
+              pyright_changed=true
             fi
           done
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "pyright_changed=$pyright_changed" >> "$GITHUB_OUTPUT"
 
   quality:
     name: quality checks
@@ -201,7 +221,7 @@ jobs:
         with:
           extra_args: --all-files --verbose
         env:
-          SKIP: no-commit-to-branch
+          SKIP: ${{ needs.classify.outputs.pyright_changed == 'true' && 'no-commit-to-branch' || 'no-commit-to-branch,typecheck' }}
           # pre-commit hooks shell out via `uv run`; without this they would
           # re-sync the venv and drop the out-of-band harness install above.
           UV_NO_SYNC: "1"


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

The quality job runs pre-commit with `--all-files`, so its `typecheck` hook currently runs even when a pull request cannot affect Pyright. As a follow-up to #7980, this classifies Pyright inputs separately and skips only that hook when no relevant file changed.

The classifier is deliberately conservative: Python and stub files, type markers, dependency/configuration files, the Makefile, pre-commit configuration, and this workflow all trigger Pyright. Renames and GitHub API uncertainty fail safe to running it.

## New public surface

none

## User-visible behavior

Before: any non-docs pull request runs Pyright as part of the quality job.

After: unrelated changes still run the quality job, but skip only its `typecheck` hook.

## Verification

- Current-head [CI](https://github.com/pydantic/pydantic-ai/actions/runs/33543718404) and [coverage](https://github.com/pydantic/pydantic-ai/actions/runs/33543718404/job/99977689859) passed.
- The [`classify changes`](https://github.com/pydantic/pydantic-ai/actions/runs/33543718404/job/99976000133) and [`quality checks`](https://github.com/pydantic/pydantic-ai/actions/runs/33543718404/job/99976064971) jobs passed; this workflow is itself a Pyright-relevant input, so the hook ran.
- `make format && make lint`
- `check-yaml` and `zizmor` on `.github/workflows/ci.yml`

## What changes for existing users

Nothing; this only reduces contributor CI work for pull requests unrelated to Pyright.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
