### PR TITLE
fix: honor Annotated Field descriptions for require_parameter_descriptions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -184,9 +184,6 @@ def function_schema(  # noqa: C901
 
         field_name = p.name
 
-        if require_parameter_descriptions and field_name not in field_descriptions:
-            missing_param_descriptions.add(field_name)
-
         if p.kind == Parameter.VAR_KEYWORD:
             var_kwargs_schema = gen_schema.generate_schema(annotation)
         else:
@@ -202,6 +199,9 @@ def function_schema(  # noqa: C901
                 field_info = FieldInfo.from_annotated_attribute(annotation, p.default)
             if field_info.description is None:
                 field_info.description = field_descriptions.get(field_name)
+
+            if require_parameter_descriptions and field_info.description is None:
+                missing_param_descriptions.add(field_name)
 
             fields[field_name] = td_schema = gen_schema._generate_td_field_schema(  # pyright: ignore[reportPrivateUsage]
                 field_name,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1120,6 +1120,22 @@ def test_enforce_parameter_descriptions_noraise() -> None:
     agent.tool(require_parameter_descriptions=True)(complete_parameter_descriptions_docstring)
 
 
+def test_enforce_parameter_descriptions_accepts_annotated_field_description() -> None:
+    toolset = FunctionToolset(require_parameter_descriptions=True)
+
+    @toolset.tool_plain
+    def add(value: Annotated[int, Field(description='The value to add')]) -> int:
+        return value
+
+    tool = toolset.tools['add']
+    assert tool.tool_def.parameters_json_schema == {
+        'additionalProperties': False,
+        'properties': {'value': {'description': 'The value to add', 'type': 'integer'}},
+        'required': ['value'],
+        'type': 'object',
+    }
+
+
 def test_json_schema_required_parameters():
     agent = Agent(FunctionModel(get_json_schema))
 


### PR DESCRIPTION
## Summary

When `require_parameter_descriptions=True`, registering a tool whose required parameter is described via `Annotated[..., Field(description=...)]` incorrectly raised `UserError: Missing parameter descriptions for ...` even though the generated JSON schema already included the description.

## Root cause

`function_schema()` checked `field_name not in field_descriptions` (docstring-only) before building `FieldInfo` from the annotation. Required parameters described with `Field(description=...)` only become visible after `FieldInfo.from_annotation()`.

## Fix

Defer the missing-description check until after `FieldInfo` is constructed and docstring descriptions are applied as a fallback.

## Test plan

- [x] Added `test_enforce_parameter_descriptions_accepts_annotated_field_description`
- [x] Verified issue reproduction script registers successfully and schema retains description + required flag
- [x] Verified tools with no parameter descriptions still raise `UserError`

Fixes #7996

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

