### PR TITLE
Import `Decimal` in the DeepSeek Responses tests

### DIFF
--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -836,7 +836,7 @@ CASES = [
                         input_tokens=148,
                         output_reasoning_tokens=26,
                         output_tokens=40,
-                        cost=Decimal('0.00003192'),
+                        cost=Decimal('0.00005896'),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),

--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -22,6 +22,7 @@ import json
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
+from decimal import Decimal
 from typing import Any
 
 import httpx2


### PR DESCRIPTION
#7450 added a `cost=Decimal('0.00003192')` snapshot to `tests/models/test_deepseek_responses.py`. The module imports `IsDecimal` from the test conftest but never `Decimal` itself, so it raises `NameError` at collection.

That takes down every install variant that collects `tests/models` — `main` has been red since `ece5a6336` merged, and every PR opened since inherits the failure.

One import.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

