### PR TITLE
Relax the realtime cancellation test deadline

### DIFF
--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -5491,7 +5491,7 @@ async def test_realtime_cancellation_does_not_wait_for_sync_tool_worker() -> Non
     await asyncio.to_thread(worker_started.wait)
     try:
         with pytest.raises(RunCancelled):
-            await asyncio.wait_for(asyncio.shield(task), timeout=1)
+            await asyncio.wait_for(asyncio.shield(task), timeout=5)
         assert not worker_finished.is_set()
         assert not any(isinstance(item, ToolResult) for item in conn.sent)
     finally:


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

The realtime sync-tool cancellation test uses a one-second deadlock guard. Two unrelated Python 3.14 CI runs exceeded that deadline, while the cancellation path passed 500 consecutive local repetitions with a maximum duration of 0.059 seconds.

Raise only the test guard to five seconds, matching the worker-cleanup guard already used by the same test. The worker remains blocked until after the cancellation assertion, so the regression remains detectable and runtime behavior is unchanged.

### Verification

- `uv run --python 3.14 pytest tests/realtime/test_session.py::test_realtime_cancellation_does_not_wait_for_sync_tool_worker -q -p no:randomly`
- `make format`
- `make lint`
- Full pre-commit typecheck and cassette checks

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

