### PR TITLE
Pin the harness pre-warm to the locked versions

### DIFF
--- a/.github/scripts/prewarm-pydantic-ai-runner.sh
+++ b/.github/scripts/prewarm-pydantic-ai-runner.sh
@@ -22,5 +22,11 @@ if [ -z "${uv_bin}" ]; then
   exit 0
 fi
 echo "[harness-prewarm] using uv=${uv_bin} cache=${UV_CACHE_DIR}"
-"${uv_bin}" sync --script "${runner}" \
+# --frozen: install exactly what the lock pins, and never rewrite it. Without it
+# `uv sync --script` re-resolves and writes `pydantic-ai-runner.lock`, which
+# leaves the workspace dirty and makes the later `git checkout` of the PR head
+# abort ("Your local changes ... would be overwritten by checkout"). It also
+# warmed the cache with re-resolved versions the sandboxed `uv run --script`
+# then ignores in favour of the locked ones.
+"${uv_bin}" sync --script "${runner}" --frozen \
   || echo "::warning::harness uv pre-warm failed; agent will install under the firewall"


### PR DESCRIPTION
The `agent` job is currently failing on `main`. The three most recent CI Review runs all died at the same step, on the same file:

```
error: Your local changes to the following files would be overwritten by checkout:
	.github/scripts/pydantic-ai-runner.lock
Please commit your changes or stash them before you switch branches.
Aborting
```

([run 1](https://github.com/pydantic/pydantic-ai/actions/runs/33640606630/job/100283018519), [run 2](https://github.com/pydantic/pydantic-ai/actions/runs/33638901896/job/100277237605), [run 3](https://github.com/pydantic/pydantic-ai/actions/runs/33636475128/job/100269200930))

## Cause

`prewarm-pydantic-ai-runner.sh` runs:

```bash
"${uv_bin}" sync --script "${runner}"
```

Without `--frozen`, `uv sync --script` re-resolves and **rewrites** `pydantic-ai-runner.lock`. That leaves the workspace dirty, so the later `Check out the PR head` step in `pydantic-ai-pr-review.md`:

```bash
git checkout --detach "$HEAD_SHA"
```

refuses to switch. That step runs under `set -euo pipefail`, so the job fails there and the reviewer never runs.

## Reproduced locally

Against a clean checkout of `main`:

```console
$ uv sync --script .github/scripts/pydantic-ai-runner
$ git status --porcelain .github/scripts/pydantic-ai-runner.lock
 M .github/scripts/pydantic-ai-runner.lock          # +5/-8

$ git checkout .github/scripts/pydantic-ai-runner.lock
$ uv sync --script .github/scripts/pydantic-ai-runner --frozen
$ git status --porcelain .github/scripts/pydantic-ai-runner.lock
                                                    # clean
```

## A second, quieter effect

Re-resolving also warmed the cache with versions the lock does not pin — locally it installed `genai-prices==0.1.5` where the lock says `0.1.1`. The sandboxed `uv run --script` afterwards honours the lock, so those downloads were wasted and the firewalled run still had to fetch the pinned versions through the AWF firewall. That is the opposite of what the pre-warm exists to do, and it would have stayed invisible even once the checkout was unblocked.

## Why `--frozen` and not `--locked`

The pre-warm is deliberately non-fatal (`|| echo "::warning::..."`). `--frozen` installs what the lock pins and never writes it. `--locked` would additionally fail when the lock is merely stale, which isn't this script's job to police.

I also considered `git checkout --force` in the workflow instead. That treats the symptom, and it's the worse option here: it would silently discard whatever the pre-warm wrote rather than not writing it, and it touches checkout semantics in a step whose surrounding comments are careful about which branch's `.github/` content ends up in the tree. Fixing the write is narrower and has no bearing on that.

## Scope

One line in a hand-maintained script, plus a comment. `pydantic-ai-pr-review.lock.yml` invokes the script by path, so nothing needs regenerating — I recompiled with gh-aw `v0.83.4` (the version in the lock's metadata) and the generated workflow is byte-identical.

I can't exercise the workflow end to end from a fork — it's `workflow_run`-triggered and gated on collaborator + same-repo — so the verification above is the local reproduction rather than a green run here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

