### PR TITLE
Preserve extra keys in `LoadCapabilityReturn` history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py
+++ b/pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py
@@ -37,6 +37,7 @@ class LoadCapabilityArgs(TypedDict):
     """ID of the capability to load."""
 
 
+@pydantic.with_config(pydantic.ConfigDict(extra='allow'))
 class LoadCapabilityReturn(TypedDict):
     """Typed return value for the `load_capability` tool."""
 

--- a/tests/test_capability_deferred_loading.py
+++ b/tests/test_capability_deferred_loading.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 
 import pytest
 
+from pydantic_ai._deferred_capabilities import LoadCapabilityReturn
 from pydantic_ai._run_context import RunContext
 from pydantic_ai.agent import Agent
 from pydantic_ai.capabilities import (
@@ -33,6 +34,7 @@ from pydantic_ai.messages import (
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
     ModelMessage,
+    ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -1004,6 +1006,43 @@ def test_load_capability_parts_round_trip_through_message_history() -> None:
     rebuilt = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json([response, request]))
     assert isinstance(rebuilt[0].parts[0], LoadCapabilityCallPart)
     assert isinstance(rebuilt[1].parts[0], LoadCapabilityReturnPart)
+
+
+def test_load_capability_return_part_round_trip_preserves_extra_content() -> None:
+    """Unknown load-capability return fields survive message-history serialization."""
+    content = cast(
+        'LoadCapabilityReturn', {'instructions': 'Confirm the order id.', 'version': 2, 'tools': ['refunds']}
+    )
+    messages: list[ModelMessage] = [ModelRequest(parts=[LoadCapabilityReturnPart(content=content, tool_call_id='c1')])]
+
+    rebuilt = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages))
+
+    assert isinstance(rebuilt[0].parts[0], LoadCapabilityReturnPart)
+    assert rebuilt[0].parts[0].content == content
+
+
+def test_load_capability_return_part_from_history_preserves_extra_content() -> None:
+    """Unknown load-capability return fields survive loading persisted message history."""
+    content = {'instructions': 'Confirm the order id.', 'version': 2, 'tools': ['refunds']}
+    raw = [
+        {
+            'kind': 'request',
+            'parts': [
+                {
+                    'part_kind': 'tool-return',
+                    'tool_name': 'load_capability',
+                    'tool_kind': 'capability-load',
+                    'content': content,
+                    'tool_call_id': 'c1',
+                }
+            ],
+        }
+    ]
+
+    loaded = ModelMessagesTypeAdapter.validate_python(raw)
+
+    assert isinstance(loaded[0].parts[0], LoadCapabilityReturnPart)
+    assert loaded[0].parts[0].content == content
 
 
 async def test_deferred_capability_loads_instructions_and_tools_e2e() -> None:


### PR DESCRIPTION
## Summary

`LoadCapabilityReturn` is the typed payload returned by the `load_capability` tool. Its Pydantic `TypedDict` adapter silently discarded unknown fields when message history was serialized and loaded again, which could lose forward-compatible capability metadata.

Configure the return payload to allow extra fields and add regression coverage for both JSON round-tripping and loading persisted message history.

Closes #8002

## Verification

- `uv run --frozen pytest tests/test_capability_deferred_loading.py`
- `uv run --frozen ruff check pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py tests/test_capability_deferred_loading.py`
- `uv run --frozen ruff format --check pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py tests/test_capability_deferred_loading.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --frozen pyright pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py tests/test_capability_deferred_loading.py`

AI assistance was used during investigation and implementation. I reviewed the change and verified the behavior and tests.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes**
- [ ] Any permitted **compatibility impact** has been considered.
- [ ] **PR title** follows the guidelines in CONTRIBUTING.md.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

