### PR TITLE
Keep a run cancelled during its first tool call resumable

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -620,7 +620,7 @@ async def main():
     except RunCancelled as exc:
         messages = exc.all_messages()
         print(f'Cancelled after {len(messages)} messages')
-        #> Cancelled after 2 messages
+        #> Cancelled after 3 messages
         await agent.run(message_history=messages)  # (2)!
 ```
 
@@ -676,7 +676,7 @@ async def main():
         assert cancelled is not None
         messages = cancelled.all_messages()
         print(f'Cancelled after {len(messages)} messages')
-        #> Cancelled after 2 messages
+        #> Cancelled after 3 messages
         await agent.run(message_history=messages)  # (3)!
 ```
 
@@ -1693,6 +1693,13 @@ with capture_run_messages() as messages:  # (2)!
                 run_id='...',
                 conversation_id='...',
             ),
+            ModelRequest(
+                parts=[],
+                timestamp=datetime.datetime(...),
+                run_id='...',
+                conversation_id='...',
+                state='interrupted',
+            ),
         ]
         """
     else:
@@ -1706,7 +1713,7 @@ _(This example is complete, it can be run "as is")_
 
 When a run is cut short by an exception while streaming, an exception inside a tool, or external cancellation, Pydantic AI still captures partial state where it can. Partial [`ModelResponse`][pydantic_ai.messages.ModelResponse] and [`ModelRequest`][pydantic_ai.messages.ModelRequest] messages have `state='interrupted'` so persistence layers and UIs can distinguish them from complete messages.
 
-For model responses, interrupted messages contain the response parts streamed before the interruption. For model requests, interrupted messages contain the tool results that completed before tool execution stopped. The captured messages reflect exactly what happened — half-finished tool call parts are not turned into synthetic tool results at capture time. When an interrupted history is passed back into a run, it is [repaired automatically](message-history.md#making-histories-provider-valid) before the next model request.
+For model responses, interrupted messages contain the response parts streamed before the interruption. For model requests, interrupted messages contain the tool results that completed before tool execution stopped — if none did, the request is still recorded, with no parts, marking the point where the response's tool calls were abandoned. The captured messages reflect exactly what happened — half-finished tool call parts are not turned into synthetic tool results at capture time. When an interrupted history is passed back into a run, it is [repaired automatically](message-history.md#making-histories-provider-valid) before the next model request.
 
 In this example, `get_volume` completes before `get_mass` raises, so the interrupted request contains the completed `get_volume` return:
 

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2203,16 +2203,21 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
             # Capture the partial tool returns collected so far. State is 'interrupted'
             # so `capture_run_messages` consumers can detect partial state. The user prompt
             # is intentionally omitted: this request was never sent to the model.
-            if output_parts:
-                ctx.state.message_history.append(
-                    _messages.ModelRequest(
-                        parts=list(output_parts),
-                        run_id=ctx.state.run_id,
-                        conversation_id=ctx.state.conversation_id,
-                        timestamp=now_utc(),
-                        state='interrupted',
-                    )
+            #
+            # It's appended even when no tool finished and it's therefore empty: this node only runs
+            # for a response that made tool calls, so the marker is what tells the resume path that
+            # those calls will never be answered and need synthesized `'interrupted'` returns.
+            # Without it, a run cancelled during its first (or only) tool call would leave a history
+            # that can't take a new prompt.
+            ctx.state.message_history.append(
+                _messages.ModelRequest(
+                    parts=list(output_parts),
+                    run_id=ctx.state.run_id,
+                    conversation_id=ctx.state.conversation_id,
+                    timestamp=now_utc(),
+                    state='interrupted',
                 )
+            )
             raise
 
         if output_final_result:

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1993,6 +1993,7 @@ class ModelRequest:
 
     Set to `'interrupted'` when the request was being assembled (e.g. collecting tool returns) and
     the run was abnormally terminated by an exception or cancellation before the request was sent to the model.
+    In that case `parts` holds only the tool returns that were collected, and is empty if none were.
     Appears in [`capture_run_messages`][pydantic_ai.capture_run_messages] output so consumers can detect partial state.
     """
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4349,7 +4349,55 @@ def test_unknown_tool():
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
+            ModelRequest(
+                parts=[],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+                state='interrupted',
+            ),
         ]
+    )
+
+
+def test_failed_run_history_is_resumable():
+    """A history captured from a run that raised is resumable, not just one from a cancelled run.
+
+    The run ends on a response whose tool call never got a result, and the interrupted request
+    that closes out the turn is empty because nothing completed. It's still recorded, so the
+    dangling call is closed out with a synthesized return and the history takes a new prompt.
+    """
+    seen_by_model: list[list[ModelMessage]] = []
+
+    def model_func(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen_by_model.append(list(messages))
+        if any(isinstance(part, UserPromptPart) and part.content == 'Never mind.' for part in messages[-1].parts):
+            return ModelResponse(parts=[TextPart('success')])
+        return ModelResponse(parts=[ToolCallPart('foobar', '{}', tool_call_id='call_foobar')])
+
+    agent = Agent(FunctionModel(model_func))
+
+    with capture_run_messages() as messages:
+        with pytest.raises(UnexpectedModelBehavior, match=r"Tool 'foobar' exceeded max retries count of 1"):
+            agent.run_sync('Hello')
+
+    result = agent.run_sync('Never mind.', message_history=messages)
+    assert result.output == 'success'
+    assert seen_by_model[-1][-1] == snapshot(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='foobar',
+                    content='The tool call was interrupted before a result was produced.',
+                    tool_call_id='call_foobar',
+                    metadata={'pydantic_ai_synthesized_tool_return': True},
+                    timestamp=IsNow(tz=timezone.utc),
+                    outcome='interrupted',
+                ),
+                UserPromptPart(content='Never mind.', timestamp=IsNow(tz=timezone.utc)),
+            ],
+            timestamp=IsNow(tz=timezone.utc),
+        )
     )
 
 
@@ -4473,6 +4521,13 @@ def test_unknown_tool_multiple_retries():
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+                state='interrupted',
             ),
         ]
     )

--- a/tests/test_run_cancellation.py
+++ b/tests/test_run_cancellation.py
@@ -484,6 +484,130 @@ async def test_tool_cancels_run_and_history_is_resumable():
     )
 
 
+def _single_tool_agent() -> tuple[Agent, list[list[ModelMessage]], asyncio.Event]:
+    """An agent whose first response calls a single tool that never returns.
+
+    Returns the agent, a list capturing the raw messages each model request receives, and an
+    event set once the tool is in flight.
+    """
+    seen_by_model: list[list[ModelMessage]] = []
+    tool_started = asyncio.Event()
+
+    def model_func(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen_by_model.append(list(messages))
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name='in_flight_tool', args={}, tool_call_id='call_only')])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(model_func))
+
+    @agent.tool_plain
+    async def in_flight_tool() -> str:
+        tool_started.set()
+        await asyncio.sleep(READINESS_WAIT_TIMEOUT)
+        return 'never reached'  # pragma: no cover
+
+    return agent, seen_by_model, tool_started
+
+
+async def test_cancel_during_only_tool_call_is_resumable():
+    """Cancelling while the response's only tool call is still in flight stays resumable.
+
+    No tool produced a result, so the interrupted request that closes out the turn is empty —
+    but it's still recorded, because it's what tells a resumed run that the response's calls
+    will never be answered. Without it the history ends in a response with an unanswered tool
+    call, and a new prompt is refused.
+    """
+    agent, seen_by_model, tool_started = _single_tool_agent()
+
+    token = CancellationToken()
+    task = asyncio.create_task(agent.run('go', cancellation_token=token))
+    await asyncio.wait_for(tool_started.wait(), timeout=READINESS_WAIT_TIMEOUT)
+    token.cancel()
+
+    with pytest.raises(RunCancelled) as exc_info:
+        await task
+
+    messages = exc_info.value.all_messages()
+    assert messages == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='go', timestamp=IsNow(tz=timezone.utc))],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name='in_flight_tool', args={}, tool_call_id='call_only')],
+                usage=RequestUsage(input_tokens=51, output_tokens=2),
+                model_name='function:model_func:',
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+                state='interrupted',
+            ),
+        ]
+    )
+
+    result = await agent.run('never mind, wrap up', message_history=messages)
+    assert result.output == 'done'
+    assert seen_by_model[-1][-1] == snapshot(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='in_flight_tool',
+                    content='The tool call was interrupted before a result was produced.',
+                    tool_call_id='call_only',
+                    metadata={'pydantic_ai_synthesized_tool_return': True},
+                    timestamp=IsNow(tz=timezone.utc),
+                    outcome='interrupted',
+                ),
+                UserPromptPart(content='never mind, wrap up', timestamp=IsNow(tz=timezone.utc)),
+            ],
+            timestamp=IsNow(tz=timezone.utc),
+        )
+    )
+
+
+async def test_cancel_during_only_tool_call_is_resumable_without_a_new_prompt():
+    """The same history also resumes with no new prompt: the synthesized return is sent on its own."""
+    agent, seen_by_model, tool_started = _single_tool_agent()
+
+    token = CancellationToken()
+    task = asyncio.create_task(agent.run('go', cancellation_token=token))
+    await asyncio.wait_for(tool_started.wait(), timeout=READINESS_WAIT_TIMEOUT)
+    token.cancel()
+
+    with pytest.raises(RunCancelled) as exc_info:
+        await task
+
+    result = await agent.run(message_history=exc_info.value.all_messages())
+    assert result.output == 'done'
+    assert seen_by_model[-1][-1] == snapshot(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='in_flight_tool',
+                    content='The tool call was interrupted before a result was produced.',
+                    tool_call_id='call_only',
+                    metadata={'pydantic_ai_synthesized_tool_return': True},
+                    timestamp=IsNow(tz=timezone.utc),
+                    outcome='interrupted',
+                )
+            ],
+            timestamp=IsNow(tz=timezone.utc),
+            run_id=IsStr(),
+            conversation_id=IsStr(),
+        )
+    )
+
+
 async def test_agent_run_cancel_from_another_task():
     """`AgentRun.cancel()` is safe to call from a sibling task (a TUI's Esc handler) and
     surfaces as `RunCancelled` from whatever is driving the run."""
@@ -868,6 +992,13 @@ async def test_task_cancel_of_run_carries_run_cancelled():
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
+            ModelRequest(
+                parts=[],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+                state='interrupted',
+            ),
         ]
     )
     assert cancelled.usage.requests == 1
@@ -901,7 +1032,7 @@ async def test_direct_await_cancellation_carries_run_cancelled_on_all_versions()
 
     (cancelled,) = recorded
     assert cancelled is not None
-    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse]
+    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse, ModelRequest]
     assert cancelled.usage.requests == 1
     assert cancelled.run_id is not None
 
@@ -930,7 +1061,7 @@ async def test_from_cancellation_through_asyncio_timeout():
 
     cancelled = RunCancelled.from_cancellation(exc_info.value)
     assert cancelled is not None
-    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse]
+    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse, ModelRequest]
     assert started.is_set()
 
 
@@ -1034,7 +1165,7 @@ async def test_iter_external_cancel_carries_run_cancelled():
 
     cancelled = RunCancelled.from_cancellation(exc_info.value)
     assert cancelled is not None
-    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse]
+    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse, ModelRequest]
     assert cancelled.usage.requests == 1
 
 
@@ -1186,11 +1317,11 @@ async def test_run_stream_events_external_cancel_of_consumer():
     assert task.cancelled()
     cancelled = RunCancelled.from_cancellation(exc_info.value)
     assert cancelled is not None
-    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse]
+    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse, ModelRequest]
     assert cancelled.usage.requests == 1
     # The handle itself also remains usable after teardown.
     (events,) = holder
-    assert [type(message) for message in events.all_messages()] == [ModelRequest, ModelResponse]
+    assert [type(message) for message in events.all_messages()] == [ModelRequest, ModelResponse, ModelRequest]
     assert events.result is None
 
 
@@ -1224,7 +1355,7 @@ async def test_run_stream_events_external_cancel_caught_in_task():
 
     (cancelled,) = recorded
     assert cancelled is not None
-    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse]
+    assert [type(message) for message in cancelled.all_messages()] == [ModelRequest, ModelResponse, ModelRequest]
 
 
 async def test_run_stream_events_external_cancel_before_iteration_attaches_nothing():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2160,6 +2160,13 @@ async def test_call_tool_wrong_name():
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
+            ModelRequest(
+                parts=[],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+                state='interrupted',
+            ),
         ]
     )
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1094,6 +1094,13 @@ async def test_toolset_max_retries_inherits_from_agent():
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
+            ModelRequest(
+                parts=[],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+                state='interrupted',
+            ),
         ]
     )
 
@@ -1118,7 +1125,15 @@ async def test_toolset_explicit_max_retries_overrides_agent():
     # Initial call + 2 retries = 3 attempts.
     assert len(attempts) == 3
     assert [type(m).__name__ for m in messages] == snapshot(
-        ['ModelRequest', 'ModelResponse', 'ModelRequest', 'ModelResponse', 'ModelRequest', 'ModelResponse']
+        [
+            'ModelRequest',
+            'ModelResponse',
+            'ModelRequest',
+            'ModelResponse',
+            'ModelRequest',
+            'ModelResponse',
+            'ModelRequest',
+        ]
     )
     retry_parts = [p for m in messages for p in getattr(m, 'parts', []) if isinstance(p, RetryPromptPart)]
     assert [p.content for p in retry_parts] == snapshot(['Always fails', 'Always fails'])
@@ -1233,7 +1248,7 @@ async def test_toolset_tool_max_retries_none_uses_tool_retries_not_output_retrie
     # retries=1 means initial call + 1 retry = 2 attempts, not 6 (which would be output_retries).
     assert len(attempts) == 2
     assert [type(m).__name__ for m in messages] == snapshot(
-        ['ModelRequest', 'ModelResponse', 'ModelRequest', 'ModelResponse']
+        ['ModelRequest', 'ModelResponse', 'ModelRequest', 'ModelResponse', 'ModelRequest']
     )
     retry_parts = [p for m in messages for p in getattr(m, 'parts', []) if isinstance(p, RetryPromptPart)]
     assert [p.content for p in retry_parts] == snapshot(['Always fails'])

--- a/tests/test_transcript_repair.py
+++ b/tests/test_transcript_repair.py
@@ -182,6 +182,55 @@ async def test_partially_answered_parallel_tool_calls():
     )
 
 
+async def test_empty_interrupted_request_closes_out_every_call():
+    """An interrupted request with no parts still closes out the response's calls.
+
+    A run cancelled before any of its tools produced a result records the interrupted request
+    empty, so the marker is all that says the calls were abandoned. Every unanswered call is
+    closed out, not just one — providers reject a request whose tool calls aren't all answered.
+    """
+    agent, received = capture_agent()
+
+    message_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart('Calculate.', timestamp=TS)], timestamp=TS),
+        ModelResponse(
+            parts=[
+                ToolCallPart('get_volume', '{"size": 6}', tool_call_id='call_volume'),
+                ToolCallPart('get_mass', '{"size": 6}', tool_call_id='call_mass'),
+            ],
+            timestamp=TS,
+        ),
+        ModelRequest(parts=[], timestamp=TS, state='interrupted'),
+    ]
+
+    await agent.run('Never mind.', message_history=message_history)
+
+    assert received[0][-1] == snapshot(
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='get_volume',
+                    content='The tool call was interrupted before a result was produced.',
+                    tool_call_id='call_volume',
+                    metadata={'pydantic_ai_synthesized_tool_return': True},
+                    timestamp=TS,
+                    outcome='interrupted',
+                ),
+                ToolReturnPart(
+                    tool_name='get_mass',
+                    content='The tool call was interrupted before a result was produced.',
+                    tool_call_id='call_mass',
+                    metadata={'pydantic_ai_synthesized_tool_return': True},
+                    timestamp=TS,
+                    outcome='interrupted',
+                ),
+                UserPromptPart(content='Never mind.', timestamp=IsDatetime()),
+            ],
+            timestamp=IsDatetime(),
+        )
+    )
+
+
 async def test_incomplete_tool_call_args_synthesized():
     """A dangling tool call whose args were cut off mid-stream is kept and synthesized a return.
 


### PR DESCRIPTION
- Closes #7977

Cancelling a run while its first (or only) function tool was still executing produced a history that couldn't take a new prompt:

```
UserError: Cannot provide a new user prompt when the message history contains unprocessed tool calls.
```

`CallToolsNode`'s teardown only appended the `ModelRequest(state='interrupted')` that closes out the turn when at least one tool had already returned:

```python
if output_parts:  # ← the gate
    ctx.state.message_history.append(ModelRequest(parts=list(output_parts), ..., state='interrupted'))
```

That gate made sense when the message was purely *captured partial state* (#5364) — an empty one carried no data. #6497 then made the same message the **resume signal**: it's what tells `_clean_message_history` that the response's tool calls will never be answered and need synthesized `outcome='interrupted'` returns. The gate silently became a bug, and whether the marker appeared came to depend on whether a *sibling* tool happened to finish first — nothing a user can reason about, and exactly backwards from what `RunCancelled.all_messages()` documents ("pass it as `message_history` to a new run (with a new user prompt or not) to resume the conversation").

`_handle_tool_calls` only runs for a response that made tool calls, so the message always means something. Recording it unconditionally fixes the reported case and, at the same time, makes histories captured from a *failed* run resumable — a run that ends in `UnexpectedModelBehavior` from retry exhaustion also leaves a dangling tool call, and now closes it out the same way.

Every unanswered call of the response is closed out, not just the one that was mid-flight, so the resumed request stays provider-valid.

### Behavior change

`capture_run_messages()` output now includes one extra empty `ModelRequest(state='interrupted')` at the end of a run that was cancelled or raised before any tool produced a result. Code asserting on exact captured-message counts on error paths sees one more message; nothing else changes, and no history that worked before stops working. This is the trade that buys the resumability above — the `agent_model_errors.py` example in `docs/agent.md` shows the new shape.

### Tests

- `test_cancel_during_only_tool_call_is_resumable` — the reported reproduction, plus the exact request the model receives on resume.
- `test_cancel_during_only_tool_call_is_resumable_without_a_new_prompt` — the other documented resume mode, which goes down a different branch.
- `test_failed_run_history_is_resumable` — the same repair on the `UnexpectedModelBehavior` path.
- `test_empty_interrupted_request_closes_out_every_call` — a persisted/hand-built history with the empty marker and two dangling calls gets a synthesized return for *both*.

The first three fail on `main` (`UserError` / missing marker) and pass with the fix.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
