### PR TITLE
Document speaking first, transcript accuracy, and other realtime gaps a production voice agent ran into

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -2,6 +2,10 @@
 
 ::: pydantic_ai.providers.Provider
 
+::: pydantic_ai.providers.infer_provider
+
+::: pydantic_ai.providers.infer_provider_class
+
 ::: pydantic_ai.providers.gateway.gateway_provider
 
 ::: pydantic_ai.providers.anthropic.AnthropicProvider

--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -92,6 +92,8 @@ The sections below describe the two kinds of deferred tools the handler can reso
 
 If a tool function always requires approval, you can pass the `requires_approval=True` argument to the [`@agent.tool`][pydantic_ai.agent.Agent.tool] decorator, [`@agent.tool_plain`][pydantic_ai.agent.Agent.tool_plain] decorator, [`Tool`][pydantic_ai.tools.Tool] class, [`FunctionToolset.tool`][pydantic_ai.toolsets.FunctionToolset.tool] decorator, or [`FunctionToolset.add_function()`][pydantic_ai.toolsets.FunctionToolset.add_function] method. Inside the function, you can then assume that the tool call has been approved.
 
+In a [realtime session](realtime/tools.md#deferred-and-approval-required-tools), approval must be resolved inline by a [`HandleDeferredToolCalls`][pydantic_ai.capabilities.HandleDeferredToolCalls] handler; without one, the call is refused every time.
+
 If approval depends on the tool call's arguments or the agent [run context][pydantic_ai.tools.RunContext], such as [dependencies](dependencies.md) or message history, raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] from the tool function. The [`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] property will be `True` if the tool call has already been approved.
 
 You can also raise it from the tool's [`args_validator`](tools-advanced.md#args-validator), which runs before the tool function and lets you reject invalid arguments before asking a human to approve them.
@@ -522,3 +524,4 @@ _(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())
 - [Advanced Tool Features](tools-advanced.md) - Custom schemas, dynamic tools, and execution details
 - [Toolsets](toolsets.md) - Managing collections of tools, including `ExternalToolset` for external tools
 - [Message History](message-history.md) - Working with message history for deferred tools, including [`run_id` / `conversation_id`](message-history.md#correlating-runs-with-run_id-and-conversation_id)
+- [Realtime tools](realtime/tools.md#deferred-and-approval-required-tools) - Approval-required and deferred tools in a live voice session

--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -92,7 +92,7 @@ The sections below describe the two kinds of deferred tools the handler can reso
 
 If a tool function always requires approval, you can pass the `requires_approval=True` argument to the [`@agent.tool`][pydantic_ai.agent.Agent.tool] decorator, [`@agent.tool_plain`][pydantic_ai.agent.Agent.tool_plain] decorator, [`Tool`][pydantic_ai.tools.Tool] class, [`FunctionToolset.tool`][pydantic_ai.toolsets.FunctionToolset.tool] decorator, or [`FunctionToolset.add_function()`][pydantic_ai.toolsets.FunctionToolset.add_function] method. Inside the function, you can then assume that the tool call has been approved.
 
-In a [realtime session](realtime/tools.md#deferred-and-approval-required-tools), approval must be resolved inline by a [`HandleDeferredToolCalls`][pydantic_ai.capabilities.HandleDeferredToolCalls] handler; without one, the call is refused every time.
+In a [realtime session](realtime/tools.md#deferred-and-approval-required-tools), approval must be resolved inline, typically by a [`HandleDeferredToolCalls`][pydantic_ai.capabilities.HandleDeferredToolCalls] handler (a capability hook can resolve it too); a call nothing resolves is refused every time.
 
 If approval depends on the tool call's arguments or the agent [run context][pydantic_ai.tools.RunContext], such as [dependencies](dependencies.md) or message history, raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] from the tool function. The [`RunContext.tool_call_approved`][pydantic_ai.tools.RunContext.tool_call_approved] property will be `True` if the tool call has already been approved.
 

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -105,6 +105,10 @@ configured with `google_input_transcription`: a pinned model ID in the shared se
 (native transcription stays on), and only `None` turns it off. Provider-specific defaults and
 deployment constraints live on the provider pages.
 
+The user transcript is a separate transcription pass, not a readout of what the realtime model
+heard directly from the audio. It can be less accurate or simply differ, so treat it as a caption
+and history record rather than ground truth for why the model responded as it did.
+
 Disabling transcription changes what a spoken turn contributes to history, replay, and text-agent
 handoff; see [History and handoff](history.md#retaining-audio) before relying on it. A
 [WebRTC sideband](deployment.md#browser-webrtc-server-sideband) receives no audio bytes to retain, so without input
@@ -129,8 +133,9 @@ async def send_image(session):
 Streaming images continuously approximates live video: the
 [camera example](../examples/realtime-camera.md) sends one camera frame per second alongside
 microphone audio. For continuous streams like that, use the session's image-retention controls to
-bound local history; see [Retaining images](history.md#retaining-images). Gemini-specific live-video
-settings belong on the [Gemini provider page](gemini.md#settings).
+bound local history; they do not change which frames the provider receives. See
+[Retaining images](history.md#retaining-images). Gemini-specific live-video settings belong on the
+[Gemini provider page](gemini.md#settings).
 
 ## Edge cases
 

--- a/docs/realtime/history.md
+++ b/docs/realtime/history.md
@@ -130,10 +130,11 @@ async def main():
         ...
 ```
 
-Images sent through [`send()`][pydantic_ai.realtime.RealtimeSession.send] are recorded by default.
-`retain_images_every_n=N` keeps the first image and then one of every `N`; the provider still receives
-every frame. `retain_images_max` defaults to `100` and evicts the oldest retained image when the cap
-is reached. Set it to `0` to retain none or `None` to remove the bound.
+These settings bound local history, not provider context: the provider still receives every frame.
+Images sent through [`send()`][pydantic_ai.realtime.RealtimeSession.send] are recorded by default;
+`retain_images_every_n=N` keeps the first image and then one of every `N`. `retain_images_max`
+defaults to `100` and evicts the oldest retained image when the cap is reached. Set it to `0` to
+retain none or `None` to remove the bound.
 
 Sampling controls history growth rate; the maximum provides the actual memory bound. Streaming
 images continuously approximates live video — the [camera example](../examples/realtime-camera.md)

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -210,8 +210,9 @@ while analysis runs. To continue the entire conversation after the voice session
 
 ## Edge cases
 
-- A response can speak and then call a tool. Its speech is finalized and reaches
-  [`stream_transcripts()`][pydantic_ai.realtime.RealtimeSession.stream_transcripts] before the tool
+- A response can speak and then call a tool. Its speech is finalized (and, with output
+  transcription on, reaches
+  [`stream_transcripts()`][pydantic_ai.realtime.RealtimeSession.stream_transcripts]) before the tool
   body runs, so a "has the agent spoken?" check inside the tool already includes that response's
   speech.
 - A tool finishing does not necessarily finish the turn; see the

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -210,6 +210,10 @@ while analysis runs. To continue the entire conversation after the voice session
 
 ## Edge cases
 
+- A response can speak and then call a tool. Its speech is finalized and reaches
+  [`stream_transcripts()`][pydantic_ai.realtime.RealtimeSession.stream_transcripts] before the tool
+  body runs, so a "has the agent spoken?" check inside the tool already includes that response's
+  speech.
 - A tool finishing does not necessarily finish the turn; see the
   [turn boundary](events.md#the-turn-boundary).
 - Short tools can make asynchronous Gemini tool calling counterproductive: the result may interrupt

--- a/docs/realtime/troubleshooting.md
+++ b/docs/realtime/troubleshooting.md
@@ -25,7 +25,7 @@ layer and stop local playback on real [barge-in](turns.md#barge-in).
 ## The greeting never plays, or the model replies twice when the visitor speaks
 
 Speaker echo or microphone transients probably cancelled the greeting while the audio path opened.
-Keep the microphone closed until assistant speech starts; see [Speaking first](turns.md#speaking-first).
+Keep the microphone closed until the greeting has played; see [Speaking first](turns.md#speaking-first).
 To confirm the cause, iterate the event stream and look for a
 [`RealtimeResponseInterruptedEvent`][pydantic_ai.realtime.RealtimeResponseInterruptedEvent] on the
 first response and any

--- a/docs/realtime/troubleshooting.md
+++ b/docs/realtime/troubleshooting.md
@@ -22,6 +22,16 @@ In push-to-talk mode, call `commit_audio()` and then `create_response()` after s
 The microphone is probably hearing speaker output. Add echo cancellation in the device/WebRTC
 layer and stop local playback on real [barge-in](turns.md#barge-in).
 
+## The greeting never plays, or the model replies twice when the visitor speaks
+
+Speaker echo or microphone transients probably cancelled the greeting while the audio path opened.
+Keep the microphone closed until assistant speech starts; see [Speaking first](turns.md#speaking-first).
+To confirm the cause, iterate the event stream and look for a
+[`RealtimeResponseInterruptedEvent`][pydantic_ai.realtime.RealtimeResponseInterruptedEvent] on the
+first response and any
+[`RealtimeSessionErrorEvent`][pydantic_ai.realtime.RealtimeSessionErrorEvent], or inspect the
+[Logfire trace](observability.md#logfire-instrumentation).
+
 ## Tools seem to stall
 
 The local tool runs concurrently, but the provider may pause speech while awaiting the result. Show

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -154,7 +154,8 @@ interruption note to the prepared request without modifying stored history.
 
 Send a text turn to have the agent open the conversation. Wait for the greeting's finalized
 [`SpeechPart`][pydantic_ai.messages.SpeechPart], which arrives once it has been spoken, before
-opening the microphone; a fixed sleep does not tell you whether the greeting has played.
+opening the microphone, and let your playback loop drain first: the part marks the end of
+generation, not of playback. A fixed sleep tells you neither.
 
 ```python
 import asyncio
@@ -183,7 +184,7 @@ can request the greeting without adding a text turn. If a response is already ac
 held until that response completes and is dropped if the user barges in, so returning from
 `create_response()` does not mean speech has started.
 
-Server VAD enables `interrupt_response`, so any detected speech cancels a greeting in flight. This
+Server VAD enables `interrupt_response` by default, so any detected speech cancels a greeting in flight. This
 includes speaker echo and microphone transients while the audio path opens; keeping the microphone
 closed until the greeting has played avoids that race.
 

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -150,6 +150,45 @@ History records a known cutoff on
 response state as interrupted. When this history is sent to a text model, Pydantic AI adds a readable
 interruption note to the prepared request without modifying stored history.
 
+## Speaking first
+
+Send a text turn to have the agent open the conversation. Wait for the first assistant
+[`SpeechPart`][pydantic_ai.messages.SpeechPart] before opening the microphone; sleeping for a fixed
+delay does not tell you whether speech has started.
+
+```python
+import asyncio
+
+from pydantic_ai import Agent
+
+agent = Agent(instructions='You are a welcoming museum guide.')
+
+
+async def wait_for_assistant_speech(session):
+    async for part in session.stream_transcripts():
+        if part.speaker == 'assistant':
+            return
+
+
+async def main():
+    async with agent.realtime('openai:gpt-realtime').session() as session:
+        speech_started = asyncio.create_task(wait_for_assistant_speech(session))
+        await session.send('Greet the visitor.')
+        await speech_started
+        ...  # open the microphone and start sending audio
+```
+
+With manual turn control, [`create_response()`][pydantic_ai.realtime.RealtimeSession.create_response]
+can request the greeting without adding a text turn. If a response is already active, the request is
+held until that response completes and is dropped if the user barges in. Returning from
+`create_response()` means the request was accepted, not that speech has started. You can also wait
+for a [`RealtimeTurnCompleteEvent`][pydantic_ai.realtime.RealtimeTurnCompleteEvent] when the whole
+greeting must finish before the microphone opens.
+
+Server VAD enables `interrupt_response`, so any detected speech cancels a greeting in flight. This
+includes speaker echo and microphone transients while the audio path opens; keeping the microphone
+closed until assistant speech starts avoids that race.
+
 ## Push-to-talk
 
 Disable automatic detection with `turn_detection=False` on models whose profile declares

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -152,9 +152,9 @@ interruption note to the prepared request without modifying stored history.
 
 ## Speaking first
 
-Send a text turn to have the agent open the conversation. Wait for the first assistant
-[`SpeechPart`][pydantic_ai.messages.SpeechPart] before opening the microphone; sleeping for a fixed
-delay does not tell you whether speech has started.
+Send a text turn to have the agent open the conversation. Wait for the greeting's finalized
+[`SpeechPart`][pydantic_ai.messages.SpeechPart], which arrives once it has been spoken, before
+opening the microphone; a fixed sleep does not tell you whether the greeting has played.
 
 ```python
 import asyncio
@@ -180,14 +180,12 @@ async def main():
 
 With manual turn control, [`create_response()`][pydantic_ai.realtime.RealtimeSession.create_response]
 can request the greeting without adding a text turn. If a response is already active, the request is
-held until that response completes and is dropped if the user barges in. Returning from
-`create_response()` means the request was accepted, not that speech has started. You can also wait
-for a [`RealtimeTurnCompleteEvent`][pydantic_ai.realtime.RealtimeTurnCompleteEvent] when the whole
-greeting must finish before the microphone opens.
+held until that response completes and is dropped if the user barges in, so returning from
+`create_response()` does not mean speech has started.
 
 Server VAD enables `interrupt_response`, so any detected speech cancels a greeting in flight. This
 includes speaker echo and microphone transients while the audio path opens; keeping the microphone
-closed until assistant speech starts avoids that race.
+closed until the greeting has played avoids that race.
 
 ## Push-to-talk
 

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -152,20 +152,27 @@ interruption note to the prepared request without modifying stored history.
 
 ## Speaking first
 
-Send a text turn to have the agent open the conversation. Wait for the greeting's finalized
-[`SpeechPart`][pydantic_ai.messages.SpeechPart], which arrives once it has been spoken, before
-opening the microphone, and let your playback loop drain first: the part marks the end of
-generation, not of playback. A fixed sleep tells you neither.
+Send a text turn to have the agent open the conversation, with playback already running. Wait for
+the greeting's finalized [`SpeechPart`][pydantic_ai.messages.SpeechPart], which arrives once it has
+been generated, then let your playback loop drain before opening the microphone. A fixed sleep tells
+you neither.
 
 ```python
 import asyncio
+from collections.abc import AsyncIterator
 
 from pydantic_ai import Agent
+from pydantic_ai.realtime import RealtimeSession
 
 agent = Agent(instructions='You are a welcoming museum guide.')
 
 
-async def wait_for_assistant_speech(session):
+async def play_audio(chunks: AsyncIterator[bytes]) -> None:
+    async for chunk in chunks:
+        ...  # Write the PCM16 chunk to your speaker or audio output stream.
+
+
+async def wait_for_assistant_speech(session: RealtimeSession) -> None:
     async for part in session.stream_transcripts():
         if part.speaker == 'assistant':
             return
@@ -173,10 +180,12 @@ async def wait_for_assistant_speech(session):
 
 async def main():
     async with agent.realtime('openai:gpt-realtime').session() as session:
-        speech_started = asyncio.create_task(wait_for_assistant_speech(session))
+        playback = asyncio.create_task(play_audio(session.stream_audio()))
+        greeted = asyncio.create_task(wait_for_assistant_speech(session))
         await session.send('Greet the visitor.')
-        await speech_started
-        ...  # open the microphone and start sending audio
+        await greeted
+        ...  # wait for the speaker to drain, then open the microphone and start sending audio
+        await playback
 ```
 
 With manual turn control, [`create_response()`][pydantic_ai.realtime.RealtimeSession.create_response]


### PR DESCRIPTION
Docs-only. A field report from a production voice agent built on `pydantic_ai.realtime` (OpenAI Realtime, server VAD, consuming the session only through `stream_audio()` / `stream_transcripts()`) turned up several things that are true of the library but not written down anywhere. Each cost real debugging time.

- **Speaking first** (`docs/realtime/turns.md`): `create_response()` was only documented as the push-to-talk verb. New section covers greeting via a text turn, gating the microphone on the greeting's finalized `SpeechPart` instead of sleeping, and why: server VAD enables `interrupt_response`, so speaker echo or mic transients while the audio path opens cancel a greeting in flight, and a `create_response()` issued while a response is active is held until it completes (dropped on barge-in), so returning from it does not mean speech has started.
- **Troubleshooting**: "The greeting never plays, or the model replies twice when the visitor speaks", with the event-stream diagnostics.
- **Input transcription is not ground truth** (`audio.md`): the user transcript is a separate transcription pass; the realtime model hears the audio directly and can be more accurate, so an agent that looks like it hallucinated may simply have heard better than the log.
- **Image retention bounds local history, not provider context** (`history.md`, `audio.md`): already stated, but trailing; now leads the paragraph. Misread twice in the field.
- **Speech lands before the tool body runs** (`tools.md` edge cases): a response that speaks and then calls a tool finalizes its speech first, so a "has the agent spoken?" check inside the tool already includes that turn.
- **Back-link** from `deferred-tools.md` to the realtime approval rules (`HandleDeferredToolCalls` required; otherwise refused every time). The link only went one way.
- `infer_provider` / `infer_provider_class` added to the providers API reference; both are used by docs examples but were absent from it.

Docs examples run under `tests/test_examples.py` against the scripted mock connection.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sRLtNqgA277g5jocQqUT3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

