### PR TITLE
Accept the environment-key call pattern in `GoogleProvider`'s overload

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -108,7 +108,7 @@ class GoogleProvider(BaseGoogleProvider):
     def __init__(
         self,
         *,
-        api_key: str,
+        api_key: str | None = None,
         http_client: AsyncHTTPClient | None = None,
         base_url: str | None = None,
         retry_options: HttpRetryOptions | None = None,
@@ -130,7 +130,8 @@ class GoogleProvider(BaseGoogleProvider):
 
         Args:
             api_key: The [API key](https://ai.google.dev/gemini-api/docs/api-key) to
-                use for authentication. It can also be set via the `GOOGLE_API_KEY` environment variable.
+                use for authentication. It can also be set via the `GOOGLE_API_KEY` environment variable,
+                or the legacy `GEMINI_API_KEY` environment variable (`GOOGLE_API_KEY` takes precedence).
             client: A pre-initialized client to use. Stored as-is, so a client built for Google Cloud
                 (`Client(vertexai=True, ...)`, or its current spelling `Client(enterprise=True, ...)`)
                 is used on that transport even though `name` stays `'google'`. `GoogleModel` reads the

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -63,7 +63,21 @@ def test_google_provider_without_api_key_raises_error(env: TestEnv):
             r" to use the Gemini API\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
         ),
     ):
-        GoogleProvider()  # pyright: ignore[reportCallIssue]  # deliberately no api_key, to test the missing-key error
+        GoogleProvider()
+
+
+@pytest.mark.parametrize('api_key_env_var', ['GOOGLE_API_KEY', 'GEMINI_API_KEY'])
+def test_google_provider_api_key_from_env(env: TestEnv, api_key_env_var: str):
+    """The current and legacy environment API keys both authenticate the Gemini API.
+
+    This is a unit test because authentication happens before any request a cassette could record.
+    """
+    for name in {'GOOGLE_API_KEY', 'GEMINI_API_KEY'} - {api_key_env_var}:
+        env.remove(name)
+    env.set(api_key_env_var, 'your-api-key')
+
+    provider = GoogleProvider()
+    assert provider.client._api_client.api_key == 'your-api-key'  # pyright: ignore[reportPrivateUsage]
 
 
 def test_google_provider_retry_options(env: TestEnv):


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David read the overload and test changes. He did not read the docstring clause, which was added
after his read.

- Closes https://github.com/pydantic/pydantic-ai/issues/7882

### Why we make these changes

`GoogleProvider` resolves `GOOGLE_API_KEY` (and the legacy `GEMINI_API_KEY`) when `api_key` is
omitted, but its non-`client` overload declared `api_key: str`, so the zero-argument call was a
Pyright error even though the docs show it (`docs/models/google.md`, `docs/input.md`). Both snippets
are `test="skip"`, and Markdown examples are not type-checked, so CI never saw the contradiction.
Widening the overload to
`api_key: str | None = None` is how `OpenAIProvider`, `AnthropicProvider`, `MistralProvider` and
`GroqProvider` already declare theirs.

### New public surface

None. The implementation signature already accepted `api_key=None`; the overload and the `api_key`
docstring are what change.

### User-visible behavior

```python
import os

from pydantic_ai.providers.google import GoogleProvider

os.environ['GOOGLE_API_KEY'] = 'your-api-key'

# Before: `reportCallIssue`, no overload matches. After: type-checks. Runtime identical either way.
provider = GoogleProvider()
```

### Verification

- `tests/providers/test_google.py::test_google_provider_api_key_from_env` is parametrized over both
  variable names and removes the other one per case, so neither case can pass on the other's value.
- `tests/providers/test_google.py::test_google_provider_without_api_key_raises_error` drops its
  `# pyright: ignore[reportCallIssue]`. `reportUnnecessaryTypeIgnoreComment` is enabled, so that
  ignore has to go, and the un-ignored call is what fails static check if the overload narrows again.

### What changes for existing users

Nothing at runtime. Existing calls keep their meaning, and the omitted-`api_key` call now type-checks.

### Credit

The fix and its test come from @AjayShivran's https://github.com/pydantic/pydantic-ai/pull/7940, which
carried the only test covering the legacy `GEMINI_API_KEY` path.

@PsychoRover reported the issue and opened https://github.com/pydantic/pydantic-ai/pull/7880.
@simpleqt opened https://github.com/pydantic/pydantic-ai/pull/7917.

All three were closed by the assignment guard before anyone reviewed them, not on merit.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


