### PR TITLE
Document the Fly.io Sprites sandbox capability

### DIFF
--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -36,6 +36,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 | [FileSystem](https://pydantic.dev/docs/ai/harness/filesystem/) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](https://pydantic.dev/docs/ai/harness/shell/) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
 | [Modal Sandbox](https://pydantic.dev/docs/ai/harness/modal-sandbox/) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
+| [Sprite Sandbox](https://pydantic.dev/docs/ai/harness/sprite-sandbox/) | Harness | Commands and files in a persistent [Sprite](https://docs.sprites.dev/) cloud computer |
 
 ### Tools & native abilities {#tools-native-abilities}
 

--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -36,7 +36,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 | [FileSystem](https://pydantic.dev/docs/ai/harness/filesystem/) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](https://pydantic.dev/docs/ai/harness/shell/) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
 | [Modal Sandbox](https://pydantic.dev/docs/ai/harness/modal-sandbox/) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
-| [Sprite Sandbox](https://pydantic.dev/docs/ai/harness/sprite-sandbox/) | Harness | Commands and files in a persistent [Sprite](https://docs.sprites.dev/) cloud computer |
+| [Fly.io Sprites Sandbox](https://pydantic.dev/docs/ai/harness/sprite-sandbox/) | Harness | Commands and files in a persistent [Fly.io Sprite](https://docs.sprites.dev/) cloud computer |
 
 ### Tools & native abilities {#tools-native-abilities}
 

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -255,6 +255,10 @@ navigation:
             path: "modal-sandbox.md"
             source: "harness"
             slug: "harness/modal-sandbox"
+          - page: "Sprite Sandbox"
+            path: "sprite-sandbox.md"
+            source: "harness"
+            slug: "harness/sprite-sandbox"
       - section: "Tools & Native Abilities"
         slug: ""
         contents:

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -255,7 +255,7 @@ navigation:
             path: "modal-sandbox.md"
             source: "harness"
             slug: "harness/modal-sandbox"
-          - page: "Sprite Sandbox"
+          - page: "Fly.io Sprites Sandbox"
             path: "sprite-sandbox.md"
             source: "harness"
             slug: "harness/sprite-sandbox"


### PR DESCRIPTION
Add the new Fly.io Sprites sandbox to the capability overview and documentation navigation.

This is the small core-docs companion to https://github.com/pydantic/pydantic-ai-harness/pull/771. The implementation and detailed documentation live in Pydantic AI Harness.

Merge order: the Harness PR must merge and deploy first. The canonical `https://pydantic.dev/docs/ai/harness/sprite-sandbox/` route intentionally follows the existing Harness capability URL pattern and will return 404 until that new Harness page is deployed.

Related context: https://github.com/superfly/sprites-ecosystem/issues/34

### Validation

- parsed `docs/navigation.yml` with Ruby YAML
- `git diff --check origin/main...HEAD`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (No compatibility impact.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
