### PR TITLE
Preserve LoadCapabilityReturn extras in message history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py
+++ b/pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py
@@ -37,6 +37,7 @@ class LoadCapabilityArgs(TypedDict):
     """ID of the capability to load."""
 
 
+@pydantic.with_config(pydantic.ConfigDict(extra='allow'))
 class LoadCapabilityReturn(TypedDict):
     """Typed return value for the `load_capability` tool."""
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2344,6 +2344,31 @@ def test_narrow_type_upgrades_json_string_content():
     assert narrowed.content == {'instructions': 'hi'}
 
 
+def test_load_capability_return_content_extras_survive_roundtrip():
+    content = {'instructions': 'hi', 'version': 2, 'extra': 'KEEP_ME'}
+    raw_messages = [
+        {
+            'kind': 'request',
+            'parts': [
+                {
+                    'part_kind': 'tool-return',
+                    'tool_kind': 'capability-load',
+                    'tool_name': 'load_capability',
+                    'tool_call_id': 'c1',
+                    'content': content,
+                }
+            ],
+        }
+    ]
+
+    messages = ModelMessagesTypeAdapter.validate_python(raw_messages)
+    assert isinstance(messages[0].parts[0], LoadCapabilityReturnPart)
+    assert messages[0].parts[0].content == content
+
+    serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    assert json.loads(serialized)[0]['parts'][0]['content'] == content
+
+
 def test_stripped_tool_kind_part_survives_roundtrip():
     """A base part that kept an unvalidatable `tool_kind` would be routed back to the typed subclass
     by the discriminator and fail validation on reload; stripping it preserves the round-trip."""


### PR DESCRIPTION
## Summary

- Preserve unknown keys in typed `load_capability` tool-return content during message-history serialization.
- Add a regression test for promotion and JSON round trips.

Fixes #8002

## Testing

- `uv run --no-project pytest tests/test_messages.py::test_load_capability_return_content_extras_survive_roundtrip -q`
- `uv run --no-project ruff check pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py tests/test_messages.py`
- `uv run --no-project ruff format --check pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py tests/test_messages.py`
- `.venv\Scripts\pyright.exe pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py tests/test_messages.py`

## Notes

- The full `tests/test_messages.py` module has two unrelated Windows MIME/newline failures on this host.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

