### PR TITLE
Make `TestModel` generate valid `datetime`, `UUID`, `time`, and URL values

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -442,6 +442,11 @@ class TestStreamedResponse(StreamedResponse):
 
 
 _chars = string.ascii_letters + string.digits + string.punctuation
+_DATE_ANCHOR = date(2024, 1, 1)
+_MAX_DAY_OFFSET = (date(9999, 12, 31) - _DATE_ANCHOR).days
+_MIN_DAY_OFFSET = (date(1, 1, 1) - _DATE_ANCHOR).days
+_DAY_SPAN = _MAX_DAY_OFFSET - _MIN_DAY_OFFSET + 1
+_UUID_INT_MODULUS = 1 << 128
 
 
 class _JsonSchemaTestData:
@@ -516,6 +521,13 @@ class _JsonSchemaTestData:
 
         return data
 
+    def _day_offset(self) -> int:
+        """Map any seed into a timedelta that stays inside datetime's year 1–9999 range."""
+        n = self.seed % _DAY_SPAN
+        if n > _MAX_DAY_OFFSET:
+            n -= _DAY_SPAN
+        return n
+
     def _str_gen(self, schema: dict[str, Any]) -> str:
         """Generate a string from a JSON Schema string."""
         if schema.get('maxLength') == 0:
@@ -526,13 +538,13 @@ class _JsonSchemaTestData:
         # first made TestModel emit `'a'` and fail Pydantic validation.
         if fmt := schema.get('format'):
             if fmt == 'date':
-                return (date(2024, 1, 1) + timedelta(days=self.seed)).isoformat()
+                return (_DATE_ANCHOR + timedelta(days=self._day_offset())).isoformat()
             if fmt == 'date-time':
-                return (datetime(2024, 1, 1, tzinfo=timezone.utc) + timedelta(days=self.seed)).isoformat()
+                return (datetime(2024, 1, 1, tzinfo=timezone.utc) + timedelta(days=self._day_offset())).isoformat()
             if fmt == 'time':
                 return time(hour=self.seed % 24).isoformat()
             if fmt == 'uuid':
-                return str(UUID(int=self.seed))
+                return str(UUID(int=self.seed % _UUID_INT_MODULUS))
             if fmt in {'uri', 'uri-reference', 'url'}:
                 return 'https://example.com'
 

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -5,8 +5,9 @@ import string
 from collections.abc import AsyncGenerator, AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import InitVar, dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Literal, cast
+from uuid import UUID
 
 import pydantic_core
 from typing_extensions import assert_never
@@ -517,16 +518,27 @@ class _JsonSchemaTestData:
 
     def _str_gen(self, schema: dict[str, Any]) -> str:
         """Generate a string from a JSON Schema string."""
-        min_len = schema.get('minLength')
-        if min_len is not None:
-            return self._char() * min_len
-
         if schema.get('maxLength') == 0:
             return ''
 
+        # Consult `format` before `minLength`. Types like `AnyUrl` emit
+        # `format: uri` together with `minLength: 1`; returning `minLength`
+        # first made TestModel emit `'a'` and fail Pydantic validation.
         if fmt := schema.get('format'):
             if fmt == 'date':
                 return (date(2024, 1, 1) + timedelta(days=self.seed)).isoformat()
+            if fmt == 'date-time':
+                return (datetime(2024, 1, 1, tzinfo=timezone.utc) + timedelta(days=self.seed)).isoformat()
+            if fmt == 'time':
+                return time(hour=self.seed % 24).isoformat()
+            if fmt == 'uuid':
+                return str(UUID(int=self.seed))
+            if fmt in {'uri', 'uri-reference', 'url'}:
+                return 'https://example.com'
+
+        min_len = schema.get('minLength')
+        if min_len is not None:
+            return self._char() * min_len
 
         return self._char()
 

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -639,6 +639,20 @@ def test_json_schema_common_string_formats():
     Formatted.model_validate(data)
 
 
+@pytest.mark.parametrize('seed', [-1, 3_000_000, 1 << 128])
+def test_string_formats_unconstrained_seeds_still_validate(seed: int):
+    """`date-time`/`uuid` generators must wrap extreme seeds instead of raising."""
+
+    class Formatted(BaseModel):
+        day: date
+        when: datetime
+        clock: time
+        id: UUID
+
+    data = _JsonSchemaTestData(Formatted.model_json_schema(), seed=seed).generate()
+    Formatted.model_validate(data)
+
+
 def test_string_formats_as_structured_output():
     """Regression for #8011: TestModel should not retry out on common pydantic string formats."""
 

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -5,13 +5,14 @@ from __future__ import annotations as _annotations
 import asyncio
 import dataclasses
 import re
-from datetime import timezone
+from datetime import date, datetime, time, timezone
 from typing import Annotated, Any, Literal
+from uuid import UUID
 
 import pytest
 from annotated_types import Ge, Gt, Le, Lt, MaxLen, MinLen
 from anyio import Event
-from pydantic import BaseModel, Field
+from pydantic import AnyUrl, BaseModel, Field
 
 from pydantic_ai import (
     Agent,
@@ -612,6 +613,50 @@ def test_narrow_exclusive_bounds_tool_args():
 
     agent.run_sync('hello', model=TestModel())
     assert calls == snapshot([{'temperature': 0.0}])
+
+
+def test_json_schema_common_string_formats():
+    """`format` must win over `minLength`, otherwise `AnyUrl` (uri + minLength 1) stays `'a'`."""
+
+    class Formatted(BaseModel):
+        day: date
+        when: datetime
+        clock: time
+        id: UUID
+        url: AnyUrl
+
+    json_schema = Formatted.model_json_schema()
+    data = _JsonSchemaTestData(json_schema).generate()
+    assert data == snapshot(
+        {
+            'day': '2024-01-01',
+            'when': '2024-01-01T00:00:00+00:00',
+            'clock': '00:00:00',
+            'id': '00000000-0000-0000-0000-000000000000',
+            'url': 'https://example.com',
+        }
+    )
+    Formatted.model_validate(data)
+
+
+def test_string_formats_as_structured_output():
+    """Regression for #8011: TestModel should not retry out on common pydantic string formats."""
+
+    class Out(BaseModel):
+        when: datetime
+        id: UUID
+        clock: time
+        url: AnyUrl
+
+    result = Agent('test', output_type=Out).run_sync('hello', model=TestModel())
+    assert result.output == snapshot(
+        Out(
+            when=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            id=UUID('00000000-0000-0000-0000-000000000000'),
+            clock=time(0, 0),
+            url=AnyUrl('https://example.com/'),
+        )
+    )
 
 
 def test_json_schema_number_generation():


### PR DESCRIPTION
- Closes #8011

`TestModel`'s JSON Schema faker already emitted a valid `format: date` string, but `date-time`, `time`, `uuid`, and `uri` still became `'a'`. For `AnyUrl` the schema also has `minLength: 1`, and that branch returned before `format` was consulted, so structured output retried out.

This consults `format` first and emits values those Pydantic types accept. No real provider.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

