### PR TITLE
Relax `test_outer_cancellation_cancels_pending_tools` readiness deadlines

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4213,8 +4213,8 @@ class TestMultipleToolCalls:
                 await result.get_output()  # pragma: no cover
 
         task = asyncio.create_task(run())
-        await asyncio.wait_for(first_done.wait(), timeout=1)
-        await asyncio.wait_for(pending_started.wait(), timeout=1)
+        await asyncio.wait_for(first_done.wait(), timeout=5)
+        await asyncio.wait_for(pending_started.wait(), timeout=5)
 
         task.cancel()
         with pytest.raises(asyncio.CancelledError):


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

The Python 3.14 all-extras job timed out while this cancellation test waited for its tool tasks to become ready. Raise both equivalent readiness guards to five seconds, matching the cancellation-test precedent in [#8004](https://github.com/pydantic/pydantic-ai/pull/8004).

[Failing CI job](https://github.com/pydantic/pydantic-ai/actions/runs/33664199418/job/100361820934?pr=7989)

Test plan: `uv run --python 3.14 pytest tests/test_streaming.py::TestMultipleToolCalls::test_outer_cancellation_cancels_pending_tools -p no:randomly -q`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

