### PR TITLE
Warn when usage extraction prevents limit enforcement

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1182,6 +1182,8 @@ Like `output_tokens_limit`, this is checked after each response, since a respons
 !!! note
     Cost is best-effort: it's `None` for models and providers [genai-prices](https://github.com/pydantic/genai-prices) has no pricing data for, including models released after your install unless you [keep prices up to date](#keeping-model-prices-up-to-date). With a [`cost_limit`][pydantic_ai.usage.UsageLimits.cost_limit], a run that could not be priced at all emits [`CostNotFoundWarning`][pydantic_ai.exceptions.CostNotFoundWarning] rather than being silently unconstrained; an unexpected pricing failure emits [`CostCalculationFailedWarning`][pydantic_ai.exceptions.CostCalculationFailedWarning]. Don't rely on `cost_limit` as a hard billing guarantee — pair it with [`request_limit`][pydantic_ai.usage.UsageLimits.request_limit] or your provider's own spend controls.
 
+    When an Agent executes a model request in-process and provider usage extraction fails, Pydantic AI continues returning the model response. If a token or cost limit depends on that usage, it emits one [`UsageLimitUnavailableWarning`][pydantic_ai.exceptions.UsageLimitUnavailableWarning] for the run because the reported usage and limit enforcement may be incomplete. Durable execution engines serialize model responses across process boundaries and do not currently preserve this warning signal.
+
 #### Model (Run) Settings
 
 Pydantic AI offers a [`settings.ModelSettings`][pydantic_ai.settings.ModelSettings] structure to help you fine tune your requests.

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -49,6 +49,7 @@ from .exceptions import (
     UndrainedPendingMessagesError,
     UnexpectedModelBehavior,
     UsageLimitExceeded,
+    UsageLimitUnavailableWarning,
     UserError,
 )
 from .format_prompt import format_as_xml
@@ -220,6 +221,7 @@ __all__ = (
     'ConcurrencyLimitExceeded',
     'CostCalculationFailedWarning',
     'CostNotFoundWarning',
+    'UsageLimitUnavailableWarning',
     'ModelRetry',
     'ToolFailed',
     'ModelAPIError',

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -4,6 +4,7 @@ import asyncio
 import dataclasses
 import inspect
 import time
+import warnings
 from asyncio import Task
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterable, Sequence
@@ -308,6 +309,7 @@ class GraphAgentState:
     usage: _usage.RunUsage = dataclasses.field(default_factory=_usage.RunUsage)
     output_retries_used: int = 0
     run_step: int = 0
+    usage_limit_warning_emitted: bool = False
     run_id: str = dataclasses.field(default_factory=lambda: str(uuid7()))
     """The unique identifier of this agent run.
 
@@ -1854,6 +1856,27 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             # response sums usage across segments (see `_check_continuation_usage`), so this caps the
             # chain's combined input rather than any single segment's — conservative, not lenient.
             ctx.deps.usage_limits.check_per_request_input_tokens(response.usage.input_tokens)
+            if (
+                not ctx.state.usage_limit_warning_emitted
+                and response.usage._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
+                and (
+                    ctx.deps.usage_limits.input_tokens_limit is not None
+                    or ctx.deps.usage_limits.output_tokens_limit is not None
+                    or ctx.deps.usage_limits.total_tokens_limit is not None
+                    or ctx.deps.usage_limits.cost_limit is not None
+                    or (
+                        ctx.deps.usage_limits.per_request_input_tokens_limit is not None
+                        and not ctx.deps.usage_limits.count_tokens_before_request
+                    )
+                )
+            ):
+                warnings.warn(
+                    'One or more usage limits could not be enforced because provider usage extraction failed. '
+                    'The recorded usage may be incomplete.',
+                    exceptions.UsageLimitUnavailableWarning,
+                    stacklevel=2,
+                )
+                ctx.state.usage_limit_warning_emitted = True
         ctx.state.message_history.append(response)
 
     async def _build_retry_node(

--- a/pydantic_ai_slim/pydantic_ai/_warnings.py
+++ b/pydantic_ai_slim/pydantic_ai/_warnings.py
@@ -16,3 +16,7 @@ class CostCalculationFailedWarning(Warning):
 
 class CostNotFoundWarning(Warning):
     """Warning raised when cost is not found."""
+
+
+class UsageLimitUnavailableWarning(Warning):
+    """Warning raised when a usage limit cannot be enforced because usage extraction failed."""

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -14,6 +14,7 @@ from ._warnings import (
     CostCalculationFailedWarning as CostCalculationFailedWarning,
     CostNotFoundWarning as CostNotFoundWarning,
     PydanticAIDeprecationWarning as PydanticAIDeprecationWarning,
+    UsageLimitUnavailableWarning as UsageLimitUnavailableWarning,
 )
 
 if sys.version_info < (3, 11):
@@ -48,6 +49,7 @@ __all__ = (
     'MessageHistoryMutatedWarning',
     'CostCalculationFailedWarning',
     'CostNotFoundWarning',
+    'UsageLimitUnavailableWarning',
     'PydanticAIDeprecationWarning',
     'FallbackExceptionGroup',
     'ToolFailed',

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -244,6 +244,7 @@ class FallbackModel(Model):
         """
         exceptions: list[Exception] = []
         rejected_responses: list[ModelResponse] = []
+        rejected_usage_extraction_failed = False
         rejected_cost: Decimal | None = None
         # Set once a pinned continuation fails and we rewind to the chain: the first successful response
         # the chain then produces is fresh generation superseding the stale suspended turn, so it must
@@ -294,6 +295,7 @@ class FallbackModel(Model):
                 raise exc
 
             if await self._should_fallback(response):
+                rejected_usage_extraction_failed |= response.usage._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
                 fill_response_cost(response)
                 if response.usage.cost is not None:
                     rejected_cost = (rejected_cost or Decimal()) + response.usage.cost
@@ -305,6 +307,8 @@ class FallbackModel(Model):
                 usage = copy(response.usage)
                 usage.cost = (usage.cost or Decimal()) + rejected_cost
                 response = replace(response, usage=usage)
+            if rejected_usage_extraction_failed:
+                response.usage._usage_extraction_failed = True  # pyright: ignore[reportPrivateUsage]
 
             # After a rewind, the first successful response is fresh generation that supersedes the
             # abandoned suspended turn (whether it ends complete or suspended), so mark it as a replace.

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -31,6 +31,8 @@ _LEGACY_USAGE_KEYS = frozenset({'requests', 'request_tokens', 'response_tokens',
 
 _LEGACY_TOKEN_ALIASES = (('input_tokens', 'request_tokens'), ('output_tokens', 'response_tokens'))
 
+_USAGE_EXTRACTION_FAILED_ATTR = '_usage_extraction_failed'
+
 
 @cache
 def _usage_serializer(usage_type: type[object]) -> SchemaSerializer:
@@ -53,6 +55,7 @@ def _serialize_usage(
     serialized = inner(value)
     assert isinstance(serialized, dict)
     result = cast(dict[str, Any], serialized).copy()
+    result.pop(_USAGE_EXTRACTION_FAILED_ATTR, None)
     extra = {
         key: item
         for key, item in value.__dict__.items()
@@ -85,6 +88,10 @@ class UsageBase:
     # Bare `pydantic_core.to_json()` looks for this attribute but does not build custom core schemas for stdlib
     # dataclasses. The descriptor builds the same serializer as `TypeAdapter` for each concrete usage class.
     __pydantic_serializer__ = _UsageSerializerDescriptor()
+
+    # Internal signal used to warn at most once after a completed response, rather than once per streamed chunk.
+    # It is deliberately excluded from usage serialization and equality below.
+    _usage_extraction_failed: bool = dataclasses.field(default=False, init=False, repr=False, compare=False)
 
     input_tokens: Annotated[
         int,
@@ -255,19 +262,25 @@ class UsageBase:
         return result
 
     def __repr__(self):
-        kv_pairs = (f'{name}={value!r}' for name, value in sorted(self.__dict__.items()) if value)
+        kv_pairs = (
+            f'{name}={value!r}'
+            for name, value in sorted(self.__dict__.items())
+            if value and name != _USAGE_EXTRACTION_FAILED_ATTR
+        )
         return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
     def __eq__(self, value: object, /) -> bool:
         if type(self) is type(value):
             missing = object()
-            keys = self.__dict__.keys() | value.__dict__.keys()
+            keys = (self.__dict__.keys() | value.__dict__.keys()) - {_USAGE_EXTRACTION_FAILED_ATTR}
             return all(getattr(self, key, missing) == getattr(value, key, missing) for key in keys)
         return NotImplemented
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""
-        return any(self.details.values()) or any(v for k, v in self.__dict__.items() if k != 'details')
+        return any(self.details.values()) or any(
+            v for k, v in self.__dict__.items() if k not in {'details', _USAGE_EXTRACTION_FAILED_ATTR}
+        )
 
 
 @dataclass(repr=False, init=False, eq=False)
@@ -290,6 +303,7 @@ class RequestUsage(UsageBase):
         """
         _incr_usage_tokens(self, incr_usage)
         _incr_usage_cost(self, incr_usage)
+        self._usage_extraction_failed |= incr_usage._usage_extraction_failed
 
     def __add__(self, other: RequestUsage) -> RequestUsage:
         """Add two RequestUsages together.
@@ -335,7 +349,9 @@ class RequestUsage(UsageBase):
                 return cls(**{k: v for k, v in extracted_usage.__dict__.items() if v is not None}, details=details)
             except Exception:
                 pass
-        return cls(details=details)
+        result = cls(details=details)
+        result._usage_extraction_failed = True
+        return result
 
 
 @dataclass(repr=False, init=False, eq=False)
@@ -430,7 +446,8 @@ def _incr_usage_tokens(slf: RunUsage | RequestUsage, incr_usage: RunUsage | Requ
         slf: The usage to increment.
         incr_usage: The usage to increment by.
     """
-    for k in (slf.__dict__.keys() | incr_usage.__dict__.keys()) - {'requests', 'tool_calls', 'details', 'cost'}:
+    excluded_fields = {'requests', 'tool_calls', 'details', 'cost', _USAGE_EXTRACTION_FAILED_ATTR}
+    for k in (slf.__dict__.keys() | incr_usage.__dict__.keys()) - excluded_fields:
         slf_value = getattr(slf, k, 0)
         incr_value = getattr(incr_usage, k, 0)
         if isinstance(slf_value, (int, float)) and isinstance(incr_value, (int, float)):

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
+import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
@@ -29,6 +30,7 @@ from pydantic_ai import (
     ToolDefinition,
     ToolReturnPart,
     UsageLimitExceeded,
+    UsageLimitUnavailableWarning,
     UserError,
     UserPromptPart,
 )
@@ -1480,6 +1482,37 @@ async def test_response_handler_rejected_cost_counts_toward_limit() -> None:
 
     with pytest.raises(UsageLimitExceeded, match=r"`usage.cost`=Decimal\('0.011'\)"):
         await Agent(model).run('test', usage_limits=UsageLimits(cost_limit=Decimal('0.01')))
+
+
+@pytest.mark.parametrize(
+    'usage_limits',
+    [UsageLimits(total_tokens_limit=100), UsageLimits(cost_limit=Decimal('1'))],
+    ids=['token-limit', 'cost-limit'],
+)
+async def test_response_handler_preserves_usage_extraction_failure(usage_limits: UsageLimits) -> None:
+    def reject_primary(response: ModelResponse) -> bool:
+        return response.model_name == 'primary'
+
+    def primary(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        usage = RequestUsage(input_tokens=1)
+        usage._usage_extraction_failed = True  # pyright: ignore[reportPrivateUsage]
+        return ModelResponse(parts=[TextPart('rejected')], usage=usage)
+
+    def fallback(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('accepted')], usage=RequestUsage(input_tokens=2, output_tokens=1))
+
+    model = FallbackModel(
+        FunctionModel(primary, model_name='primary'),
+        FunctionModel(fallback, model_name='fallback'),
+        fallback_on=reject_primary,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        result = await Agent(model).run('test', usage_limits=usage_limits)
+
+    assert result.output == 'accepted'
+    assert len([w for w in caught if issubclass(w.category, UsageLimitUnavailableWarning)]) == 1
 
 
 async def test_response_handler_preserves_successful_model_usage_for_pricing() -> None:

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -3887,7 +3887,9 @@ def test_xai_usage_fallback_when_extract_fails(monkeypatch: pytest.MonkeyPatch):
     # Mock RequestUsage.extract to return zeros, simulating genai-prices extraction failure
     def mock_extract(cls: type[RequestUsage], *args: Any, **kwargs: Any) -> RequestUsage:
         details: dict[str, int] = kwargs.get('details') or {}
-        return RequestUsage(details=details)
+        usage = RequestUsage(details=details)
+        usage._usage_extraction_failed = True  # pyright: ignore[reportPrivateUsage]
+        return usage
 
     monkeypatch.setattr(xai_module.RequestUsage, 'extract', classmethod(mock_extract))
 
@@ -3899,6 +3901,7 @@ def test_xai_usage_fallback_when_extract_fails(monkeypatch: pytest.MonkeyPatch):
         response, model='unknown-model', provider='unknown', provider_url='https://unknown.example.com'
     )
     assert result == snapshot(RequestUsage(input_tokens=15, output_tokens=8))
+    assert result._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_xai_usage_with_server_side_tools(allow_model_requests: None):

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -18,6 +18,7 @@ from pydantic_ai import (
     CostCalculationFailedWarning,
     CostNotFoundWarning,
     ModelMessage,
+    ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -26,10 +27,13 @@ from pydantic_ai import (
     ToolCallPart,
     ToolReturnPart,
     UsageLimitExceeded,
+    UsageLimitUnavailableWarning,
     UserPromptPart,
+    usage as usage_module,
 )
 from pydantic_ai._genai_prices import best_effort_price, calculate_price_for_usage
 from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.models import function as function_model_module
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.output import ToolOutput
@@ -1320,6 +1324,158 @@ def test_best_effort_price_unexpected_error_warns(monkeypatch: pytest.MonkeyPatc
     with pytest.warns(CostCalculationFailedWarning, match='Failed to get cost: RuntimeError: kaboom'):
         price = best_effort_price(RequestUsage(input_tokens=10), model_name='gpt-4o', provider_name='openai')
     assert price is None
+
+
+def test_request_usage_extract_tracks_failed_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Provider:
+        def __init__(self, outcome: GenaiPricesUsage | Exception):
+            self.outcome = outcome
+
+        def extract_usage(self, data: object, *, api_flavor: str = 'default') -> tuple[str, GenaiPricesUsage]:
+            if isinstance(self.outcome, Exception):
+                raise self.outcome
+            return 'test-model', self.outcome
+
+    class Snapshot:
+        def __init__(self, outcomes: list[GenaiPricesUsage | Exception]):
+            self.outcomes = iter(outcomes)
+
+        def find_provider(self, model_ref: object, provider_id: object, provider_api_url: object) -> Provider:
+            outcome = next(self.outcomes)
+            if isinstance(outcome, LookupError):
+                raise outcome
+            return Provider(outcome)
+
+    recovered_snapshot = Snapshot([RuntimeError('bad URL extractor'), LookupError(), GenaiPricesUsage(input_tokens=3)])
+    monkeypatch.setattr(usage_module, 'get_snapshot', lambda: recovered_snapshot)
+    recovered = RequestUsage.extract(
+        {}, provider='gateway', provider_url='https://gateway.example', provider_fallback='google'
+    )
+    assert recovered == RequestUsage(input_tokens=3)
+    assert not recovered._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
+
+    failed_snapshot = Snapshot([RuntimeError('broken extractor')] * 3)
+    monkeypatch.setattr(usage_module, 'get_snapshot', lambda: failed_snapshot)
+    failed = RequestUsage.extract(
+        {}, provider='google', provider_url='https://google.example', provider_fallback='google'
+    )
+    assert failed == RequestUsage()
+    assert failed._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
+    serialized = ModelMessagesTypeAdapter.dump_json([ModelResponse(parts=[TextPart('done')], usage=failed)])
+    assert b'_usage_extraction_failed' not in serialized
+    [round_tripped] = ModelMessagesTypeAdapter.validate_json(serialized)
+    assert isinstance(round_tripped, ModelResponse)
+    assert not round_tripped.usage._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
+
+    unknown_snapshot = Snapshot([LookupError()] * 3)
+    monkeypatch.setattr(usage_module, 'get_snapshot', lambda: unknown_snapshot)
+    unknown = RequestUsage.extract({}, provider='unknown', provider_url='https://unknown.example', provider_fallback='')
+    assert unknown == RequestUsage()
+    assert unknown._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
+
+    class BrokenLookupSnapshot:
+        def find_provider(self, model_ref: object, provider_id: object, provider_api_url: object) -> None:
+            raise RuntimeError('broken provider lookup')
+
+    monkeypatch.setattr(usage_module, 'get_snapshot', BrokenLookupSnapshot)
+    lookup_failed = RequestUsage.extract({}, provider='google', provider_url='', provider_fallback='google')
+    assert lookup_failed._usage_extraction_failed  # pyright: ignore[reportPrivateUsage]
+
+
+def mock_failed_usage_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Provider:
+        def extract_usage(self, data: object, *, api_flavor: str = 'default') -> object:
+            raise RuntimeError('broken extractor')
+
+    class Snapshot:
+        def find_provider(self, model_ref: object, provider_id: object, provider_api_url: object) -> Provider:
+            return Provider()
+
+    monkeypatch.setattr(usage_module, 'get_snapshot', Snapshot)
+
+
+@pytest.mark.parametrize(
+    'usage_limits',
+    [UsageLimits(total_tokens_limit=1_000), UsageLimits(cost_limit=Decimal('1'))],
+    ids=['token-limit', 'cost-limit'],
+)
+async def test_usage_extraction_failure_warns_once_when_limit_depends_on_usage(
+    monkeypatch: pytest.MonkeyPatch, usage_limits: UsageLimits
+) -> None:
+    mock_failed_usage_extraction(monkeypatch)
+    calls = 0
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        request_usage = RequestUsage.extract({}, provider='google', provider_url='', provider_fallback='google')
+        # FunctionModel replaces completely empty usage with an estimate. Keep the failure marker while
+        # making this response non-empty so the public Agent path receives it unchanged.
+        request_usage.input_tokens = 1
+        parts = [ToolCallPart(tool_name='noop', args={}, tool_call_id='call-1')] if calls == 1 else [TextPart('done')]
+        return ModelResponse(
+            parts=parts,
+            usage=request_usage,
+            model_name='gemini-2.5-flash',
+            provider_name='google',
+        )
+
+    agent = Agent(FunctionModel(model_function))
+
+    @agent.tool_plain
+    def noop() -> None:
+        pass
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        result = await agent.run('go', usage_limits=usage_limits)
+
+    assert result.output == 'done'
+    assert len([w for w in caught if issubclass(w.category, UsageLimitUnavailableWarning)]) == 1
+
+
+async def test_streaming_usage_extraction_failure_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExtractingStreamedResponse(function_model_module.FunctionStreamedResponse):
+        async def _get_event_iterator(self):
+            async for event in super()._get_event_iterator():
+                chunk_usage = RequestUsage.extract({}, provider='google', provider_url='', provider_fallback='google')
+                self._usage.incr(chunk_usage)
+                yield event
+
+    mock_failed_usage_extraction(monkeypatch)
+    monkeypatch.setattr(function_model_module, 'FunctionStreamedResponse', ExtractingStreamedResponse)
+
+    async def stream_function(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+        yield 'one'
+        yield 'two'
+        yield 'three'
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        async with Agent(FunctionModel(stream_function=stream_function)).run_stream(
+            'go', usage_limits=UsageLimits(total_tokens_limit=1_000)
+        ) as result:
+            await result.get_output()
+
+    assert len([w for w in caught if issubclass(w.category, UsageLimitUnavailableWarning)]) == 1
+
+
+async def test_usage_extraction_failure_without_response_usage_limit_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
+) -> None:
+    mock_failed_usage_extraction(monkeypatch)
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[TextPart('done')],
+            usage=RequestUsage.extract({}, provider='google', provider_url='', provider_fallback='google'),
+        )
+
+    await Agent(FunctionModel(model_function)).run('go', usage_limits=UsageLimits(request_limit=1))
+
+    assert not [w for w in recwarn.list if issubclass(w.category, UsageLimitUnavailableWarning)]
 
 
 def test_check_cost_disabled_by_default():


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

Provider usage extraction can currently fail and silently become empty usage. When a token or cost limit is configured, that limit can then appear enforced even though the data needed to enforce it is missing.

This change preserves the successful model response and emits one filterable `UsageLimitUnavailableWarning` per in-process Agent run when a configured limit depends on provider usage that could not be extracted.

### What changes

- Mark usage only when every provider-extraction candidate fails; a later successful candidate remains clean.
- Carry one typed, private failure flag through streamed usage without exposing it in serialized usage, equality, repr, or `has_values()`.
- Warn once per run after a completed response, never once per stream chunk.
- Keep request/tool-only limits and pre-counted input limits silent.
- Preserve the failure signal when a `FallbackModel` response handler rejects a paid response.
- Leave existing cost calculation and `CostNotFoundWarning` behavior unchanged.

### Narrow boundary

This PR intentionally addresses only the configured usage-limit case discussed in #7808. Runs without a token or cost limit — including monitoring or billing consumers that observe false zero usage — remain unchanged and need a separate design decision.

Durable execution engines serialize model responses across process boundaries and do not currently preserve this private warning signal. Supporting that would require a backward-compatible durable result format and is intentionally outside this bug fix.

### Verification

- Added Agent regressions for token limits, cost limits, request-only limits, repeated streaming chunks, response-based fallback, provider candidate recovery, and non-leaking serialization.
- Added an xAI regression proving raw-token fallback does not hide the extraction failure.
- Ran 155 focused tests, Ruff, and Pyright scoped to the relevant core files and tests. Optional xAI SDK tests were skipped locally and are covered by CI.

Related to #7808.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
