### PR TITLE
fix(openrouter): set supports_tool_return_schema=False for Google models (#8074)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -113,12 +113,20 @@ def _openrouter_google_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a Google model accessed via OpenRouter.
 
     Uses the legacy transformer to maintain compatibility with OpenRouter's
-    translation layer, which doesn't fully support modern JSON Schema features.
+    translation layer, which doesn't fully support modern JSON Schema features,
+    and sets `supports_tool_return_schema=False` so return schemas are injected
+    into tool descriptions rather than dropped by OpenAI-compatible gateway transports.
     """
     profile = google_model_profile(model_name)
     if profile is None:  # pragma: no cover
         return None
-    return merge_profile(profile, ModelProfile(json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer))
+    return merge_profile(
+        profile,
+        ModelProfile(
+            json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer,
+            supports_tool_return_schema=False,
+        ),
+    )
 
 
 class OpenRouterProvider(_OpenAICompatibleProvider):

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -24,11 +24,13 @@ from ..conftest import TestEnv, try_import
 with try_import() as imports_successful:
     import openai
 
+    from pydantic_ai.models import ModelRequestParameters
     from pydantic_ai.models.openrouter import OpenRouterModel
     from pydantic_ai.providers.openrouter import (
         OpenRouterProvider,
         _OpenRouterGoogleJsonSchemaTransformer,  # pyright: ignore[reportPrivateUsage]
     )
+    from pydantic_ai.tools import ToolDefinition
 
 
 pytestmark = [
@@ -345,3 +347,67 @@ def test_openrouter_google_json_schema_transformer():
     # Removed fields
     assert '$schema' not in result
     assert 'title' not in result
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'google/gemini-2.5-flash',
+        'google/gemini-2.5-pro',
+        'google/gemini-3.0-pro',
+    ],
+)
+def test_openrouter_google_model_profile_supports_tool_return_schema(model_name: str) -> None:
+    """Google models relayed through OpenRouter set supports_tool_return_schema=False."""
+    # The native Google profile sets supports_tool_return_schema=True
+    native_profile = google_model_profile(model_name)
+    assert native_profile is not None
+    assert native_profile.get('supports_tool_return_schema') is True
+
+    # The OpenRouter overlay clears supports_tool_return_schema so schemas are injected into descriptions
+    provider = OpenRouterProvider(api_key='api-key')
+    profile = provider.model_profile(model_name)
+    assert profile is not None
+    assert profile.get('supports_tool_return_schema') is False
+
+
+def test_openrouter_google_model_return_schema_injection() -> None:
+    """Return schemas are injected into tool definitions for Google models on OpenRouter."""
+    provider = OpenRouterProvider(api_key='api-key')
+    model = OpenRouterModel('google/gemini-2.5-flash', provider=provider)
+    assert model.profile.get('supports_tool_return_schema') is False
+
+    td_opt_in = ToolDefinition(
+        name='lookup_user',
+        description='Look up user by ID',
+        parameters_json_schema={'type': 'object', 'properties': {'user_id': {'type': 'string'}}},
+        return_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        include_return_schema=True,
+    )
+    td_no_opt_in = ToolDefinition(
+        name='delete_user',
+        description='Delete a user',
+        parameters_json_schema={'type': 'object', 'properties': {'user_id': {'type': 'string'}}},
+        return_schema={'type': 'object', 'properties': {'success': {'type': 'boolean'}}},
+        include_return_schema=False,
+    )
+    params = ModelRequestParameters(
+        function_tools=[td_opt_in, td_no_opt_in],
+        output_tools=[],
+        output_mode='auto',
+        output_object=None,
+    )
+
+    _, prepared_params = model.prepare_request(None, params)
+
+    # Opted-in tool gets return schema injected into its description, and return_schema field cleared
+    assert prepared_params.function_tools[0].return_schema is None
+    assert prepared_params.function_tools[0].description is not None
+    assert 'Look up user by ID' in prepared_params.function_tools[0].description
+    assert 'Return schema:' in prepared_params.function_tools[0].description
+    assert '"name": {\n      "type": "string"\n    }' in prepared_params.function_tools[0].description
+
+    # Tool without opt-in gets return_schema cleared without injection into description
+    assert prepared_params.function_tools[1].return_schema is None
+    assert prepared_params.function_tools[1].description == 'Delete a user'
+    assert 'Return schema:' not in (prepared_params.function_tools[1].description or '')


### PR DESCRIPTION
﻿Fixes #8074

### Problem Description
When Google models (e.g. `google/gemini-2.5-flash`, `google/gemini-3.0-pro`) are accessed via `OpenRouterProvider`, the provider resolves model profiles by overlaying `_openrouter_google_model_profile` on top of `google_model_profile`.

`google_model_profile` sets `supports_tool_return_schema=True` because Google's native Gemini API supports structured return schemas (`response_json_schema`) directly on function declarations. However, OpenRouter relays models through an OpenAI Chat-compatible wire format (`OpenAIChatModel`).

In `models/openai.py`, `return_schema` is never serialized over the wire. Instead, `pydantic-ai` relies on `prepare_return_schemas(params, supports_tool_return_schema=...)` to inject the return schema into tool descriptions whenever `supports_tool_return_schema` is `False`. Because `supports_tool_return_schema` remained `True` in OpenRouter's Google model profile:
1. `prepare_return_schemas` did not inject return schemas into tool descriptions.
2. `OpenAIChatModel` dropped `return_schema` on the wire.
As a result, tools with `include_return_schema=True` lost their return schema entirely when invoked through OpenRouter.

### Reproduction Trace
```python
from pydantic_ai.providers.openrouter import OpenRouterProvider
from pydantic_ai.models.openrouter import OpenRouterModel
from pydantic_ai.tools import ToolDefinition
from pydantic_ai.models import ModelRequestParameters

provider = OpenRouterProvider(api_key='test-key')
profile = provider.model_profile('google/gemini-2.5-flash')
print(profile.get('supports_tool_return_schema'))
# Before fix: True (schemas lost over OpenAI chat wire protocol)
# After fix: False (injected into tool descriptions)
```

### Proposed Changes
1. In `pydantic_ai_slim/pydantic_ai/providers/openrouter.py`:
   - In `_openrouter_google_model_profile`, set `supports_tool_return_schema=False` in the merged overlay `ModelProfile`.
2. In `tests/providers/test_openrouter.py`:
   - Added `test_openrouter_google_model_profile_supports_tool_return_schema` to verify that Google models through OpenRouter report `supports_tool_return_schema == False` (while native `google_model_profile` reports `True`).
   - Added `test_openrouter_google_model_return_schema_injection` to verify that `prepare_request` injects return schemas into tool descriptions for opted-in tools and clears `return_schema` from tool definitions.

### Verification Record
Ran pytest suite for `tests/providers/test_openrouter.py`:
```bash
pytest tests/providers/test_openrouter.py -v
```
Output:
```
tests/providers/test_openrouter.py::test_openrouter_provider PASSED [  4%]
tests/providers/test_openrouter.py::test_openrouter_provider_with_app_attribution PASSED [  8%]
tests/providers/test_openrouter.py::test_openrouter_provider_app_attribution_from_env PASSED [ 12%]
tests/providers/test_openrouter.py::test_openrouter_provider_app_attribution_skipped_for_prebuilt_client PASSED [ 16%]
tests/providers/test_openrouter.py::test_openrouter_provider_need_api_key PASSED [ 20%]
tests/providers/test_openrouter.py::test_openrouter_pass_openai_client PASSED [ 25%]
tests/providers/test_openrouter.py::test_openrouter_with_google_model PASSED [ 29%]
tests/providers/test_openrouter.py::test_openrouter_provider_model_profile PASSED [ 33%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_cache_capabilities[anthropic/claude-sonnet-4.6-expected_flags0] PASSED [ 37%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_cache_capabilities[google/gemini-2.5-flash-expected_flags1] PASSED [ 41%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_cache_capabilities[openai/gpt-5-mini-expected_flags2] PASSED [ 45%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_cache_capabilities[~anthropic/claude-sonnet-latest-expected_flags3] PASSED [ 50%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_cache_capabilities[~google/gemini-pro-latest-expected_flags4] PASSED [ 54%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_forced_tool_choice_with_thinking[anthropic/claude-sonnet-4.6-False] PASSED [ 58%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_forced_tool_choice_with_thinking[~anthropic/claude-sonnet-latest-False] PASSED [ 62%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_forced_tool_choice_with_thinking[google/gemini-2.5-flash-True] PASSED [ 66%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_forced_tool_choice_with_thinking[openai/gpt-5-mini-True] PASSED [ 70%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_forced_tool_choice_with_thinking[unknown/model-True] PASSED [ 75%]
tests/providers/test_openrouter.py::test_openrouter_model_profile_requires_provider_prefix PASSED [ 79%]
tests/providers/test_openrouter.py::test_openrouter_google_json_schema_transformer PASSED [ 83%]
tests/providers/test_openrouter.py::test_openrouter_google_model_profile_supports_tool_return_schema[google/gemini-2.5-flash] PASSED [ 87%]
tests/providers/test_openrouter.py::test_openrouter_google_model_profile_supports_tool_return_schema[google/gemini-2.5-pro] PASSED [ 91%]
tests/providers/test_openrouter.py::test_openrouter_google_model_profile_supports_tool_return_schema[google/gemini-3.0-pro] PASSED [ 95%]
tests/providers/test_openrouter.py::test_openrouter_google_model_return_schema_injection PASSED [100%]

============================= 24 passed in 11.21s =============================
```

Also verified formatting and linting:
```bash
ruff check pydantic_ai_slim/pydantic_ai/providers/openrouter.py tests/providers/test_openrouter.py
ruff format --check pydantic_ai_slim/pydantic_ai/providers/openrouter.py tests/providers/test_openrouter.py
```
Both passed cleanly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

