### PR TITLE
Install `strict-no-cover` only in the coverage job and authenticate CI's Git fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ env:
   UV_FROZEN: "1"
   # Ubuntu's system interpreters are older and slower than uv's optimized managed builds.
   UV_PYTHON_PREFERENCE: only-managed
+  # Authenticate the Git fetches uv makes for Git-sourced dependencies. Anonymous HTTPS clones are
+  # capped per client IP, and runners that share an egress pool exhaust that budget as a matrix
+  # fans out, at which point GitHub answers with a credential challenge that surfaces as
+  # `could not read Username for 'https://github.com'` and fails the install before any test runs.
+  # `GIT_CONFIG_*` applies to every `uv sync` and implicit `uv run` sync without writing credentials
+  # into the checkout, so `actions/checkout`'s `persist-credentials: false` still holds.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: url.https://x-access-token:${{ github.token }}@github.com/.insteadOf
+  GIT_CONFIG_VALUE_0: https://github.com/
 
 permissions:
   contents: read
@@ -875,11 +884,11 @@ jobs:
           enable-cache: true
           cache-suffix: dev
 
-      - run: uv sync --group dev
-      - run: uv run coverage combine
-      - run: uv run coverage report
+      - run: uv sync --group dev --group coverage
+      - run: uv run --no-sync coverage combine
+      - run: uv run --no-sync coverage report
 
-      - run: uv run strict-no-cover
+      - run: uv run --no-sync strict-no-cover
         env:
           COVERAGE_FILE: .coverage/.coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,10 +206,6 @@ dev = [
     "pytest-pretty>=1.3.0",
     "pytest-recording>=0.13.2",
     "boto3-stubs[bedrock-runtime]>=1.42.63",
-    # Pinned at the in-process rework, which reads `Coverage._get_file_reporter` -- a private API --
-    # and so declares `coverage>=7,<8`. A future coverage 8.x bump would be blocked on this
-    # dependency until upstream reworks it off that API.
-    "strict-no-cover @ git+https://github.com/pydantic/strict-no-cover.git@6c644106e03138abae01d8d60105d4a7ad4916a1",
     "pytest-xdist>=3.6.1",
     # Needed for PyCharm users
     "pip>=26.1",
@@ -229,6 +225,16 @@ dev = [
     "mcp-types>=2.0.0",
     # BlockBuster minor releases may add breaking detection rules; keep this test detector on 1.5.x.
     "blockbuster>=1.5.26,<1.6",
+]
+# `strict-no-cover` is only invoked by the final coverage audit, which runs on a GitHub-hosted
+# runner. Keeping it out of `dev` means the test matrix -- twenty cells of which run on Ubicloud --
+# never fetches a Git dependency during setup, so GitHub's per-IP unauthenticated clone limit
+# cannot take the matrix down.
+coverage = [
+    # Pinned at the in-process rework, which reads `Coverage._get_file_reporter` -- a private API --
+    # and so declares `coverage>=7,<8`. A future coverage 8.x bump would be blocked on this
+    # dependency until upstream reworks it off that API.
+    "strict-no-cover @ git+https://github.com/pydantic/strict-no-cover.git@6c644106e03138abae01d8d60105d4a7ad4916a1",
 ]
 lint = [
     "griffecli>=2.1.0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -5320,6 +5320,9 @@ xai-realtime = [
 ]
 
 [package.dev-dependencies]
+coverage = [
+    { name = "strict-no-cover" },
+]
 dev = [
     { name = "anyio" },
     { name = "asgi-lifespan" },
@@ -5346,7 +5349,6 @@ dev = [
     { name = "pytest-pretty" },
     { name = "pytest-recording" },
     { name = "pytest-xdist" },
-    { name = "strict-no-cover" },
     { name = "tavily-python" },
 ]
 lint = [
@@ -5390,6 +5392,7 @@ requires-dist = [
 provides-extras = ["ag-ui", "bedrock", "bedrock-mantle", "cohere", "dbos", "duckduckgo", "exa", "examples", "google-realtime", "groq", "huggingface", "mcp-tasks", "mistral", "openai-realtime", "openrouter", "prefect", "realtime", "retries", "sentence-transformers", "spec", "tavily", "temporal", "ui", "voyageai", "web-fetch", "xai", "xai-realtime"]
 
 [package.metadata.requires-dev]
+coverage = [{ name = "strict-no-cover", git = "https://github.com/pydantic/strict-no-cover.git?rev=6c644106e03138abae01d8d60105d4a7ad4916a1" }]
 dev = [
     { name = "anyio", specifier = ">=4.7.0" },
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
@@ -5416,7 +5419,6 @@ dev = [
     { name = "pytest-pretty", specifier = ">=1.3.0" },
     { name = "pytest-recording", specifier = ">=0.13.2" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "strict-no-cover", git = "https://github.com/pydantic/strict-no-cover.git?rev=6c644106e03138abae01d8d60105d4a7ad4916a1" },
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
 lint = [


### PR DESCRIPTION
Main has been red since [`db5ded4`](https://github.com/pydantic/pydantic-ai/commit/db5ded4673e4fc18e3db9faf96f2e72bc52ffa55), and it is not a test failure: the matrix cells die during `uv sync`, before any test runs.

```text
× Failed to download and build `strict-no-cover @ git+https://github.com/pydantic/strict-no-cover.git@6c644106...`
├─▶ failed to fetch commit `6c644106e03138abae01d8d60105d4a7ad4916a1`
    fatal: could not read Username for 'https://github.com': terminal prompts disabled
    fatal: expected flush after ref listing
hint: `strict-no-cover` was included because `pydantic-ai:dev` depends on `strict-no-cover`
```

### What is going on

`actions/checkout` runs with `persist-credentials: false`, so the Git fetch uv makes for `strict-no-cover` is anonymous. GitHub [caps unauthenticated HTTPS clones per client IP](https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/), and the Ubicloud runners share an egress pool, so twenty matrix cells fanning out with a cold cache exhaust that budget. Once it is gone GitHub answers with a credential challenge, and with no credentials to offer, Git fails the install.

Two observations pin it down:

- Every Ubicloud cell that still passes is a **cache hit** — it installs `strict-no-cover` from the uv cache and never contacts GitHub. Every cell that actually attempts the fetch fails. That is why reruns stop helping once the seedable cache keys are seeded: the four remaining failures reran on four different Ubicloud datacenters (`FSN1-DC15/16/23/24`) and four different VM hosts, and all four failed again.
- `ubuntu-latest` cells are unaffected because they are GitHub-hosted. That is also why #8019 was green as a fork PR and only went red once the `push` branch of the runner routing put it on Ubicloud.

`uv.lock` changing rotates every setup-uv cache key, so any lock bump re-exposes the whole matrix. Nothing here is a Ubicloud outage — their status page and GitHub's are both clean, and will stay clean, because this is the steady state.

### The change

`strict-no-cover` is invoked exactly once, by `uv run strict-no-cover` in the `coverage` job, which runs on `ubuntu-latest`. It has no business being installed by twenty test cells. Move it into a non-default `coverage` dependency group that only that job syncs; the coverage steps switch to `uv run --no-sync` so `uv run` cannot re-sync the extra group away. The Git revision and the `coverage>=7,<8` coupling are unchanged.

That alone removes every Git fetch from the Ubicloud matrix. Additionally, authenticate uv's Git fetches with the job's own `GITHUB_TOKEN` (`contents: read`) via `GIT_CONFIG_*`, so the failure class is gone for any Git dependency added later, on any runner. Env-based config applies to `uv sync` and to implicit `uv run` syncs alike without writing credentials into the checkout, so `persist-credentials: false` still holds.

Verified locally that the rewrite is real rather than silently ignored — `GIT_CURL_VERBOSE=1` shows the request going to `https://x-access-token:***@github.com/pydantic/strict-no-cover.git` — and that the group move lands where intended:

| `uv export` invocation | `strict-no-cover` |
| --- | --- |
| `--only-dev` | absent |
| `--all-extras --no-extra mcp-tasks` | absent |
| `--group dev --group coverage` | present |

`uv lock --locked` is clean; the `uv.lock` diff is the group move and nothing else.

### Longer term

Publishing the pinned revision to PyPI and replacing the VCS pin with a version constraint would take Git out of environment setup entirely. That belongs in `pydantic/strict-no-cover`, and this change is not blocked on it.

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXcdqUonLVdUwFmKQL4DVw


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

