### PR TITLE
Constrain pre-push review models and call count

### DIFF
--- a/.agents/skills/pre-push-review/SKILL.md
+++ b/.agents/skills/pre-push-review/SKILL.md
@@ -19,12 +19,21 @@ allowed-tools:
 
 # Pre-push Review
 
-Use a fresh reviewer to catch problems while they are still cheap to fix. Run this before the
-first push. Run it before a later push only when the caller's three-review budget permits.
+Catch problems while they are still cheap to fix. Run this before the first push. Run it before a
+later push only when the caller's three-review budget permits.
 
 This is the local counterpart to `douwebot`: a high-judgment standards review paid for by
 the developer's model subscription. It is independent of the automatic `CI Review`, which
 runs on GitHub after CI passes.
+
+## Select the reviewer tier
+
+Run the review in a fresh subagent.
+
+- In Claude Code, set the reviewer's model to `opus`.
+- In Codex, dispatch the Terra-pinned `reviewer` agent.
+- Do not use Fable or Sol for this review.
+- In other harnesses, use the normal reviewer selection.
 
 ## Read the review rubric
 

--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -55,11 +55,11 @@ applied automatically — don't set them.
 - Commit the exact state you intend to push. Leave nothing staged, unstaged or uncommitted unless
   the user's instructions override this.
 - Run `pre-push-review` in a fresh subagent before the first push in the current task.
-- In Claude Code, set the pre-push reviewer's model to `opus`.
-- In Codex, dispatch the Terra-pinned `reviewer` agent.
-- Do not use Fable or Sol for pre-push review. Other harnesses use their normal reviewer selection.
+- Use the reviewer tier defined by `pre-push-review`.
 - Dispatch `pre-push-review` at most three times per PR during one task. Count every dispatch,
   including repeated reviews after findings.
+- Track the count in the current task plan. Use the branch name until a PR number exists.
+- Reserve the next count before dispatch. Include `call N of 3` in the reviewer prompt.
 - Count only `pre-push-review` dispatches. Do not count the final metadata review.
 - Address every finding and commit the fixes. Repeat the review while the three-call budget remains.
 - After the third review, fix its findings and run the relevant local checks. Do not dispatch a

--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -59,9 +59,11 @@ applied automatically — don't set them.
 - Dispatch `pre-push-review` at most three times per PR during one task. Count every dispatch,
   including repeated reviews after findings.
 - Track the count in the current task plan. Use the branch name until a PR number exists.
+- When the PR exists, rename the branch-keyed plan entry to the PR number. Preserve its count.
 - Reserve the next count before dispatch. Include `call N of 3` in the reviewer prompt.
 - Count only `pre-push-review` dispatches. Do not count the final metadata review.
-- Address every finding and commit the fixes. Repeat the review while the three-call budget remains.
+- Address every finding and commit the fixes. Stop after a review returns no findings.
+- Reserve another review only after committing fixes and only while the three-call budget remains.
 - After the third review, fix its findings and run the relevant local checks. Do not dispatch a
   fourth review; continue with the push, CI, and hosted review.
 - Never force-push an open PR branch. Push follow-up commits so previous reviews remain valid;

--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -54,8 +54,16 @@ applied automatically — don't set them.
 ## Before you push
 - Commit the exact state you intend to push. Leave nothing staged, unstaged or uncommitted unless
   the user's instructions override this.
-- Run `pre-push-review`. Address every finding, commit the fixes, and repeat the review until it
-  returns no findings. This applies before the first PR push and between every later PR iteration.
+- Run `pre-push-review` in a fresh subagent before the first push in the current task.
+- In Claude Code, set the pre-push reviewer's model to `opus`.
+- In Codex, dispatch the Terra-pinned `reviewer` agent.
+- Do not use Fable or Sol for pre-push review. Other harnesses use their normal reviewer selection.
+- Dispatch `pre-push-review` at most three times per PR during one task. Count every dispatch,
+  including repeated reviews after findings.
+- Count only `pre-push-review` dispatches. Do not count the final metadata review.
+- Address every finding and commit the fixes. Repeat the review while the three-call budget remains.
+- After the third review, fix its findings and run the relevant local checks. Do not dispatch a
+  fourth review; continue with the push, CI, and hosted review.
 - Never force-push an open PR branch. Push follow-up commits so previous reviews remain valid;
   maintainers can squash them when merging.
 - Attempt the push. If it fails, read the real error — do not preemptively decide you lack

--- a/.claude/skills/pre-push-review
+++ b/.claude/skills/pre-push-review
@@ -1,0 +1,1 @@
+../../.agents/skills/pre-push-review

--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
-description: Run a high-judgment local review of the current branch before pushing, both before a
-  PR exists and between PR iterations
+name: pre-push-review
+description: Run an independent local review of the current branch before a push when the PR's
+  three-call review budget permits
 allowed-tools:
   - Read
   - Glob
@@ -18,8 +19,8 @@ allowed-tools:
 
 # Pre-push Review
 
-Use the strongest locally available reviewer to catch problems while they are still cheap
-to fix. Run this before the first push and again before every later push to an existing PR.
+Use a fresh reviewer to catch problems while they are still cheap to fix. Run this before the
+first push. Run it before a later push only when the caller's three-review budget permits.
 
 This is the local counterpart to `douwebot`: a high-judgment standards review paid for by
 the developer's model subscription. It is independent of the automatic `CI Review`, which

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ AGENTS.override.md
 !.agents/skills/complete-partial-pr/
 .agents/skills/complete-partial-pr/*
 !.agents/skills/complete-partial-pr/SKILL.md
+!.agents/skills/pre-push-review/
+.agents/skills/pre-push-review/*
+!.agents/skills/pre-push-review/SKILL.md
 !.agents/skills/adding-a-provider-api-feature/
 .agents/skills/adding-a-provider-api-feature/*
 !.agents/skills/adding-a-provider-api-feature/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,7 @@ AGENTS.override.md
 !.claude/skills/address-feedback/
 .claude/skills/address-feedback/*
 !.claude/skills/address-feedback/SKILL.md
-!.claude/skills/pre-push-review/
-.claude/skills/pre-push-review/*
-!.claude/skills/pre-push-review/SKILL.md
+!.claude/skills/pre-push-review
 !.claude/skills/testing-skill/
 .claude/skills/testing-skill/*
 !.claude/skills/testing-skill/SKILL.md


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Constrain local pre-push review to a useful, bounded check instead of an open-ended review loop.

### What changed

- Use `opus` for Claude Code pre-push review and the Terra-pinned `reviewer` for Codex.
- Prohibit Fable and Sol for this review while leaving other harnesses unchanged.
- Cap `pre-push-review` at three dispatches per PR per task, with a persisted task-plan count and an explicit stopping condition.
- Move `pre-push-review` to the portable `.agents/skills` path and retain Claude discovery through a compatibility symlink.

### Verification

- Skill validator passes through both `.agents` and `.claude` discovery paths.
- Repository pre-commit checks pass for every changed file.
- Three Terra pre-push review calls completed; the final review reported no findings.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/7998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

