### PR TITLE
docs: fix broken external links flagged by link check (#7924)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ The project uses:
 - `pytest` in `tests/`, via `make test`, with:
     - `inline-snapshot` for inline assertions
     - `pytest-recording` and `vcrpy` for recording and playing back requests to model APIs
-- Documentation is published by [pydantic/unified-docs](https://github.com/pydantic/unified-docs).
+- Documentation is published by [pydantic/pydantic-docs](https://github.com/pydantic/pydantic-docs).
   `docs/navigation.yml` owns the Pydantic AI sidebar, routes, and redirects; `tests/test_examples.py`
   tests all code examples in the docs (including docstrings).
 - [`logfire`](docs/logfire.md) for OTel instrumentation of Pydantic AI and `httpx`

--- a/docs/durable_execution/backends.md
+++ b/docs/durable_execution/backends.md
@@ -8,9 +8,8 @@ backend. Use it when you are integrating a durable execution system that is not 
 The complete implementations for [Temporal][pydantic_ai.durable_exec.temporal.TemporalDurability],
 [DBOS][pydantic_ai.durable_exec.dbos.DBOSDurability], and
 [Prefect][pydantic_ai.durable_exec.prefect.PrefectDurability] are useful references. The external
-[Restate](https://github.com/restatedev/sdk-python/tree/main/packages/integrations/pydantic-ai),
-[AWS Lambda](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/aws_lambda),
-and [Absurd](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/absurd)
+[Restate](https://github.com/restatedev/sdk-python/tree/main/python/restate/ext/pydantic) and
+[AWS Lambda](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/aws_lambda)
 integrations show the same public builder with JSON journals.
 
 ## Choose a backend tier


### PR DESCRIPTION
Fixes #7924

The scheduled link check flagged several dead external links. I verified each one against its live HTTP status before touching it:

- `pydantic/unified-docs` (AGENTS.md, and CLAUDE.md via the symlink) returns 404. The public repo for the shared docs infrastructure is `pydantic/pydantic-docs`, so the reference now points there. If `unified-docs` is intentionally private, I'm happy to drop the link instead.
- Restate integration in `docs/durable_execution/backends.md`: the old path `packages/integrations/pydantic-ai` returns 404; the integration now lives at `python/restate/ext/pydantic` in `restatedev/sdk-python` (verified 200).
- Absurd integration: `pydantic_ai_harness/absurd` no longer exists anywhere in the pydantic-ai-harness tree, and the durable execution docs no longer list Absurd as a backend, so I removed it from the sentence. The `pydantic_ai.durable_exec` module docstrings still mention Absurd as a supported engine type — if there is a canonical new link, I'll gladly point there instead.

Left unchanged on purpose:
- `pydantic_ai_harness/aws_lambda` returned 404 when #7924 was filed but resolves now, so it stays (as noted in the issue comments).
- The coverage-badge 400s, the starlette connection errors, and the huggingface 500 are transient/external and out of scope here.

Verification: after the change, every external link in the two touched files was checked live with the same accept rules as the scheduled lychee sweep (2xx/403/429) — all pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

