### PR TITLE
Ignore starlette's deprecated `anyio.abc.BlockingPortal` import warning in the test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,6 +450,12 @@ filterwarnings = [
     # logfire to use logging.warning() instead of warnings.warn() for this diagnostic — it's
     # informational, not a deprecation, and should never be able to crash execution.
     "ignore:Found propagated trace context:RuntimeWarning",
+    # `starlette.testclient` still references the `anyio.abc.BlockingPortal` alias that anyio 4.15.0
+    # deprecated, so the warning fires at import time and fails collection of every test module that
+    # imports it. There is nothing to bump to: starlette's `master` still uses the alias.
+    # TODO: Drop once starlette moves to `anyio.from_thread.BlockingPortal`.
+    # https://github.com/Kludex/starlette/issues/3497
+    "ignore:The anyio.abc.BlockingPortal alias is deprecated:DeprecationWarning:starlette.testclient",
 ]
 
 # https://coverage.readthedocs.io/en/latest/config.html#run


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-sonnet-5 on behalf of David.

The [latest versions canary](https://github.com/pydantic/pydantic-ai/actions/runs/33711554785) (job: `latest versions canary / resolve and test at latest versions`) went red on both matrix cells of the `v2.38.0` tag run, blocking the release. Four identical collection errors, all on `tests/test_ui_web.py`:

```
tests/test_ui_web.py:39: in <module>
    from starlette.testclient import TestClient
.venv/lib/python3.1X/site-packages/starlette/testclient.py:53: in <module>
    _PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
E   DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated, use anyio.from_thread.BlockingPortal instead.
```

`anyio` 4.15.0 (released 2026-09-02) made `anyio.abc.BlockingPortal` a deprecated lazy alias for `anyio.from_thread.BlockingPortal` (agronholm/anyio#1169). `starlette/testclient.py:53` evaluates that alias at module scope, so importing `starlette.testclient` now warns at import time — and our `filterwarnings = ["error"]` turns it into a collection error. `tests/test_ui_web.py` wraps the import in `try_import()`, which only swallows `ImportError`, so the escaped `DeprecationWarning` fails the module.

Not a runtime break for users: nothing we ship touches the alias (our only `anyio.abc` import is `TaskGroup` in `pydantic_graph/graph_builder.py`, which is not one of anyio's deprecated aliases). This is our own strict test config meeting an upstream deprecation starlette hasn't migrated off.

### The fix

A message- and module-scoped filter, matching the precedent already in that list (`ag-ui-protocol`, `dbos`/`opentelemetry`, `voyageai`, …): cause named, removal condition stated, upstream tracker linked.

Scoping it to `starlette.testclient` is deliberate. `anyio.abc` deprecates six other aliases (`CapacityLimiter`, `Condition`, `Event`, `Lock`, `Semaphore`, `CancelScope`); a message-only filter would cover `BlockingPortal` everywhere, including our own code if it ever picked it up. This one only silences starlette's call site.

Filed upstream: Kludex/starlette#3497.

### Verification

- `tests/test_ui_web.py`: 95 passed.
- Reproduced and confirmed the fix out-of-tree against `anyio==4.15.0` + `starlette==1.6.0`: `python -W error -c 'import starlette.testclient'` raises the `DeprecationWarning`; adding the exact filter string from this diff imports cleanly.
- `make format && make lint` clean.

### One thing for a maintainer to weigh

`latest-versions-canary.yml`'s header says the only two valid responses to a red canary are to migrate (and raise the floor) or add a temporary upper cap, and that "Suppressing the signal is not one of them."

Neither applies here. There is nothing to migrate to — starlette's `master` still uses the alias — and capping `anyio` or `starlette` would degrade real installs (`anyio` is a base requirement of three published packages) to work around a warning users never hit. I read this as the third class the same header already carves out: "Test tooling drifting under us … is a real but different problem." I left the workflow comment alone rather than widen a release-blocking fix, but if you want that clause spelled out, say so and I'll add it.

- Closes #<issue> — n/a, caught by the release-gating canary rather than reported.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

