### PR TITLE
Clarify async example setup and documentation prose

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -117,7 +117,7 @@ async def main():
     """
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 You can also pass messages from previous runs to continue a conversation or provide context, as described in [Messages and Chat History](message-history.md).
 
@@ -355,7 +355,7 @@ async def main():
     #> The capital of France is Paris.
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 - The `AgentRun` is an async iterator that yields each node (`BaseNode` or `End`) in the flow.
 - The run ends when an `End` node is returned.
@@ -427,7 +427,7 @@ async def main():
 3. When you call `await agent_run.next(node)`, it executes that node in the agent's graph, updates the run's history, and returns the _next_ node to run.
 4. You could also inspect or mutate the new `node` here as needed.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 #### Accessing usage and final output
 
@@ -629,7 +629,7 @@ async def main():
 
 [UI adapter](ui/overview.md) users can persist this resumable history with the `on_cancel` callback.
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 [`agent.run_sync()`][pydantic_ai.agent.AbstractAgent.run_sync] accepts the same token. Calling `token.cancel()` from another thread is the only way to interrupt a synchronous run while it is blocked.
 
@@ -684,7 +684,7 @@ async def main():
 2. External cancellation is never converted: `asyncio.timeout()`, [`TaskGroup`][asyncio.TaskGroup], and [Temporal](durable_execution/temporal.md) cancellation semantics are preserved. The run state rides along on the original `CancelledError`.
 3. [`RunCancelled.all_messages()`][pydantic_ai.exceptions.RunCancelled.all_messages] contains everything completed before cancellation, including completed tool results. Any dangling tool call is [repaired automatically](message-history.md#making-histories-provider-valid) when the history is resumed.
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 On Python 3.10, asyncio recreates `CancelledError` across an `await task` boundary, but chains the original exception -- carrying the attached run state -- via `__context__`, which `from_cancellation()` traverses. The chain is attached only to the first `await` of the cancelled task, so later awaits of the same task see an unchained exception; [`capture_run_messages()`][pydantic_ai.agent.capture_run_messages] is the fallback when only history is needed.
 
@@ -708,7 +708,7 @@ async def main():
 
 1. Idempotent, a no-op once the run has finished, and callable before the first iteration to prevent the run from starting at all.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Externally cancelling the consuming task works here too: the background run tears down, the propagating `CancelledError` carries the run state for `from_cancellation()`, and the handle's `all_messages()` and `usage` remain accessible afterwards.
 
@@ -771,7 +771,7 @@ async def main():
 2. First-party cancellation is a `RunCancelled` you can consume: the run stopped because your own code asked it to, so returning normally is fine.
 3. External cancellation stays `CancelledError`, and a stop button's `task.cancel()` is indistinguishable from a timeout or a [`TaskGroup`][asyncio.TaskGroup] tearing down -- so re-raise it (swallowing it would break those teardowns), reaching for [`from_cancellation()`][pydantic_ai.exceptions.RunCancelled.from_cancellation] only to capture the partial state first. It returns `None` when nothing is attached, e.g. an application shutdown unrelated to this run.
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 !!! note "Why two exception types?"
     Cancellation can originate from two different places, and only one of them is Pydantic AI's to name:
@@ -803,7 +803,7 @@ async def main():
 1. `AgentRun.cancel()` is safe to call from another task and is a no-op once the run has finished.
 2. Inside the `agent.iter()` block, cancellation surfaces as `asyncio.CancelledError`; after the context exits, first-party cancellation raises `RunCancelled` with a detached state snapshot.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 #### Message History After Cancellation
 
@@ -829,7 +829,7 @@ async def main():
 1. The message history includes the interrupted response with any partial content that was received before cancellation.
 2. The interrupted response state lets your application decide whether to keep, inspect, or discard the partial response before reusing the history.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 !!! note "Reusing interrupted history"
     Interrupted history can be passed directly into another run. Before the next model request, Pydantic AI [repairs the transcript](message-history.md#making-histories-provider-valid): any tool call that never received a result — including one whose arguments were cut off mid-stream — is answered with a synthesized [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart] telling the model it was interrupted.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -117,7 +117,7 @@ async def main():
     """
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 You can also pass messages from previous runs to continue a conversation or provide context, as described in [Messages and Chat History](message-history.md).
 
@@ -355,7 +355,7 @@ async def main():
     #> The capital of France is Paris.
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 - The `AgentRun` is an async iterator that yields each node (`BaseNode` or `End`) in the flow.
 - The run ends when an `End` node is returned.
@@ -427,7 +427,7 @@ async def main():
 3. When you call `await agent_run.next(node)`, it executes that node in the agent's graph, updates the run's history, and returns the _next_ node to run.
 4. You could also inspect or mutate the new `node` here as needed.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 #### Accessing usage and final output
 
@@ -629,7 +629,7 @@ async def main():
 
 [UI adapter](ui/overview.md) users can persist this resumable history with the `on_cancel` callback.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 [`agent.run_sync()`][pydantic_ai.agent.AbstractAgent.run_sync] accepts the same token. Calling `token.cancel()` from another thread is the only way to interrupt a synchronous run while it is blocked.
 
@@ -684,7 +684,7 @@ async def main():
 2. External cancellation is never converted: `asyncio.timeout()`, [`TaskGroup`][asyncio.TaskGroup], and [Temporal](durable_execution/temporal.md) cancellation semantics are preserved. The run state rides along on the original `CancelledError`.
 3. [`RunCancelled.all_messages()`][pydantic_ai.exceptions.RunCancelled.all_messages] contains everything completed before cancellation, including completed tool results. Any dangling tool call is [repaired automatically](message-history.md#making-histories-provider-valid) when the history is resumed.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 On Python 3.10, asyncio recreates `CancelledError` across an `await task` boundary, but chains the original exception -- carrying the attached run state -- via `__context__`, which `from_cancellation()` traverses. The chain is attached only to the first `await` of the cancelled task, so later awaits of the same task see an unchained exception; [`capture_run_messages()`][pydantic_ai.agent.capture_run_messages] is the fallback when only history is needed.
 
@@ -708,7 +708,7 @@ async def main():
 
 1. Idempotent, a no-op once the run has finished, and callable before the first iteration to prevent the run from starting at all.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Externally cancelling the consuming task works here too: the background run tears down, the propagating `CancelledError` carries the run state for `from_cancellation()`, and the handle's `all_messages()` and `usage` remain accessible afterwards.
 
@@ -771,7 +771,7 @@ async def main():
 2. First-party cancellation is a `RunCancelled` you can consume: the run stopped because your own code asked it to, so returning normally is fine.
 3. External cancellation stays `CancelledError`, and a stop button's `task.cancel()` is indistinguishable from a timeout or a [`TaskGroup`][asyncio.TaskGroup] tearing down -- so re-raise it (swallowing it would break those teardowns), reaching for [`from_cancellation()`][pydantic_ai.exceptions.RunCancelled.from_cancellation] only to capture the partial state first. It returns `None` when nothing is attached, e.g. an application shutdown unrelated to this run.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 !!! note "Why two exception types?"
     Cancellation can originate from two different places, and only one of them is Pydantic AI's to name:
@@ -803,7 +803,7 @@ async def main():
 1. `AgentRun.cancel()` is safe to call from another task and is a no-op once the run has finished.
 2. Inside the `agent.iter()` block, cancellation surfaces as `asyncio.CancelledError`; after the context exits, first-party cancellation raises `RunCancelled` with a detached state snapshot.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 #### Message History After Cancellation
 
@@ -829,7 +829,7 @@ async def main():
 1. The message history includes the interrupted response with any partial content that was received before cancellation.
 2. The interrupted response state lets your application decide whether to keep, inspect, or discard the partial response before reusing the history.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 !!! note "Reusing interrupted history"
     Interrupted history can be passed directly into another run. Before the next model request, Pydantic AI [repairs the transcript](message-history.md#making-histories-provider-valid): any tool call that never received a result — including one whose arguments were cut off mid-stream — is answered with a synthesized [`ToolReturnPart`][pydantic_ai.messages.ToolReturnPart] telling the model it was interrupted.

--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -12,11 +12,11 @@ Capabilities can provide any combination of:
 
 This makes them the primary extension point for Pydantic AI. Whether you're building a memory system, a guardrail, a cost tracker, or an approval workflow, a capability is the right abstraction.
 
-Capabilities can be always-on or [loaded by the model on demand](on-demand.md). The [capability index below](#available-capabilities) spans Pydantic AI itself and [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/), [third-party packages](third-party.md) provide many more, and you can define your own, [declaratively](#bundling-behavior-with-capability) or by [subclassing](custom.md). To run agents durably across failures, restarts, and long waits, see [Durable Execution](../durable_execution/overview.md).
+Capabilities can be always-on or [loaded by the model on demand](on-demand.md). The [capability index below](#available-capabilities) covers Pydantic AI and [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/). [Third-party packages](third-party.md) provide many more capabilities, and you can define your own [declaratively](#bundling-behavior-with-capability) or by [subclassing](custom.md). To run agents durably across failures, restarts, and long waits, see [Durable Execution](../durable_execution/overview.md).
 
 ## Available capabilities
 
-Capabilities come from two packages, and they all compose, with each other and with your own. Core (`pydantic-ai`) ships the capabilities that require model or framework support: provider-native tools, provider APIs, and deep loop integration. **[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/)**, the official capability library and harness for Pydantic AI, ships everything else, from single capabilities to [complete agents](https://pydantic.dev/docs/ai/harness/coder/). The **Package** column says which; every entry links to its documentation.
+Capabilities come from two packages, and they compose with each other and with capabilities you define. Core (`pydantic-ai`) ships the capabilities that require model or framework support: provider-native tools, provider APIs, and deep loop integration. **[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/)**, the official capability library and harness for Pydantic AI, ships everything else, from single capabilities to [complete agents](https://pydantic.dev/docs/ai/harness/coder/). The **Package** column says which; every entry links to its documentation.
 
 ### Harnesses
 

--- a/docs/capabilities/thinking.md
+++ b/docs/capabilities/thinking.md
@@ -67,13 +67,12 @@ You can customize the tags using the [`thinking_tags`][pydantic_ai.profiles.Mode
 
 Some [OpenAI-compatible model providers](../models/openai.md#openai-compatible-models) might also support native thinking parts that are not delimited by tags. Instead, they are sent and received as separate, custom fields in the API. Typically, if you are calling the model via the `<provider>:<model>` shorthand, Pydantic AI handles it for you. Nonetheless, you can still configure the fields with [`openai_chat_thinking_field`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_chat_thinking_field].
 
-If your provider recommends to send back these custom fields not changed, for caching or interleaved thinking benefits, you can also achieve this with [`openai_chat_send_back_thinking_parts`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_chat_send_back_thinking_parts].
+If your provider recommends sending these custom fields back unchanged for caching or interleaved thinking, use [`openai_chat_send_back_thinking_parts`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_chat_send_back_thinking_parts].
 
 ### OpenAI Responses
 
 The [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] can generate native thinking parts.
-To enable this functionality, you need to set the
-[`OpenAIResponsesModelSettings.openai_reasoning_effort`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_reasoning_effort] and [`OpenAIResponsesModelSettings.openai_reasoning_summary`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_reasoning_summary] [model settings](../agent.md#model-run-settings).
+Set [`OpenAIResponsesModelSettings.openai_reasoning_effort`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_reasoning_effort] and [`OpenAIResponsesModelSettings.openai_reasoning_summary`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_reasoning_summary] in the [model settings](../agent.md#model-run-settings) to enable native thinking parts.
 Models that support it can additionally use a `pro` [reasoning mode](../models/openai.md#reasoning-mode), which is independent of the effort and never set by the unified `thinking` setting.
 
 By default, the unique IDs of reasoning, text, and function call parts from the message history are sent to the model, which can result in errors like `"Item 'rs_123' of type 'reasoning' was provided without its required following item."`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,7 +139,7 @@ async def main():
     await agent.to_cli()
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Both run the same chat interface as `clai`, so an agent with tools shows each call as it runs and
 marks it done when the result arrives, exactly as described under [CLI Usage](#cli-usage).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,7 +139,7 @@ async def main():
     await agent.to_cli()
 ```
 
-_(You'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Both run the same chat interface as `clai`, so an agent with tools shows each call as it runs and
 marks it done when the result arrives, exactly as described under [CLI Usage](#cli-usage).

--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -482,7 +482,7 @@ async def main():
 2. The optional `metadata` parameter passes the `task_id` so it can be matched with results later, accessible in `DeferredToolRequests.metadata` keyed by `tool_call_id`.
 3. In reality, this would typically happen in a separate process that polls for the task status or is notified when all pending tasks are complete.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 ## Observing deferred tool calls in a stream
 
@@ -514,7 +514,7 @@ async def main():
                 #> Resolved: ['update_file_dotenv', 'delete_file']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## See Also
 

--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -482,7 +482,7 @@ async def main():
 2. The optional `metadata` parameter passes the `task_id` so it can be matched with results later, accessible in `DeferredToolRequests.metadata` keyed by `tool_call_id`.
 3. In reality, this would typically happen in a separate process that polls for the task status or is notified when all pending tasks are complete.
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Observing deferred tool calls in a stream
 
@@ -514,7 +514,7 @@ async def main():
                 #> Resolved: ['update_file_dotenv', 'delete_file']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## See Also
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -47,7 +47,7 @@ async def main():
 2. Pass the dataclass type to the `deps_type` argument of the [`Agent` constructor][pydantic_ai.agent.Agent.__init__]. **Note**: we're passing the type here, NOT an instance, this parameter is not actually used at runtime, it's here so we can get full type checking of the agent.
 3. When running the agent, pass an instance of the dataclass to the `deps` parameter.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Accessing Dependencies
 
@@ -96,7 +96,7 @@ async def main():
 3. Access the HTTP client through the [`.deps`][pydantic_ai.tools.RunContext.deps] attribute.
 4. Access the API key through the same attribute.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 In addition to [`.deps`][pydantic_ai.tools.RunContext.deps], [`RunContext`][pydantic_ai.tools.RunContext] provides access to the running agent via [`.agent`][pydantic_ai.tools.RunContext.agent], which is useful when [tools](tools.md), [hooks](hooks.md), or [capabilities](capabilities/overview.md) need to read agent properties like [`name`][pydantic_ai.agent.Agent.name] or [`output_type`][pydantic_ai.agent.Agent.output_type]. The [`.realtime`][pydantic_ai.tools.RunContext.realtime] property identifies realtime sessions without requiring a model type check, and [`.realtime_session`][pydantic_ai.tools.RunContext.realtime_session] exposes the live [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] to tools and hooks once it is connected.
 
@@ -157,7 +157,7 @@ async def main():
 1. Here we use a synchronous `httpx.Client` instead of an asynchronous `httpx.AsyncClient`.
 2. To match the synchronous dependency, the system prompt function is now a plain function, not a coroutine.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Full Example
 
@@ -225,7 +225,7 @@ async def main():
 1. To pass `RunContext` to a tool, use the [`tool`][pydantic_ai.agent.Agent.tool] decorator.
 2. `RunContext` may optionally be passed to a [`output_validator`][pydantic_ai.agent.Agent.output_validator] function as the first argument.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Overriding Dependencies
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -47,7 +47,7 @@ async def main():
 2. Pass the dataclass type to the `deps_type` argument of the [`Agent` constructor][pydantic_ai.agent.Agent.__init__]. **Note**: we're passing the type here, NOT an instance, this parameter is not actually used at runtime, it's here so we can get full type checking of the agent.
 3. When running the agent, pass an instance of the dataclass to the `deps` parameter.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Accessing Dependencies
 
@@ -96,7 +96,7 @@ async def main():
 3. Access the HTTP client through the [`.deps`][pydantic_ai.tools.RunContext.deps] attribute.
 4. Access the API key through the same attribute.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 In addition to [`.deps`][pydantic_ai.tools.RunContext.deps], [`RunContext`][pydantic_ai.tools.RunContext] provides access to the running agent via [`.agent`][pydantic_ai.tools.RunContext.agent], which is useful when [tools](tools.md), [hooks](hooks.md), or [capabilities](capabilities/overview.md) need to read agent properties like [`name`][pydantic_ai.agent.Agent.name] or [`output_type`][pydantic_ai.agent.Agent.output_type]. The [`.realtime`][pydantic_ai.tools.RunContext.realtime] property identifies realtime sessions without requiring a model type check, and [`.realtime_session`][pydantic_ai.tools.RunContext.realtime_session] exposes the live [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] to tools and hooks once it is connected.
 
@@ -106,9 +106,9 @@ Dependency fields can also be referenced in instructions and descriptions via [t
 
 [System prompt functions](agent.md#system-prompts), [function tools](tools.md) and [output validators](output.md#output-validator-functions) are all run in the async context of an agent run.
 
-If these functions are not coroutines (e.g. `async def`) they are called with
-[`run_in_executor`][asyncio.loop.run_in_executor] in a thread pool. It's therefore marginally preferable
-to use `async` methods where dependencies perform IO, although synchronous dependencies should work fine too.
+If these functions are synchronous, defined with `def` rather than `async def`, Pydantic AI calls them with
+[`run_in_executor`][asyncio.loop.run_in_executor] in a thread pool. Prefer `async` functions when dependencies
+perform I/O, although synchronous dependencies also work.
 
 !!! note "`run` vs. `run_sync` and Asynchronous vs. Synchronous dependencies"
     Whether you use synchronous or asynchronous dependencies is completely independent of whether you use `run` or `run_sync` — `run_sync` is just a wrapper around `run` and agents are always run in an async context.
@@ -157,7 +157,7 @@ async def main():
 1. Here we use a synchronous `httpx.Client` instead of an asynchronous `httpx.AsyncClient`.
 2. To match the synchronous dependency, the system prompt function is now a plain function, not a coroutine.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Full Example
 
@@ -225,7 +225,7 @@ async def main():
 1. To pass `RunContext` to a tool, use the [`tool`][pydantic_ai.agent.Agent.tool] decorator.
 2. `RunContext` may optionally be passed to a [`output_validator`][pydantic_ai.agent.Agent.output_validator] function as the first argument.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Overriding Dependencies
 

--- a/docs/direct.md
+++ b/docs/direct.md
@@ -93,7 +93,7 @@ async def main():
     """
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## When to Use the direct API vs Agent
 

--- a/docs/direct.md
+++ b/docs/direct.md
@@ -93,7 +93,7 @@ async def main():
     """
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## When to Use the direct API vs Agent
 

--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -104,7 +104,7 @@ async def main():
 3. Attach durability via `capabilities=[...]`. The capability routes model requests and MCP communication through DBOS steps when the agent runs inside a workflow. Because DBOS workflows must be registered before `DBOS.launch()`, the agent must also be constructed before calling `DBOS.launch()`.
 4. Wrap `agent.run()` in your own `@DBOS.workflow` to make the run durable.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Because the same agent works inside and outside a DBOS workflow, [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability] composes with all other [capabilities](../capabilities/overview.md) without each needing a DBOS-specific wrapper variant.
 

--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -104,7 +104,7 @@ async def main():
 3. Attach durability via `capabilities=[...]`. The capability routes model requests and MCP communication through DBOS steps when the agent runs inside a workflow. Because DBOS workflows must be registered before `DBOS.launch()`, the agent must also be constructed before calling `DBOS.launch()`.
 4. Wrap `agent.run()` in your own `@DBOS.workflow` to make the run durable.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Because the same agent works inside and outside a DBOS workflow, [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability] composes with all other [capabilities](../capabilities/overview.md) without each needing a DBOS-specific wrapper variant.
 
@@ -245,4 +245,4 @@ DBOS has no selective non-retryable-exception support, so if you enable step ret
 
 DBOS can be configured to generate OpenTelemetry spans for each workflow and step execution, and Pydantic AI emits spans for each agent run, model request, and tool invocation. You can send these spans to [Pydantic Logfire](../logfire.md) to get a full, end-to-end view of what's happening in your application.
 
-For more information about DBOS logging and tracing, please see the [DBOS docs](https://docs.dbos.dev/python/tutorials/logging-and-tracing) for details.
+See the [DBOS docs](https://docs.dbos.dev/python/tutorials/logging-and-tracing) for logging and tracing details.

--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -102,7 +102,7 @@ async def main():
 2. Attach durability via `capabilities=[...]`. The capability routes model requests, tool calls, and MCP communication through Prefect tasks when the agent runs inside a flow.
 3. Wrap `agent.run()` in your own `@flow` to make the run durable.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Because the same agent works inside and outside a Prefect flow, [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability] composes with all other [capabilities](../capabilities/overview.md) without each needing a Prefect-specific wrapper variant.
 
@@ -286,7 +286,7 @@ async def main():
     #> Paris
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Retry Considerations
 

--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -102,7 +102,7 @@ async def main():
 2. Attach durability via `capabilities=[...]`. The capability routes model requests, tool calls, and MCP communication through Prefect tasks when the agent runs inside a flow.
 3. Wrap `agent.run()` in your own `@flow` to make the run durable.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Because the same agent works inside and outside a Prefect flow, [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability] composes with all other [capabilities](../capabilities/overview.md) without each needing a Prefect-specific wrapper variant.
 
@@ -286,7 +286,7 @@ async def main():
     #> Paris
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Retry Considerations
 

--- a/docs/durable_execution/restate.md
+++ b/docs/durable_execution/restate.md
@@ -44,7 +44,7 @@ A durable agent has three building blocks:
       [External APIs, services, databases, etc.]
 ```
 
-See the [Restate documentation](https://docs.restate.dev/ai/patterns/durable-agents) for more information.
+See [Restate's durable-agent documentation](https://docs.restate.dev/ai/patterns/durable-agents).
 
 ## Durable Agent
 

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -156,7 +156,7 @@ async def main():
 9. We start the worker that will listen on the specified task queue and run workflows and activities. In a real world application, this might be run in a separate service.
 10. We call on the server to execute the workflow on a worker that's listening on the specified task queue.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Because the same agent works inside and outside a workflow, [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability] composes with all other [capabilities](../capabilities/overview.md) (instrumentation, [`SetToolMetadata`][pydantic_ai.capabilities.SetToolMetadata], [`ProcessEventStream`][pydantic_ai.capabilities.ProcessEventStream], etc.) without each needing a Temporal-specific wrapper variant.
 

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -156,7 +156,7 @@ async def main():
 9. We start the worker that will listen on the specified task queue and run workflows and activities. In a real world application, this might be run in a separate service.
 10. We call on the server to execute the workflow on a worker that's listening on the specified task queue.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Because the same agent works inside and outside a workflow, [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability] composes with all other [capabilities](../capabilities/overview.md) (instrumentation, [`SetToolMetadata`][pydantic_ai.capabilities.SetToolMetadata], [`ProcessEventStream`][pydantic_ai.capabilities.ProcessEventStream], etc.) without each needing a Temporal-specific wrapper variant.
 

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -36,7 +36,7 @@ async def main():
     #> Embedded 3 documents
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 !!! tip "Queries vs Documents"
     Some embedding models optimize differently for queries and documents. Use
@@ -75,7 +75,7 @@ async def main():
     #> Cost: $0.000000
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Choosing a model
 
@@ -184,7 +184,7 @@ async def main():
     #> 1536
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 See [OpenAI's embedding models](https://platform.openai.com/docs/guides/embeddings) for available models.
 
@@ -208,7 +208,7 @@ async def main():
     #> 256
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 #### OpenAI-Compatible Providers {#openai-compatible}
 
@@ -290,7 +290,7 @@ async def main():
     #> 3072
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 See the [Google Embeddings documentation](https://ai.google.dev/gemini-api/docs/embeddings) for available models.
 
@@ -336,7 +336,7 @@ async def main():
     #> 768
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 #### Task Conditioning
 
@@ -411,7 +411,7 @@ async def main():
     #> 1024
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 See the [Cohere Embed documentation](https://docs.cohere.com/docs/cohere-embed) for available models.
 
@@ -467,7 +467,7 @@ async def main():
     #> 1024
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 See the [VoyageAI Embeddings documentation](https://docs.voyageai.com/docs/embeddings) for available models.
 
@@ -716,7 +716,7 @@ async def main():
     #> 768
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 [`lightonai/DenseOn`](https://huggingface.co/lightonai/DenseOn) is a strong recent 149M-parameter general-purpose model that encodes queries and documents asymmetrically: [`embed_query()`][pydantic_ai.embeddings.Embedder.embed_query] and [`embed_documents()`][pydantic_ai.embeddings.Embedder.embed_documents] automatically apply the model's `query:` / `document:` prompts. See the [Sentence Transformers pretrained models](https://www.sbert.net/docs/sentence_transformer/pretrained_models.html) documentation and the [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) for more options; see also [Choosing a model](#choosing-a-model) above.
 
@@ -791,7 +791,7 @@ async def main():
     #> 256
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Token Counting
 
@@ -817,7 +817,7 @@ async def main():
     #> Max tokens: 1024
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Testing
 
@@ -844,7 +844,7 @@ async def test_my_rag_system():
 
 Setting [`ALLOW_MODEL_REQUESTS`][pydantic_ai.models.ALLOW_MODEL_REQUESTS] to `False` also blocks embedding requests, so an embedder you forgot to override raises instead of quietly calling the provider. [`TestEmbeddingModel`][pydantic_ai.embeddings.TestEmbeddingModel] and [`SentenceTransformerEmbeddingModel`][pydantic_ai.embeddings.sentence_transformers.SentenceTransformerEmbeddingModel] are unaffected, as neither reaches a provider.
 
-This covers [`count_tokens()`][pydantic_ai.embeddings.Embedder.count_tokens] as well, but only where tokenization happens server-side: Google and Cohere count tokens through an API call and are blocked, while OpenAI tokenizes locally with `tiktoken` and is not.
+This also covers [`count_tokens()`][pydantic_ai.embeddings.Embedder.count_tokens], but only when tokenization happens server-side: Google and Cohere count tokens through an API call and are blocked, while OpenAI tokenizes locally with `tiktoken`, so its token counting is not blocked.
 
 ## Instrumentation
 

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -36,7 +36,7 @@ async def main():
     #> Embedded 3 documents
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 !!! tip "Queries vs Documents"
     Some embedding models optimize differently for queries and documents. Use
@@ -75,7 +75,7 @@ async def main():
     #> Cost: $0.000000
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Choosing a model
 
@@ -184,7 +184,7 @@ async def main():
     #> 1536
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 See [OpenAI's embedding models](https://platform.openai.com/docs/guides/embeddings) for available models.
 
@@ -208,7 +208,7 @@ async def main():
     #> 256
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 #### OpenAI-Compatible Providers {#openai-compatible}
 
@@ -290,7 +290,7 @@ async def main():
     #> 3072
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 See the [Google Embeddings documentation](https://ai.google.dev/gemini-api/docs/embeddings) for available models.
 
@@ -336,7 +336,7 @@ async def main():
     #> 768
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 #### Task Conditioning
 
@@ -411,7 +411,7 @@ async def main():
     #> 1024
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 See the [Cohere Embed documentation](https://docs.cohere.com/docs/cohere-embed) for available models.
 
@@ -467,7 +467,7 @@ async def main():
     #> 1024
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 See the [VoyageAI Embeddings documentation](https://docs.voyageai.com/docs/embeddings) for available models.
 
@@ -716,7 +716,7 @@ async def main():
     #> 768
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 [`lightonai/DenseOn`](https://huggingface.co/lightonai/DenseOn) is a strong recent 149M-parameter general-purpose model that encodes queries and documents asymmetrically: [`embed_query()`][pydantic_ai.embeddings.Embedder.embed_query] and [`embed_documents()`][pydantic_ai.embeddings.Embedder.embed_documents] automatically apply the model's `query:` / `document:` prompts. See the [Sentence Transformers pretrained models](https://www.sbert.net/docs/sentence_transformer/pretrained_models.html) documentation and the [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) for more options; see also [Choosing a model](#choosing-a-model) above.
 
@@ -791,7 +791,7 @@ async def main():
     #> 256
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Token Counting
 
@@ -817,7 +817,7 @@ async def main():
     #> Max tokens: 1024
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Testing
 

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -150,7 +150,7 @@ case1 = Case(
 dataset = Dataset(name='capital_quiz', cases=[case1])
 ```
 
-_(This example is complete and can be run as written.)_
+_(This example is complete, it can be run "as is")_
 
 See [Dataset Management](evals/how-to/dataset-management.md) to learn about saving, loading, and generating datasets.
 
@@ -195,7 +195,7 @@ dataset.add_evaluator(MyEvaluator())
 1. You can add built-in evaluators to a dataset using the [`add_evaluator`][pydantic_evals.dataset.Dataset.add_evaluator] method.
 2. This custom evaluator returns a simple score based on whether the output matches the expected output.
 
-_(This example is complete and can be run as written.)_
+_(This example is complete, it can be run "as is")_
 
 Learn more:
 
@@ -267,7 +267,7 @@ report.print(include_input=True, include_output=True, include_durations=False)  
 4. Run the evaluation with [`evaluate_sync`][pydantic_evals.dataset.Dataset.evaluate_sync], which runs the function against all test cases in the dataset, and returns an [`EvaluationReport`][pydantic_evals.reporting.EvaluationReport] object.
 5. Print the report with [`print`][pydantic_evals.reporting.EvaluationReport.print], which shows the results of the evaluation. We have omitted duration here just to keep the printed output from changing from run to run.
 
-_(This example is complete and can be run as written.)_
+_(This example is complete, it can be run "as is")_
 
 See [Quick Start](evals/quick-start.md) for more examples and [Concurrency & Performance](evals/how-to/concurrency.md) to learn about controlling parallel execution.
 

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -150,7 +150,7 @@ case1 = Case(
 dataset = Dataset(name='capital_quiz', cases=[case1])
 ```
 
-_(This example is complete, it can be run "as is")_
+_(This example is complete and can be run as written.)_
 
 See [Dataset Management](evals/how-to/dataset-management.md) to learn about saving, loading, and generating datasets.
 
@@ -195,7 +195,7 @@ dataset.add_evaluator(MyEvaluator())
 1. You can add built-in evaluators to a dataset using the [`add_evaluator`][pydantic_evals.dataset.Dataset.add_evaluator] method.
 2. This custom evaluator returns a simple score based on whether the output matches the expected output.
 
-_(This example is complete, it can be run "as is")_
+_(This example is complete and can be run as written.)_
 
 Learn more:
 
@@ -267,7 +267,7 @@ report.print(include_input=True, include_output=True, include_durations=False)  
 4. Run the evaluation with [`evaluate_sync`][pydantic_evals.dataset.Dataset.evaluate_sync], which runs the function against all test cases in the dataset, and returns an [`EvaluationReport`][pydantic_evals.reporting.EvaluationReport] object.
 5. Print the report with [`print`][pydantic_evals.reporting.EvaluationReport.print], which shows the results of the evaluation. We have omitted duration here just to keep the printed output from changing from run to run.
 
-_(This example is complete, it can be run "as is")_
+_(This example is complete and can be run as written.)_
 
 See [Quick Start](evals/quick-start.md) for more examples and [Concurrency & Performance](evals/how-to/concurrency.md) to learn about controlling parallel execution.
 

--- a/docs/evals/evaluators/report-evaluators.md
+++ b/docs/evals/evaluators/report-evaluators.md
@@ -574,9 +574,8 @@ class AsyncAccuracy(ReportEvaluator):
 
 ## Serialization
 
-Report evaluators are serialized to and from YAML/JSON dataset files using the same format as
-case-level evaluators. This means datasets with report evaluators can be fully round-tripped
-through file serialization.
+Report evaluators use the same YAML/JSON format as case-level evaluators, so datasets containing
+them can be round-tripped through serialization.
 
 **Example YAML dataset with report evaluators:**
 

--- a/docs/evals/how-to/dataset-management.md
+++ b/docs/evals/how-to/dataset-management.md
@@ -312,7 +312,7 @@ async def main():
 4. Call [`generate_dataset`][pydantic_evals.generation.generate_dataset] to create a [`Dataset`][pydantic_evals.dataset.Dataset] with 2 cases confirming to the schema.
 5. Save the dataset to a YAML file, this will also write `questions_cases_schema.json` with the schema JSON schema for `questions_cases.yaml` to make editing easier. The magic `yaml-language-server` comment is supported by at least vscode, jetbrains/pycharm (more details [here](https://github.com/redhat-developer/yaml-language-server#using-inlined-schema)).
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main(answer))`.)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 You can also write datasets as JSON files:
 
@@ -388,7 +388,7 @@ async def main():
 1. Generate the [`Dataset`][pydantic_evals.dataset.Dataset] exactly as above.
 2. Save the dataset to a JSON file. This also writes `questions_cases_schema.json`, the JSON Schema for `questions_cases.json`. The `$schema` key tells editors which schema to use while you edit the file. Although this is not a formal specification, it works in VS Code and PyCharm; see [the discussion](https://github.com/json-schema-org/json-schema-spec/issues/828).
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main(answer))`.)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Type-Safe Datasets
 

--- a/docs/evals/how-to/dataset-management.md
+++ b/docs/evals/how-to/dataset-management.md
@@ -221,7 +221,7 @@ For complete details on serialization with custom evaluators, see [Dataset Seria
 
 Pydantic Evals allows you to generate test datasets using LLMs with [`generate_dataset`][pydantic_evals.generation.generate_dataset].
 
-Datasets can be generated in either JSON or YAML format, in both cases a JSON schema file is generated alongside the dataset and referenced in the dataset, so you should get type checking and auto-completion in your editor.
+Generate datasets as JSON or YAML. For either format, Pydantic Evals writes a JSON Schema alongside the dataset and references it from the file. Supported editors can then provide type checking and autocomplete.
 
 ```python {title="generate_dataset_example.py"}
 from __future__ import annotations
@@ -312,7 +312,7 @@ async def main():
 4. Call [`generate_dataset`][pydantic_evals.generation.generate_dataset] to create a [`Dataset`][pydantic_evals.dataset.Dataset] with 2 cases confirming to the schema.
 5. Save the dataset to a YAML file, this will also write `questions_cases_schema.json` with the schema JSON schema for `questions_cases.yaml` to make editing easier. The magic `yaml-language-server` comment is supported by at least vscode, jetbrains/pycharm (more details [here](https://github.com/redhat-developer/yaml-language-server#using-inlined-schema)).
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main(answer))` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main(answer))`.)_
 
 You can also write datasets as JSON files:
 
@@ -386,9 +386,9 @@ async def main():
 ```
 
 1. Generate the [`Dataset`][pydantic_evals.dataset.Dataset] exactly as above.
-2. Save the dataset to a JSON file, this will also write `questions_cases_schema.json` with the JSON schema for `questions_cases.json`. This time the `$schema` key is included in the JSON file to define the schema for IDEs to use while you edit the file, there's no formal spec for this, but it works in vscode and pycharm and is discussed at length in [json-schema-org/json-schema-spec#828](https://github.com/json-schema-org/json-schema-spec/issues/828).
+2. Save the dataset to a JSON file. This also writes `questions_cases_schema.json`, the JSON Schema for `questions_cases.json`. The `$schema` key tells editors which schema to use while you edit the file. Although this is not a formal specification, it works in VS Code and PyCharm; see [the discussion](https://github.com/json-schema-org/json-schema-spec/issues/828).
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main(answer))` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main(answer))`.)_
 
 ## Type-Safe Datasets
 

--- a/docs/evals/how-to/dataset-management.md
+++ b/docs/evals/how-to/dataset-management.md
@@ -312,7 +312,7 @@ async def main():
 4. Call [`generate_dataset`][pydantic_evals.generation.generate_dataset] to create a [`Dataset`][pydantic_evals.dataset.Dataset] with 2 cases confirming to the schema.
 5. Save the dataset to a YAML file, this will also write `questions_cases_schema.json` with the schema JSON schema for `questions_cases.yaml` to make editing easier. The magic `yaml-language-server` comment is supported by at least vscode, jetbrains/pycharm (more details [here](https://github.com/redhat-developer/yaml-language-server#using-inlined-schema)).
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 You can also write datasets as JSON files:
 
@@ -388,7 +388,7 @@ async def main():
 1. Generate the [`Dataset`][pydantic_evals.dataset.Dataset] exactly as above.
 2. Save the dataset to a JSON file. This also writes `questions_cases_schema.json`, the JSON Schema for `questions_cases.json`. The `$schema` key tells editors which schema to use while you edit the file. Although this is not a formal specification, it works in VS Code and PyCharm; see [the discussion](https://github.com/json-schema-org/json-schema-spec/issues/828).
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Type-Safe Datasets
 

--- a/docs/evals/how-to/lifecycle.md
+++ b/docs/evals/how-to/lifecycle.md
@@ -66,7 +66,7 @@ The case metadata drives per-case behavior without needing custom [`Case`][pydan
 
 ### Conditional Teardown
 
-The `teardown()` hook receives the full result, so you can vary cleanup logic based on success or failure — for example, keeping test environments up for manual inspection when a case fails. The `result` can be `None` if evaluation is interrupted before the case produces a report result, so handle that branch when your cleanup depends on the case outcome:
+The `teardown()` hook receives the full result, so cleanup can differ for successful and failed cases. For example, keep a failed case's environment for manual inspection. If evaluation is interrupted before the case produces a report result, `result` is `None`; handle that case when cleanup depends on the outcome:
 
 ```python
 from pydantic_evals import Case, Dataset

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -41,7 +41,7 @@ The first known use of "hello, world" was in a 1974 textbook about the C program
 
 ## Quick Start
 
-This section contains instructions on how to set up your account and run your app with Pydantic AI Gateway credentials.
+Set up your account and run your app with Pydantic AI Gateway credentials.
 
 ### Create an account
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -185,7 +185,7 @@ async def main():
 7. [`g.build()`][pydantic_graph.graph_builder.GraphBuilder.build] returns a [`Graph`][pydantic_graph.graph_builder.Graph] ready to execute.
 8. [`graph.run()`][pydantic_graph.graph_builder.Graph.run] is async and returns the raw output value (the `int` returned by the `End` node).
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 A [mermaid diagram](#mermaid-diagrams) for this graph can be generated with `print(fives_graph)`, or by calling [`fives_graph.render()`][pydantic_graph.graph_builder.Graph.render]:
 
@@ -327,7 +327,7 @@ async def main():
 17. Initialize the state. This will be passed to the graph run and mutated as the graph runs.
 18. Run the graph with the initial state. The first node to execute is determined by the `start` step we wired into [`g.start_node`][pydantic_graph.graph_builder.GraphBuilder.start_node].
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 A [mermaid diagram](#mermaid-diagrams) for this graph can be generated with `print(vending_machine_graph)`:
 
@@ -504,7 +504,7 @@ async def main():
     """
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Iterating Over a Graph
 
@@ -586,7 +586,7 @@ async def main():
     #> 5
 ```
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Mermaid Diagrams
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -185,7 +185,7 @@ async def main():
 7. [`g.build()`][pydantic_graph.graph_builder.GraphBuilder.build] returns a [`Graph`][pydantic_graph.graph_builder.Graph] ready to execute.
 8. [`graph.run()`][pydantic_graph.graph_builder.Graph.run] is async and returns the raw output value (the `int` returned by the `End` node).
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 A [mermaid diagram](#mermaid-diagrams) for this graph can be generated with `print(fives_graph)`, or by calling [`fives_graph.render()`][pydantic_graph.graph_builder.Graph.render]:
 
@@ -327,7 +327,7 @@ async def main():
 17. Initialize the state. This will be passed to the graph run and mutated as the graph runs.
 18. Run the graph with the initial state. The first node to execute is determined by the `start` step we wired into [`g.start_node`][pydantic_graph.graph_builder.GraphBuilder.start_node].
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 A [mermaid diagram](#mermaid-diagrams) for this graph can be generated with `print(vending_machine_graph)`:
 
@@ -504,7 +504,7 @@ async def main():
     """
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Iterating Over a Graph
 
@@ -586,7 +586,7 @@ async def main():
     #> 5
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 ## Mermaid Diagrams
 

--- a/docs/graph/builder/decisions.md
+++ b/docs/graph/builder/decisions.md
@@ -64,7 +64,7 @@ async def main():
     #> left
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Type Matching
 
@@ -112,7 +112,7 @@ async def main():
     #> Got int: 42
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Matching Union Types
 
@@ -162,7 +162,7 @@ async def main():
     #> Got number: 42
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 !!! note
     [`TypeExpression`][pydantic_graph.util.TypeExpression] is only necessary for complex type expressions like unions (`int | str`), `Literal`, and other type forms that aren't valid as runtime `type` objects. For simple types like `int`, `str`, or custom classes, you can pass them directly to `g.match()`.
@@ -216,7 +216,7 @@ async def main():
     #> 7 is odd
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Branch Priority
 
@@ -264,7 +264,7 @@ async def main():
     #> Branch A
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Both branches could match `10`, but Branch A is first, so it's taken.
 
@@ -306,7 +306,7 @@ async def main():
     #> Caught: 100
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Nested Decisions
 
@@ -367,7 +367,7 @@ async def main():
     #> Large positive
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Branching with Labels
 
@@ -416,7 +416,7 @@ async def main():
     #> Path A
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Next Steps
 

--- a/docs/graph/builder/decisions.md
+++ b/docs/graph/builder/decisions.md
@@ -64,7 +64,7 @@ async def main():
     #> left
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Type Matching
 
@@ -112,7 +112,7 @@ async def main():
     #> Got int: 42
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Matching Union Types
 
@@ -162,7 +162,7 @@ async def main():
     #> Got number: 42
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 !!! note
     [`TypeExpression`][pydantic_graph.util.TypeExpression] is only necessary for complex type expressions like unions (`int | str`), `Literal`, and other type forms that aren't valid as runtime `type` objects. For simple types like `int`, `str`, or custom classes, you can pass them directly to `g.match()`.
@@ -216,7 +216,7 @@ async def main():
     #> 7 is odd
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Branch Priority
 
@@ -264,7 +264,7 @@ async def main():
     #> Branch A
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Both branches could match `10`, but Branch A is first, so it's taken.
 
@@ -306,7 +306,7 @@ async def main():
     #> Caught: 100
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Nested Decisions
 
@@ -367,7 +367,7 @@ async def main():
     #> Large positive
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Branching with Labels
 
@@ -416,7 +416,7 @@ async def main():
     #> Path A
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Next Steps
 

--- a/docs/graph/builder/index.md
+++ b/docs/graph/builder/index.md
@@ -78,7 +78,7 @@ async def main():
     #> Final state: 1
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Key Concepts
 
@@ -164,7 +164,7 @@ async def main():
     #> Items processed: 5
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 In this example:
 
@@ -240,7 +240,7 @@ async def main():
                 break
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The [`GraphRun`][pydantic_graph.graph_builder.GraphRun] object provides:
 

--- a/docs/graph/builder/index.md
+++ b/docs/graph/builder/index.md
@@ -78,7 +78,7 @@ async def main():
     #> Final state: 1
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Key Concepts
 
@@ -164,7 +164,7 @@ async def main():
     #> Items processed: 5
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 In this example:
 
@@ -240,7 +240,7 @@ async def main():
                 break
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The [`GraphRun`][pydantic_graph.graph_builder.GraphRun] object provides:
 

--- a/docs/graph/builder/joins.md
+++ b/docs/graph/builder/joins.md
@@ -53,7 +53,7 @@ async def main():
     #> [1, 4, 9, 16, 25]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Built-in Reducers
 
@@ -100,7 +100,7 @@ async def main():
     #> ['value-10', 'value-20', 'value-30']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### `reduce_list_extend`
 
@@ -144,7 +144,7 @@ async def main():
     #> [0, 0, 0, 1, 1, 2]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### `reduce_dict_update`
 
@@ -188,7 +188,7 @@ async def main():
     #> {'apple': 5, 'banana': 6, 'cherry': 6}
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### `reduce_null`
 
@@ -239,7 +239,7 @@ async def main():
     #> 15
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### `reduce_sum`
 
@@ -282,7 +282,7 @@ async def main():
     #> 100
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### `ReduceFirstValue`
 
@@ -335,7 +335,7 @@ async def main():
     #> Tasks completed: ...
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 ## Custom Reducers
 
@@ -377,7 +377,7 @@ async def main():
     #> 50
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Reducers with State Access
 
@@ -459,7 +459,7 @@ async def main():
     #> State total_sum: 275
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Canceling Sibling Tasks
 
@@ -524,7 +524,7 @@ async def main():
     #> Searches completed: 3
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 Note that only 3 searches completed instead of all 5, because the reducer canceled the remaining tasks after finding a match.
 
@@ -599,7 +599,7 @@ async def main():
     #> Group B: [30, 60]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Customizing Join Nodes
 

--- a/docs/graph/builder/joins.md
+++ b/docs/graph/builder/joins.md
@@ -53,7 +53,7 @@ async def main():
     #> [1, 4, 9, 16, 25]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Built-in Reducers
 
@@ -100,7 +100,7 @@ async def main():
     #> ['value-10', 'value-20', 'value-30']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### `reduce_list_extend`
 
@@ -144,7 +144,7 @@ async def main():
     #> [0, 0, 0, 1, 1, 2]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### `reduce_dict_update`
 
@@ -188,7 +188,7 @@ async def main():
     #> {'apple': 5, 'banana': 6, 'cherry': 6}
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### `reduce_null`
 
@@ -239,7 +239,7 @@ async def main():
     #> 15
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### `reduce_sum`
 
@@ -282,7 +282,7 @@ async def main():
     #> 100
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### `ReduceFirstValue`
 
@@ -335,7 +335,7 @@ async def main():
     #> Tasks completed: ...
 ```
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Custom Reducers
 
@@ -377,7 +377,7 @@ async def main():
     #> 50
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Reducers with State Access
 
@@ -459,7 +459,7 @@ async def main():
     #> State total_sum: 275
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Canceling Sibling Tasks
 
@@ -524,7 +524,7 @@ async def main():
     #> Searches completed: 3
 ```
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Note that only 3 searches completed instead of all 5, because the reducer canceled the remaining tasks after finding a match.
 
@@ -599,7 +599,7 @@ async def main():
     #> Group B: [30, 60]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Customizing Join Nodes
 

--- a/docs/graph/builder/parallel.md
+++ b/docs/graph/builder/parallel.md
@@ -59,7 +59,7 @@ async def main():
     #> [11, 12, 13]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 All three steps receive the same input value (`10`) and execute in parallel.
 
@@ -105,7 +105,7 @@ async def main():
     #> [1, 4, 9, 16, 25]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Spreading AsyncIterables
 
@@ -153,7 +153,7 @@ async def main():
     #> [3, 6, 9]
 ```
 
-_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 This allows for progressive processing where downstream steps can start working on early results while later results are still being generated.
 
@@ -198,7 +198,7 @@ async def main():
     #> ['Value: 10', 'Value: 20', 'Value: 30']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Empty Iterables
 
@@ -241,7 +241,7 @@ async def main():
     #> []
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Nested Parallel Operations
 
@@ -291,7 +291,7 @@ async def main():
     #> [11, 12, 21, 22]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The result contains:
 - From 10: `10+1=11` and `10+2=12`
@@ -343,7 +343,7 @@ async def main():
     #> ['num:1', 'num:2', 'num:3', 'num:4']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Edge Labels
 
@@ -391,7 +391,7 @@ async def main():
     #> ['item-1', 'item-2', 'item-3']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## State Sharing in Parallel Execution
 
@@ -440,7 +440,7 @@ async def main():
     #> Tracked: [1, 2, 3]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Edge Transformations
 
@@ -481,7 +481,7 @@ async def main():
     #> The answer is: 84
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The transform function receives a [`StepContext`][pydantic_graph.step.StepContext] with the current inputs and has access to state and dependencies. This is useful for:
 
@@ -534,7 +534,7 @@ async def main():
     #> ['Processed: 10', 'Processed: 20', 'Processed: 30']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Next Steps
 

--- a/docs/graph/builder/parallel.md
+++ b/docs/graph/builder/parallel.md
@@ -59,7 +59,7 @@ async def main():
     #> [11, 12, 13]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 All three steps receive the same input value (`10`) and execute in parallel.
 
@@ -105,7 +105,7 @@ async def main():
     #> [1, 4, 9, 16, 25]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Spreading AsyncIterables
 
@@ -153,7 +153,7 @@ async def main():
     #> [3, 6, 9]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, call `asyncio.run(main())`.)_
 
 This allows for progressive processing where downstream steps can start working on early results while later results are still being generated.
 
@@ -198,7 +198,7 @@ async def main():
     #> ['Value: 10', 'Value: 20', 'Value: 30']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Empty Iterables
 
@@ -241,7 +241,7 @@ async def main():
     #> []
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Nested Parallel Operations
 
@@ -291,7 +291,7 @@ async def main():
     #> [11, 12, 21, 22]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The result contains:
 - From 10: `10+1=11` and `10+2=12`
@@ -343,7 +343,7 @@ async def main():
     #> ['num:1', 'num:2', 'num:3', 'num:4']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Edge Labels
 
@@ -391,7 +391,7 @@ async def main():
     #> ['item-1', 'item-2', 'item-3']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## State Sharing in Parallel Execution
 
@@ -440,7 +440,7 @@ async def main():
     #> Tracked: [1, 2, 3]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Edge Transformations
 
@@ -481,7 +481,7 @@ async def main():
     #> The answer is: 84
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The transform function receives a [`StepContext`][pydantic_graph.step.StepContext] with the current inputs and has access to state and dependencies. This is useful for:
 
@@ -534,7 +534,7 @@ async def main():
     #> ['Processed: 10', 'Processed: 20', 'Processed: 30']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Next Steps
 

--- a/docs/graph/builder/steps.md
+++ b/docs/graph/builder/steps.md
@@ -37,7 +37,7 @@ async def main():
     #> 1
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Step Context
 
@@ -91,7 +91,7 @@ async def main():
     #> ['Hello', 'World']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Working with Inputs
 
@@ -137,7 +137,7 @@ async def main():
     #> Result: 42
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Dependency Injection
 
@@ -186,7 +186,7 @@ async def main():
     #> 50
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Customizing Steps
 
@@ -282,7 +282,7 @@ async def main():
     #> Operations: ['add 5', 'multiply by 2', 'subtract 3']
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The computation is: `(10 + 5) * 2 - 3 = 27`
 
@@ -331,7 +331,7 @@ async def main():
     #> [1, 4, 9, 16, 25]
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### How Streaming Steps Work
 
@@ -395,7 +395,7 @@ async def main():
     #> 15
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Type Safety
 

--- a/docs/graph/builder/steps.md
+++ b/docs/graph/builder/steps.md
@@ -37,7 +37,7 @@ async def main():
     #> 1
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Step Context
 
@@ -91,7 +91,7 @@ async def main():
     #> ['Hello', 'World']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Working with Inputs
 
@@ -137,7 +137,7 @@ async def main():
     #> Result: 42
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Dependency Injection
 
@@ -186,7 +186,7 @@ async def main():
     #> 50
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Customizing Steps
 
@@ -282,7 +282,7 @@ async def main():
     #> Operations: ['add 5', 'multiply by 2', 'subtract 3']
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The computation is: `(10 + 5) * 2 - 3 = 27`
 
@@ -331,7 +331,7 @@ async def main():
     #> [1, 4, 9, 16, 25]
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### How Streaming Steps Work
 
@@ -395,7 +395,7 @@ async def main():
     #> 15
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `import asyncio; asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Type Safety
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -50,21 +50,21 @@ print(result.output)
 !!! info
     Some models do not support audio input. Please check the model's documentation to confirm whether it supports audio input.
 
-You can provide audio input using either [`AudioUrl`][pydantic_ai.AudioUrl] or [`BinaryContent`][pydantic_ai.BinaryContent]. The process is analogous to the examples above.
+For audio, use [`AudioUrl`][pydantic_ai.AudioUrl] or [`BinaryContent`][pydantic_ai.BinaryContent].
 
 ## Video Input
 
 !!! info
     Some models do not support video input. Please check the model's documentation to confirm whether it supports video input.
 
-You can provide video input using either [`VideoUrl`][pydantic_ai.VideoUrl] or [`BinaryContent`][pydantic_ai.BinaryContent]. The process is analogous to the examples above.
+For video, use [`VideoUrl`][pydantic_ai.VideoUrl] or [`BinaryContent`][pydantic_ai.BinaryContent].
 
 ## Document Input
 
 !!! info
     Some models do not support document input. Please check the model's documentation to confirm whether it supports document input.
 
-You can provide document input using either [`DocumentUrl`][pydantic_ai.DocumentUrl] or [`BinaryContent`][pydantic_ai.BinaryContent]. The process is similar to the examples above.
+For documents, use [`DocumentUrl`][pydantic_ai.DocumentUrl] or [`BinaryContent`][pydantic_ai.BinaryContent].
 
 If you have a direct URL for the document, you can use [`DocumentUrl`][pydantic_ai.DocumentUrl]:
 

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -377,7 +377,7 @@ Agent.instrument_all(instrumentation_settings)
 
 ### Excluding binary content
 
-When `include_binary_content=False` is set, binary file data (images, audio, documents) is excluded from telemetry: from user prompts and model responses, from tool returns, from the agent's own output and the arguments its output function receives, and from run and tool deferral metadata. The media type is still recorded everywhere; where the value is recorded as the file itself rather than as a message part, so are its vendor metadata and its identifier, which is derived from the content when you don't set one.
+When `include_binary_content=False`, Pydantic AI excludes binary file data, including images, audio, and documents, from telemetry for user prompts, model responses, tool returns, the agent's output, output-function arguments, and run and tool deferral metadata. The media type remains recorded everywhere. When a value is recorded as a file rather than a message part, its vendor metadata and identifier are recorded too; Pydantic AI derives the identifier from the content when you do not set one.
 
 Binary content is found inside dictionaries, lists and [`ToolReturn`][pydantic_ai.messages.ToolReturn]s, but not inside your own types: a [`BinaryContent`][pydantic_ai.messages.BinaryContent] held as a field of a model or dataclass you define is still recorded in full.
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -76,7 +76,7 @@ async def main():
 1. Define the MCP toolset with the URL used to connect.
 2. Create an agent with the MCP toolset attached.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 **What's happening here?**
 
@@ -150,7 +150,7 @@ async def main():
     #> The answer is 12.
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Loading MCP toolsets from configuration {#loading-mcp-toolsets-from-configuration}
 
@@ -508,7 +508,7 @@ async def main():
 
 1. `per_run_step=False` builds the toolset once per run instead of ahead of each run step, so the whole run shares a single MCP session.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Because the per-run toolset's session is established inside the run itself, credentials held in a `ContextVar` also resolve correctly with this pattern — but passing them through deps is more explicit and doesn't depend on task-local state.
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -76,7 +76,7 @@ async def main():
 1. Define the MCP toolset with the URL used to connect.
 2. Create an agent with the MCP toolset attached.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 **What's happening here?**
 
@@ -150,7 +150,7 @@ async def main():
     #> The answer is 12.
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Loading MCP toolsets from configuration {#loading-mcp-toolsets-from-configuration}
 
@@ -508,7 +508,7 @@ async def main():
 
 1. `per_run_step=False` builds the toolset once per run instead of ahead of each run step, so the whole run shares a single MCP session.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Because the per-run toolset's session is established inside the run itself, credentials held in a `ContextVar` also resolve correctly with this pattern — but passing them through deps is more explicit and doesn't depend on task-local state.
 

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -140,7 +140,7 @@ async def main():
         """
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Using Messages as Input for Further Agent Runs
 

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -140,7 +140,7 @@ async def main():
         """
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Using Messages as Input for Further Agent Runs
 

--- a/docs/models/anthropic.md
+++ b/docs/models/anthropic.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-To use `AnthropicModel` models, you need to either install `pydantic-ai`, or install `pydantic-ai-slim` with the `anthropic` optional group:
+To use `AnthropicModel`, install either `pydantic-ai` or `pydantic-ai-slim` with the `anthropic` optional group:
 
 ```bash
 pip/uv-add "pydantic-ai-slim[anthropic]"

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -545,4 +545,4 @@ agent = Agent(GoogleModel('gemini-3.7-flash'), model_settings=model_settings)
 ## Streaming cancellation
 
 !!! note "Transport cancellation"
-    [`cancel()`][pydantic_ai.result.StreamedRunResult.cancel] safely interrupts an active local stream pull, including one running in another task. The `google-genai` SDK exposes no documented per-stream transport handle, so closing the returned iterator does not guarantee immediate HTTP teardown or when remote generation and billing stop. See [googleapis/python-genai#2425](https://github.com/googleapis/python-genai/issues/2425).
+    [`cancel()`][pydantic_ai.result.StreamedRunResult.cancel] safely interrupts an active local stream pull, including one running in another task. The `google-genai` SDK exposes no documented per-stream transport handle, so closing the returned iterator does not guarantee immediate HTTP teardown or indicate when remote generation stops and billing ends. See [googleapis/python-genai#2425](https://github.com/googleapis/python-genai/issues/2425).

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -418,7 +418,7 @@ async def main():
                     print(event.delta.content_delta)
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 A `'phase'` key appears in `provider_details` whenever the model labels its output, but it is only sent back on models that [`OpenAIModelProfile.openai_supports_phase`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_supports_phase] marks as accepting it. On every other model the label is surfaced to you and dropped from follow-up requests.
 

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -418,7 +418,7 @@ async def main():
                     print(event.delta.content_delta)
 ```
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 A `'phase'` key appears in `provider_details` whenever the model labels its output, but it is only sent back on models that [`OpenAIModelProfile.openai_supports_phase`][pydantic_ai.profiles.openai.OpenAIModelProfile.openai_supports_phase] marks as accepting it. On every other model the label is surfaced to you and dropped from follow-up requests.
 

--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -184,7 +184,7 @@ async def main():
 5. Define a tool on the delegate agent that uses the dependencies to make an HTTP request.
 6. Usage now includes 4 requests — 2 from the calling agent and 2 from the delegate agent.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 This example shows how even a fairly simple agent delegation can lead to a complex control flow:
 
@@ -333,7 +333,7 @@ async def main():  # (7)!
 6. Define a function to find the user's seat preference, which asks the user for their seat preference and then calls the agent to extract the seat preference.
 7. Now that we've put our logic for running each agent into separate functions, our main app becomes very simple.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The control flow for this example can be summarised as follows:
 

--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -184,7 +184,7 @@ async def main():
 5. Define a tool on the delegate agent that uses the dependencies to make an HTTP request.
 6. Usage now includes 4 requests — 2 from the calling agent and 2 from the delegate agent.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 This example shows how even a fairly simple agent delegation can lead to a complex control flow:
 
@@ -333,7 +333,7 @@ async def main():  # (7)!
 6. Define a function to find the user's seat preference, which asks the user for their seat preference and then calls the agent to extract the seat preference.
 7. Now that we've put our logic for running each agent into separate functions, our main app becomes very simple.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The control flow for this example can be summarised as follows:
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -310,7 +310,7 @@ async def main():
             #> name='test' value=42
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Output modes
 
@@ -662,7 +662,7 @@ async def main():
             #> Once upon a time, there was a curious cat named Whiskers who loved to explore the world around him...
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ## Image output
 
@@ -780,7 +780,7 @@ async def main():
 2. The [`Agent.run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream] method is used to start a streamed run, this method returns a context manager so the connection can be closed when the stream completes.
 3. Each item yield by [`StreamedRunResult.stream_text()`][pydantic_ai.result.StreamedRunResult.stream_text] is the complete text response, extended as new data is received.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The optional `debounce_by` argument of [`stream_text()`][pydantic_ai.result.StreamedRunResult.stream_text] controls how long Pydantic AI groups incoming chunks before yielding. The default `0.1` groups chunks for up to 0.1 seconds; pass `None` to yield as soon as each chunk arrives. Debouncing is especially helpful for long structured responses, where it reduces the overhead of validating each chunk as it arrives.
 
@@ -806,7 +806,7 @@ async def main():
 
 1. [`stream_text`][pydantic_ai.result.StreamedRunResult.stream_text] will error if the response is not text.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 !!! warning "Output message not included in `messages`"
     The final output message will **NOT** be added to result messages if you use `.stream_text(delta=True)`,
@@ -854,7 +854,7 @@ async def main():
             #> {'name': 'Ben', 'dob': date(1990, 1, 28), 'bio': 'Likes the chain the dog and the pyramid'}
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 #### Making structured responses appear faster
 
@@ -909,7 +909,7 @@ async def main():
                         record_event(event)
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 Each value from `stream_output()` is an accumulated snapshot, not a delta. An incomplete field or list item may be absent until enough data has arrived for it to pass partial validation, so update the rendered value from each snapshot rather than appending every yield.
 
@@ -964,7 +964,7 @@ async def main():
 1. [`stream_response`][pydantic_ai.result.StreamedRunResult.stream_response] streams the data as [`ModelResponse`][pydantic_ai.messages.ModelResponse] objects, thus iteration can't fail with a `ValidationError`.
 2. [`validate_response_output`][pydantic_ai.result.StreamedRunResult.validate_response_output] validates the data, `allow_partial=True` enables pydantic's [`experimental_allow_partial` flag on `TypeAdapter`][pydantic.type_adapter.TypeAdapter.validate_json].
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 ### Cancelling Streams
 
@@ -995,7 +995,7 @@ async def main():
 
 1. Breaking out of the loop leaves the `async with` block, which cancels the background run task and closes the HTTP connection.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 The yielded [`AgentRunEvents`][pydantic_ai.agent.AgentRunEvents] handle exposes `cancel()` to cancel the whole run (see [Cancelling a Run](agent.md#cancelling-a-run)); continued iteration then raises [`RunCancelled`][pydantic_ai.exceptions.RunCancelled]. It also provides `all_messages()`, `new_messages()`, `usage`, and the completed `result`. From inside a tool or `event_stream_handler`, use [`RunContext.cancel()`][pydantic_ai.tools.RunContext.cancel] instead. As a response-level alternative, [`StreamedRunResult.cancel()`][pydantic_ai.result.StreamedRunResult.cancel] from `run_stream()` stops only the current model response.
 
@@ -1028,7 +1028,7 @@ async def main():
 3. The `cancelled` property reflects the cancellation state.
 4. The final [`ModelResponse`][pydantic_ai.messages.ModelResponse] is marked with `state='interrupted'` so that downstream code can identify incomplete responses.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 If you `break` out of `stream_text()` and then leave the surrounding `async with` block, the stream is cleaned up as the context exits. Use `cancel()` when you want to stop generation immediately instead of only stopping local consumption.
 
@@ -1058,7 +1058,7 @@ async def main():
 
 1. `AgentStream.cancel()` cancels the stream at the model request level.
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 To abort the run itself rather than just the current response -- and for how cancellation is recorded in message history -- see [Cancelling a Run](agent.md#cancelling-a-run).
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -310,7 +310,7 @@ async def main():
             #> name='test' value=42
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Output modes
 
@@ -662,7 +662,7 @@ async def main():
             #> Once upon a time, there was a curious cat named Whiskers who loved to explore the world around him...
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ## Image output
 
@@ -780,7 +780,7 @@ async def main():
 2. The [`Agent.run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream] method is used to start a streamed run, this method returns a context manager so the connection can be closed when the stream completes.
 3. Each item yield by [`StreamedRunResult.stream_text()`][pydantic_ai.result.StreamedRunResult.stream_text] is the complete text response, extended as new data is received.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The optional `debounce_by` argument of [`stream_text()`][pydantic_ai.result.StreamedRunResult.stream_text] controls how long Pydantic AI groups incoming chunks before yielding. The default `0.1` groups chunks for up to 0.1 seconds; pass `None` to yield as soon as each chunk arrives. Debouncing is especially helpful for long structured responses, where it reduces the overhead of validating each chunk as it arrives.
 
@@ -806,7 +806,7 @@ async def main():
 
 1. [`stream_text`][pydantic_ai.result.StreamedRunResult.stream_text] will error if the response is not text.
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 !!! warning "Output message not included in `messages`"
     The final output message will **NOT** be added to result messages if you use `.stream_text(delta=True)`,
@@ -854,7 +854,7 @@ async def main():
             #> {'name': 'Ben', 'dob': date(1990, 1, 28), 'bio': 'Likes the chain the dog and the pyramid'}
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 #### Making structured responses appear faster
 
@@ -909,7 +909,7 @@ async def main():
                         record_event(event)
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 Each value from `stream_output()` is an accumulated snapshot, not a delta. An incomplete field or list item may be absent until enough data has arrived for it to pass partial validation, so update the rendered value from each snapshot rather than appending every yield.
 
@@ -964,7 +964,7 @@ async def main():
 1. [`stream_response`][pydantic_ai.result.StreamedRunResult.stream_response] streams the data as [`ModelResponse`][pydantic_ai.messages.ModelResponse] objects, thus iteration can't fail with a `ValidationError`.
 2. [`validate_response_output`][pydantic_ai.result.StreamedRunResult.validate_response_output] validates the data, `allow_partial=True` enables pydantic's [`experimental_allow_partial` flag on `TypeAdapter`][pydantic.type_adapter.TypeAdapter.validate_json].
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 ### Cancelling Streams
 
@@ -995,7 +995,7 @@ async def main():
 
 1. Breaking out of the loop leaves the `async with` block, which cancels the background run task and closes the HTTP connection.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 The yielded [`AgentRunEvents`][pydantic_ai.agent.AgentRunEvents] handle exposes `cancel()` to cancel the whole run (see [Cancelling a Run](agent.md#cancelling-a-run)); continued iteration then raises [`RunCancelled`][pydantic_ai.exceptions.RunCancelled]. It also provides `all_messages()`, `new_messages()`, `usage`, and the completed `result`. From inside a tool or `event_stream_handler`, use [`RunContext.cancel()`][pydantic_ai.tools.RunContext.cancel] instead. As a response-level alternative, [`StreamedRunResult.cancel()`][pydantic_ai.result.StreamedRunResult.cancel] from `run_stream()` stops only the current model response.
 
@@ -1028,7 +1028,7 @@ async def main():
 3. The `cancelled` property reflects the cancellation state.
 4. The final [`ModelResponse`][pydantic_ai.messages.ModelResponse] is marked with `state='interrupted'` so that downstream code can identify incomplete responses.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 If you `break` out of `stream_text()` and then leave the surrounding `async with` block, the stream is cleaned up as the context exits. Use `cancel()` when you want to stop generation immediately instead of only stopping local consumption.
 
@@ -1058,7 +1058,7 @@ async def main():
 
 1. `AgentStream.cancel()` cancels the stream at the model request level.
 
-_(This example is complete, it can be run "as is" -- you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 To abort the run itself rather than just the current response -- and for how cancellation is recorded in message history -- see [Cancelling a Run](agent.md#cancelling-a-run).
 

--- a/docs/realtime/azure.md
+++ b/docs/realtime/azure.md
@@ -35,7 +35,7 @@ async def main():
                 break  # keep listening in a real call; we stop after one reply
 ```
 
-_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
+_(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())`; no other changes are needed.)_
 
 For explicit configuration, use
 [`AzureProvider.for_realtime()`][pydantic_ai.providers.azure.AzureProvider.for_realtime]. It accepts

--- a/docs/realtime/azure.md
+++ b/docs/realtime/azure.md
@@ -35,7 +35,7 @@ async def main():
                 break  # keep listening in a real call; we stop after one reply
 ```
 
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
+_(This example is complete except for the async entry point. To run it, add `import asyncio` and call `asyncio.run(main())`.)_
 
 For explicit configuration, use
 [`AzureProvider.for_realtime()`][pydantic_ai.providers.azure.AzureProvider.for_realtime]. It accepts


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Many async documentation examples use a note that calls the snippet complete and runnable while still requiring an `asyncio` import or entry-point call. The completed documentation audit also identified a restrained set of local prose defects and packed sentences.

This PR gives all 96 async examples one import-agnostic instruction: ensure `asyncio` is imported, add `asyncio.run(main())`, and make no other changes. It also fixes two pre-existing notes that incorrectly called `main(answer)`. Sync example notes retain the established house style.

The remaining edits are source-verified Group 2 corrections and focused sentence-architecture improvements that preserve existing conditions, limitations, and technical boundaries. The change is documentation-only and builds independently on the merged first cleanup PR, #7991.

### Verification

- `make format && make lint`
- Full changed-file pre-commit suite
- `uv run pytest tests/test_examples.py -p no:randomly -q` — 922 passed, 187 skipped
- Offline links and heading anchors — 3,122 checked, 0 errors
- Hosted docs-only CI and documentation snippets
- Mandatory pre-push review — no findings on the final diff
- Macroscope and `douwebot` findings triaged and resolved

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).