### PR TITLE
Hide the duplicated title heading on the front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Pydantic AI
+hideTitle: true
 description: "How Python does AI: agents, realtime voice, image generation, embeddings. Every model, every interface, typed end to end."
 ---
 


### PR DESCRIPTION
The overview page opens with the Pydantic AI wordmark, and Starlight renders the frontmatter title as an `<h1>` directly above it, so the name appears twice.

<!-- Docs-only change; no linked issue. -->

`hideTitle: true` is the opt-in flag added in pydantic/unified-docs#254 (merged), so this is a one-line frontmatter change.

### Why the earlier attempt didn't work

#8064 removed `# Pydantic AI {.hide}` from the markdown on the theory that it was the visible heading. It wasn't, and that change was a no-op for rendering: `stripLeadingH1` in unified-docs already strips a leading `# ...` from every synced page, and `extractH1Title` uses it to *populate* frontmatter `title:` when a page has none. The heading on the page is Starlight's own `PageTitle`, rendered from that frontmatter — nothing a docs repo writes in its markdown can affect it. (The `{.hide}` was MkDocs attr-list syntax from when MkDocs rendered these docs, inert under Starlight; removing it was still right, just not for the stated reason.)

### What the flag does

It hides the heading visually rather than dropping it. The page still needs an `<h1>` for its document outline, and Starlight anchors both the back-to-top link and the first table-of-contents entry at that element's id. So it stays in the accessibility tree, clipped out of the visual flow, and the page name is still announced to anyone who can't see the wordmark.

Verified that the flag survives the sync's frontmatter rewriting (`injectSidebarOrder` prepends `title:`/`sidebar:` and leaves other keys alone).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EkyQrAYWj3qzZBvB7YHUR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

