### PR TITLE
Clarify `send_audio` input and recoverable errors in agent skill

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -225,7 +225,9 @@ session to consume the **same part/event vocabulary as a streamed run** — `Par
 `FunctionToolCallEvent` / `FunctionToolResultEvent`, plus realtime control events (`RealtimeInputSpeechStartEvent`,
 `RealtimeInputSpeechEndEvent`, `RealtimeResponseInterruptedEvent`, ...). Use `RealtimeTurnCompleteEvent` as the exchange
 boundary, when generation and tool work are complete. This is not always the end of audible speech:
-on WebRTC sidebands, track playback with `RealtimeOutputSpeechStartEvent` and `RealtimeOutputSpeechEndEvent`.
+on WebRTC sidebands, track playback with `RealtimeOutputSpeechStartEvent` and `RealtimeOutputSpeechEndEvent`. Before
+passing raw microphone bytes to `send_audio`, convert them to mono PCM16 at `session.audio_input_sample_rate`; raw
+chunks carry no sample-rate metadata.
 
 ```python {test="skip"}
 from pydantic_ai import Agent
@@ -246,7 +248,8 @@ async def main(microphone_chunk: bytes):
     async with agent.realtime(
         'openai:gpt-realtime', model_settings=settings
     ).session() as session:
-        await session.send_audio(microphone_chunk)  # PCM16 bytes
+        # The chunk must already be mono PCM16 at `session.audio_input_sample_rate`.
+        await session.send_audio(microphone_chunk)
         await session.commit_audio()
         await session.create_response()
         # Input transcription can finish after the model's response.
@@ -261,8 +264,11 @@ async def main(microphone_chunk: bytes):
                     user_turn_complete = True
                 case RealtimeTurnCompleteEvent():
                     turn_complete = True
-                case RealtimeSessionErrorEvent(message=message):
-                    raise RuntimeError(message)
+                case RealtimeSessionErrorEvent(message=message, recoverable=recoverable):
+                    if recoverable:
+                        print('realtime warning:', message)
+                    else:
+                        raise RuntimeError(message)
             if turn_complete and user_turn_complete:
                 break
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -264,11 +264,9 @@ async def main(microphone_chunk: bytes):
                     user_turn_complete = True
                 case RealtimeTurnCompleteEvent():
                     turn_complete = True
-                case RealtimeSessionErrorEvent(message=message, recoverable=recoverable):
-                    if recoverable:
-                        print('realtime warning:', message)
-                    else:
-                        raise RuntimeError(message)
+                case RealtimeSessionErrorEvent(message=message, recoverable=True):
+                    # The connection remains usable, but this turn may not complete.
+                    raise RuntimeError(message)
             if turn_complete and user_turn_complete:
                 break
 


### PR DESCRIPTION
### Summary

- document that raw microphone chunks passed to `send_audio` must be mono PCM16 at `session.audio_input_sample_rate`
- clarify that a recoverable `RealtimeSessionErrorEvent` keeps the connection usable but can still terminate the current turn

This addresses realtime skill feedback originating from pydantic/skills#50.

### Tests

- `uv run pytest tests/test_skill_examples.py tests/realtime/test_session.py::test_control_events_and_recoverable_error_pass_through tests/realtime/test_session.py::test_fatal_session_error_raises tests/realtime/test_openai.py::test_map_error_event_with_type_and_code_is_recoverable -q` (60 passed)
- `uv run pre-commit run --files pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).