### PR TITLE
Emit speech finalized by a tool call on `stream_transcripts()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -2421,6 +2421,11 @@ class RealtimeSession:
             call_part,
             response_usage_follows=event.response_usage_follows,
         ):
+            # Published as well as queued: folding the call in first ends the in-flight assistant part,
+            # so a turn that speaks *and* calls a tool ("let me look that up") emits its
+            # `PartEndEvent(SpeechPart)` here rather than on the translation path, and the transcript
+            # views would otherwise miss exactly the turns where the assistant speaks and acts.
+            self._publish_taps(out)
             await self._queue.put(out)
         mode = self._tool_manager.get_parallel_execution_mode()
         is_barrier = mode == 'sequential' or self._tool_manager.is_sequential(call_part)

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1384,6 +1384,73 @@ async def test_tool_call_round_builds_classic_history() -> None:
     )
 
 
+async def test_speech_finalized_by_a_tool_call_reaches_the_transcript_view() -> None:
+    """Speech the model finalizes by calling a tool still reaches `stream_transcripts()`.
+
+    A voice agent's most useful turn says something ("let me look that up") *and* calls a tool. The
+    tool-call dispatch path finalizes the in-flight `SpeechPart` before folding the call in, so that
+    turn's transcript only reaches subscribers if the dispatch path publishes to the taps the way the
+    ordinary translation path does.
+    """
+    conn = FakeRealtimeConnection(
+        [
+            InputTranscript(text="what's the weather in Paris", is_final=True),
+            OutputTranscript(text='Let me check that for you.', is_final=True),
+            ToolCall(tool_call_id='tc_1', tool_name='get_weather', args='{"city": "Paris"}'),
+            OutputTranscript(text="It's sunny in Paris", is_final=True),
+            ResponseDone(),
+        ]
+    )
+
+    async def runner(name: str, args: dict[str, Any], call_id: str) -> str:
+        return 'Sunny, 22C'
+
+    session = RealtimeSession(conn, runner, model_name='m')
+    async with session:
+        _, transcripts, deltas = await asyncio.gather(
+            drain_events(session),
+            aiter_to_list(session.stream_transcripts()),
+            aiter_to_list(session.stream_transcripts(delta=True)),
+        )
+
+    # The speech that preceded the call is on the view, not just in history.
+    assert transcripts == snapshot(
+        [
+            SpeechPart(speaker='user', transcript="what's the weather in Paris"),
+            SpeechPart(speaker='assistant', transcript='Let me check that for you.'),
+            SpeechPart(speaker='assistant', transcript="It's sunny in Paris"),
+        ]
+    )
+    # The same turns as history records, so a consumer reading the view sees what the assistant said.
+    assert [
+        (part.speaker, part.transcript)
+        for message in session.new_messages()
+        for part in message.parts
+        if isinstance(part, SpeechPart)
+    ] == [(part.speaker, part.transcript) for part in transcripts]
+    # The delta view already tracked the pre-call speech; ending its turn clears the running text so
+    # the answer's deltas don't continue it.
+    assert deltas == snapshot(
+        [
+            TranscriptUpdate(
+                index=0,
+                speaker='user',
+                delta="what's the weather in Paris",
+                transcript="what's the weather in Paris",
+            ),
+            TranscriptUpdate(
+                index=1,
+                speaker='assistant',
+                delta='Let me check that for you.',
+                transcript='Let me check that for you.',
+            ),
+            TranscriptUpdate(
+                index=3, speaker='assistant', delta="It's sunny in Paris", transcript="It's sunny in Paris"
+            ),
+        ]
+    )
+
+
 async def test_late_input_transcript_still_precedes_the_response_it_prompted() -> None:
     """A user turn keeps its place in history however late the provider transcribes it.
 


### PR DESCRIPTION
`RealtimeSession` has two paths that put translated events on the session queue, and only one of them fed the transcript taps.

`_handle_non_tool_pump_event` publishes as it enqueues, but `_dispatch_tool_call` only enqueued. That matters because `_handle_tool_call_part` opens by calling `_finalize_assistant_part`: a response that both speaks and calls a tool — "let me look that up for you" plus the lookup — has its in-flight `SpeechPart` ended *there*, so its `PartEndEvent(SpeechPart)` was emitted on the one path that never reached `_publish_taps`.

The result: `stream_transcripts()` silently dropped exactly the turns where the assistant speaks *and* acts, while `all_messages()` and the main event stream kept them. For a voice agent that's the most load-bearing turn there is, and a consumer treating the transcript view as the record of what was said reads it as the model having gone quiet.

The fix is to publish on that path too, so both dispatch paths feed the taps.

Scope — the two adjacent paths that share the shape but do *not* share the defect, checked rather than assumed:

- `_complete_tool_call`'s events also bypass `_publish_taps`, but it returns only a `FunctionToolResultEvent`, which `_publish_taps` ignores. Adding the call there would be a no-op.
- The cancellation/reconnect path (`_finalize_lost_state`) does call `_finalize_assistant_part`, but its events are returned through `_handle_control_event` → `_translate_event` → the publishing path, so they already reach the taps. The `close()` caller deliberately discards them, with no consumer left.

The delta view (`stream_transcripts(delta=True)`) was never affected — transcript deltas arrive on the translation path — and neither were the audio taps, which the tool-call path never feeds. The new test pins both alongside the fixed behavior.

Reported directly rather than via an issue.

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

