### PR TITLE
Fix the realtime "Speaking first" and relay examples, the `interrupt(played_ms=)` cancel race, and two provider tables

### DIFF
--- a/docs/realtime/AGENTS.md
+++ b/docs/realtime/AGENTS.md
@@ -34,4 +34,4 @@ the four provider pages (canonical for installs, model names, settings, quirks).
   that tool name elsewhere.
 - Browser WebRTC ships in Pydantic AI: `docs/realtime/deployment.md#browser-webrtc-server-sideband` is the canonical
   owner of the topology, and don't present third-party media platforms as the WebRTC story. Azure
-  Voice Live is still an in-flight PR (#6642): mention it as coming to Pydantic AI where relevant.
+  Voice Live ships too: `docs/realtime/azure.md` owns its routing and settings.

--- a/docs/realtime/capabilities.md
+++ b/docs/realtime/capabilities.md
@@ -51,7 +51,7 @@ a realtime model. Pass [`RealtimeModelSettings`][pydantic_ai.realtime.RealtimeMo
 | `RunContext` field | Value in a realtime session |
 | --- | --- |
 | [`ctx.model_settings`][pydantic_ai.tools.RunContext.model_settings] | The merged [`RealtimeModelSettings`][pydantic_ai.realtime.RealtimeModelSettings] the session was connected with. |
-| [`ctx.realtime`][pydantic_ai.tools.RunContext.realtime] | `True` from `before_run` onward. |
+| [`ctx.realtime`][pydantic_ai.tools.RunContext.realtime] | `True` for the whole run, including `for_run` and instruction functions that run before the connection exists. |
 | [`ctx.realtime_session`][pydantic_ai.tools.RunContext.realtime_session] | The live [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] once it is connected. |
 
 !!! note

--- a/docs/realtime/deployment.md
+++ b/docs/realtime/deployment.md
@@ -42,6 +42,7 @@ from pydantic_ai import Agent
 
 agent = Agent(instructions='You are a concise voice assistant.')
 realtime = agent.realtime('openai:gpt-realtime')
+sideband_tasks: set[asyncio.Task[None]] = set()
 
 
 async def handle_offer(sdp_offer: str) -> str:
@@ -52,9 +53,15 @@ async def handle_offer(sdp_offer: str) -> str:
             async for event in session:
                 print(event)
 
-    asyncio.create_task(run_sideband())
+    task = asyncio.create_task(run_sideband())
+    sideband_tasks.add(task)  # (1)!
+    task.add_done_callback(sideband_tasks.discard)
     return answer.sdp
 ```
+
+1. asyncio keeps only a weak reference to a task, so hold one yourself until the call ends; the done
+   callback also surfaces an error the sideband session raised instead of leaving it as a "never
+   retrieved" warning.
 
 The secure offer-relay flow never gives the browser a token. As an alternative,
 [`AgentRealtime.create_client_secret`][pydantic_ai.agent.AgentRealtime.create_client_secret] mints a
@@ -107,19 +114,29 @@ app = FastAPI()
 @app.websocket('/voice')
 async def voice_socket(websocket: WebSocket):
     await websocket.accept()
+
+    async def microphone():
+        while True:
+            yield await websocket.receive_bytes()
+
     async with agent.realtime('openai:gpt-realtime').session() as session:
 
-        async def pump_input():
-            while True:
-                await session.send_audio(await websocket.receive_bytes())
-
-        input_task = asyncio.create_task(pump_input())
-        try:
+        async def playback():
             async for chunk in session.stream_audio():
                 await websocket.send_bytes(chunk)
+
+        playback_task = asyncio.create_task(playback())
+        try:
+            await session.send_audio(microphone())
         finally:
-            input_task.cancel()
+            playback_task.cancel()
 ```
+
+[`send_audio()`][pydantic_ai.realtime.RealtimeSession.send_audio] consumes the async iterator for the
+whole call, so when the browser disconnects, `receive_bytes()` raises, the `finally` stops playback,
+and leaving the `async with` block hangs up the provider session. Driving the input from a bare
+`asyncio.create_task` instead would swallow that error and leave the billed session open with nobody
+listening.
 
 ## SIP/telephony bridge
 

--- a/docs/realtime/lifecycle.md
+++ b/docs/realtime/lifecycle.md
@@ -91,10 +91,12 @@ reports whether the reconnect carried the conversation through without cutting a
 
 How a reply the drop caught in flight is handled depends on the mechanism. Under native resumption
 (xAI) the recorded response simply stays open: output on the new connection continues it, the turn
-completes with the response terminal as usual, and `state_restored` stays `True`. Gemini also reports
-`True` but closes the cut reply as an interrupted response (keeping any partial transcript in history)
-before the [`RealtimeSessionReconnectEvent`][pydantic_ai.realtime.RealtimeSessionReconnectEvent] and
-stays quiet until the next input.
+completes with the response terminal as usual, and `state_restored` stays `True`. Gemini reports
+`True` once the server has issued a resumption handle (shortly after connect; a drop before that
+reports `False` and cancels running tools) but closes the cut reply as an interrupted response
+(keeping any partial transcript in history) before the
+[`RealtimeSessionReconnectEvent`][pydantic_ai.realtime.RealtimeSessionReconnectEvent] and stays
+quiet until the next input.
 
 Local replay (OpenAI, Azure OpenAI) restores only the finalized turns, so a reply in flight when the
 socket dropped cannot continue. The session settles it before emitting the event — the partial reply

--- a/docs/realtime/overview.md
+++ b/docs/realtime/overview.md
@@ -145,8 +145,8 @@ and quirks:
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | [OpenAI](openai.md) | ✓ | ✓ | ✓ | ✓ | ✓ | `gpt-realtime-2*` models | Replays local history |
 | [Azure OpenAI](azure.md) | ✓ | ✓ | ✓ | ✓ | ✓ | `gpt-realtime-2*` models | Replays local history |
-| [Google Gemini](gemini.md) | ✓ | ✓ | ✗ | ✗ | Opt-in, native-audio models | ✓ | ✓, when enabled |
-| [xAI](xai.md) | ✓ | ✗ | ✗ | ✗ | ✗ | `grok-voice-latest` and `-think-` models | ✓ |
+| [Google Gemini](gemini.md) | ✓ | ✓ | ✗ | ✗ | Opt-in, native-audio models | Native-audio and 3.x models | ✓, with a `reconnect` policy |
+| [xAI](xai.md) | ✓ | ✗ | ✗ | ✗ | ✗ | `grok-voice-latest` and `-think-` models | ✓, with a `reconnect` policy |
 
 For portable branching, inspect [`RealtimeModel.profile`][pydantic_ai.realtime.RealtimeModel.profile]
 or [`RealtimeSession.profile`][pydantic_ai.realtime.RealtimeSession.profile]: the

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -106,16 +106,17 @@ flush-attribute-truncate-cancel treatment as `handle_barge_in=True`:
 
 ```python
 import asyncio
+from collections.abc import AsyncIterator
 
 from pydantic_ai.realtime import RealtimeInputSpeechStartEvent, RealtimeSession
 
 
 async def conversation(session: RealtimeSession) -> None:
-    async def play_audio() -> None:
-        async for chunk in session.stream_audio():
+    async def play_audio(chunks: AsyncIterator[bytes]) -> None:
+        async for chunk in chunks:
             ...  # write the chunk to your speaker, waiting until the device consumed it
 
-    playback = asyncio.create_task(play_audio())
+    playback = asyncio.create_task(play_audio(session.stream_audio()))
     async for event in session:
         if isinstance(event, RealtimeInputSpeechStartEvent):
             await session.interrupt(played_bytes=session.played_audio_bytes)
@@ -127,11 +128,12 @@ count actual device consumption yourself and pass that. This handler covers the 
 report speech onset; on Gemini, which interrupts itself and leaves only the local flush to do,
 prefer `handle_barge_in=True`, which performs that flush for you.
 
-Interrupting while the provider has a speech segment open sends only the truncation on the models
-whose own turn detection cancels the response being spoken over (OpenAI and Azure OpenAI by
-default, and xAI): a second, client-side cancel racing the provider's can be applied to the *next*
-response and silence the reply to the barge-in. An interruption you raise outside a speech segment
-— a stop button, a tool cutting the model off — still cancels, since nothing else is stopping it.
+Interrupting between the provider's speech onset and the start of its next response sends only the
+truncation on the models whose own turn detection cancels the response being spoken over (OpenAI
+and Azure OpenAI by default, and xAI): a second, client-side cancel racing the provider's can be
+applied to the *next* response and silence the reply to the barge-in. This holds for every form of
+`interrupt()`. An interruption you raise outside that window — a stop button, a tool cutting the
+model off — still cancels, since nothing else is stopping it.
 
 Finally, when playback doesn't drain a single session-long `stream_audio()` iterator — several
 consumers, a playback layer that buffers ahead of the device, or a transport where the session
@@ -154,9 +156,9 @@ async def handle_events(session: RealtimeSession, speaker: Speaker):
     async for event in session:
         if isinstance(event, RealtimeInputSpeechStartEvent) and speaker.has_unplayed_audio():
             speaker.flush()
-            if session.profile['supports_output_truncation']:
+            if session.profile.get('supports_output_truncation', False):
                 await session.interrupt(played_ms=speaker.played_ms())
-            elif session.profile['supports_interruption']:
+            elif session.profile.get('supports_interruption', False):
                 await session.interrupt()
 ```
 
@@ -187,7 +189,7 @@ import asyncio
 from collections.abc import AsyncIterator
 
 from pydantic_ai import Agent
-from pydantic_ai.realtime import RealtimeSession
+from pydantic_ai.messages import SpeechPart
 
 agent = Agent(instructions='You are a welcoming museum guide.')
 
@@ -197,8 +199,8 @@ async def play_audio(chunks: AsyncIterator[bytes]) -> None:
         ...  # Write the PCM16 chunk to your speaker or audio output stream.
 
 
-async def wait_for_assistant_speech(session: RealtimeSession) -> None:
-    async for part in session.stream_transcripts():
+async def wait_for_assistant_speech(parts: AsyncIterator[SpeechPart]) -> None:
+    async for part in parts:
         if part.speaker == 'assistant':
             return
 
@@ -206,11 +208,11 @@ async def wait_for_assistant_speech(session: RealtimeSession) -> None:
 async def main():
     async with agent.realtime('openai:gpt-realtime').session() as session:
         playback = asyncio.create_task(play_audio(session.stream_audio()))
-        greeted = asyncio.create_task(wait_for_assistant_speech(session))
+        greeted = asyncio.create_task(wait_for_assistant_speech(session.stream_transcripts()))
         await session.send('Greet the visitor.')
         await greeted
         ...  # wait for the speaker to drain, then open the microphone and start sending audio
-        await playback
+    await playback  # the audio view ends once the session has closed
 ```
 
 With manual turn control, [`create_response()`][pydantic_ai.realtime.RealtimeSession.create_response]

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1730,8 +1730,10 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         do not apply; structured output should be delegated to a normal [`Agent`][pydantic_ai.Agent] (see the
         realtime docs). Capabilities run `for_run` once when the session connects; their instructions,
         toolsets, and native tools are applied. Tool hooks (`prepare_tools` and `before`/`after`/`wrap`/
-        `on_error` for `tool_validate` and `tool_execute`) run for each tool call. Run-, graph-,
-        model-request-, event-stream-, and output-stage hooks do not run.
+        `on_error` for `tool_validate` and `tool_execute`) run for each tool call. Run hooks
+        (`before_run`, `after_run`, `wrap_run`, `on_run_error`) run once around the session and
+        event-stream hooks wrap the session iterator; graph, model-request, and output-stage hooks
+        do not run.
 
         ```python
         from pydantic_ai import Agent
@@ -1760,8 +1762,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                 (there is no per-request rebuild in a realtime session).
             toolsets: Optional additional toolsets for the session, on top of the agent's.
             capabilities: Optional additional capabilities for the session. Their `for_run`, setup
-                contributions, and tool-lifecycle hooks apply; run, model-request, graph, event-stream,
-                and output hooks are not invoked.
+                contributions, and tool-lifecycle hooks apply; run hooks fire once around the session
+                and event-stream hooks wrap the iterator; model-request, graph, and output hooks are not
+                invoked.
             usage: Optional [`RunUsage`][pydantic_ai.usage.RunUsage] to accumulate token usage into;
                 exposed as `session.usage`. A fresh one is used when omitted.
             usage_limits: Optional [`UsageLimits`][pydantic_ai.usage.UsageLimits]. Request, token, and

--- a/pydantic_ai_slim/pydantic_ai/profiles/google.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/google.py
@@ -227,10 +227,13 @@ def google_realtime_model_profile(model_name: str) -> RealtimeModelProfile:
         # a `WebFetch()` or `CodeExecutionTool()` a silent no-op; leaving them out means a `local=`
         # fallback is used instead, or the shared `UserError` points at one.
         'supported_native_tools': frozenset({WebSearchTool}),
-        # Every current Gemini Live model takes a thinking config (verified live for both
+        # The native-audio Live models and 3.x take a thinking config (verified live for
         # `gemini-2.5-flash-native-audio-latest` and `gemini-3.1-flash-live-preview`), which Google
-        # documents as `thinkingBudget` on the 2.5 family and `thinkingLevel` on 3.x.
-        'supports_thinking': True,
+        # documents as `thinkingBudget` on the 2.5 family and `thinkingLevel` on 3.x. The Vertex
+        # half-cascade `gemini-live-2.5-flash` is the exception: it closes the session with `1007
+        # thinking_level is not supported by this model` (and rejects a `thinking_budget` too), so
+        # it reports `False` and the shared `thinking` setting is skipped instead of sent.
+        'supports_thinking': 'native-audio' in model_name or not model_name.startswith('gemini-live-2.5'),
         # Only the native-audio models actually honor `Behavior.NON_BLOCKING`; verified live with
         # a slow tool, where `gemini-2.5-flash-native-audio-latest` keeps speaking throughout and
         # `gemini-3.1-flash-live-preview` accepts the flag but still goes silent until the result

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1500,11 +1500,16 @@ class RealtimeSession:
         # Truncate before cancelling: cancellation triggers `response.done`, which clears the tracked
         # output item, so a truncate sent afterwards could no-op. Both frames go out under one hold of
         # the send lock, so a tool result completing in between can't start a new response for the
-        # cancel to hit instead.
-        await self._send_frame(
-            *([TruncateOutput(audio_end_ms=played_ms)] if played_ms is not None else []),
-            CancelResponse(),
-        )
+        # cancel to hit instead. The client cancel is skipped while the provider's own turn detection
+        # is already cancelling the response spoken over — the same rule as the `played_bytes` path
+        # and `handle_barge_in=True` — so it can't land on the *next* response instead.
+        frames: list[TruncateOutput | CancelResponse] = []
+        if played_ms is not None:
+            frames.append(TruncateOutput(audio_end_ms=played_ms))
+        if not self._server_cancelled_the_response_on_speech:
+            frames.append(CancelResponse())
+        if frames:
+            await self._send_frame(*frames)
         self._pending_interrupted_at_ms = played_ms
         # Mark the barge-in in the trace. When the caller supplied `played_ms` (the ms of output audio
         # actually played before truncating), record it so a reader can see how far the response got before

--- a/pydantic_ai_slim/pydantic_ai/realtime/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/azure.py
@@ -111,7 +111,19 @@ _AZURE_REALTIME_API_BASES: tuple[tuple[tuple[str, ...], frozenset[AzureRealtimeA
     # Voice-Live-only models — auto-routed there. Native-audio models, then the cascade chat families
     # served via Azure speech-to-text and text-to-speech (`gpt-4o` also covers `gpt-4o-mini`; `gpt-5` and
     # `gpt-4.1` cover their point releases like `gpt-5.2`).
-    (('phi4-mm-realtime', 'azure-realtime', 'gpt-4o', 'gpt-4.1', 'gpt-5', 'phi4-mini'), _VOICE_LIVE),
+    (
+        (
+            'phi4-mm-realtime',
+            'azure-realtime',
+            'gpt-realtime-datazone',
+            'gpt-realtime-1.5-datazone',
+            'gpt-4o',
+            'gpt-4.1',
+            'gpt-5',
+            'phi4-mini',
+        ),
+        _VOICE_LIVE,
+    ),
 )
 
 

--- a/pydantic_ai_slim/pydantic_ai/realtime/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/settings.py
@@ -125,8 +125,9 @@ class RealtimeModelSettings(TypedDict, total=False):
     [`thinking`][pydantic_ai.settings.ModelSettings.thinking] setting on the request-response models.
 
     `True` enables it at the provider default, and `'minimal'`/`'low'`/`'medium'`/`'high'`/`'xhigh'`
-    selects an effort level. `False` disables thinking on Gemini. OpenAI realtime does not accept a
-    disabled effort, so `False` omits `reasoning` and leaves the model's default behavior unchanged.
+    selects an effort level. `False` disables thinking on Gemini and xAI (sent as `reasoning.effort:
+    'none'` there). OpenAI realtime does not accept a disabled effort, so `False` omits `reasoning`
+    and leaves the model's default behavior unchanged.
     OpenAI and Gemini apply it only to models whose profile reports
     [`supports_thinking`][pydantic_ai.realtime.RealtimeModelProfile.supports_thinking]. Other models
     silently ignore it. Providers with a richer native config expose it separately

--- a/tests/realtime/test_azure.py
+++ b/tests/realtime/test_azure.py
@@ -167,6 +167,9 @@ def test_azure_realtime_apis_default_absent_for_unknown_model() -> None:
         ('gpt-4o-mini', frozenset({'voice_live'})),
         # A GA-only `-realtime` variant is matched before the bare cascade name it also starts with.
         ('gpt-4o-realtime-preview', frozenset({'azure_openai'})),
+        # The data-zone `gpt-realtime` deployments exist only on Voice Live.
+        ('gpt-realtime-datazone', frozenset({'voice_live'})),
+        ('gpt-realtime-1.5-datazone', frozenset({'voice_live'})),
     ],
 )
 def test_azure_realtime_apis_name_boundary_matching(model_name: str, expected: frozenset[str] | None) -> None:

--- a/tests/realtime/test_google.py
+++ b/tests/realtime/test_google.py
@@ -808,6 +808,12 @@ def test_profile() -> None:
     # and URL context is accepted but never actually grounds, so neither is advertised and a
     # `local=` fallback is used instead.
     assert profile.get('supported_native_tools') == frozenset({WebSearchTool})
+    # The Vertex half-cascade `gemini-live-2.5-flash` closes the session with `1007 thinking_level is
+    # not supported by this model`, so the shared `thinking` setting is skipped there; its native-audio
+    # sibling and the 3.x models take it.
+    assert GoogleRealtimeModel('gemini-live-2.5-flash').profile.get('supports_thinking') is False
+    assert GoogleRealtimeModel('gemini-live-2.5-flash-native-audio').profile.get('supports_thinking') is True
+    assert GoogleRealtimeModel('gemini-3.1-flash-live-preview').profile.get('supports_thinking') is True
     assert GoogleRealtimeModel('gemini-3.1-flash-live-preview').profile.get('supported_native_tools') == frozenset(
         {WebSearchTool}
     )

--- a/tests/realtime/test_google_ws.py
+++ b/tests/realtime/test_google_ws.py
@@ -479,7 +479,7 @@ def test_profile_allow_seeding() -> None:
         supports_webrtc=False,
         supports_seeding_images=True,
         supports_seeding_audio=False,
-        supports_thinking=True,  # every current Gemini Live model takes a thinking config
+        supports_thinking=True,  # native-audio and 3.x Live models take a thinking config
         # Supported, not enabled: gates the opt-in `google_async_tool_calls` setting.
         supports_async_tool_calls=True,
         # Gemini Live renders an opted-in return schema natively (the declaration's `response`).

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1633,6 +1633,30 @@ async def test_interrupt_played_bytes_cancels_once_the_next_response_has_started
         assert conn.sent == [TruncateOutput(audio_end_ms=0), CancelResponse()]
 
 
+async def test_interrupt_played_ms_skips_the_cancel_while_the_server_interrupts_on_speech() -> None:
+    """`interrupt(played_ms=...)` and a bare `interrupt()` follow the same client-cancel rule as `played_bytes`.
+
+    The docs promise that an interruption raised between the provider's speech onset and its next
+    response sends only the truncation on a VAD that cancels server-side, whichever form of
+    `interrupt()` the app uses; before this, only the `played_bytes` path honoured that.
+    """
+    conn = _GatedRealtimeConnection(
+        [AudioDelta(b'a' * _CHUNK)],
+        [RealtimeInputSpeechStartEvent(), RealtimeInputSpeechEndEvent()],
+        interrupts_response_on_speech=True,
+    )
+    session = RealtimeSession(conn, _noop_runner)
+    async with session:
+        conn.release.set()
+        async for event in session:  # pragma: no branch
+            if isinstance(event, RealtimeInputSpeechEndEvent):
+                break
+        await session.interrupt(played_ms=50)
+        assert conn.sent == [TruncateOutput(audio_end_ms=50)]
+        await session.interrupt()
+        assert conn.sent == [TruncateOutput(audio_end_ms=50)]
+
+
 async def test_interrupt_played_bytes_cancels_outside_a_speech_segment() -> None:
     """An interruption the app raises itself still cancels, even on a VAD that interrupts on speech.
 


### PR DESCRIPTION
A bundle of small, independent fixes found by a docs-versus-implementation audit of the realtime usage surface, done right after #8103–#8110. None of them changes a documented behaviour: each one makes the implementation or an example match what the docs already promise.

**Code**

- `interrupt(played_ms=...)` and a bare `interrupt()` now skip the client-side cancel while the provider's own turn detection is already cancelling the response spoken over, the rule `interrupt(played_bytes=...)` and `handle_barge_in=True` already follow and that turns.md describes. Before, the `played_ms` example in turns.md sent exactly the racing cancel the paragraph below it warns about.
- The Vertex half-cascade `gemini-live-2.5-flash` reports `supports_thinking=False`. Live, any thinking config closes the session with `1007 thinking_level is not supported by this model`; the native-audio and 3.x models still take it.
- Azure routes the Voice-Live-only `gpt-realtime-datazone` and `gpt-realtime-1.5-datazone` deployments to Voice Live.
- The `thinking` docstring says `False` disables thinking on xAI as well as Gemini, which is what `xai.py` sends.

**Docs**

- The "Speaking first" example in turns.md awaited the playback task inside the `async with` block. An audio view only ends when the session closes, so on a live provider that line never returned; the docs test passed because the mock ends its stream. Playback is now awaited after the block, and both playback examples subscribe their views eagerly by passing the iterator into the task, as audio.md tells readers to.
- The deployment.md WebSocket relay drove the microphone from a bare `asyncio.create_task`, so a browser disconnect raised silently inside that task and the handler stayed blocked on `stream_audio()` with the billed session open. It now feeds `send_audio()` an async iterator, so the disconnect propagates and leaving the block hangs up. The sideband example keeps a reference to its task.
- `Agent.realtime()`'s docstring said run and event-stream hooks do not run in a realtime session; they do, and capabilities.md says so.
- Wording: the interrupt cancel-skip window is "from speech onset until the next response starts", Gemini's `state_restored` is only `True` once a resumption handle exists, the reconnect table cells say "with a `reconnect` policy", `ctx.realtime` is `True` for the whole run, `profile.get(...)` on a `total=False` TypedDict, and the realtime AGENTS.md no longer calls Azure Voice Live an in-flight PR.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

