### PR TITLE
Treat empty `CompactionPart` content as a failed compaction

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2970,7 +2970,7 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    return not requires_encrypted_content and bool(part.content)
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_tool_availability.py
+++ b/tests/test_tool_availability.py
@@ -60,6 +60,7 @@ _INVALID_WIRE_BOUNDARIES = [
     pytest.param(CompactionPart(content='foreign', provider_name='anthropic'), 'openai', id='foreign-provider'),
     pytest.param(CompactionPart(provider_name='openai'), 'openai', id='openai-without-encrypted-content'),
     pytest.param(CompactionPart(provider_name='anthropic'), 'anthropic', id='anthropic-without-content'),
+    pytest.param(CompactionPart(content='', provider_name='anthropic'), 'anthropic', id='anthropic-empty-content'),
 ]
 
 


### PR DESCRIPTION
Closes #7773

`_compaction_part_is_wire_boundary()` currently treats an empty plaintext summary as a valid compaction boundary because it checks whether `part.content` is not `None`. This can cause `_post_compaction_window_for_response()` to discard earlier history even though the empty summary cannot replace it.

Use the same non-empty semantics as `CompactionPart.has_content()` for plaintext boundaries, while leaving the encrypted-content path unchanged. Add an empty-content case to the existing serving-provider wire-window tests.

### Tests

- `.venv\Scripts\pytest.exe tests/test_tool_availability.py -k serving_providers_wire_window` — 8 passed
- `.venv\Scripts\ruff.exe check pydantic_ai_slim/pydantic_ai/messages.py tests/test_tool_availability.py` — passed
- `.venv\Scripts\pyright.exe pydantic_ai_slim/pydantic_ai/messages.py` — 0 errors

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

