### PR TITLE
Move the capability-event examples off Harness's `file_system` event namespace

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -302,7 +302,7 @@ Pydantic AI has two families of user-defined events. They ride the same stream a
 |---|---|---|
 | **Use it when** | your application wants to tell its own stream consumer or frontend something | your [capability](capabilities/overview.md) wants to tell other capabilities and the host application something |
 | **Emit from** | an application tool, an [output validator](output.md#output-validator-functions), a [hook](hooks.md), an `event_stream_handler`, or [`AgentRun.emit()`][pydantic_ai.run.AgentRun.emit] | a [capability](capabilities/custom.md) hook or a tool the capability contributes |
-| **Naming** | flat and process-wide, like `progress` | namespaced, like `file_system.file_read` |
+| **Naming** | flat and process-wide, like `progress` | namespaced, like `workspace.file_read` |
 | **Reaches the frontend** | yes, via the [AG-UI](ui/ag-ui.md) and [Vercel AI](ui/vercel-ai.md) adapters | no, it is an internal signal; re-publish it as a `CustomEvent` if the frontend needs it |
 | **Can carry a decision** | no | yes, with `dispatch='immediate'` |
 

--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -204,28 +204,28 @@ from pydantic_ai import CapabilityEvent, RunContext
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.toolsets import AgentToolset, FunctionToolset
 
-FILE_SYSTEM = 'file_system'
+WORKSPACE = 'workspace'
 
 
 @dataclass(kw_only=True)
-class FileWriteEvent(CapabilityEvent, namespace=FILE_SYSTEM):
+class FileWriteEvent(CapabilityEvent, namespace=WORKSPACE):
     path: str
     bytes_written: int
 
 
-file_system = FunctionToolset()
+workspace = FunctionToolset()
 
 
-@file_system.tool
+@workspace.tool
 async def write_file(ctx: RunContext[Any], path: str, content: str) -> str:
     await ctx.emit(FileWriteEvent(path=path, bytes_written=len(content)))
     return f'Wrote {path}'
 
 
 @dataclass
-class FileSystem(AbstractCapability[Any]):
+class Workspace(AbstractCapability[Any]):
     def get_toolset(self) -> AgentToolset[Any] | None:
-        return file_system
+        return workspace
 ```
 
 _(This example is complete, it can be run "as is")_
@@ -270,7 +270,7 @@ _(This example is complete, it can be run "as is")_
 
 An event hook belongs to the application rather than to a capability, so it is one of the places application `CustomEvent`s can be emitted.
 
-The namespace and event name form the serialized `kind` (for example, `file_system.file_read`), and the event name is derived from the class name unless you pass an explicit `name=`. A namespace is required: defining a `CapabilityEvent` subclass without one raises `TypeError` there and then, rather than letting an unnamespaced event reach the stream. You only give it once per family, though — an event subclassing another capability event inherits its namespace and contributes just its own name, so a shared base is the tidiest way to define a family — and a subclass can pass its own `namespace=` to move out of the one it inherited. Mark a base that only carries the namespace and fields common to the family `abstract=True`, and it stays out of the registry and can't be emitted itself, while its subclasses register as usual. Decorate it with `@dataclass` like any other event: an undecorated base contributes no fields at all, which is rejected rather than left to surface as a payload quietly missing them. The `kind` is the event's wire identifier, so renaming the class renames the tag with it, breaking compatibility wherever events outlive the emitting process — [durable execution](../durable_execution/overview.md) histories and caches, persisted event logs, subscribers matching on the kind. A capability published as a library should pin `name=` on each of its events. Kinds are registered when the class is defined and must be unique within the process; re-executing the same class definition (as when re-running a notebook cell) replaces the registration. Import the module defining an event before creating the adapter that deserializes it, as each pydantic `TypeAdapter` captures the kinds registered when it is created. Otherwise the event becomes an [`UnknownCapabilityEvent`][pydantic_ai.messages.UnknownCapabilityEvent] and a `UserWarning` is emitted, without losing payload fields; serializing it again preserves the wire representation so a later consumer can recover the typed event.
+The namespace and event name form the serialized `kind` (for example, `workspace.file_read`), and the event name is derived from the class name unless you pass an explicit `name=`. A namespace is required: defining a `CapabilityEvent` subclass without one raises `TypeError` there and then, rather than letting an unnamespaced event reach the stream. You only give it once per family, though — an event subclassing another capability event inherits its namespace and contributes just its own name, so a shared base is the tidiest way to define a family — and a subclass can pass its own `namespace=` to move out of the one it inherited. Mark a base that only carries the namespace and fields common to the family `abstract=True`, and it stays out of the registry and can't be emitted itself, while its subclasses register as usual. Decorate it with `@dataclass` like any other event: an undecorated base contributes no fields at all, which is rejected rather than left to surface as a payload quietly missing them. The `kind` is the event's wire identifier, so renaming the class renames the tag with it, breaking compatibility wherever events outlive the emitting process — [durable execution](../durable_execution/overview.md) histories and caches, persisted event logs, subscribers matching on the kind. A capability published as a library should pin `name=` on each of its events. Kinds are registered when the class is defined and must be unique within the process; re-executing the same class definition (as when re-running a notebook cell) replaces the registration. Import the module defining an event before creating the adapter that deserializes it, as each pydantic `TypeAdapter` captures the kinds registered when it is created. Otherwise the event becomes an [`UnknownCapabilityEvent`][pydantic_ai.messages.UnknownCapabilityEvent] and a `UserWarning` is emitted, without losing payload fields; serializing it again preserves the wire representation so a later consumer can recover the typed event.
 
 ### Reacting to events
 
@@ -325,12 +325,12 @@ from pydantic_ai import CapabilityEvent, RunContext
 from pydantic_ai.capabilities import AbstractCapability, on_event
 from pydantic_ai.toolsets import FunctionToolset
 
-FILE_SYSTEM = 'file_system'
+WORKSPACE = 'workspace'
 
 
 @dataclass(kw_only=True)
 class FileWriteStartEvent(
-    CapabilityEvent, namespace=FILE_SYSTEM, dispatch='immediate'
+    CapabilityEvent, namespace=WORKSPACE, dispatch='immediate'
 ):
     path: str
     cancelled: bool = False
@@ -341,10 +341,10 @@ class FileWriteStartEvent(
         self.cancel_reason = reason
 
 
-file_system = FunctionToolset()
+workspace = FunctionToolset()
 
 
-@file_system.tool
+@workspace.tool
 async def write_file(ctx: RunContext[Any], path: str, content: str) -> str:
     event = await ctx.emit(FileWriteStartEvent(path=path))  # (1)!
     if event.cancelled:  # (2)!

--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -315,7 +315,7 @@ Listeners run sequentially in capability order, and marked methods within one ca
 
 Decision events that need listener mutations before the emitter continues declare `dispatch='immediate'` on the event class:
 
-Building on the file-system capability above, a write can announce itself before it happens and let a listener veto it:
+Building on the workspace capability above, a write can announce itself before it happens and let a listener veto it:
 
 ```python {title="cancellable_capability_event.py"}
 from dataclasses import dataclass

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -110,7 +110,7 @@ Use hooks when the user wants observability, auditing, or light interception wit
 
 A capability announces things to other capabilities and to the host application with `CapabilityEvent`, not with the application-owned `CustomEvent` covered in AGENTS-CORE.md. The split is enforced: emitting a `CustomEvent` from a capability raises `UserError`, and so does emitting a `CapabilityEvent` from application code.
 
-Define each event as a dataclass subclass carrying a namespace, and await `ctx.emit(event)` from an async capability hook or a tool the capability contributes. The namespace plus the event name form the serialized `kind` (`file_system.file_read`), which is the wire identifier, so a published capability should pin `name=` on each event. The payload can't reuse the envelope's field names: `data`, `capability_id`, `tool_call_id`, `tool_name`, and `event_kind` are rejected at class definition.
+Define each event as a dataclass subclass carrying a namespace, and await `ctx.emit(event)` from an async capability hook or a tool the capability contributes. The namespace plus the event name form the serialized `kind` (`workspace.file_read`), which is the wire identifier, so a published capability should pin `name=` on each event. The payload can't reuse the envelope's field names: `data`, `capability_id`, `tool_call_id`, `tool_name`, and `event_kind` are rejected at class definition.
 
 React with `@on_event(SomeEvent, OtherEvent)` on an async capability method; a bare `@on_event` sees every `AgentStreamEvent`. Listeners run in capability order, then definition order, and the emitting capability receives its own events. This is the way to coordinate two capabilities without a shared object between them.
 
@@ -129,7 +129,7 @@ from pydantic_ai.capabilities import AbstractCapability, on_event
 
 
 @dataclass(kw_only=True)
-class FileReadEvent(CapabilityEvent, namespace='file_system', name='file_read'):
+class FileReadEvent(CapabilityEvent, namespace='workspace', name='file_read'):
     path: str
 
 


### PR DESCRIPTION
The capability-event examples in the capabilities guide and in the agent skill's capabilities reference declare their namespace as `file_system`, and the skill's `FileReadEvent` pins `name='file_read'` on top of it. That is exactly the `kind` [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/filesystem/)'s real `FileSystem` capability registers.

Kinds must be unique within a process, so a reader who copies the skill's example into an application that also uses Harness's `FileSystem` gets a `UserError` at import, raised from two class definitions that never mention each other. The two `docs/` examples don't collide today — `file_system.file_write` and `file_system.file_write_start` are not kinds Harness registers — but they teach the same squatting, and are one rename on either side away from the same failure.

The examples now use `workspace`. The guide's prose says to keep the namespace in a module-level constant and give it the capability's name or `id`, so the example capability is renamed to `Workspace` along with it and the advice still describes what the code does. The two prose lines that used `file_system.file_read` to illustrate the `kind` shape move with them.

Docs and skill only; no library code changes.

## Linked Issue

Fixes #8051

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior (the docs examples are the tests: `tests/test_examples.py` runs all four changed snippets)
- [x] Documentation updated

## Verification

`pytest tests/test_examples.py -k 'capabilities/overview or agent.md'` → 42 passed, 5 skipped. Ruff and pyright are unaffected (no library code changed).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

