### PR TITLE
Reject invalid `DeferredToolResults.approvals` values

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deferred.py
+++ b/pydantic_ai_slim/pydantic_ai/_deferred.py
@@ -16,10 +16,10 @@ from __future__ import annotations as _annotations
 from dataclasses import KW_ONLY, dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
-from pydantic import Discriminator, Tag
+from pydantic import Discriminator, StrictBool, Tag
 
 from . import _utils
-from .exceptions import ModelRetry, ToolFailed
+from .exceptions import ModelRetry, ToolFailed, UserError
 from .messages import RetryPromptPart, ToolCallPart, ToolReturn
 
 
@@ -165,8 +165,8 @@ class DeferredToolResults:
 
     calls: dict[str, DeferredToolCallResult | Any] = field(default_factory=dict[str, DeferredToolCallResult | Any])
     """Map of tool call IDs to results for tool calls that required external execution."""
-    approvals: dict[str, bool | DeferredToolApprovalResult] = field(
-        default_factory=dict[str, bool | DeferredToolApprovalResult]
+    approvals: dict[str, StrictBool | DeferredToolApprovalResult] = field(
+        default_factory=dict[str, StrictBool | DeferredToolApprovalResult]
     )
     """Map of tool call IDs to results for tool calls that required human-in-the-loop approval."""
     metadata: dict[str, dict[str, Any]] = field(default_factory=dict[str, dict[str, Any]])
@@ -190,6 +190,11 @@ class DeferredToolResults:
                 approval = ToolApproved()
             elif approval is False:
                 approval = ToolDenied()
+            elif not isinstance(approval, (ToolApproved, ToolDenied)):
+                raise UserError(
+                    f'Invalid approval result for tool call {tool_call_id!r}: '
+                    'expected `bool`, `ToolApproved`, or `ToolDenied`'
+                )
             tool_call_results[tool_call_id] = approval
 
         call_result_types = _utils.get_union_args(DeferredToolCallResult)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,11 +3,11 @@ import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 import pydantic_core
 import pytest
-from pydantic import AliasChoices, BaseModel, Field, TypeAdapter, WithJsonSchema
+from pydantic import AliasChoices, BaseModel, Field, TypeAdapter, ValidationError, WithJsonSchema
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from pydantic_core import PydanticSerializationError, core_schema
 from pytest import LogCaptureFixture
@@ -1766,6 +1766,40 @@ def test_tool_raises_approval_required():
     assert result.output == snapshot('Done!')
 
 
+@pytest.mark.parametrize('approval', [None, 'yes'])
+def test_invalid_deferred_tool_approval_does_not_execute(approval: object):
+    """Not a VCR test: invalid approval values are application inputs, not provider responses."""
+    executed = False
+
+    def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('my_tool', {}, tool_call_id='call-1')])
+        return ModelResponse(parts=[TextPart('Done!')])  # pragma: no cover
+
+    agent = Agent(FunctionModel(llm), output_type=[str, DeferredToolRequests])
+
+    @agent.tool_plain(requires_approval=True)
+    def my_tool() -> str:  # pragma: no cover
+        nonlocal executed
+        executed = True
+        return 'executed'
+
+    result = agent.run_sync('Run the tool')
+    assert isinstance(result.output, DeferredToolRequests)
+    invalid_approval = cast(bool | ToolApproved | ToolDenied, approval)  # Simulate invalid runtime input.
+
+    with pytest.raises(
+        UserError,
+        match="Invalid approval result for tool call 'call-1': expected `bool`, `ToolApproved`, or `ToolDenied`",
+    ):
+        agent.run_sync(
+            message_history=result.all_messages(),
+            deferred_tool_results=DeferredToolResults(approvals={'call-1': invalid_approval}),
+        )
+
+    assert not executed
+
+
 @pytest.mark.parametrize('end_strategy', ['early', 'graceful', 'exhaustive'])
 def test_resume_deferred_tool_with_invalid_output_call(end_strategy: EndStrategy):
     """Not a VCR test: pins internal resume validation and message-history shape via `FunctionModel`,
@@ -2904,6 +2938,11 @@ def test_deferred_tool_results_serializable():
     assert TypeAdapter(DeferredToolCallResult).validate_python(results.calls['tool-failed']) == ToolFailed(
         'The tool failed.'
     )
+
+
+def test_deferred_tool_results_does_not_coerce_approval():
+    with pytest.raises(ValidationError):
+        TypeAdapter(DeferredToolResults).validate_python({'approvals': {'call-1': 'yes'}})
 
 
 def test_deferred_tool_call_result_tool_failed():


### PR DESCRIPTION
Closes #8060

Invalid deferred approval values could pass the completeness check and reach tool execution. This makes approval handling fail closed at the `DeferredToolResults` boundary:

- direct invalid values raise `UserError`
- deserialized approval values must be strict booleans
- valid booleans, `ToolApproved`, and `ToolDenied` keep their existing behavior

> [!WARNING]
> **Compatibility impact:** Code passing values outside the documented approval types, or relying on Pydantic to coerce strings or integers to booleans, now raises an error.
>
> **Why this can ship in a minor release:** These values were outside the declared contract, and accepting them could execute a protected tool without explicit approval.
>
> **Migration:** Pass `True`, `False`, `ToolApproved`, or `ToolDenied`. Omit unresolved call IDs until a decision is available.

**Release note:** Invalid deferred approval values now fail closed instead of executing protected tools or becoming tool results.

### Verification

- `uv run pytest tests/test_tools.py -k 'deferred_tool or approval_required' -q`
- `uv run pytest tests/test_capability_output_hooks.py -k deferred -q`
- targeted Pyright for both changed files
- Ruff check and format check

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** are included.
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver where required. No API-check waiver is required for this change.
- [x] **PR title** is fit for the release changelog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

