### PR TITLE
Make the `cancel_siblings.py` docs example deterministic

### DIFF
--- a/docs/graph/builder/joins.md
+++ b/docs/graph/builder/joins.md
@@ -498,10 +498,10 @@ async def main():
 
     @g.step
     async def search(ctx: StepContext[SearchState, None, str]) -> str:
-        """Simulate a slow search operation."""
-        # make the search artificially slower for 'item4' and 'item5'
-        search_duration = 0.1 if ctx.inputs not in {'item4', 'item5'} else 1.0
-        await asyncio.sleep(search_duration)
+        """Simulate a search that never finishes for 'item4' and 'item5'."""
+        if ctx.inputs in {'item4', 'item5'}:
+            # These searches only ever end by being canceled.
+            await asyncio.Event().wait()
         ctx.state.searches_completed += 1
         return ctx.inputs
 


### PR DESCRIPTION
`test_docs_examples[docs/graph/builder/joins.md:468:cancel_siblings.py]` flakes. It reddened an unrelated realtime PR (#8062) on `test on 3.12 (lowest-versions)` with:

```
-    #> Searches completed: 3
+    #> Searches completed: 4
```

The example gave `item1`, `item2` and `target_item` a `0.1` second sleep and `item4`/`item5` a `1.0` second one, so `Searches completed: 3` only held while the reducer's `cancel_sibling_tasks()` fired inside that ~0.9 second margin. Under xdist on a loaded runner the event loop can stall past it — the slow searches' sleeps elapse too, they increment the counter, and the example prints 4 or 5.

The searches that are meant to be cancelled now await an event that is never set, so they cannot complete on their own however the loop is scheduled, and the ones that should finish no longer sleep at all. The line count is unchanged, so the example still starts at line 468 and keeps its test id.

Reproduction, injecting a blocking `time.sleep` into the running loop to emulate a loaded runner (12-50 graph runs per cell, `(result, searches_completed)`):

| Injected stall | Old timings | This PR |
| --- | --- | --- |
| none | `('target_item', 3)` | `('target_item', 3)` |
| 1.0s at t=0.05s | **`('target_item', 5)`** | `('target_item', 3)` |
| 1.0s at t=0.0s | — | `('target_item', 3)` |
| 2.0s at t=0.001s | — | `('target_item', 3)` |
| 3.0s at t=0.0005s | — | `('target_item', 3)` |
| 1.5s at t=0.01s | — | `('target_item', 3)` |

Worth noting the old form could also race the other way: because all three fast searches shared one sleep duration, a stall landing between `target_item` completing and the reducer cancelling could have cancelled `item1`/`item2` before they incremented, printing fewer than 3. Neither direction is reachable now.

`cancel_sibling_tasks` keeps its timing-free unit coverage in `tests/graph/builder/test_graph_edge_cases.py` (`test_reducer_stop_iteration` and its explicit-fork-ids sibling), so this example is not the regression guard for the cancellation behavior itself — which is why making the cancelled searches wait indefinitely is safe here rather than load-bearing.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

