### PR TITLE
Use plain `uv add` in the front-page tabs again

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     A complete coding agent in your terminal: workspace-rooted [file access](https://pydantic.dev/docs/ai/harness/filesystem/), allowlisted [shell](https://pydantic.dev/docs/ai/harness/shell/), [repo orientation](https://pydantic.dev/docs/ai/harness/repo-context/), [planning](https://pydantic.dev/docs/ai/harness/planning/), and [context management](https://pydantic.dev/docs/ai/harness/compaction/) that survives long sessions. Here with [web search](capabilities/web-search.md) and a second-opinion [advisor](https://pydantic.dev/docs/ai/harness/advisor/) snapped on alongside:
 
     ```bash
-    pip/uv-add pydantic-ai pydantic-ai-harness
+    uv add pydantic-ai pydantic-ai-harness
     ```
 
     ```python {test="skip" lint="skip"}
@@ -91,7 +91,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     Give the agent an [output type](output.md) and [tools](tools.md), and every run comes back validated and typed:
 
     ```bash
-    pip/uv-add pydantic-ai
+    uv add pydantic-ai
     ```
 
     ```python {title="review_sentiment.py"}
@@ -130,7 +130,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     Attach [`TemporalDurability`](durable_execution/temporal.md) and the same agent runs inside a [Temporal](durable_execution/temporal.md) workflow under [durable execution](durable_execution/overview.md): every model and tool call becomes a durable activity, so a run working through a background queue survives restarts, failures, and long waits:
 
     ```bash
-    pip/uv-add "pydantic-ai[temporal]"
+    uv add "pydantic-ai[temporal]"
     ```
 
     ```python {title="durable_research.py"}
@@ -167,7 +167,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     Put the same agent on a live voice session, [tools](realtime/tools.md) and [capabilities](realtime/capabilities.md) included:
 
     ```bash
-    pip/uv-add "pydantic-ai[openai-realtime]"
+    uv add "pydantic-ai[openai-realtime]"
     ```
 
     ```python {test="skip" lint="skip"}
@@ -202,7 +202,7 @@ From simple typed data extraction to complex, long-running multi-agent collabora
     Ask for an image and make it the run's typed [output](output.md):
 
     ```bash
-    pip/uv-add pydantic-ai
+    uv add pydantic-ai
     ```
 
     ```python {title="logo_generation.py"}


### PR DESCRIPTION
Fixes a live regression from #8064: all five example tabs on [the overview page](https://pydantic.dev/docs/ai/overview/) currently render the literal text `pip/uv-add pydantic-ai` in place of a pip/uv toggle.

<!-- Docs-only fix; no linked issue. -->

### What went wrong

`pip/uv-add` works everywhere else in the docs (61 uses across 37 pages) because every one of those is at the top level of a page. It does not survive being nested inside a tab, and #8064 moved it into tabs.

Two independent gaps in the unified-docs transform, both confirmed by calling the functions directly:

1. **`transformUvPipShorthand` only matches an unindented fence.** Its pattern is ``` /```bash\n(.*?)(…|pip\/uv[- ]add|…)(.+?)\n```/g ```, and the closing `\n``` ` cannot match a fence indented four spaces inside a tab. Given the indented input it returns the content completely unchanged, which is exactly the literal text now on the page.
2. **`transformTabs` does not recurse into tab content.** Even with the first gap fixed, the replacement it generates is an inner `=== "pip"` / `=== "uv"` group, and a nested group is dedented into the outer `<TabItem>` and emitted as literal markdown rather than a nested `<Tabs>`.

So this needs both an indentation-aware shorthand *and* nested-group support in `transformTabs`. That belongs in unified-docs; this PR restores the working rendering in the meantime.

### This change

Reverts the five tab install commands to plain `uv add`, which is what they were before #8064. Every other `pip/uv-add` in the docs is unindented and keeps working.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EkyQrAYWj3qzZBvB7YHUR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

