### PR TITLE
docs(durable): explain how tool calls run durably and toolset extension points

### DIFF
--- a/docs/durable_execution/overview.md
+++ b/docs/durable_execution/overview.md
@@ -19,3 +19,20 @@ Additional external SDK integrations:
 
 - [Kitaru](./kitaru.md)
 - [Apache Airflow](./airflow.md)
+
+## How tool calls run durably
+
+Each engine wraps your toolsets so that every tool call executes inside the engine's durable unit (a Temporal activity, Prefect task, DBOS step, and so on). The shared scaffolding lives in `pydantic_ai.durable_exec._toolset` and is specialized per toolset kind:
+
+- `DurableFunctionToolset` wraps `FunctionToolset` (your `@agent.tool` functions).
+- `DurableDynamicToolset` wraps toolsets supplied at run time via `DynamicToolset`.
+- `DurableMCPToolset` wraps `MCPToolset` connections.
+
+These wrappers are applied automatically by the engine-specific agent classes; you do not construct them by hand. They exist so the engine can run one tool call per durable unit and replay it deterministically after a failure.
+
+Two extension points control per-tool behavior:
+
+- `resolve_tool_config` maps each tool to either a durable config mapping (merged into the engine's per-operation config, e.g. a Temporal `ActivityConfig`) or `False` to run the tool inline, outside any durable unit. Engines that restrict inline execution reject it here with their own error wording (for example, Temporal requires async tools and forbids inline MCP tools).
+- `lifecycle` controls when the wrapped toolset is entered relative to the durable context: `'enter-outside-durable'` (function and MCP toolsets; entered only outside the durable unit), `'enter-always'`, or `'enter-never'` (dynamic toolsets, whose members are managed per step).
+
+If you need custom hook work to survive retries, move it into a durable unit too — see [durable capability operations](../capabilities/custom.md#durable-capability-operations).

--- a/docs/durable_execution/overview.md
+++ b/docs/durable_execution/overview.md
@@ -22,7 +22,7 @@ Additional external SDK integrations:
 
 ## How tool calls run durably
 
-Each engine wraps your toolsets so that every tool call executes inside the engine's durable unit (a Temporal activity, Prefect task, DBOS step, and so on). The shared scaffolding lives in `pydantic_ai.durable_exec._toolset` and is specialized per toolset kind:
+Each engine wraps your toolsets so that, by default, every tool call executes inside the engine's durable unit (a Temporal activity, Prefect task, DBOS step, and so on). The shared scaffolding lives in `pydantic_ai.durable_exec._toolset` and is specialized per toolset kind:
 
 - `DurableFunctionToolset` wraps `FunctionToolset` (your `@agent.tool` functions).
 - `DurableDynamicToolset` wraps toolsets supplied at run time via `DynamicToolset`.
@@ -33,6 +33,6 @@ These wrappers are applied automatically by the engine-specific agent classes; y
 Two extension points control per-tool behavior:
 
 - `resolve_tool_config` maps each tool to either a durable config mapping (merged into the engine's per-operation config, e.g. a Temporal `ActivityConfig`) or `False` to run the tool inline, outside any durable unit. Engines that restrict inline execution reject it here with their own error wording (for example, Temporal requires async tools and forbids inline MCP tools).
-- `lifecycle` controls when the wrapped toolset is entered relative to the durable context: `'enter-outside-durable'` (function and MCP toolsets; entered only outside the durable unit), `'enter-always'`, or `'enter-never'` (dynamic toolsets, whose members are managed per step).
+- `lifecycle` controls when the wrapped toolset is entered relative to the durable context. Its value is engine- and toolset-specific: `'enter-outside-durable'`, `'enter-always'`, or `'enter-never'` (dynamic toolsets, whose members are managed per step).
 
 If you need custom hook work to survive retries, move it into a durable unit too — see [durable capability operations](../capabilities/custom.md#durable-capability-operations).


### PR DESCRIPTION
## What changed

Adds a "How tool calls run durably" section to the durable execution overview documenting the previously undocumented toolset layer (`pydantic_ai.durable_exec._toolset`):

- the three wrappers (`DurableFunctionToolset`, `DurableDynamicToolset`, `DurableMCPToolset`) and that engines apply them automatically;
- the `resolve_tool_config` extension point (config mapping merged into the engine's per-operation config, or `False` for inline execution, with engine restrictions such as Temporal requiring async tools and forbidding inline MCP tools);
- the `lifecycle` values (`enter-outside-durable`, `enter-always`, `enter-never`) and which wrapper uses which;
- a pointer to durable capability operations for custom hook work.

## Why

#7704 notes the `_toolset` module is decoupled from the core framework and its usage conditions are not documented; the overview page had no mention of toolsets at all. All statements were verified against `_toolset.py` and the temporal/prefect engine implementations.

## How I checked

- Cross-referenced every claim with `pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py`, `temporal/_function_toolset.py`, `temporal/_mcp_toolset.py`, `temporal/_dynamic_toolset.py` and the prefect equivalents;
- docs-only change, no code touched.

Related: #7704

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

