### PR TITLE
Give the front-page use-case tabs stable analytics slugs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ description: "How Python does AI: agents, realtime voice, image generation, embe
 
 From simple typed data extraction to complex, long-running multi-agent collaboration, Pydantic AI and [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/) have got you covered.
 
-=== "Coding agent"
+=== "Coding agent" {#coding-agent}
 
     A complete coding agent in your terminal: workspace-rooted [file access](https://pydantic.dev/docs/ai/harness/filesystem/), allowlisted [shell](https://pydantic.dev/docs/ai/harness/shell/), [repo orientation](https://pydantic.dev/docs/ai/harness/repo-context/), [planning](https://pydantic.dev/docs/ai/harness/planning/), and [context management](https://pydantic.dev/docs/ai/harness/compaction/) that survives long sessions. Here with [web search](capabilities/web-search.md) and a second-opinion [advisor](https://pydantic.dev/docs/ai/harness/advisor/) snapped on alongside:
 
@@ -86,7 +86,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
 
     **Build this →** [Coder](https://pydantic.dev/docs/ai/harness/coder/), from the [Harness](https://pydantic.dev/docs/ai/harness/)
 
-=== "Data extraction"
+=== "Data extraction" {#data-extraction}
 
     Give the agent an [output type](output.md) and [tools](tools.md), and every run comes back validated and typed:
 
@@ -125,7 +125,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
 
     **Build this →** [Agents](agent.md), [Function Tools](tools.md), and [Structured Output](output.md)
 
-=== "Durable workflow"
+=== "Durable workflow" {#durable-workflow}
 
     Attach [`TemporalDurability`](durable_execution/temporal.md) and the same agent runs inside a [Temporal](durable_execution/temporal.md) workflow under [durable execution](durable_execution/overview.md): every model and tool call becomes a durable activity, so a run working through a background queue survives restarts, failures, and long waits:
 
@@ -162,7 +162,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
 
     **Build this →** [Durable Execution](durable_execution/overview.md)
 
-=== "Realtime voice"
+=== "Realtime voice" {#realtime-voice}
 
     Put the same agent on a live voice session, [tools](realtime/tools.md) and [capabilities](realtime/capabilities.md) included:
 
@@ -197,7 +197,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
 
     **Build this →** [Realtime Voice](realtime/overview.md), starting from the [voice assistant example](examples/realtime-voice.md)
 
-=== "Image gen"
+=== "Image gen" {#image-gen}
 
     Ask for an image and make it the run's typed [output](output.md):
 


### PR DESCRIPTION
Pairs with **pydantic/unified-docs#251**, which implements P0.1 of the docs-analytics plan. This is the docs-repo half: five one-line changes marking the "What are you building?" tabs with stable analytics keys.

```diff
-=== "Coding agent"
+=== "Coding agent" {#coding-agent}
```

<!-- Docs-only change; no linked issue. -->

### Why

The AI docs are the site's second-largest section by pageviews and have no named analytics events, so these tabs are measurable only through autocapture — which keys off two identifiers that both move on their own:

- **Starlight's panel ids are page-global render-order artifacts.** #8064 reordered two tabs and removed one, so `#tab-panel-152` and `-153` swap meaning at the next deploy and `-155` disappears, silently re-pointing every historical series.
- **Rendered link text is rewritten by browser translation**, and #8064 also renamed two of the English labels.

Both keys break at the same deploy, so this is the cleanest moment to introduce one that doesn't.

The slug is authored rather than derived from the label precisely because a rename is what just happened here.

### Compatibility

This renders identically today. The current `transformTabs` pattern in unified-docs matches only the quoted label and ignores the rest of the line, so `{#slug}` is dropped on the deployed site and picked up once #251 lands. The two PRs can merge in either order.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EkyQrAYWj3qzZBvB7YHUR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

