### PR TITLE
Accept non-string `metadata` values from OpenAI-compatible chat completions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -358,6 +358,9 @@ class _ChatCompletion(chat.ChatCompletion):
     service_tier: str | None = None  # type: ignore[reportIncompatibleVariableOverride]
     """OpenAI-compatible providers can return arbitrary `service_tier` values (e.g. `"standard"`, `"on_demand"`)."""
 
+    metadata: dict[str, Any] | None = None
+    """OpenAI-compatible providers can return non-string `metadata` values (e.g. Nebius returns a list under `weight_versions`)."""
+
 
 class _ChatCompletionChunk(ChatCompletionChunk):  # pyright: ignore[reportUnusedClass] — subclassed in openrouter.py
     """Relaxes strict Literal validation on fields that OpenAI-compatible providers may return non-standard values for."""
@@ -1195,7 +1198,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         This method may be overridden by subclasses of `OpenAIChatModel` to apply custom completion validations.
         """
-        return _ChatCompletion.model_validate(response.model_dump())
+        return _ChatCompletion.model_validate(response.model_dump(warnings=False))
 
     def _process_provider_details(self, response: chat.ChatCompletion) -> dict[str, Any] | None:
         """Hook that response content to provider details.

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4978,6 +4978,26 @@ async def test_service_tier_non_standard_value(allow_model_requests: None):
     assert result.output == 'hello'
 
 
+class _ChatCompletionWithMetadata(chat.ChatCompletion):
+    """`ChatCompletion.metadata: dict[str, str] | None` as declared by openai >= 3.2.0."""
+
+    metadata: dict[str, str] | None = None
+
+
+async def test_metadata_non_string_value(allow_model_requests: None):
+    """OpenAI-compatible providers can return `metadata` values outside the SDK's `dict[str, str]`."""
+    c = _ChatCompletionWithMetadata.model_validate(
+        dict(completion_message(ChatCompletionMessage(content='hello', role='assistant')))
+    )
+    c.metadata = {'weight_version': 'default', 'weight_versions': [{'version': 'default', 'start': 0, 'end': 44}]}  # pyright: ignore[reportAttributeAccessIssue]  # simulate Nebius response
+
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+    result = await agent.run('Hello')
+    assert result.output == 'hello'
+
+
 async def test_tool_choice_fallback(allow_model_requests: None) -> None:
     profile = merge_profile(
         OpenAIModelProfile(openai_supports_tool_choice_required=False), openai_model_profile('stub')


### PR DESCRIPTION
Fixes #8009

## Problem

Every non-streaming request through `OpenAIChatModel` + `NebiusProvider` fails with `UnexpectedModelBehavior: ... 1 validation error for ChatCompletion metadata.weight_versions Input should be a valid string`.

## Root cause

Nebius returns `"metadata": {"weight_version": "default", "weight_versions": [{...}]}`. openai >= 3.2.0 types `ChatCompletion.metadata` as `Dict[str, str] | None` (the lock is on 3.0.0, which has no such field). The SDK never validates it, but `_validate_completion` re-validates via `_ChatCompletion.model_validate(response.model_dump())`, which rejects the list, and the `model_dump()` itself emits a Pydantic serializer `UserWarning` on every request.

## Fix

Relax `metadata` on `_ChatCompletion` to `dict[str, Any] | None`, as `service_tier` already is, and pass `warnings=False` to the `model_dump()` that feeds re-validation. `metadata` is not consumed downstream. The OpenRouter, Z.AI and Snowflake subclasses inherit `_ChatCompletion` but keep their own `model_dump()` calls; I left those alone since I have not seen this shape from those providers.

## Validation

The test builds the completion from a `ChatCompletion` subclass declaring `metadata: dict[str, str] | None` like openai >= 3.2.0. On the locked 3.0.0 that covers the warning half only, since `_ChatCompletion` inherits the typed field only from the newer SDK, so I also ran everything with openai 3.3.1.

- `uv run pytest tests/models/test_openai.py -k metadata_non_string`: red on main (serializer `UserWarning` under `filterwarnings = error`), green with the patch. Same with `--with openai==3.3.1`, where dropping only the field relaxation fails on the validation error.
- `uv run pytest tests/models/test_openai.py`: 231 passed.
- `uv run pyright` on both changed files: 0 errors on the lock and with openai 3.3.1.
- `make lint`: clean.
- Live Nebius request (`zai-org/GLM-5.3-Flash`, openai 3.7.0, `python -W error::UserWarning`): fails on main, returns `Ok.` with the patch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

