### PR TITLE
Dispatch tool calls with the live `ToolDefinition` in `CombinedToolset` and `FunctionToolset`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from typing_extensions import Self
@@ -22,8 +22,7 @@ class _CombinedToolsetTool(ToolsetTool[AgentDepsT]):
 
     source_toolset: AbstractToolset[AgentDepsT]
     source_tool: ToolsetTool[AgentDepsT]
-    combined_tool_def_fields: tuple[tuple[str, object], ...]
-    combined_toolset_id: str | None
+    original_combined_tool: _CombinedToolsetTool[AgentDepsT] | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass
@@ -84,7 +83,7 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
                 if tool_def.toolset_id is None and tool_toolset.id is not None:
                     tool_def = replace(tool_def, toolset_id=tool_toolset.id)
 
-                all_tools[name] = _CombinedToolsetTool(
+                combined_tool = _CombinedToolsetTool(
                     toolset=tool_toolset,
                     tool_def=tool_def,
                     max_retries=tool.max_retries,
@@ -92,13 +91,9 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
                     args_validator_func=tool.args_validator_func,
                     source_toolset=toolset,
                     source_tool=tool,
-                    combined_tool_def_fields=tuple(
-                        (field.name, getattr(tool_def, field.name))
-                        for field in fields(tool_def)
-                        if field.name != 'toolset_id'
-                    ),
-                    combined_toolset_id=tool_def.toolset_id,
                 )
+                combined_tool.original_combined_tool = combined_tool
+                all_tools[name] = combined_tool
         return all_tools
 
     async def call_tool(
@@ -106,21 +101,11 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
     ) -> Any:
         assert isinstance(tool, _CombinedToolsetTool)
         source_tool = tool.source_tool
-        source_tool_def = tool.tool_def
-        toolset_id_changed = source_tool_def.toolset_id != tool.combined_toolset_id
-        other_field_changed = any(
-            getattr(source_tool_def, name) is not original_value
-            for name, original_value in tool.combined_tool_def_fields
-        )
-        if not toolset_id_changed and not other_field_changed:
-            source_tool_def = source_tool.tool_def
-        elif not toolset_id_changed:
-            source_tool_def = replace(source_tool_def, toolset_id=source_tool.tool_def.toolset_id)
-
-        if source_tool.tool_def is not source_tool_def:
+        if tool is not tool.original_combined_tool:
+            source_tool_def = replace(tool.tool_def, toolset_id=source_tool.tool_def.toolset_id)
             source_tool = replace(source_tool, tool_def=source_tool_def)
-        if isinstance(source_tool, FunctionToolsetTool) and source_tool.timeout != source_tool_def.timeout:
-            source_tool = replace(source_tool, timeout=source_tool_def.timeout)
+            if isinstance(source_tool, FunctionToolsetTool) and source_tool.timeout != source_tool_def.timeout:
+                source_tool = replace(source_tool, timeout=source_tool_def.timeout)
         return await tool.source_toolset.call_tool(name, tool_args, ctx, source_tool)
 
     def apply(self, visitor: Callable[[AbstractToolset[AgentDepsT]], None]) -> None:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from typing import Any
 
 from typing_extensions import Self
@@ -13,6 +13,7 @@ from ..exceptions import UserError
 from ..messages import InstructionPart
 from ._instruction_collection import flatten_instruction_contributions
 from .abstract import AbstractToolset, ToolsetTool
+from .function import FunctionToolsetTool
 
 
 @dataclass(kw_only=True)
@@ -21,6 +22,8 @@ class _CombinedToolsetTool(ToolsetTool[AgentDepsT]):
 
     source_toolset: AbstractToolset[AgentDepsT]
     source_tool: ToolsetTool[AgentDepsT]
+    combined_tool_def_fields: tuple[tuple[str, object], ...]
+    combined_toolset_id: str | None
 
 
 @dataclass
@@ -89,6 +92,12 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
                     args_validator_func=tool.args_validator_func,
                     source_toolset=toolset,
                     source_tool=tool,
+                    combined_tool_def_fields=tuple(
+                        (field.name, getattr(tool_def, field.name))
+                        for field in fields(tool_def)
+                        if field.name != 'toolset_id'
+                    ),
+                    combined_toolset_id=tool_def.toolset_id,
                 )
         return all_tools
 
@@ -96,7 +105,23 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
     ) -> Any:
         assert isinstance(tool, _CombinedToolsetTool)
-        return await tool.source_toolset.call_tool(name, tool_args, ctx, tool.source_tool)
+        source_tool = tool.source_tool
+        source_tool_def = tool.tool_def
+        toolset_id_changed = source_tool_def.toolset_id != tool.combined_toolset_id
+        other_field_changed = any(
+            getattr(source_tool_def, name) is not original_value
+            for name, original_value in tool.combined_tool_def_fields
+        )
+        if not toolset_id_changed and not other_field_changed:
+            source_tool_def = source_tool.tool_def
+        elif not toolset_id_changed:
+            source_tool_def = replace(source_tool_def, toolset_id=source_tool.tool_def.toolset_id)
+
+        if source_tool.tool_def is not source_tool_def:
+            source_tool = replace(source_tool, tool_def=source_tool_def)
+        if isinstance(source_tool, FunctionToolsetTool) and source_tool.timeout != source_tool_def.timeout:
+            source_tool = replace(source_tool, timeout=source_tool_def.timeout)
+        return await tool.source_toolset.call_tool(name, tool_args, ctx, source_tool)
 
     def apply(self, visitor: Callable[[AbstractToolset[AgentDepsT]], None]) -> None:
         for toolset in self.toolsets:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -301,6 +301,42 @@ async def test_function_toolset_with_defaults_overridden():
         return a - b  # pragma: no cover
 
 
+@pytest.mark.parametrize('prepared_toolset_id', [None, 'prepared-source'])
+async def test_prepared_combined_toolset_dispatches_updated_tool(prepared_toolset_id: str | None):
+    received_definitions: list[ToolDefinition] = []
+
+    class InspectingToolset(FunctionToolset[None]):
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+        ) -> Any:
+            received_definitions.append(tool.tool_def)
+            return await super().call_tool(name, tool_args, ctx, tool)
+
+    source_toolset = InspectingToolset(id='source')
+
+    @source_toolset.tool_plain
+    async def slow_tool() -> None:
+        await anyio.sleep(0.1)
+
+    def prepare_tool(ctx: RunContext[None], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
+        tool_defs[0].metadata = {'source': 'prepared'}
+        tool_defs[0].timeout = 0.01
+        if prepared_toolset_id is None:
+            tool_defs[0].toolset_id = ''.join(['s', 'ource'])
+        else:
+            tool_defs[0].toolset_id = prepared_toolset_id
+        return tool_defs
+
+    toolset = PreparedToolset(CombinedToolset([source_toolset]), prepare_tool)
+    ctx = build_run_context(None)
+    tool = (await toolset.get_tools(ctx))['slow_tool']
+
+    with pytest.raises(ModelRetry, match=re.escape('Timed out after 0.01 seconds')):
+        await toolset.call_tool('slow_tool', {}, ctx, tool)
+    assert received_definitions[0].metadata == {'source': 'prepared'}
+    assert received_definitions[0].toolset_id == prepared_toolset_id
+
+
 async def test_prepared_toolset_sync_prepare_func():
     """`PreparedToolset` accepts a synchronous prepare function (no await needed)."""
     base_toolset = FunctionToolset()

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -301,8 +301,7 @@ async def test_function_toolset_with_defaults_overridden():
         return a - b  # pragma: no cover
 
 
-@pytest.mark.parametrize('prepared_toolset_id', [None, 'prepared-source'])
-async def test_prepared_combined_toolset_dispatches_updated_tool(prepared_toolset_id: str | None):
+async def test_prepared_combined_toolset_dispatches_updated_tool():
     received_definitions: list[ToolDefinition] = []
 
     class InspectingToolset(FunctionToolset[None]):
@@ -321,10 +320,6 @@ async def test_prepared_combined_toolset_dispatches_updated_tool(prepared_toolse
     def prepare_tool(ctx: RunContext[None], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
         tool_defs[0].metadata = {'source': 'prepared'}
         tool_defs[0].timeout = 0.01
-        if prepared_toolset_id is None:
-            tool_defs[0].toolset_id = ''.join(['s', 'ource'])
-        else:
-            tool_defs[0].toolset_id = prepared_toolset_id
         return tool_defs
 
     toolset = PreparedToolset(CombinedToolset([source_toolset]), prepare_tool)
@@ -334,7 +329,7 @@ async def test_prepared_combined_toolset_dispatches_updated_tool(prepared_toolse
     with pytest.raises(ModelRetry, match=re.escape('Timed out after 0.01 seconds')):
         await toolset.call_tool('slow_tool', {}, ctx, tool)
     assert received_definitions[0].metadata == {'source': 'prepared'}
-    assert received_definitions[0].toolset_id == prepared_toolset_id
+    assert received_definitions[0].toolset_id is None
 
 
 async def test_prepared_toolset_sync_prepare_func():


### PR DESCRIPTION
A toolset that wraps another one can change a tool's `ToolDefinition` between the moment the tool is listed and the moment it's called — that's what `prepare_tools` is for. Two places along the dispatch path read a copy of the definition taken at listing time instead, so those changes reached the model but not the toolset that ends up running the tool.

## `CombinedToolset`

`get_tools()` wraps each tool in a `_CombinedToolsetTool` holding the tool it came from, and `call_tool()` dispatched with that cached `source_tool`. Anything an outer wrapper changed on the way out — `metadata`, `strict`, `requires_approval` — was invisible by the time the call came back in. Every sibling wrapper toolset already dispatches with the tool it was handed; `PrefixedToolset` is the closest comparison.

It now does the same, restoring the source toolset's own `toolset_id`: the `toolset_id` a `CombinedToolset` fills in is for the model's benefit, so a source toolset keeps seeing `None` there exactly as before.

## `FunctionToolset`

`FunctionToolsetTool` carries a `timeout` copied from `tool_def.timeout` when the tool is built, and `call_tool()` read that copy. A `prepare` function that sets a timeout was therefore ignored with no `CombinedToolset` in sight:

```python
toolset = FunctionToolset()

@toolset.tool_plain(timeout=10)
async def slow() -> None:
    await asyncio.sleep(1)

def prepare_tools(ctx, tool_defs):
    return [replace(tool_def, timeout=0.01) for tool_def in tool_defs]

# Before: sleeps for a second. After: `ModelRetry('Timed out after 0.01 seconds.')`
```

`call_tool()` now reads `tool.tool_def.timeout`. The field stays — it's reachable public surface, and whether a tool should carry a timeout the definition doesn't already hold is a question this bug shouldn't settle.

- Closes #7380

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (Not applicable.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
