### PR TITLE
Improve documentation-writing guidance

### DIFF
--- a/agent_docs/code-simplification.md
+++ b/agent_docs/code-simplification.md
@@ -16,8 +16,6 @@
 - Flatten nested `if` statements with no intervening code into `if condition1 and condition2:` — Reduces nesting depth and improves readability without changing logic
 <!-- rule:-1 -->
 - Use tuple syntax for `isinstance()` checks, not `|` union — tuples are faster at runtime — Runtime performance optimization: tuple syntax avoids the overhead of union type creation
-<!-- rule:34 -->
-- Link to official provider/project docs instead of duplicating model lists, features, or setup details — prevents stale documentation and reduces maintenance burden — Exhaustive inline lists become outdated quickly; authoritative external sources stay current and reduce maintenance
 <!-- rule:519 -->
 - Use dict comprehensions instead of empty dict + loop — more concise and idiomatic Python — Reduces boilerplate, improves readability, and signals intent more clearly for simple mappings and filtered sequences
 <!-- rule:1001 -->

--- a/agent_docs/documentation.md
+++ b/agent_docs/documentation.md
@@ -23,7 +23,7 @@
 - Give each maintained fact one canonical home and link to it elsewhere. Link changing provider inventories, feature lists, and setup details to their authoritative source instead of copying them.
 - When a section needs a stable explicit anchor, add `{#custom-id}` to its heading and link to that ID. Use generated fragments only when they are clear and stable.
 - Put user-facing features where users naturally look for them, not only in API reference docstrings.
-- Use current, supported model identifiers in reader-facing examples.
+- Use current frontier models in reader-facing examples. Verify the latest supported identifiers instead of copying static examples from this guidance.
 - Use Markdown headings for real document sections. Register new published pages in `docs/navigation.yml`.
 - Link to rendered Pydantic AI Harness documentation when it exists. Use the Harness repository only when no published page covers the capability.
 

--- a/agent_docs/documentation.md
+++ b/agent_docs/documentation.md
@@ -1,49 +1,42 @@
 # Documentation
 
-> Rules for writing docstrings, comments, user-facing documentation, and maintaining documentation accuracy
+> Guidance for documentation, docstrings, comments, examples, and other user-facing text
 
-**When to check**: When writing or updating documentation, comments, or docstrings
+**When to check**: When writing or reviewing documentation, comments, docstrings, examples, or user-facing text
 
-## Rules
+## Write for reader value
 
-<!-- rule:272 -->
-- Wrap all code identifiers in docstrings with single backticks — parameters, variables, functions, classes, types, fields, API terms — Ensures consistent docstring formatting and makes code elements visually distinct for better readability
-<!-- rule:339 -->
-- Remove comments that restate obvious code — explain non-obvious intent, edge cases, or constraints instead — Reduces noise and maintenance burden while preserving information that can't be inferred from self-documenting code
-<!-- rule:35 -->
-- Use Markdown heading syntax (`##`, `###`, `####`) instead of bold text for sections — preserves semantic structure and document hierarchy — Proper heading levels enable navigation, accessibility, and consistent documentation structure across all `.md` files
-<!-- rule:396 -->
-- Establish one canonical source per topic and link to it — prevents inconsistency and maintenance burden — Documentation that's duplicated across locations becomes outdated differently, creating contradictions and requiring multiple updates for every change
-- When linking to a section of a docs page from anywhere in the repo — a docstring, a skill reference, an example README — use the `{#custom-id}` pinned on that heading in `docs/`, never an id copied out of a rendered page's URL — A copied id is whatever the site's slugifier happened to generate that week, so it goes dead the moment the heading is pinned or the slugifier changes; only files under `docs/`, `examples/`, and the repository root are anchor-checked in CI, so a link written anywhere else has nothing to catch it
-<!-- rule:34 -->
-- Link to official provider/project docs instead of duplicating model lists, features, or setup details — prevents stale documentation and reduces maintenance burden — Exhaustive inline lists become outdated quickly; authoritative external sources stay current and reduce maintenance
-<!-- rule:138 -->
-- Update all related docs in the same PR when changing functionality, APIs, or capabilities — includes docstrings, comments, external docs (e.g., `pydantic.dev/docs/ai`), and API references — Prevents documentation drift that misleads users about actual behavior, limitations, or API contracts
-<!-- rule:107 -->
-- Register new `docs/` files in `docs/navigation.yml` — Keeps the published pydantic.dev/docs/ai navigation complete and prevents orphaned pages or route drift
-<!-- rule:31 -->
-- Use consistent terminology across code, docs, comments, and errors (e.g., `freeform` vs `free-form`, `messages` vs `last message`) — prevents user confusion and makes codebase searchable — Inconsistent terminology fragments documentation searches, confuses users trying to map concepts between docs and code, and signals poor API design quality
-<!-- rule:76 -->
-- Prefix future work with `TODO:` and link workarounds to upstream/internal issues — enables tracking and cleanup when conditions change — Explicit markers with tracking links prevent abandoned workarounds and make technical debt actionable and removable when upstream fixes land
-<!-- rule:611 -->
-- Reference issues and PRs in comments and docstrings with the full URL (`https://github.com/pydantic/pydantic-ai/issues/1234`), not the `#1234` shorthand — The shorthand isn't clickable outside GitHub's own rendering (IDEs, generated API docs, plain-text views), so a full link stays navigable wherever the code is read
-<!-- rule:386 -->
-- Keep docs and implementation in sync — when they conflict, explicitly decide which to update and fix it — Prevents user confusion and wasted debugging time when documented behavior doesn't match actual behavior; applies to params, config options, component characteristics, and especially test docstrings which must describe what's actually validated
-<!-- rule:106 -->
-- Document provider feature support with 'Supported by:' sections — link each provider, list supported/unsupported, distinguish variants (Google Gemini vs Google Cloud (formerly known as Vertex AI)), include syntax/config/permissions — Prevents users from attempting unsupported features and enables quick evaluation of provider capabilities without trial-and-error testing across multiple providers
-<!-- rule:750 -->
-- Document all defaults comprehensively: explicit values, fallback chains, compatibility tradeoffs (backward/forward), and implicit/conditional defaults from parameter interactions — Prevents API confusion and misuse by making fallback behavior, override precedence, and compatibility constraints discoverable in docstrings rather than requiring code archaeology
-<!-- rule:150 -->
-- Comment non-obvious conditionals — explain edge cases, error handling, and state-based logic — Intent isn't always clear from code alone; comments prevent confusion during maintenance and debugging
-<!-- rule:368 -->
-- Document what code does now, not what it used to do — skip historical references like "original", "old", "legacy", or "this used to do X" — Historical comments become outdated noise that confuses future readers; focus on current behavior and rationale
-<!-- rule:801 -->
-- Keep documentation concise—focus on essential information, not implementation details or edge cases — Reduces maintenance burden and improves readability by avoiding unnecessary detail that becomes outdated or clutters the docs
-<!-- rule:313 -->
-- Document workarounds with (1) expected behavior, (2) why it fails, and (3) that it compensates for external constraints — Prevents future developers from "fixing" workarounds that address API limitations, spec non-compliance, or external bugs — these look like code smells but are actually intentional compensations
-<!-- rule:623 -->
-- Avoid line numbers in comments/docstrings — use function/class names instead — Line numbers become stale immediately when code changes, breaking the reference and misleading readers
-<!-- rule:656 -->
-- Document new user-facing features in dedicated sections where users naturally encounter them, not just in docstrings — Users discover features through conceptual docs and guides, not API references — ensures feature discoverability and proper context
-<!-- rule:-4 -->
-- Link to a Pydantic AI Harness capability via its docs page at `https://pydantic.dev/docs/ai/harness/<slug>/` (e.g. `https://pydantic.dev/docs/ai/harness/exa-search/`, `https://pydantic.dev/docs/ai/harness/compaction/`), not its GitHub repo/README — the harness has published docs; only fall back to a GitHub link when a capability has no docs page yet — Gives readers rendered, canonical docs instead of raw source, and matches how the rest of the repo references the harness (`https://pydantic.dev/docs/ai/harness/`)
+- Minimize the inference required from the reader. Preserve every useful fact, condition, consequence, limitation, and distinction.
+- Test each clause, parenthetical, comparison, contrast, and explanatory tail by removing it mentally. Delete it only when the reader loses nothing useful; shorten or rewrite it when the same information can be clearer.
+- Prefer direct, concrete statements and observable behavior over generic framing, unsupported promotion, vague referents, empty reassurance, or an obvious inverse.
+- Preserve alternatives and negative boundaries when they prevent a plausible misunderstanding. Words such as `rather than`, `only`, `never`, and `without` often carry essential information.
+- Preserve useful human voice. Change second person, passive voice, long sentences, parentheses, dashes, or colloquial language only when the specific passage becomes clearer or more accurate.
+- Use one precise term for each concept across code, docs, comments, errors, and other user-facing text.
+
+## Documentation and examples
+
+- Help readers decide what to do and then do it correctly. Lead with the reader's action or decision when that improves findability, while retaining prerequisites and consequences.
+- Make the recommended approach easy to find. Explain meaningful alternatives, trade-offs, conflicts, and negative boundaries.
+- Lead with current APIs. Include deprecated or historical behavior only when readers need migration or compatibility guidance.
+- Include implementation details only when they change a user decision or explain observable behavior.
+- Document behavior changes in every affected user-facing surface in the same PR. Fix any conflict between documentation and implementation instead of leaving competing contracts.
+- Give each maintained fact one canonical home and link to it elsewhere. Link changing provider inventories, feature lists, and setup details to their authoritative source instead of copying them.
+- When a section needs a stable explicit anchor, add `{#custom-id}` to its heading and link to that ID. Use generated fragments only when they are clear and stable.
+- Put user-facing features where users naturally look for them, not only in API reference docstrings.
+- Use current, supported model identifiers in reader-facing examples.
+- Use Markdown headings for real document sections. Register new published pages in `docs/navigation.yml`.
+- Link to rendered Pydantic AI Harness documentation when it exists. Use the Harness repository only when no published page covers the capability.
+
+## Docstrings
+
+- Help users choose and correctly use public APIs. State behavior, important conditions, errors, side effects, defaults, precedence, and boundaries without repeating the signature or implementation.
+- For configurable features, document the default, fallback and precedence conditions, compatibility consequences, and when users should override it.
+- Format code identifiers as Markdown code or API reference links, as appropriate.
+- For provider-dependent APIs, identify supported providers and explain differences that affect user choices. Do not claim mechanisms the provider does not document.
+
+## Code comments
+
+- Explain non-obvious intent, invariants, constraints, trade-offs, or why an obvious implementation is wrong. Do not narrate behavior that is clear from the code.
+- Describe the current constraint. Keep history only when it explains a live compatibility boundary, workaround, regression risk, or otherwise surprising decision.
+- Explain a workaround's intended behavior and the external constraint it compensates for. Mark future cleanup with `TODO:` and link it to a tracking issue.
+- Use stable references. Link GitHub issues and PRs with full URLs, and name symbols or behavior instead of line numbers.

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -112,15 +112,11 @@
 
 ## Documentation
 
-<!-- rule:132 -->
-- Use latest/frontier models (e.g., `'gpt-5'` not `'gpt-4o'`) in docs and examples — Shows users current best practices and prevents outdated examples from becoming cargo-culted into production code
 <!-- rule:390 -->
 - Use provider-prefixed model identifiers (`{provider}:{model}`) and platform-specific formats (e.g., AWS Bedrock requires `us.anthropic.claude-{model}-{version}:0`) — Prevents misconfiguration and API errors by matching exact identifier formats required by each platform, ensures consistency across docs and code
 
 ## General
 
-<!-- rule:-2 -->
-- Use latest frontier models (e.g. `openai:gpt-5.2`, `anthropic:claude-opus-4-6`) in `docs/examples` — Outdated model references make our product look unmaintained and reduce user trust
 <!-- rule:449 -->
 - Use `make install` to regenerate lock files (e.g., `uv.lock`) after dependency changes — Ensures reproducible builds and keeps lock file diffs minimal. Update the package manager (uv, npm, pip-tools) to latest first and start from clean state. If diffs are unexpectedly large, reset to base branch and regenerate to isolate actual changes — prevents spurious conflicts and version drift.
 <!-- rule:717 -->
@@ -133,7 +129,7 @@
 Check these when working in specific areas:
 
 - **[Code Simplification & Idioms](code-simplification.md)**: When refactoring code for clarity or looking to simplify complex patterns
-- **[Documentation](documentation.md)**: When writing or updating documentation, comments, or docstrings
+- **[Documentation](documentation.md)**: When writing or reviewing documentation, comments, docstrings, examples, or other user-facing text
 - **[API Design & Interfaces](api-design.md)**: When designing or modifying public APIs, parameters, or class interfaces
 - **[Pydantic AI Slim Architecture](pydantic-ai-slim.md)**: When changing agents, tools, output, message history, providers, profiles, capabilities, toolsets, UI adapters, or durable execution
 <!-- /braindump -->

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,75 +1,36 @@
 <!-- braindump: rules extracted from PR review patterns -->
 
-# docs/ Guidelines
+# `docs/` guidelines
 
-## Documentation
+Follow the general [documentation guidance](../agent_docs/documentation.md). These rules cover published Markdown under `docs/`.
 
-<!-- rule:232 -->
-- Link all concepts, features, and API elements to their docs/reference pages using anchor fragments (`#section-name`) for specific sections — Improves discoverability and reduces user friction by providing direct navigation to relevant documentation context
-- Pin an explicit `{#custom-id}` on a heading as soon as anything links to it and its generated id would surprise the person writing that link — unpinned, `github-slugger` drops punctuation and turns every space into its own dash, so `## Tools & native abilities` would generate `#tools--native-abilities` (doubled, the `&` vanishing between two spaces) and `## SIP/telephony bridge` generates `#siptelephony-bridge` (glued, the `/` vanishing inside a word); a literal `-` is kept rather than dropped and compounds it, so `## Agentic Chat - Code` would generate `#agentic-chat---code` — An explicit id is stable across slugifier changes and reads better than the generated one, but it also *replaces* the generated id, so pin before a link exists rather than after: `SIP/telephony bridge` is left unpinned precisely because nothing links to it yet. `.github/workflows/ci.yml` fails the build on an unresolvable anchor in `docs/`, `examples/`, or a root `*.md`, though not on one inside a docstring
-<!-- rule:66 -->
-- Use reference-style links for API elements: `[ElementName][module.path.ElementName]` — enables hover docs and navigation on the published documentation site — Provides interactive documentation features like tooltips and jump-to-definition that plain backticks cannot support
-<!-- rule:714 -->
-- Omit deprecated features from user-facing docs — document only current approaches — Prevents users from learning outdated patterns and reduces confusion about the recommended way forward
-<!-- rule:82 -->
-- Write project name as `Pydantic AI` (two words) in docs — not `Pydantic-AI`, `PydanticAI`, or `pAI` — Maintains consistent brand identity and prevents confusion across documentation
-<!-- rule:359 -->
-- Structure code examples as: context/intro → code block → caveats/details (never code before context) — Ensures readers understand purpose and usage before seeing code, making docs more learnable and preventing confusion
-<!-- rule:93 -->
-- Hide implementation details from user docs unless they affect user decisions — focus on what users can control, not how it works internally — Keeps documentation clean and maintainable by separating user-facing APIs from implementation that may change
-<!-- rule:52 -->
-- Structure docs with progressive disclosure: concept → capabilities → examples (standalone first) → config → edge cases — Helps readers build mental models incrementally, reducing cognitive load and making features easier to adopt
-<!-- rule:152 -->
-- In docs, show the **recommended approach first**, then introduce alternatives with explicit relational language ("In addition to...", "As an alternative to...") using specific feature names — Prevents users from adopting legacy or suboptimal patterns by ensuring they encounter the best practice first
-<!-- rule:109 -->
-- Remove docs content describing features "working as expected" — focus only on integration-specific concerns, limitations, or deviations — Reduces cognitive load and maintenance burden by eliminating noise; prevents documentation staleness from trivial statements
-<!-- rule:67 -->
-- Keep provider-specific config/features in `docs/models/{provider}.md` and `docs/api/models/{provider}.md`; general docs stay provider-agnostic with one minimal example + links — Prevents duplication, keeps general feature docs clean and maintainable, ensures users find provider-specific details in one canonical location rather than scattered across multiple pages
-<!-- rule:941 -->
-- Avoid `test="skip"` in code examples unless unavoidable (external services, credentials, non-deterministic behavior) — use mocks or fixtures instead — Testable documentation examples prove the code works and prevent docs from drifting out of sync with actual behavior
-<!-- rule:727 -->
-- Link to canonical sources rather than duplicating lists or summaries maintained elsewhere — Prevents docs from becoming outdated when the source of truth changes
-<!-- rule:808 -->
-- Focus docs on user tasks and public APIs, defer implementation details to docstrings — Task-oriented guides help users accomplish goals faster, while keeping advanced/internal details in API reference prevents overwhelming users with complexity when sensible defaults exist
-<!-- rule:301 -->
-- In docs, consolidate examples showing parameter variations into one block with notes — split only for mutually exclusive params or distinct use cases — Reduces cognitive load and makes docs more scannable by avoiding repetitive boilerplate for simple parameter alternatives
-<!-- rule:58 -->
-- In docs examples, demonstrate realistic use cases that show *why* the feature matters — prevents misleading users with toy scenarios or debugging code that obscure actual value — Well-crafted examples help users understand when to apply features and avoid implementing unnecessary patterns for problems solvable with simpler approaches
-<!-- rule:54 -->
-- Use fence-level `{test="skip" lint="skip"}` instead of inline suppressions in doc examples — keeps code clean and reader-focused — Documentation code should model best practices; fence-level skip directives separate tooling concerns from the example itself, while inline `# noqa` or `# type: ignore` pollutes pedagogical code with implementation details
-<!-- rule:151 -->
-- Cross-reference alternatives and explain trade-offs when documenting overlapping features — Prevents users from missing better-suited options or implementing duplicate functionality when multiple approaches exist (e.g., `UsageLimits` vs rate-limiting, provider-specific implementations)
-<!-- rule:1112 -->
-- Document default behavior and use cases for all configurable features — helps users decide when to override defaults — Users can't make informed configuration choices without knowing what happens by default and when alternatives are appropriate
-- When docs contrast prior and current Pydantic AI behavior, name the first version with the current behavior. Do not repeat a version already supplied by the page or section. Do not add historical prose when current behavior alone is sufficient.
-<!-- rule:135 -->
-- Use actual, currently available model names in documentation examples — prevents user confusion and copy-paste errors with non-existent models — Ensures users can run documentation examples without modification and avoids frustration from referencing models that don't exist yet or are hypothetical
-<!-- rule:508 -->
-- Verify rendered documentation through a unified-docs preview before merging — catches broken internal/external references early — Prevents documentation drift and broken links from reaching users, especially after code refactoring
-<!-- rule:283 -->
-- Use admonitions (`!!! note`, `!!! warning`) for callouts, not blockquotes (`>`) or GitHub alerts (`> [!NOTE]`) — Ensures consistent rendering and prevents callouts from cluttering the table of contents
-<!-- rule:618 -->
-- Nest subtopics, examples, and config details within parent sections — improves discoverability and reduces redundant context — Hierarchical organization makes documentation easier to navigate and understand by grouping related content together rather than scattering it across top-level sections or separate files.
-<!-- rule:298 -->
-- In provider feature support tables, use a `Notes` or `Provider Support Notes` column for variations, limitations, and special values — keeps table structure clean and constraints discoverable — Centralizes provider-specific exceptions in one scannable location instead of scattering them across config examples or inline parentheticals, making cross-provider differences easier to find
-<!-- rule:634 -->
-- In provider feature tables, use standard labels (`Full feature support`, `Limited parameter support`) and move unsupported variants to `Unsupported` column, not inline exceptions — Ensures consistent, scannable documentation structure where users can quickly identify exact support boundaries across providers
-<!-- rule:168 -->
-- When documenting alternative approaches, explain tradeoffs (limitations, requirements, benefits, use-cases) and warn about conflicts when combining them — Helps users make informed decisions and avoid subtle bugs from conflicting configurations
+## Links and structure
+
+- Use reference-style links for API elements: `[ElementName][module.path.ElementName]`. They provide hover documentation and API navigation on the published site.
+- Write the project name as `Pydantic AI`.
+- Use admonitions (`!!! note`, `!!! warning`) for callouts, not blockquotes or GitHub alerts.
+- Keep provider-specific configuration and behavior in `docs/models/{provider}.md` and `docs/api/models/{provider}.md`. General guides use a minimal provider-agnostic example and link to the provider page.
+- In provider feature tables, use a `Notes` or `Provider Support Notes` column for variations, limitations, and special values. Use the standard labels `Full feature support` and `Limited parameter support`, and put unsupported variants in the `Unsupported` column.
+
+## Examples
+
+- Keep code examples executable unless they require external services, credentials, or non-deterministic behavior. Use mocks or fixtures when they keep the example representative.
+- Put example-level exclusions on the fence, such as `{test="skip" lint="skip"}`, rather than adding tooling suppressions to pedagogical code.
+- Combine parameter variations when one example plus notes preserves every meaningful difference. Split examples when use cases, prerequisites, or constraints differ.
+- Use examples that demonstrate a credible user task or decision without introducing complexity unrelated to the feature.
+
+## Review
+
+- Render documentation in a unified-docs preview before merging.
 
 <!-- /braindump -->
 
-## Plain language
+# Front pages: `docs/index.md` and `README.md`
 
-Use "shape" only for concrete structure or wire representation. Otherwise name the concept, such as configuration, signature, setup, or sequence.
+The docs index and repository README tell the same story on two surfaces. Keep their shared wording and code examples synchronized while preserving the markup each renderer needs:
 
-# Front pages: docs/index.md and README.md sync contract
-
-The docs index and the repository README are one story on two surfaces. Whenever one changes, mirror the other in the same PR (enforced by `tests/test_docs_parity.py`):
-
-- `docs/index.md` uses relative links, tabs (`=== "..."`), numbered annotations (`(1)!`), and MkDocs-only markup. `README.md` uses absolute links (`https://pydantic.dev/docs/ai/...`), `###` sections instead of tabs, and plain one-line `#` comments instead of annotations (GitHub renders annotation markers literally).
-- The mirrored code examples (coding agent, data extraction, realtime voice, image generation, embeddings, `bank_support.py`) must stay code-identical across both surfaces; only comments/annotations and fence attributes may differ.
-- `README.md` is included in `tests/test_examples.py`'s `find_examples`, so its snippets are tested and linted. Snippets that cannot run here (`pydantic_ai_harness` imports, interactive realtime sessions) are excluded by content match in `find_filter_examples`, not by fence attributes, so README fences stay bare for GitHub rendering.
-- Wording that appears on both surfaces (paragraph one, the whatever-you-came-to-build line, the Why bullets, section intros) must match word for word modulo link form.
-- No em dashes anywhere in these files; use colons, semicolons, commas, parentheses, or sentence breaks instead.
-- The harness repo's front pages (`pydantic/pydantic-ai-harness` `docs/index.md` + `README.md`) carry the same positioning: when the tagline or Harness framing changes here, check those too (see `agent_docs/docs-conventions.md` in that repo).
+- `docs/index.md` uses relative links, tabs (`=== "..."`), numbered annotations (`(1)!`), and MkDocs-only markup.
+- `README.md` uses absolute documentation links, `###` sections instead of tabs, and plain one-line `#` comments instead of annotations.
+- Mirrored code examples remain code-identical; only comments, annotations, link forms, and fence attributes may differ.
+- README snippets that cannot run in the documentation test environment are excluded by `tests/test_examples.py`, not by fence attributes, so README fences remain compatible with GitHub rendering.
+- When the shared tagline or Harness framing changes, check the Harness repository's `docs/index.md` and `README.md` too.


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

This consolidates repository guidance for documentation prose, docstrings, code comments, examples, and other user-facing text.

- Replaces blanket style prescriptions with a reader-value test that preserves useful facts, boundaries, alternatives, and human voice.
- Makes `agent_docs/documentation.md` the canonical general contract and limits `docs/AGENTS.md` to published-Markdown specifics.
- Removes duplicate model-example and external-source rules, plus the unsupported front-page em-dash ban.
- Preserves stable cross-reference syntax, executable-example expectations, provider-support tables, configurable defaults, and public API docstring requirements.

### Verification

- `make format && make lint`
- Targeted pre-commit hooks for all changed files
- Two independent pre-push reviews; the second returned no findings

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

