### PR TITLE
Stop the docs navigation dispatcher failing on its own acknowledgement

### DIFF
--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -91,8 +91,11 @@ jobs:
           )
 
           # Update an existing navigation or legacy preview comment on reruns.
+          # `gh api` rejects `--slurp` together with `--jq`, so the filter runs in a
+          # separate `jq`. `--slurp` is what makes the pages one array of arrays, which
+          # is why the filter opens with `.[][]`.
           existing=$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-            --jq '([.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))] | last).url // empty')
+            | jq -r '([.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))] | last).url // empty')
           if [ -n "$existing" ]; then
             gh api -X PATCH "$existing" -f body="$body"
           else


### PR DESCRIPTION
## What happened

On #8063 the `Docs Navigation Check` job went red while the check it dispatches had already **passed**. The PR ended up with two comments giving opposite impressions: the real one from `pydantic-docs` saying "Navigation passed", and a degraded one saying validation was queued but the acknowledgement could not be posted.

The steps run in the order verify, app-token, **dispatch**, acknowledge. Dispatch succeeded, so the validation ran and reported normally. The acknowledgement step then failed on:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

`gh api` rejects that flag combination outright, and the step runs under `bash -e`, so the failed command substitution ended the step and turned the whole job red after the useful work was already done.

## Fix

Run the filter in a separate `jq`. `--paginate --slurp` stays, so the pages still arrive as one array of arrays and the existing filter keeps its leading `.[][]`; a comment now records why that shape is what it is, since the `--slurp` and the `.[][]` are easy to break independently.

The failure-reporting fallback behaved correctly throughout, which is the only reason the missing acknowledgement was visible rather than silent.

## Verification

- `.github/scripts/test_docs_navigation_workflow.py`: 2 passed. It asserts on both `--paginate --slurp` and `| last).url // empty`, which this change preserves.
- `bash -n` on the extracted step script: clean.

This path had never run before: every previous `Docs Navigation Check` run in recent history shows `skipped`, because the job only executes when `trigger:docs` is applied. #8063 was the first real execution, which is why a latent flag incompatibility surfaced now.

Note that `pull_request_target` runs the base branch's copy of the workflow, so this cannot prove itself green on its own PR. It takes effect for navigation PRs once it is on `main`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

