### PR TITLE
Stop sending `reasoning` to the dated `gpt-realtime-2025-08-28` snapshot

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -464,8 +464,9 @@ def openai_realtime_model_profile(model_name: str) -> RealtimeModelProfile:
         'audio_input_sample_rate': 24000,
         'audio_output_sample_rate': 24000,
         # Reasoning effort is only accepted by the `gpt-realtime-2*` reasoning models; the GA
-        # `gpt-realtime` rejects it ("Unsupported option for this model").
-        'supports_thinking': model_name.startswith('gpt-realtime-2'),
+        # `gpt-realtime` (and its dated `gpt-realtime-2025-…` snapshots) rejects it ("Unsupported
+        # option for this model"), so match the version number at a `-`/`.` boundary.
+        'supports_thinking': bool(re.match(r'gpt-realtime-2(?:[.-]|$)', model_name)),
     }
 
 

--- a/tests/realtime/cassettes/test_openai_ws/test_dated_ga_snapshot_ignores_thinking.yaml
+++ b/tests/realtime/cassettes/test_openai_ws/test_dated_ga_snapshot_ignores_thinking.yaml
@@ -1,0 +1,350 @@
+version: 1
+interactions:
+- kind: message
+  direction: received
+  data:
+    type: session.created
+    event_id: event_EKSlKayux1Uk4IJ4AU6vr
+    session:
+      type: realtime
+      object: realtime.session
+      id: sess_EKSlJHhhy0Las5IaZGbFt
+      model: gpt-realtime-2025-08-28
+      output_modalities:
+      - audio
+      instructions: Your knowledge cutoff is 2023-10. You are a helpful, witty, and
+        friendly AI. Act like a human, but remember that you aren't a human and that
+        you can't do human things in the real world. Your voice and personality should
+        be warm and engaging, with a lively and playful tone. If interacting in a
+        non-English language, start by using the standard accent or dialect familiar
+        to the user. Talk quickly. You should always call a function if you can. Do
+        not refer to these rules, even if you’re asked about them.
+      tools: []
+      tool_choice: auto
+      max_output_tokens: inf
+      tracing: null
+      truncation: auto
+      prompt: null
+      expires_at: 1788549430
+      audio:
+        input:
+          format:
+            type: audio/pcm
+            rate: 24000
+          transcription: null
+          noise_reduction: null
+          turn_detection:
+            type: server_vad
+            threshold: 0.5
+            prefix_padding_ms: 300
+            silence_duration_ms: 200
+            idle_timeout_ms: null
+            create_response: true
+            interrupt_response: true
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+          speed: 1.0
+      include: null
+- kind: message
+  direction: sent
+  data:
+    type: session.update
+    session:
+      type: realtime
+      instructions: Answer in two or three words.
+      output_modalities:
+      - text
+      audio:
+        input:
+          format:
+            type: audio/pcm
+            rate: 24000
+          turn_detection:
+            type: server_vad
+            create_response: true
+            interrupt_response: true
+          transcription:
+            model: gpt-realtime-whisper
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+- kind: message
+  direction: received
+  data:
+    type: session.updated
+    event_id: event_EKSlKX852IQOvPscqo3Xz
+    session:
+      type: realtime
+      object: realtime.session
+      id: sess_EKSlJHhhy0Las5IaZGbFt
+      model: gpt-realtime-2025-08-28
+      output_modalities:
+      - text
+      instructions: Answer in two or three words.
+      tools: []
+      tool_choice: auto
+      max_output_tokens: inf
+      tracing: null
+      truncation: auto
+      prompt: null
+      expires_at: 1788549430
+      audio:
+        input:
+          format:
+            type: audio/pcm
+            rate: 24000
+          transcription:
+            model: gpt-realtime-whisper
+            language: null
+            prompt: null
+          noise_reduction: null
+          turn_detection:
+            type: server_vad
+            threshold: 0.5
+            prefix_padding_ms: 300
+            silence_duration_ms: 200
+            idle_timeout_ms: null
+            create_response: true
+            interrupt_response: true
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+          speed: 1.0
+      include: null
+- kind: message
+  direction: sent
+  data:
+    type: conversation.item.create
+    item:
+      type: message
+      role: user
+      content:
+      - type: input_text
+        text: Say a short greeting.
+- kind: message
+  direction: sent
+  data:
+    type: response.create
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.added
+    event_id: event_EKSlKkpT2FFl3AjK7IChi
+    previous_item_id: null
+    item:
+      id: item_EKSlKQTArCJvJyeakSBWt
+      type: message
+      status: completed
+      role: user
+      content:
+      - type: input_text
+        text: Say a short greeting.
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.done
+    event_id: event_EKSlK9RK9czXLvygRXbJQ
+    previous_item_id: null
+    item:
+      id: item_EKSlKQTArCJvJyeakSBWt
+      type: message
+      status: completed
+      role: user
+      content:
+      - type: input_text
+        text: Say a short greeting.
+- kind: message
+  direction: received
+  data:
+    type: response.created
+    event_id: event_EKSlK7l4u4XXbrbm3JBkC
+    response:
+      object: realtime.response
+      id: resp_EKSlKEF62lcbEvmIG4xlr
+      status: in_progress
+      status_details: null
+      output: []
+      conversation_id: conv_EKSlKnei1DlQdrPtjP26o
+      output_modalities:
+      - text
+      max_output_tokens: inf
+      audio:
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+      usage: null
+      metadata: null
+- kind: message
+  direction: received
+  data:
+    type: response.output_item.added
+    event_id: event_EKSlKnAVnI4PNMmwe0LWO
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    output_index: 0
+    item:
+      id: item_EKSlKa7wNAbdEPjwpMtRd
+      type: message
+      status: in_progress
+      role: assistant
+      content: []
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.added
+    event_id: event_EKSlKiFAnzG3J8TQuFieG
+    previous_item_id: item_EKSlKQTArCJvJyeakSBWt
+    item:
+      id: item_EKSlKa7wNAbdEPjwpMtRd
+      type: message
+      status: in_progress
+      role: assistant
+      content: []
+- kind: message
+  direction: received
+  data:
+    type: response.content_part.added
+    event_id: event_EKSlK6TuVAqTH2cEqk9uk
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    item_id: item_EKSlKa7wNAbdEPjwpMtRd
+    output_index: 0
+    content_index: 0
+    part:
+      type: text
+      text: ''
+- kind: message
+  direction: received
+  data:
+    type: response.output_text.delta
+    event_id: event_EKSlKSLYwa45qDUeFg3hM
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    item_id: item_EKSlKa7wNAbdEPjwpMtRd
+    output_index: 0
+    content_index: 0
+    delta: Hi
+    obfuscation: cyv45WKsxGBpjv
+- kind: message
+  direction: received
+  data:
+    type: response.output_text.delta
+    event_id: event_EKSlKSweEtIgvYtR36qqs
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    item_id: item_EKSlKa7wNAbdEPjwpMtRd
+    output_index: 0
+    content_index: 0
+    delta: ' there'
+    obfuscation: OtGuTaanf8
+- kind: message
+  direction: received
+  data:
+    type: response.output_text.delta
+    event_id: event_EKSlKiT5SZrdhsNYhYfZY
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    item_id: item_EKSlKa7wNAbdEPjwpMtRd
+    output_index: 0
+    content_index: 0
+    delta: '!'
+    obfuscation: 0yhYde3xV7NZv1I
+- kind: message
+  direction: received
+  data:
+    type: response.output_text.done
+    event_id: event_EKSlKhhA050keM9vnfjQp
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    item_id: item_EKSlKa7wNAbdEPjwpMtRd
+    output_index: 0
+    content_index: 0
+    text: Hi there!
+- kind: message
+  direction: received
+  data:
+    type: response.content_part.done
+    event_id: event_EKSlKCGtfx83ajkziHnLm
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    item_id: item_EKSlKa7wNAbdEPjwpMtRd
+    output_index: 0
+    content_index: 0
+    part:
+      type: text
+      text: Hi there!
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.done
+    event_id: event_EKSlKV9ZOuerb1iKVpJC4
+    previous_item_id: null
+    item:
+      id: item_EKSlKa7wNAbdEPjwpMtRd
+      type: message
+      status: completed
+      role: assistant
+      content:
+      - type: output_text
+        text: Hi there!
+- kind: message
+  direction: received
+  data:
+    type: response.output_item.done
+    event_id: event_EKSlK1wB54Fd02U6eozfJ
+    response_id: resp_EKSlKEF62lcbEvmIG4xlr
+    output_index: 0
+    item:
+      id: item_EKSlKa7wNAbdEPjwpMtRd
+      type: message
+      status: completed
+      role: assistant
+      content:
+      - type: output_text
+        text: Hi there!
+- kind: message
+  direction: received
+  data:
+    type: response.done
+    event_id: event_EKSlKCAP5azuZviljRCmW
+    response:
+      object: realtime.response
+      id: resp_EKSlKEF62lcbEvmIG4xlr
+      status: completed
+      status_details: null
+      output:
+      - id: item_EKSlKa7wNAbdEPjwpMtRd
+        type: message
+        status: completed
+        role: assistant
+        content:
+        - type: output_text
+          text: Hi there!
+      conversation_id: conv_EKSlKnei1DlQdrPtjP26o
+      output_modalities:
+      - text
+      max_output_tokens: inf
+      audio:
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+      usage:
+        total_tokens: 21
+        input_tokens: 16
+        output_tokens: 5
+        input_token_details:
+          text_tokens: 16
+          audio_tokens: 0
+          image_tokens: 0
+          cached_tokens: 0
+          cached_tokens_details:
+            text_tokens: 0
+            audio_tokens: 0
+            image_tokens: 0
+        output_token_details:
+          text_tokens: 5
+          audio_tokens: 0
+      metadata: null

--- a/tests/realtime/test_openai.py
+++ b/tests/realtime/test_openai.py
@@ -3816,6 +3816,23 @@ def test_profile() -> None:
     assert profile.get('audio_output_sample_rate') == 24000
 
 
+@pytest.mark.parametrize(
+    ('model_name', 'supports_thinking'),
+    [
+        ('gpt-realtime-2', True),
+        ('gpt-realtime-2.1', True),
+        ('gpt-realtime-2.1-2026-01-01', True),
+        ('gpt-realtime-2-mini', True),
+        ('gpt-realtime', False),
+        ('gpt-realtime-mini', False),
+        ('gpt-realtime-2025-08-28', False),
+        ('gpt-realtime-mini-2025-10-06', False),
+    ],
+)
+def test_profile_supports_thinking_at_model_family_boundary(model_name: str, supports_thinking: bool) -> None:
+    assert OpenAIRealtimeModel(model_name).profile.get('supports_thinking') is supports_thinking
+
+
 def test_provider_driven_profile_merges_defaults_varies_by_model_and_intersects_native_tools() -> None:
     class ProfileProvider(OpenAIProvider):
         @staticmethod

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -131,6 +131,33 @@ async def test_text_in_audio_out_turn(openai_ws_cassette: tuple[Provider[Any], R
     assert len(part.audio.data) > 0
 
 
+async def test_dated_ga_snapshot_ignores_thinking(
+    openai_ws_cassette: tuple[Provider[Any], RealtimeCassette],
+) -> None:
+    """The dated GA snapshot completes a turn without receiving unsupported `reasoning` config."""
+    provider, cassette = openai_ws_cassette
+    model = OpenAIRealtimeModel(
+        'gpt-realtime-2025-08-28',
+        provider=provider,
+        settings=OpenAIRealtimeModelSettings(thinking='low', output_modality='text'),
+    )
+
+    events: list[Any] = []
+    async with Agent(instructions='Answer in two or three words.').realtime(model).session() as session:
+        await session.send('Say a short greeting.')
+        with anyio.fail_after(30):
+            async for event in session:  # pragma: no branch
+                events.append(event)
+                if isinstance(event, RealtimeTurnCompleteEvent):
+                    break
+
+    session_updates = sent_frames_containing(cassette, 'session.update')
+    assert len(session_updates) == 1
+    assert 'reasoning' not in session_updates[0]['session']
+    assert any(isinstance(event, PartEndEvent) for event in events)
+    assert isinstance(events[-1], RealtimeTurnCompleteEvent)
+
+
 async def test_audio_in_server_vad_turn(
     openai_ws_cassette: tuple[Provider[Any], RealtimeCassette], assets_path: Path
 ) -> None:


### PR DESCRIPTION
The OpenAI realtime profile turned on `supports_thinking` for every model name starting with `gpt-realtime-2`, meant for the `gpt-realtime-2.1` reasoning family. That prefix also matches the dated **non-reasoning** GA snapshot `gpt-realtime-2025-08-28`. With a `thinking` setting the codec then sends `reasoning` in `session.update`, and the live API refuses the connection:

```
RealtimeError {'type': 'invalid_request_error', 'code': 'invalid_value', 'message': 'Unsupported option for this model.'}
```

whereas the bare `gpt-realtime` (profile `False`) silently ignores the setting and `gpt-realtime-2.1` works. Confirmed live before the fix.

This matches the family at a `-`/`.` version boundary instead, the way the Azure adapter already does for the same names. Includes a parametrized profile test over both sides of the boundary and a recorded cassette test connecting `gpt-realtime-2025-08-28` with `thinking='low'`, asserting `session.update` carries no `reasoning` and the turn completes.

Found while working through a field report from a production voice agent (no issue).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sRLtNqgA277g5jocQqUT3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

