### PR TITLE
Render `ToolChoice` on the settings API reference page

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -5,5 +5,6 @@
       inherited_members: true
       members:
         - ModelSettings
+        - ToolChoice
         - ToolOrOutput
         - ServiceTier


### PR DESCRIPTION
`ModelSettings.tool_choice` is typed `ToolChoice` (`settings.py:251`), but `docs/api/settings.md` does not list `ToolChoice` in its `members:` filter, so the rendered field shows a type name with nothing to resolve to.

The neighbouring aliases do resolve. That same members list already includes `ServiceTier`, used by `ModelSettings.service_tier`, and `ToolOrOutput`, which is itself one arm of `ToolChoice`'s union (`ToolChoiceScalar | list[str] | ToolOrOutput | None`). So the convention on this page is already to render the alias types that `ModelSettings` fields are declared with, and `ToolChoice` is the one that got missed.

It looks like a slip rather than a decision: #3611, which added the `tool_choice` setting, is also what added `ToolOrOutput` to this list, and it added `ToolChoice` to `pydantic_ai.__all__` at the same time. `ToolChoice` already carries a docstring ("Type alias for all valid tool_choice values"), so it renders without any other change.

One line, adding it to the list next to its own component type.

Ran `uv run pytest tests/test_examples.py -k settings` (8 passed, 2 skipped).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

About me: I'm a freshman in college. I found this by diffing `pydantic_ai.__all__` against what the API pages actually render, then checked that the omission was inconsistent with the page's own convention rather than assuming any unrendered export is a bug. I used Claude Code to check my reasoning and read the diff myself. If you keep this list deliberately short and would rather not add alias types, closing this is completely fine.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

