### PR TITLE
Prevent synthetic reasoning IDs from reaching OpenAI Responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3624,7 +3624,14 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         if item.provider_name == self.system:
                             raw_content = (item.provider_details or {}).get('raw_content')
 
-                        if item.id and (should_send_item_id or raw_content):
+                        # Chat Completions stores its reasoning field name (`reasoning` or
+                        # `reasoning_content`) as a synthetic part ID. A matching provider name does
+                        # not make that a Responses item ID, but native Responses reasoning always
+                        # carries at least one of these protocol artifacts.
+                        native_reasoning = bool(
+                            item.id and (item.id.startswith('rs_') or item.signature or raw_content)
+                        )
+                        if item.id and native_reasoning and (should_send_item_id or raw_content):
                             signature: str | None = None
                             if (
                                 item.signature

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3624,13 +3624,11 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         if item.provider_name == self.system:
                             raw_content = (item.provider_details or {}).get('raw_content')
 
-                        # Chat Completions stores its reasoning field name (`reasoning` or
-                        # `reasoning_content`) as a synthetic part ID. A matching provider name does
-                        # not make that a Responses item ID, but native Responses reasoning always
-                        # carries at least one of these protocol artifacts.
-                        native_reasoning = bool(
-                            item.id and (item.id.startswith('rs_') or item.signature or raw_content)
-                        )
+                        # Chat Completions stores its content/reasoning field name as a synthetic
+                        # part ID. Preserve opaque IDs from compatible Responses APIs unless they
+                        # collide with one of those sentinels without carrying native wire data.
+                        synthetic_chat_reasoning = item.id in ('content', 'reasoning', 'reasoning_content')
+                        native_reasoning = not synthetic_chat_reasoning or bool(item.signature or raw_content)
                         if item.id and native_reasoning and (should_send_item_id or raw_content):
                             signature: str | None = None
                             if (

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -5102,6 +5102,75 @@ async def test_openai_responses_thinking_without_summary(allow_model_requests: N
     )
 
 
+@pytest.mark.parametrize(
+    ('thinking_part', 'expected_input'),
+    [
+        pytest.param(
+            ThinkingPart(content='thinking', id='reasoning_content', provider_name='openai'),
+            {'role': 'assistant', 'content': '<think>\nthinking\n</think>'},
+            id='chat-field-id',
+        ),
+        pytest.param(
+            ThinkingPart(content='thinking', id='rs_123', provider_name='openai'),
+            {
+                'id': 'rs_123',
+                'summary': [{'text': 'thinking', 'type': 'summary_text'}],
+                'encrypted_content': None,
+                'type': 'reasoning',
+            },
+            id='openai-responses-id',
+        ),
+        pytest.param(
+            ThinkingPart(content='thinking', id='compatible-api-id', provider_name='openai', signature='encrypted'),
+            {
+                'id': 'compatible-api-id',
+                'summary': [{'text': 'thinking', 'type': 'summary_text'}],
+                'encrypted_content': 'encrypted',
+                'type': 'reasoning',
+            },
+            id='compatible-responses-signature',
+        ),
+        pytest.param(
+            ThinkingPart(
+                content='summary',
+                id='compatible-api-id',
+                provider_name='openai',
+                provider_details={'raw_content': ['raw thinking']},
+            ),
+            {
+                'id': 'compatible-api-id',
+                'summary': [{'text': 'summary', 'type': 'summary_text'}],
+                'encrypted_content': None,
+                'type': 'reasoning',
+                'content': [{'text': 'raw thinking', 'type': 'reasoning_text'}],
+            },
+            id='compatible-responses-raw-cot',
+        ),
+    ],
+)
+async def test_openai_responses_reasoning_replay_requires_native_evidence(
+    allow_model_requests: None, thinking_part: ThinkingPart, expected_input: object
+) -> None:
+    response = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg_123',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(response)
+    model = OpenAIResponsesModel('gpt-5', provider=OpenAIProvider(openai_client=mock_client))
+    history: list[ModelMessage] = [ModelResponse(parts=[thinking_part], provider_name='openai')]
+
+    await model.request(history, None, ModelRequestParameters())
+
+    assert get_mock_responses_kwargs(mock_client)[0]['input'] == [expected_input]
+
+
 async def test_openai_responses_thinking_with_multiple_summaries(allow_model_requests: None):
     c = response_message(
         [

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -5108,7 +5108,17 @@ async def test_openai_responses_thinking_without_summary(allow_model_requests: N
         pytest.param(
             ThinkingPart(content='thinking', id='reasoning_content', provider_name='openai'),
             {'role': 'assistant', 'content': '<think>\nthinking\n</think>'},
-            id='chat-field-id',
+            id='chat-reasoning-content-field-id',
+        ),
+        pytest.param(
+            ThinkingPart(content='thinking', id='reasoning', provider_name='openai'),
+            {'role': 'assistant', 'content': '<think>\nthinking\n</think>'},
+            id='chat-reasoning-field-id',
+        ),
+        pytest.param(
+            ThinkingPart(content='thinking', id='content', provider_name='openai'),
+            {'role': 'assistant', 'content': '<think>\nthinking\n</think>'},
+            id='chat-tagged-content-field-id',
         ),
         pytest.param(
             ThinkingPart(content='thinking', id='rs_123', provider_name='openai'),
@@ -5148,7 +5158,7 @@ async def test_openai_responses_thinking_without_summary(allow_model_requests: N
         ),
     ],
 )
-async def test_openai_responses_reasoning_replay_requires_native_evidence(
+async def test_openai_responses_does_not_replay_chat_reasoning_ids(
     allow_model_requests: None, thinking_part: ThinkingPart, expected_input: object
 ) -> None:
     response = response_message(


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why we make these changes

Fallbacks can feed reasoning returned by an OpenAI-compatible Chat Completions model into an OpenAI Responses model. Chat reasoning field names such as `reasoning_content` were mistaken for native Responses item IDs, causing the next request to fail with `Invalid 'input[1].id'`; this was observed in [genai-prices](https://github.com/pydantic/genai-prices/issues/554#issuecomment-5430672696) and [pydantic-ai](https://github.com/pydantic/pydantic-ai/issues/8013#issuecomment-5509925186).

The parent issues cover unrelated work, so this PR references the exact reports without closing either issue.

## New public surface

None.

## User-visible behavior

```diff
Agent fallback
└─ OpenAIChatModel returns ThinkingPart(id='reasoning_content')
   └─ OpenAIResponsesModel.request()
      └─ OpenAIResponsesModel._map_messages()
-        └─ ResponseReasoningItemParam(id='reasoning_content') → HTTP 400
+        └─ EasyInputMessageParam(content='<think>…</think>') → portable replay
```

Native OpenAI `rs_` IDs and compatible Responses opaque IDs, signatures, and raw chain-of-thought data continue to use native reasoning replay.

## Verification

- [`test_openai_responses_does_not_replay_chat_reasoning_ids`](https://github.com/dsfaccini/pydantic-ai/blob/eeda67fb7/tests/models/test_openai_responses.py#L5105-L5185)
- Existing OpenAI summary/signature and DeepSeek raw-CoT replay tests

## What changes for existing users

Cross-model fallbacks no longer send Chat reasoning field names as Responses item IDs; native Responses histories are unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
