### PR TITLE
Support `override(tools=...)` in Prefect flows and DBOS workflows, and reject it explicitly on Temporal

### DIFF
--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -206,6 +206,8 @@ If you prefer strict ordering, you can configure the agent to run tools sequenti
 
 Additional toolsets can be passed per run via `agent.run(toolsets=...)`. Non-executing toolsets like [`ExternalToolset`][pydantic_ai.toolsets.ExternalToolset], and [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset]s whose tools DBOS runs inline, are supported. [`MCPToolset`][pydantic_ai.mcp.MCPToolset]s and dynamic toolsets must be set when constructing the agent so their steps are registered before the workflow runs; passing them at runtime raises a `UserError`.
 
+The agent's own tools can be replaced for a run with [`agent.override(tools=...)`][pydantic_ai.agent.AbstractAgent.override], as DBOS runs function tools inline and has nothing to register ahead of the run.
+
 
 ## Step Configuration
 

--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -228,6 +228,8 @@ When a provider pauses a model turn mid-flight (Anthropic `pause_turn`) or runs 
 
 Additional toolsets can be passed per run via `agent.run(toolsets=...)`, but only toolsets that don't need durable wrapping are supported: non-executing toolsets like [`ExternalToolset`][pydantic_ai.toolsets.ExternalToolset], whose tools are executed outside the agent run, and [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset]s whose tools all opt out of task wrapping with `metadata={'prefect': False}`. Other executing toolsets ([`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset] and [`MCPToolset`][pydantic_ai.mcp.MCPToolset]) and dynamic toolsets must be set when constructing the agent so their tasks are registered before the flow runs; passing them at runtime raises a `UserError`.
 
+The agent's own tools can be replaced for a run with [`agent.override(tools=...)`][pydantic_ai.agent.AbstractAgent.override]. A tool's task is built when the tool is called, inside the flow, so the replacement tools run in tasks just like the agent's original tools.
+
 ## Task Configuration
 
 You can customize Prefect task behavior, such as retries and timeouts, by passing [`TaskConfig`][pydantic_ai.durable_exec.prefect.TaskConfig] objects to the [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability] constructor:

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -335,6 +335,8 @@ class MultiModelWorkflow:
 
 Additional toolsets can be passed per run via `agent.run(toolsets=...)`, but only toolsets that don't need durable wrapping are supported: non-executing toolsets like [`ExternalToolset`][pydantic_ai.toolsets.ExternalToolset], whose tools are executed outside the agent run, and [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset]s whose tools all opt out of activity wrapping with [`metadata={'temporal': False}`](#per-tool-activity-config). Other executing toolsets ([`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset] and [`MCPToolset`][pydantic_ai.mcp.MCPToolset]) and dynamic toolsets must be set when constructing the agent so their activities can be registered with the worker before the workflow runs; passing them at runtime raises a `UserError`.
 
+For the same reason, the agent's own tools can't be replaced for a run with [`agent.override(tools=...)`][pydantic_ai.agent.AbstractAgent.override]: a tool call runs in an activity that was registered with the worker when the agent was constructed and looks the tool up in the toolset it was registered with, so a tool added per-run would not be found. Doing so raises a `UserError`.
+
 ## Activity Configuration
 
 Temporal activity configuration, like timeouts and retry policies, can be customized by passing [`temporalio.workflow.ActivityConfig`](https://python.temporal.io/temporalio.workflow._activities.ActivityConfig.html) objects to the [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability] constructor:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 
 from pydantic_ai._run_context import set_current_run_context
 from pydantic_ai._utils import get_union_args
-from pydantic_ai.agent import EventStreamHandler
+from pydantic_ai.agent import EventStreamHandler, _AgentFunctionToolset  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.capabilities import ProcessEventStream
 from pydantic_ai.capabilities.abstract import AbstractCapability, CapabilityOrdering, leaf_capabilities
@@ -56,6 +56,8 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
     _durable_unit_noun: ClassVar[str]
     _durable_container_noun: ClassVar[str]
     _tool_config_key: ClassVar[str | None] = None
+    _supports_overridden_tools: ClassVar[bool]
+    """Whether the engine can durably wrap the agent's own function toolset rebuilt per run by `override(tools=...)`."""
 
     name: str
     """Unique name used to identify the agent's durable units (activities/steps/tasks). Defaults to the agent's `name`."""
@@ -143,6 +145,16 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
                 # non-executing packaging; the toolset it wraps is visited separately by this
                 # same walk and judged on its own identity.
                 return
+            if isinstance(leaf, _AgentFunctionToolset):
+                if self._supports_overridden_tools:
+                    return
+                raise UserError(
+                    f'Tools cannot be contextually overridden with `override(tools=...)` inside a '
+                    f'{self.engine_name} {self._durable_container_noun}, they must be set at agent creation '
+                    f'time. A tool call runs in an {self._durable_unit_noun} registered when the agent is '
+                    f'constructed, which looks the tool up in the toolset it was registered with, so tools '
+                    f'added per-run would not be found.'
+                )
             runtime_leaves.append(leaf)
 
         toolset.apply(collect)
@@ -251,8 +263,13 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
 
         def swap(ts: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
             ts_id = ts.id
-            if ts_id is not None and ts_id in self._toolsets_by_id:
-                return self._toolsets_by_id[ts_id]
+            if ts_id is not None and (registered := self._toolsets_by_id.get(ts_id)) is not None:
+                if isinstance(ts, _AgentFunctionToolset) and registered.wrapped is not ts:
+                    # `override(tools=...)` rebuilt the agent's own function toolset for this run.
+                    # The registered wrapper closed over the construction-time instance, so returning
+                    # it would silently drop the overridden tools; wrap this run's instance instead.
+                    return self._wrap_leaf_toolset(ts) or ts
+                return registered
             return ts
 
         return toolset.visit_and_replace(swap)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -58,6 +58,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
 
     _durable_unit_noun = 'step'
     _durable_container_noun = 'workflow'
+    _supports_overridden_tools = True
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -61,6 +61,7 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
     _durable_unit_noun = 'task'
     _durable_container_noun = 'flow'
     _tool_config_key = 'prefect'
+    _supports_overridden_tools = True
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -146,6 +146,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
     _durable_unit_noun = 'activity'
     _durable_container_noun = 'workflow'
     _tool_config_key = 'temporal'
+    _supports_overridden_tools = False
 
     run_context_type: type[TemporalRunContext[AgentDepsT]]
     """The `TemporalRunContext` subclass used to serialize/deserialize the run context."""

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2265,6 +2265,51 @@ async def test_prefect_durability_rejects_executing_runtime_toolsets(kind: str) 
         await run_agent()
 
 
+async def test_prefect_durability_override_tools_in_flow() -> None:
+    """`override(tools=...)` works inside a flow, and the overridden tools still run durably.
+
+    An active `TaskRunContext` proves the overridden tool went through the task boundary rather
+    than executing inline.
+    """
+    ran_in_task: list[bool] = []
+
+    def overridden_tool() -> str:
+        ran_in_task.append(TaskRunContext.get() is not None)
+        return 'sunny'
+
+    def call_overridden_tool(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[TextPart(content='done')])
+        return ModelResponse(parts=[ToolCallPart('overridden_tool', {})])
+
+    agent = Agent(
+        FunctionModel(call_overridden_tool),
+        name='durability_override_tools',
+        capabilities=[PrefectDurability()],
+    )
+
+    @flow
+    async def run_agent() -> str:
+        with agent.override(tools=[overridden_tool]):
+            return (await agent.run('Hello')).output
+
+    assert await run_agent() == 'done'
+    assert ran_in_task == [True]
+
+
+async def test_prefect_durability_override_tools_still_rejects_runtime_toolsets() -> None:
+    """An active `tools` override doesn't disarm the guard for genuinely per-run toolsets."""
+    agent = Agent(TestModel(), name='durability_override_tools_reject', capabilities=[PrefectDurability()])
+
+    @flow
+    async def run_agent() -> None:
+        with agent.override(tools=[get_weather]):
+            await agent.run('Hello', toolsets=[FunctionToolset(id='runtime_fn')])
+
+    with pytest.raises(UserError, match='FunctionToolset cannot be passed to '):
+        await run_agent()
+
+
 async def test_prefect_durability_allows_fully_opted_out_runtime_function_toolset() -> None:
     def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
         if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -9430,6 +9430,41 @@ async def test_durability_rejects_runtime_executing_toolsets_in_workflow(allow_m
             )
 
 
+@workflow.defn
+class DurabilityOverrideToolsWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        with simple_durable_agent.override(tools=[get_weather]):
+            result = await simple_durable_agent.run(prompt)
+        return result.output  # pragma: no cover
+
+
+async def test_durability_rejects_override_tools_in_workflow(allow_model_requests: None, client: Client):
+    """`override(tools=...)` is rejected in a workflow, with a message naming the override.
+
+    The activity that runs a tool call resolves it against the toolset it closed over at
+    construction time, so tools installed per-run aren't there to be found.
+    """
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[DurabilityOverrideToolsWorkflow],
+        plugins=[AgentPlugin(simple_durable_agent)],
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await client.execute_workflow(
+                DurabilityOverrideToolsWorkflow.run,
+                args=['What is the capital of Mexico?'],
+                id=DurabilityOverrideToolsWorkflow.__name__,
+                task_queue=TASK_QUEUE,
+            )
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, ApplicationError)
+    assert cause.type == UserError.__name__
+    # The rejection is deliberate, so the message has to name what the caller actually did.
+    assert '`override(tools=...)`' in cause.message
+
+
 async def test_durability_allows_runtime_toolsets_outside_workflow(allow_model_requests: None):
     """Outside a workflow the capability is transparent, so per-run executing toolsets are fine."""
 


### PR DESCRIPTION
- Closes #6981

`agent.override(tools=...)` inside a durable run was rejected with a `UserError` about `run(toolsets=...)`, which the caller never passed. Behind that guard was a second, silent problem: with the guard relaxed, the overridden tools were dropped and the model saw none.

**The misreported rejection.** `_reject_runtime_toolsets` matches construction-time toolsets by object identity, but under an active override `Agent.toolsets` builds a fresh `_AgentFunctionToolset` on every call, so the match can never succeed. The guard now recognises that type instead.

**The dropped tools.** Past the guard, `swap` replaces a toolset by `id`, and `_AgentFunctionToolset.id` is the constant `'<agent>'`, registered at bind time against the construction-time instance, so the run's tools were discarded. `swap` now wraps this run's instance when the registered wrapper closed over a different one.

**Temporal is the exception.** Its tool-call activity is registered with the worker up front, closed over the construction-time toolset, and resolves the tool there, so a callable installed per-run in workflow code can't cross that boundary. Prefect builds a tool's task when the wrapper runs, and DBOS runs function tools inline, so both can honour the override. A new `_supports_overridden_tools` class var draws the line, and Temporal raises a `UserError` naming `override(tools=...)`.

Docs: each engine's "Toolsets at Runtime" section now states where `override(tools=...)` is supported.

## Tests

- `test_prefect_durability_override_tools_in_flow`: the overridden tool runs, and an active `TaskRunContext` proves it went through the task boundary rather than inline.
- `test_prefect_durability_override_tools_still_rejects_runtime_toolsets`: an active override doesn't disarm the guard for genuine per-run toolsets.
- `test_durability_rejects_override_tools_in_workflow`: Temporal rejects with a message naming `override(tools=...)`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

