### PR TITLE
Allow tag releases after intentional CI skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -925,10 +925,12 @@ jobs:
             }}
           jobs: ${{ toJSON(needs) }}
 
+  # `check` may succeed with intentionally skipped ancestors, so downstream jobs must override
+  # GitHub's default success check and inspect the result of their direct dependency.
   # Note: this should match the `deploy-docs-manual` job in manually-deploy-docs.yml
   deploy-docs:
     needs: [check]
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    if: ${{ !cancelled() && github.ref_type == 'tag' && needs.check.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token
@@ -956,7 +958,7 @@ jobs:
   release-build:
     name: build release artifacts
     needs: [check]
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    if: ${{ !cancelled() && github.ref_type == 'tag' && needs.check.result == 'success' }}
     runs-on: ubuntu-latest
 
     outputs:
@@ -998,7 +1000,7 @@ jobs:
   release:
     name: publish to PyPI
     needs: [release-build]
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    if: ${{ !cancelled() && github.ref_type == 'tag' && needs.release-build.result == 'success' }}
     runs-on: ubuntu-latest
 
     environment:
@@ -1026,7 +1028,7 @@ jobs:
   send-tweet:
     name: Send tweet
     needs: [release]
-    if: needs.release.result == 'success'
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -916,11 +916,13 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           # The canary runs on tag refs only, and `docs-only` runs only for Markdown-only PRs.
-          # Full CI jobs may skip only when the classifier selected that reduced PR path.
+          # On tags only `docs-only` may skip; full CI jobs may skip only on the reduced PR path.
           allowed-skips: >-
             ${{
               needs.classify.outputs.docs_only == 'true'
               && 'quality,mypy,test,test-durable-exec,test-lowest-versions,test-temporal-latest,test-examples,test-fastmcp-4,latest-versions-canary,coverage'
+              || github.ref_type == 'tag'
+              && 'docs-only'
               || 'docs-only,latest-versions-canary'
             }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
The `v2.38.1` tag completed the full test matrix and its aggregate `check`, but GitHub propagated the intentional `docs-only` skip through the release dependency chain. This skipped artifact building, docs deployment, and PyPI publishing.

Downstream jobs now override the implicit `success()` check, stop on cancellation, and require their immediate dependency to have succeeded. The aggregate gate also permits `latest-versions-canary` to skip only on non-tag runs, preserving the requirement that the canary pass before publishing a tag. This keeps the docs-only optimization and restores the existing release flow without changing its build/publish security split.

Closes #8042

## Verification

- `uv run pre-commit run check-yaml --files .github/workflows/ci.yml`
- `uv run pre-commit run zizmor --files .github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`
- Audited docs-only PR, full PR, `main` push, successful tag, failed check/canary/build, and cancellation paths

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
