### PR TITLE
Wrap botocore transport errors in `ModelAPIError` in `BedrockConverseModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -204,6 +204,7 @@ async def _call_bedrock(
     method: Callable[..., _BedrockCallResult],
     params: Mapping[str, Any],
     extra_headers: dict[str, str] | None,
+    model_name: str,
 ) -> _BedrockCallResult:
     _register_extra_headers(client)
     headers = dict(extra_headers or {})
@@ -215,7 +216,17 @@ async def _call_bedrock(
         finally:
             _extra_headers_var.reset(context_token)
 
-    return await anyio.to_thread.run_sync(call)
+    try:
+        return await anyio.to_thread.run_sync(call)
+    except BotoCoreError as e:
+        # botocore raises its transport failures (`ReadTimeoutError`, `EndpointConnectionError`,
+        # `ConnectionClosedError`, ...) as `BotoCoreError`, not `ClientError`, so `_map_api_errors` doesn't see
+        # them and they'd escape unwrapped, bypassing `FallbackModel` and `except ModelAPIError` handlers. Wrap
+        # them here, at the call that opens the request, rather than in `_map_api_errors`: that also guards the
+        # chunk reads in `BedrockStreamedResponse._get_event_iterator`, where the cancel guard
+        # (`get_stream_cancel_errors`) relies on seeing botocore's own types. Mirrors the Anthropic and OpenAI
+        # models, which wrap their SDKs' `APIConnectionError` on the request but let chunk-read errors through.
+        raise ModelAPIError(model_name=model_name, message=str(e)) from e
 
 
 _SUPPORTED_IMAGE_FORMATS = ('jpeg', 'png', 'gif', 'webp')
@@ -815,7 +826,9 @@ class BedrockConverseModel(Model[BaseClient]):
         # One client object for both registration and the call, in case the property is reassigned mid-request.
         client = self.client
         with _map_api_errors(self.model_name, self._provider.model_id_namespace):
-            response = await _call_bedrock(client, client.count_tokens, params, settings.get('extra_headers'))
+            response = await _call_bedrock(
+                client, client.count_tokens, params, settings.get('extra_headers'), self.model_name
+            )
         return usage.RequestUsage(input_tokens=response['inputTokens'])
 
     @asynccontextmanager
@@ -1057,10 +1070,12 @@ class BedrockConverseModel(Model[BaseClient]):
         with _map_api_errors(self.model_name, self._provider.model_id_namespace):
             if stream:
                 model_response = await _call_bedrock(
-                    client, client.converse_stream, params, settings.get('extra_headers')
+                    client, client.converse_stream, params, settings.get('extra_headers'), self.model_name
                 )
             else:
-                model_response = await _call_bedrock(client, client.converse, params, settings.get('extra_headers'))
+                model_response = await _call_bedrock(
+                    client, client.converse, params, settings.get('extra_headers'), self.model_name
+                )
         return model_response
 
     @staticmethod

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -19,7 +19,12 @@ from typing_extensions import ParamSpec, TypedDict, assert_never
 
 try:
     from botocore.client import BaseClient
-    from botocore.exceptions import BotoCoreError, ClientError
+    from botocore.exceptions import (
+        BotoCoreError,
+        ClientError,
+        ConnectionError as BotocoreConnectionError,
+        HTTPClientError,
+    )
     from botocore.model import StructureShape
 except ImportError as _import_error:
     raise ImportError(
@@ -145,6 +150,9 @@ def _map_api_errors(model_name: str, model_id_namespace: str = 'bedrock') -> Gen
                 suggested_model_id=suggested_model_id,
             ) from e
         raise ModelAPIError(model_name=model_name, message=str(e)) from e
+    except (HTTPClientError, BotocoreConnectionError) as e:
+        # botocore raises transport failures (timeouts, connection errors) as `BotoCoreError`, not `ClientError`.
+        raise ModelAPIError(model_name=model_name, message=str(e)) from e
 
 
 class _BotocoreRequestParams(TypedDict):
@@ -204,7 +212,6 @@ async def _call_bedrock(
     method: Callable[..., _BedrockCallResult],
     params: Mapping[str, Any],
     extra_headers: dict[str, str] | None,
-    model_name: str,
 ) -> _BedrockCallResult:
     _register_extra_headers(client)
     headers = dict(extra_headers or {})
@@ -216,17 +223,7 @@ async def _call_bedrock(
         finally:
             _extra_headers_var.reset(context_token)
 
-    try:
-        return await anyio.to_thread.run_sync(call)
-    except BotoCoreError as e:
-        # botocore raises its transport failures (`ReadTimeoutError`, `EndpointConnectionError`,
-        # `ConnectionClosedError`, ...) as `BotoCoreError`, not `ClientError`, so `_map_api_errors` doesn't see
-        # them and they'd escape unwrapped, bypassing `FallbackModel` and `except ModelAPIError` handlers. Wrap
-        # them here, at the call that opens the request, rather than in `_map_api_errors`: that also guards the
-        # chunk reads in `BedrockStreamedResponse._get_event_iterator`, where the cancel guard
-        # (`get_stream_cancel_errors`) relies on seeing botocore's own types. Mirrors the Anthropic and OpenAI
-        # models, which wrap their SDKs' `APIConnectionError` on the request but let chunk-read errors through.
-        raise ModelAPIError(model_name=model_name, message=str(e)) from e
+    return await anyio.to_thread.run_sync(call)
 
 
 _SUPPORTED_IMAGE_FORMATS = ('jpeg', 'png', 'gif', 'webp')
@@ -826,9 +823,7 @@ class BedrockConverseModel(Model[BaseClient]):
         # One client object for both registration and the call, in case the property is reassigned mid-request.
         client = self.client
         with _map_api_errors(self.model_name, self._provider.model_id_namespace):
-            response = await _call_bedrock(
-                client, client.count_tokens, params, settings.get('extra_headers'), self.model_name
-            )
+            response = await _call_bedrock(client, client.count_tokens, params, settings.get('extra_headers'))
         return usage.RequestUsage(input_tokens=response['inputTokens'])
 
     @asynccontextmanager
@@ -1070,12 +1065,10 @@ class BedrockConverseModel(Model[BaseClient]):
         with _map_api_errors(self.model_name, self._provider.model_id_namespace):
             if stream:
                 model_response = await _call_bedrock(
-                    client, client.converse_stream, params, settings.get('extra_headers'), self.model_name
+                    client, client.converse_stream, params, settings.get('extra_headers')
                 )
             else:
-                model_response = await _call_bedrock(
-                    client, client.converse, params, settings.get('extra_headers'), self.model_name
-                )
+                model_response = await _call_bedrock(client, client.converse, params, settings.get('extra_headers'))
         return model_response
 
     @staticmethod

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -75,7 +75,7 @@ from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, TestEnv, try_import
 
 with try_import() as imports_successful:
     from botocore.client import BaseClient
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import BotoCoreError, ClientError, ReadTimeoutError
     from botocore.hooks import HierarchicalEmitter
     from mypy_boto3_bedrock_runtime import BedrockRuntimeClient
     from mypy_boto3_bedrock_runtime.type_defs import MessageUnionTypeDef, SystemContentBlockTypeDef, ToolTypeDef
@@ -96,7 +96,7 @@ pytestmark = [
 class _StubBedrockClient:
     """Minimal Bedrock client that always raises the provided error."""
 
-    def __init__(self, error: ClientError):
+    def __init__(self, error: ClientError | BotoCoreError):
         self._error = error
         self.meta = SimpleNamespace(endpoint_url='https://bedrock.stub', events=HierarchicalEmitter())
 
@@ -164,7 +164,7 @@ async def test_bedrock_model_blocks_requests_when_disabled():
         await model.count_tokens(messages, None, model_request_parameters)
 
 
-def _bedrock_model_with_client_error(error: ClientError) -> BedrockConverseModel:
+def _bedrock_model_with_client_error(error: ClientError | BotoCoreError) -> BedrockConverseModel:
     """Instantiate a BedrockConverseModel wired to always raise the given error."""
     return BedrockConverseModel(
         'us.amazon.nova-micro-v1:0',
@@ -630,6 +630,32 @@ async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
     assert exc_info.value.message == snapshot(
         'An error occurred (TestException) when calling the count_tokens operation: broken connection'
     )
+
+
+async def test_bedrock_botocore_error(allow_model_requests: None):
+    """Transport errors raised by botocore itself (`ReadTimeoutError`, `EndpointConnectionError`, ...) derive from
+    `BotoCoreError`, not `ClientError`, so they need their own `ModelAPIError` mapping for `FallbackModel` and
+    `except ModelAPIError` handlers to see them.
+
+    Not a VCR test: a cassette replays a recorded HTTP response, it can't make botocore time out or fail to connect.
+    """
+    error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
+    model = _bedrock_model_with_client_error(error)
+    params = ModelRequestParameters()
+
+    with pytest.raises(ModelAPIError) as exc_info:
+        await model.request([ModelRequest.user_text_prompt('hi')], None, params)
+
+    assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
+    assert exc_info.value.__cause__ is error
+
+    with pytest.raises(ModelAPIError):
+        async with model.request_stream([ModelRequest.user_text_prompt('hi')], None, params) as stream:
+            async for _ in stream:
+                pass
+
+    with pytest.raises(ModelAPIError):
+        await model.count_tokens([ModelRequest.user_text_prompt('hi')], None, params)
 
 
 def _bedrock_arn(resource: str) -> str:

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -638,26 +638,16 @@ async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
     )
 
 
-@pytest.mark.parametrize(
-    ('error', 'expected_message'),
-    [
-        (ReadTimeoutError(endpoint_url='https://bedrock.stub'), 'Read timeout on endpoint URL: "https://bedrock.stub"'),
-        (
-            EndpointConnectionError(endpoint_url='https://bedrock.stub'),
-            'Could not connect to the endpoint URL: "https://bedrock.stub"',
-        ),
-    ],
-    ids=['read_timeout', 'endpoint_connection'],
-)
-async def test_bedrock_request_transport_error(allow_model_requests: None, error: BotoCoreError, expected_message: str):
+async def test_bedrock_request_transport_error(allow_model_requests: None):
     """Not a VCR test: a cassette replays a recorded response, it cannot make botocore time out or fail to connect."""
+    error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
     model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
     with pytest.raises(ModelAPIError) as exc_info:
         await model.request([ModelRequest.user_text_prompt('hi')], None, params)
 
-    assert exc_info.value.message == expected_message
+    assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
     assert exc_info.value.model_name == 'us.amazon.nova-micro-v1:0'
     assert exc_info.value.__cause__ is error
 
@@ -822,7 +812,7 @@ async def test_bedrock_stream_non_http_error(allow_model_requests: None):
 
 async def test_bedrock_stream_transport_error(allow_model_requests: None):
     """Not a VCR test: a cassette replays a recorded response, it cannot make botocore time out or fail to connect."""
-    error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
+    error = EndpointConnectionError(endpoint_url='https://bedrock.stub')
     model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
@@ -831,7 +821,7 @@ async def test_bedrock_stream_transport_error(allow_model_requests: None):
             async for _ in stream:
                 pass
 
-    assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
+    assert exc_info.value.message == snapshot('Could not connect to the endpoint URL: "https://bedrock.stub"')
 
 
 async def test_stub_provider_properties():

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -639,21 +639,24 @@ async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
 
 
 @pytest.mark.parametrize(
-    'error',
+    ('error', 'expected_message'),
     [
-        ReadTimeoutError(endpoint_url='https://bedrock.stub'),
-        EndpointConnectionError(endpoint_url='https://bedrock.stub'),
+        (ReadTimeoutError(endpoint_url='https://bedrock.stub'), 'Read timeout on endpoint URL: "https://bedrock.stub"'),
+        (
+            EndpointConnectionError(endpoint_url='https://bedrock.stub'),
+            'Could not connect to the endpoint URL: "https://bedrock.stub"',
+        ),
     ],
     ids=['read_timeout', 'endpoint_connection'],
 )
-async def test_bedrock_request_transport_error(allow_model_requests: None, error: BotoCoreError):
+async def test_bedrock_request_transport_error(allow_model_requests: None, error: BotoCoreError, expected_message: str):
     model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
     with pytest.raises(ModelAPIError) as exc_info:
         await model.request([ModelRequest.user_text_prompt('hi')], None, params)
 
-    assert exc_info.value.message == str(error)
+    assert exc_info.value.message == expected_message
     assert exc_info.value.__cause__ is error
 
 
@@ -668,7 +671,7 @@ async def test_bedrock_count_tokens_transport_error(allow_model_requests: None):
     assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
 
 
-async def test_bedrock_request_config_error_not_wrapped(allow_model_requests: None):
+async def test_bedrock_request_param_validation_error_not_wrapped(allow_model_requests: None):
     """Only transport failures become `ModelAPIError`; client-side botocore errors still surface as themselves."""
     error = ParamValidationError(report='bad params')
     model = _bedrock_model_with_error(error)

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -75,7 +75,13 @@ from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, TestEnv, try_import
 
 with try_import() as imports_successful:
     from botocore.client import BaseClient
-    from botocore.exceptions import BotoCoreError, ClientError, ReadTimeoutError
+    from botocore.exceptions import (
+        BotoCoreError,
+        ClientError,
+        EndpointConnectionError,
+        ParamValidationError,
+        ReadTimeoutError,
+    )
     from botocore.hooks import HierarchicalEmitter
     from mypy_boto3_bedrock_runtime import BedrockRuntimeClient
     from mypy_boto3_bedrock_runtime.type_defs import MessageUnionTypeDef, SystemContentBlockTypeDef, ToolTypeDef
@@ -149,7 +155,7 @@ async def test_bedrock_client_property_can_be_reassigned(bedrock_provider: Bedro
 
 
 async def test_bedrock_model_blocks_requests_when_disabled():
-    model = _bedrock_model_with_client_error(ClientError({'Error': {'Code': 'TestError'}}, 'Converse'))
+    model = _bedrock_model_with_error(ClientError({'Error': {'Code': 'TestError'}}, 'Converse'))
     messages: list[ModelMessage] = [ModelRequest.user_text_prompt('hello')]
     model_request_parameters = ModelRequestParameters()
 
@@ -164,7 +170,7 @@ async def test_bedrock_model_blocks_requests_when_disabled():
         await model.count_tokens(messages, None, model_request_parameters)
 
 
-def _bedrock_model_with_client_error(error: ClientError | BotoCoreError) -> BedrockConverseModel:
+def _bedrock_model_with_error(error: ClientError | BotoCoreError) -> BedrockConverseModel:
     """Instantiate a BedrockConverseModel wired to always raise the given error."""
     return BedrockConverseModel(
         'us.amazon.nova-micro-v1:0',
@@ -608,7 +614,7 @@ async def test_bedrock_count_tokens_error(allow_model_requests: None, bedrock_pr
 
 async def test_bedrock_request_non_http_error(allow_model_requests: None):
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'converse')
-    model = _bedrock_model_with_client_error(error)
+    model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
     with pytest.raises(ModelAPIError) as exc_info:
@@ -621,7 +627,7 @@ async def test_bedrock_request_non_http_error(allow_model_requests: None):
 
 async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'count_tokens')
-    model = _bedrock_model_with_client_error(error)
+    model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
     with pytest.raises(ModelAPIError) as exc_info:
@@ -632,30 +638,43 @@ async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
     )
 
 
-async def test_bedrock_botocore_error(allow_model_requests: None):
-    """Transport errors raised by botocore itself (`ReadTimeoutError`, `EndpointConnectionError`, ...) derive from
-    `BotoCoreError`, not `ClientError`, so they need their own `ModelAPIError` mapping for `FallbackModel` and
-    `except ModelAPIError` handlers to see them.
-
-    Not a VCR test: a cassette replays a recorded HTTP response, it can't make botocore time out or fail to connect.
-    """
-    error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
-    model = _bedrock_model_with_client_error(error)
+@pytest.mark.parametrize(
+    'error',
+    [
+        ReadTimeoutError(endpoint_url='https://bedrock.stub'),
+        EndpointConnectionError(endpoint_url='https://bedrock.stub'),
+    ],
+    ids=['read_timeout', 'endpoint_connection'],
+)
+async def test_bedrock_request_transport_error(allow_model_requests: None, error: BotoCoreError):
+    model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
     with pytest.raises(ModelAPIError) as exc_info:
         await model.request([ModelRequest.user_text_prompt('hi')], None, params)
 
-    assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
+    assert exc_info.value.message == str(error)
     assert exc_info.value.__cause__ is error
 
-    with pytest.raises(ModelAPIError):
-        async with model.request_stream([ModelRequest.user_text_prompt('hi')], None, params) as stream:
-            async for _ in stream:
-                pass
 
-    with pytest.raises(ModelAPIError):
+async def test_bedrock_count_tokens_transport_error(allow_model_requests: None):
+    error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
+    model = _bedrock_model_with_error(error)
+    params = ModelRequestParameters()
+
+    with pytest.raises(ModelAPIError) as exc_info:
         await model.count_tokens([ModelRequest.user_text_prompt('hi')], None, params)
+
+    assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
+
+
+async def test_bedrock_request_config_error_not_wrapped(allow_model_requests: None):
+    """Only transport failures become `ModelAPIError`; client-side botocore errors still surface as themselves."""
+    error = ParamValidationError(report='bad params')
+    model = _bedrock_model_with_error(error)
+
+    with pytest.raises(ParamValidationError):
+        await model.request([ModelRequest.user_text_prompt('hi')], None, ModelRequestParameters())
 
 
 def _bedrock_arn(resource: str) -> str:
@@ -781,7 +800,7 @@ async def test_bedrock_count_tokens_tool_config(
 
 async def test_bedrock_stream_non_http_error(allow_model_requests: None):
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'converse_stream')
-    model = _bedrock_model_with_client_error(error)
+    model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
     with pytest.raises(ModelAPIError) as exc_info:
@@ -792,10 +811,23 @@ async def test_bedrock_stream_non_http_error(allow_model_requests: None):
     assert 'broken connection' in exc_info.value.message
 
 
+async def test_bedrock_stream_transport_error(allow_model_requests: None):
+    error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
+    model = _bedrock_model_with_error(error)
+    params = ModelRequestParameters()
+
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with model.request_stream([ModelRequest.user_text_prompt('hi')], None, params) as stream:
+            async for _ in stream:
+                pass
+
+    assert exc_info.value.message == snapshot('Read timeout on endpoint URL: "https://bedrock.stub"')
+
+
 async def test_stub_provider_properties():
     # tests the test utility itself...
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'test'}}, 'converse')
-    model = _bedrock_model_with_client_error(error)
+    model = _bedrock_model_with_error(error)
     provider = model._provider  # pyright: ignore[reportPrivateUsage]
 
     assert provider.name == 'bedrock-stub'

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -650,6 +650,7 @@ async def test_bedrock_count_tokens_non_http_error(allow_model_requests: None):
     ids=['read_timeout', 'endpoint_connection'],
 )
 async def test_bedrock_request_transport_error(allow_model_requests: None, error: BotoCoreError, expected_message: str):
+    """Not a VCR test: a cassette replays a recorded response, it cannot make botocore time out or fail to connect."""
     model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
 
@@ -657,10 +658,12 @@ async def test_bedrock_request_transport_error(allow_model_requests: None, error
         await model.request([ModelRequest.user_text_prompt('hi')], None, params)
 
     assert exc_info.value.message == expected_message
+    assert exc_info.value.model_name == 'us.amazon.nova-micro-v1:0'
     assert exc_info.value.__cause__ is error
 
 
 async def test_bedrock_count_tokens_transport_error(allow_model_requests: None):
+    """Not a VCR test: a cassette replays a recorded response, it cannot make botocore time out or fail to connect."""
     error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
     model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()
@@ -672,7 +675,10 @@ async def test_bedrock_count_tokens_transport_error(allow_model_requests: None):
 
 
 async def test_bedrock_request_param_validation_error_not_wrapped(allow_model_requests: None):
-    """Only transport failures become `ModelAPIError`; client-side botocore errors still surface as themselves."""
+    """Only transport failures become `ModelAPIError`; client-side botocore errors still surface as themselves.
+
+    Not a VCR test: a real request never raises a client-side botocore error on demand.
+    """
     error = ParamValidationError(report='bad params')
     model = _bedrock_model_with_error(error)
 
@@ -815,6 +821,7 @@ async def test_bedrock_stream_non_http_error(allow_model_requests: None):
 
 
 async def test_bedrock_stream_transport_error(allow_model_requests: None):
+    """Not a VCR test: a cassette replays a recorded response, it cannot make botocore time out or fail to connect."""
     error = ReadTimeoutError(endpoint_url='https://bedrock.stub')
     model = _bedrock_model_with_error(error)
     params = ModelRequestParameters()


### PR DESCRIPTION
- Closes #8130

`BedrockConverseModel` only mapped `ClientError`, so botocore's own transport failures (`ReadTimeoutError`, `EndpointConnectionError`, `ConnectionClosedError`, ...), which derive from `BotoCoreError`, escaped `agent.run()` unwrapped and bypassed `FallbackModel` (default `fallback_on=(ModelAPIError,)`) and `except ModelAPIError` handlers. Repro and details in #8130.

The fix wraps `BotoCoreError` in `_call_bedrock`, the helper that opens `converse`, `converse_stream` and `count_tokens`, raising `ModelAPIError(model_name, str(e)) from e` like the existing `ClientError`-without-status branch does. It deliberately doesn't go into `_map_api_errors`: that context manager also guards the chunk reads in `BedrockStreamedResponse._get_event_iterator`, and the cancel guard (`get_stream_cancel_errors` -> `(BotoCoreError, ClientError)`) needs botocore's raw types there after `cancel()`. This mirrors `anthropic.py` / `openai.py`, which wrap `APIConnectionError` on the request and let bare httpx errors propagate from chunk reads (see the base `get_stream_cancel_errors` docstring).

| | Before | After |
|---|---|---|
| `ReadTimeoutError` / `EndpointConnectionError` while opening `converse`, `converse_stream` or `count_tokens` | raw botocore exception out of `agent.run()` | `ModelAPIError`, botocore error kept as `__cause__` |
| `FallbackModel(bedrock, other)` on a Bedrock timeout while opening the request | run fails with `ReadTimeoutError` | falls back to `other` |
| `ClientError` with HTTP status (throttling, validation, 5xx) | `ModelHTTPError` | unchanged |
| `ClientError` without status, `EventStreamError` mid-stream | `ModelAPIError` / `ModelHTTPError` | unchanged |
| botocore errors raised from chunk reads mid-stream, including after `cancel()` | raw | unchanged |

Test: `test_bedrock_botocore_error` drives `request`, `request_stream` and `count_tokens` through the existing `_StubBedrockClient` with a `ReadTimeoutError` (the stub's type hint is widened to `ClientError | BotoCoreError`). Not a VCR test since a cassette can't make botocore time out. With the source change reverted it fails as:

```
>       raise self._error
E       botocore.exceptions.ReadTimeoutError: Read timeout on endpoint URL: "https://bedrock.stub"
```

Locally: `tests/models/test_bedrock.py`, `tests/providers/test_bedrock.py` and `tests/models/test_fallback.py` pass (332 tests); `ruff format --check`, `ruff check` and `pyright` are clean on both files.

Code that caught the raw botocore exception around `agent.run()` will now see `ModelAPIError` instead, with the original as `__cause__`, the same as it already does for Anthropic/OpenAI connection errors.

Out of scope: `embeddings/bedrock.py` has the same `except ClientError`-only handling around `invoke_model`; left as is to keep this to the model.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver — n/a.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

