### PR TITLE
Use `context_window_used` to trigger stateless OpenAI compaction

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -369,7 +369,7 @@ agent = Agent(
 )
 ```
 
-As an alternative, `OpenAICompaction` supports a **stateless mode** (`stateless=True`) that calls the stateless `/responses/compact` endpoint via a `before_model_request` hook. Use this in [ZDR](https://openai.com/enterprise-privacy/) environments where OpenAI must not retain conversation data, when using [`openai_store=False`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_store], or when you need explicit out-of-band control over when compaction runs. Stateless mode requires you to specify either a [`message_count_threshold`][pydantic_ai.models.openai.OpenAICompaction] or a custom `trigger` callable:
+As an alternative, `OpenAICompaction` supports a **stateless mode** (`stateless=True`) that calls the stateless `/responses/compact` endpoint via a `before_model_request` hook. Use this in [ZDR](https://openai.com/enterprise-privacy/) environments where OpenAI must not retain conversation data, when using [`openai_store=False`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_store], or when you need explicit out-of-band control over when compaction runs. Stateless mode requires a context-window, message-count, or custom trigger:
 
 ```python {title="openai_compaction_stateless.py" test="skip"}
 from pydantic_ai import Agent
@@ -377,11 +377,13 @@ from pydantic_ai.models.openai import OpenAICompaction
 
 agent = Agent(
     'openai-responses:gpt-5.2',
-    capabilities=[OpenAICompaction(message_count_threshold=20)],
+    capabilities=[OpenAICompaction(context_window_used_threshold=0.8)],
 )
 ```
 
-The mode is inferred from which parameters you pass: supplying `message_count_threshold` or `trigger` implies stateless mode, otherwise stateful mode is used. You can also pass `stateless=True` or `stateless=False` explicitly. Mixing parameters from different modes raises [`UserError`][pydantic_ai.exceptions.UserError].
+`context_window_used_threshold` compacts when the latest response's [`context_window_used`][pydantic_ai.tools.RunContext.context_window_used] reaches the given fraction. It leaves history unchanged when usage is unknown, including before the first response. Because newly added content can make the next request larger than that estimate, leave enough headroom below `1.0`.
+
+The mode is inferred from which parameters you pass: supplying `context_window_used_threshold`, `message_count_threshold`, or `trigger` implies stateless mode, otherwise stateful mode is used. You can also pass `stateless=True` or `stateless=False` explicitly. Mixing parameters from different modes raises [`UserError`][pydantic_ai.exceptions.UserError].
 
 !!! tip
     Stateful compaction pairs especially well with [`openai_previous_response_id='auto'`](#referencing-earlier-responses) or [`openai_conversation_id`](#using-durable-conversations). Both rely on OpenAI's server-side conversation state, so OpenAI can use a previously compacted context as the starting point for the next turn without you having to resend it.

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
@@ -76,6 +76,23 @@ Rules of thumb:
 
 ## Manage Context Size
 
+For provider-native stateless compaction with the OpenAI Responses API, use
+`OpenAICompaction` instead of writing a history processor:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAICompaction
+
+agent = Agent(
+    'openai-responses:gpt-5.2',
+    capabilities=[OpenAICompaction(context_window_used_threshold=0.8)],
+)
+```
+
+This calls OpenAI's `/responses/compact` endpoint before the next request when the latest response's
+context-window usage reaches the configured fraction. If usage or the model's context window is unknown,
+it leaves history unchanged.
+
 Use `capabilities=[ProcessHistory(...)]` to trim or rewrite message history before each model request. `ProcessHistory` is a thin wrapper around the `before_model_request` lifecycle hook — for richer control (access to `RunContext`/`ModelRequestContext`, ability to short-circuit the model call), hook the event directly via `capabilities=[Hooks(before_model_request=fn)]`.
 
 ```python

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -4793,11 +4793,13 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
       [`openai_store=False`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_store],
       or when you need explicit out-of-band control over when compaction runs.
 
-      Requires either `message_count_threshold` or a custom `trigger` callable.
+      Requires `context_window_used_threshold`, `message_count_threshold`, or a
+      custom `trigger` callable.
 
     If `stateless` is not set, it is inferred from which parameters you
-    provide: passing any stateless-only parameter (`message_count_threshold`
-    or `trigger`) implies `stateless=True`; otherwise stateful mode is used.
+    provide: passing any stateless-only parameter
+    (`context_window_used_threshold`, `message_count_threshold`, or `trigger`)
+    implies `stateless=True`; otherwise stateful mode is used.
 
     Example usage:
 
@@ -4820,7 +4822,7 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
     # Stateless mode for ZDR environments or explicit control:
     agent = Agent(
         'openai-responses:gpt-5.2',
-        capabilities=[OpenAICompaction(message_count_threshold=20)],
+        capabilities=[OpenAICompaction(context_window_used_threshold=0.8)],
     )
     ```
     """
@@ -4830,6 +4832,7 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
         *,
         stateless: bool | None = None,
         token_threshold: int | None = None,
+        context_window_used_threshold: float | None = None,
         message_count_threshold: int | None = None,
         trigger: Callable[[list[ModelMessage]], bool] | None = None,
     ) -> None:
@@ -4838,20 +4841,31 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
         Args:
             stateless: Select the compaction mode explicitly. If `None` (the
                 default), the mode is inferred from the other parameters:
-                passing any stateless-only parameter (`message_count_threshold`
-                or `trigger`) implies `stateless=True`; otherwise stateful
-                mode is used.
+                passing any stateless-only parameter
+                (`context_window_used_threshold`, `message_count_threshold`,
+                or `trigger`) implies `stateless=True`; otherwise stateful mode
+                is used.
             token_threshold: Stateful-mode only. Input token threshold at which
                 OpenAI's server-side compaction is triggered. Corresponds to
                 `compact_threshold` in the `context_management` API field. If
                 `None`, OpenAI picks a server-side default.
+            context_window_used_threshold: Stateless-mode only. Compact when
+                [`RunContext.context_window_used`][pydantic_ai.tools.RunContext.context_window_used]
+                reaches this fraction of the model's context window. Must be
+                greater than `0` and at most `1`. If context-window usage is
+                unknown, compaction is not triggered.
             message_count_threshold: Stateless-mode only. Compact when the
                 message count exceeds this threshold.
             trigger: Stateless-mode only. Custom callable that decides whether
                 to compact based on the current messages. Takes precedence
-                over `message_count_threshold`.
+                over the configured thresholds.
         """
-        has_stateless_only = message_count_threshold is not None or trigger is not None
+        if context_window_used_threshold is not None and not 0 < context_window_used_threshold <= 1:
+            raise UserError('`context_window_used_threshold` must be greater than 0 and at most 1.')
+
+        has_stateless_only = (
+            context_window_used_threshold is not None or message_count_threshold is not None or trigger is not None
+        )
         has_stateful_only = token_threshold is not None
 
         if stateless is None:
@@ -4861,23 +4875,25 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
             if has_stateful_only:
                 raise UserError(
                     '`token_threshold` is only valid for stateful compaction (`stateless=False`). '
-                    'For stateless `/compact` endpoint compaction, use `message_count_threshold` or `trigger`.'
+                    'For stateless `/compact` endpoint compaction, use `context_window_used_threshold`, '
+                    '`message_count_threshold`, or `trigger`.'
                 )
             if not has_stateless_only:
                 raise UserError(
-                    '`stateless=True` requires `message_count_threshold` or `trigger` '
-                    'to determine when to invoke the `/compact` endpoint.'
+                    '`stateless=True` requires `context_window_used_threshold`, `message_count_threshold`, '
+                    'or `trigger` to determine when to invoke the `/compact` endpoint.'
                 )
         else:
             if has_stateless_only:
                 raise UserError(
-                    '`message_count_threshold` and `trigger` are only valid for stateless compaction '
-                    '(`stateless=True`). For stateful server-side compaction, use `token_threshold` '
-                    '(or omit it to use the OpenAI-managed default).'
+                    '`context_window_used_threshold`, `message_count_threshold`, and `trigger` are only valid '
+                    'for stateless compaction (`stateless=True`). For stateful server-side compaction, use '
+                    '`token_threshold` (or omit it to use the OpenAI-managed default).'
                 )
 
         self.stateless = stateless
         self.token_threshold = token_threshold
+        self.context_window_used_threshold = context_window_used_threshold
         self.message_count_threshold = message_count_threshold
         self.trigger = trigger
 
@@ -4900,11 +4916,13 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
 
         return resolve
 
-    def _should_compact(self, messages: list[ModelMessage]) -> bool:
+    def _should_compact(self, messages: list[ModelMessage], context_window_used: float | None = None) -> bool:
         if not self.stateless:
             return False
         if self.trigger is not None:
             return self.trigger(messages)
+        if self.context_window_used_threshold is not None:
+            return context_window_used is not None and context_window_used >= self.context_window_used_threshold
         if self.message_count_threshold is not None:
             return len(messages) > self.message_count_threshold
         return False  # pragma: no cover
@@ -4914,7 +4932,12 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
         request_context: ModelRequestContext,
     ) -> ModelRequestContext:
-        if not self._should_compact(request_context.messages):
+        context_window_used = None
+        if self.context_window_used_threshold is not None:
+            context_window_used = replace(
+                ctx, model=request_context.model, messages=request_context.messages
+            ).context_window_used
+        if not self._should_compact(request_context.messages, context_window_used):
             return request_context
 
         from .wrapper import WrapperModel

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -13412,14 +13412,17 @@ async def test_openai_responses_text_content_input(allow_model_requests: None, o
 
 
 async def test_openai_responses_compact_messages(allow_model_requests: None, openai_api_key: str):
-    """Test OpenAI compaction: multi-turn conversation compacted via OpenAICompaction capability."""
+    """Stateless compaction triggers when the previous response fills the configured window fraction."""
     from pydantic_ai.models.openai import OpenAICompaction
 
-    model = OpenAIResponsesModel('gpt-4o-mini', provider=OpenAIProvider(api_key=openai_api_key))
+    model = OpenAIResponsesModel(
+        'gpt-4o-mini', provider=OpenAIProvider(api_key=openai_api_key), profile={'context_window': 100}
+    )
     agent = Agent(
         model=model,
         instructions='You are a helpful math assistant. Give short answers.',
-        capabilities=[OpenAICompaction(message_count_threshold=4)],
+        # The cassette reports 38 then 60 tokens, so only the third run compacts.
+        capabilities=[OpenAICompaction(context_window_used_threshold=0.5)],
     )
 
     message_history: list[Any] = []
@@ -13427,7 +13430,6 @@ async def test_openai_responses_compact_messages(allow_model_requests: None, ope
     message_history = result.all_messages()
     result = await agent.run('And 3+3?', message_history=message_history)
     message_history = result.all_messages()
-    # Third run should trigger compaction (>4 messages)
     result = await agent.run('And 5+5?', message_history=message_history)
 
     # Verify the result is reasonable
@@ -13442,7 +13444,7 @@ async def test_openai_responses_compact_messages(allow_model_requests: None, ope
         for part in msg.parts
         if isinstance(part, CompactionPart)
     ]
-    assert len(compaction_parts) >= 1
+    assert len(compaction_parts) == 1
     compaction = compaction_parts[0]
     assert compaction.provider_name == 'openai'
     assert compaction.provider_details is not None

--- a/tests/test_capability_hooks.py
+++ b/tests/test_capability_hooks.py
@@ -4609,7 +4609,7 @@ class TestCompaction:
                 ModelRequest(parts=[UserPromptPart(content='1')]),
                 ModelResponse(parts=[TextPart(content='r1')]),
                 ModelRequest(parts=[UserPromptPart(content='2')]),
-            ]
+            ],
         )
 
     def test_openai_compaction_should_compact_no_config(self):
@@ -4621,6 +4621,24 @@ class TestCompaction:
         assert cap.stateless is False
         assert not cap._should_compact([ModelRequest(parts=[UserPromptPart(content='hi')])])  # pyright: ignore[reportPrivateUsage]
 
+    def test_openai_compaction_should_compact_at_context_window_threshold(self):
+        """The stateless threshold uses the latest response's context-window utilization."""
+        pytest.importorskip('openai')
+        from pydantic_ai.models.openai import OpenAICompaction
+
+        cap = OpenAICompaction(context_window_used_threshold=0.8)
+        assert cap._should_compact([], 0.8)  # pyright: ignore[reportPrivateUsage]
+        assert not cap._should_compact([], 0.79)  # pyright: ignore[reportPrivateUsage]
+        assert not cap._should_compact([])  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.parametrize('threshold', [0, -0.1, 1.1])
+    def test_openai_compaction_rejects_invalid_context_window_threshold(self, threshold: float):
+        pytest.importorskip('openai')
+        from pydantic_ai.models.openai import OpenAICompaction
+
+        with pytest.raises(UserError, match='greater than 0 and at most 1'):
+            OpenAICompaction(context_window_used_threshold=threshold)
+
     def test_openai_compaction_mode_inference(self):
         """`stateless` is inferred from which mode-specific fields are passed."""
         pytest.importorskip('openai')
@@ -4628,6 +4646,7 @@ class TestCompaction:
 
         assert OpenAICompaction().stateless is False
         assert OpenAICompaction(token_threshold=1000).stateless is False
+        assert OpenAICompaction(context_window_used_threshold=0.8).stateless is True
         assert OpenAICompaction(message_count_threshold=5).stateless is True
         assert OpenAICompaction(trigger=lambda _msgs: True).stateless is True
 
@@ -4684,11 +4703,11 @@ class TestCompaction:
             OpenAICompaction(stateless=False, trigger=lambda _msgs: True)
 
     def test_openai_compaction_stateless_requires_trigger(self):
-        """`stateless=True` without message_count_threshold or trigger raises UserError."""
+        """`stateless=True` without a threshold or trigger raises UserError."""
         pytest.importorskip('openai')
         from pydantic_ai.models.openai import OpenAICompaction
 
-        with pytest.raises(UserError, match='requires `message_count_threshold` or `trigger`'):
+        with pytest.raises(UserError, match='requires `context_window_used_threshold`'):
             OpenAICompaction(stateless=True)
 
     def test_openai_compaction_serialization_name(self):


### PR DESCRIPTION
Adds an opt-in `context_window_used_threshold` to `OpenAICompaction` stateless mode. The capability calls `/responses/compact` when the latest response usage reaches that fraction of the model context window, and does nothing when usage or the context window is unknown.

The existing recorded OpenAI VCR flow now verifies that the first two turns remain unmodified and the third turn compacts after the recorded usage crosses the threshold.

### Tests

- `uv run pytest tests/test_capability_hooks.py::TestCompaction tests/models/test_openai_responses.py::test_openai_responses_compact_messages -q --tb=short`
- Commit hooks: format, lint, typecheck, cassette validation

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

