### PR TITLE
Assert `IsDecimal()` instead of a literal `cost` in the DeepSeek Responses tests

### DIFF
--- a/tests/models/test_deepseek_responses.py
+++ b/tests/models/test_deepseek_responses.py
@@ -22,7 +22,6 @@ import json
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from decimal import Decimal
 from typing import Any
 
 import httpx2
@@ -74,8 +73,11 @@ def get_temperature(city: str) -> float:
     return 21.0
 
 
-# DeepSeek V4 prices vary by request time. These response-shape cases assert that a cost was
-# calculated without duplicating genai-prices' time-dependent pricing tests.
+# DeepSeek V4 prices vary by request time: genai-prices doubles the rate during 01:00-04:00 and
+# 06:00-10:00 UTC, and a cost is priced from `ModelResponse.timestamp`, which the model stamps with
+# the wall clock rather than replaying it off the cassette. So these response-shape cases assert
+# that a cost was calculated without duplicating genai-prices' time-dependent pricing tests — a
+# literal pin here holds only for the pricing tier and window it was recorded in.
 @dataclass(frozen=True)
 class Case:
     id: str
@@ -836,7 +838,7 @@ CASES = [
                         input_tokens=148,
                         output_reasoning_tokens=26,
                         output_tokens=40,
-                        cost=Decimal('0.00005896'),
+                        cost=IsDecimal(),
                     ),
                     model_name='deepseek-v4-flash',
                     timestamp=IsDatetime(),


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

David has not reviewed this diff line by line.

@DouweM — this touches the line you changed in #7987, so flagging you directly.

## Why we make these changes

`main` is red for seven hours of every day.

genai-prices 0.1.5 ([#7942](https://github.com/pydantic/pydantic-ai/pull/7942)) gives `deepseek-v4-flash` two `TimeOfDateConstraint` price tiers that double the rate during 01:00–04:00 and 06:00–10:00 UTC. A `cost` is priced from `ModelResponse.timestamp`, which `OpenAIResponsesModel._process_response` stamps with wall-clock `now_utc()` — the cassette does not replay it. So a literal `cost` pin in this file holds only for the pricing tier and window it was recorded in.

#7942 already settled this for the file: it converted all ten `cost` pins to `IsDecimal()`, dropped the `Decimal` import, and left a comment above `Case` saying these cases assert *that* a cost was calculated rather than what it came to. [#7450](https://github.com/pydantic/pydantic-ai/pull/7450) was branched before that landed and added an eighth case, whose `cost=Decimal('0.00003192')` became the eleventh pin — and, because #7942 had removed it, no `Decimal` import, so the breakage surfaced as a collection-time `NameError` first. [#7987](https://github.com/pydantic/pydantic-ai/pull/7987) restored the import and re-pinned to the then-current off-peak price, which cleared the `NameError` but left the pin time-dependent. This diff removes that import again as a consequence of dropping the last literal, not as a revert of its intent.

This brings that eleventh pin back in line with the other ten, and extends the comment to name the mechanism so a third literal doesn't land there.

## New public surface

none

## Evidence

Two docs-only commits on `main`, identical test content, different clock:

| commit | run started | `test on …` jobs |
|---|---|---|
| [`0abce4fe6`](https://github.com/pydantic/pydantic-ai/actions/runs/33575635048) | 00:30 UTC | 25 / 25 green |
| [`a29ebea16`](https://github.com/pydantic/pydantic-ai/actions/runs/33579825934) | 01:32 UTC | 0 / 25 green |

Priced through `genai_prices.calc_price` for this case's usage (`input_tokens=148`, `output_tokens=40`): `0.00005896` off-peak — the pin on `main` — and `0.00011792` inside either window, exactly double.

## Verification

`uv run pytest tests/models/test_deepseek_responses.py tests/models/test_deepseek.py -q -p no:randomly`, run at 02:08 UTC inside the 01:00–04:00 window: 19 passed, 100% coverage on both files. On `main` the same command in the same window fails `test_deepseek_responses[native_output]` with `Decimal('0.00011792')` against the pinned `Decimal('0.00005896')`. This PR's own CI also ran entirely inside that window.

## What changes for existing users

Nothing — test-only change.

<details>
<summary>Scope decisions</summary>

- **This removes the only literal cost assertion on the Responses path.** The ten sibling pins already made that trade in #7942; the Chat path keeps two frozen-clock literals in `tests/models/test_deepseek.py`, so DeepSeek cost arithmetic stays covered there.
- **Why not reuse `freeze_deepseek_off_peak_pricing` here.** That fixture freezes the clock to 2026-08-13, which now predates `deepseek-v4-flash`'s `StartDateConstraint(2026-08-17)` — so it pins a tier DeepSeek no longer charges, and every future tier makes the frozen date staler. Chasing it forward is a treadmill, and applying the freeze here would also impose a clock on ten sibling pins that don't need one.
- **`test_deepseek.py`'s two frozen-clock pins are deliberately left alone.** They are deterministic and green; the freeze makes them a regression net for the Chat path's usage mapping. No issue filed — there is nothing broken to track.
- **`IsDecimal()` rather than `IsDecimal(gt=0)`.** Matches the ten siblings. `IsDecimal()` does accept `Decimal('0')`, so a silently-zeroed cost would pass — if you want that guard, it should be all eleven pins or none, and I'm happy to do all eleven in this PR.
- **No other test needed the change.** `TimeOfDateConstraint` appears on exactly four models in genai-prices 0.1.5 — `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash`, `deepseek-v4-pro`, all under provider `deepseek`. The only literal `cost` pins on any of them are the two in `test_deepseek.py`. DeepSeek-named models served elsewhere (`deepseek-r1-distill-llama-70b` on Groq, `us.deepseek.r1-v1:0` on Bedrock, `deepseek/deepseek-chat` on OpenRouter) price under those providers, which carry no time-of-day tier.

</details>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
