### PR TITLE
Bound the realtime session event queue while nothing is iterating it

### DIFF
--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -74,6 +74,9 @@ An unconsumed view buffers up to its bound, dropping the oldest item when full, 
 [`close()`][pydantic_ai.realtime.RealtimeSession.close] discards pending items and ends every live
 iterator; [`closed`][pydantic_ai.realtime.RealtimeSession.closed] reports the state.
 
+If nothing is iterating the session, the session keeps the most recent 512 audio and transcript
+delta events for a late `async for`; older deltas are discarded. Structural events are always kept.
+
 ### Live captions
 
 For live captions, pass `delta=True` to

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -74,8 +74,9 @@ An unconsumed view buffers up to its bound, dropping the oldest item when full, 
 [`close()`][pydantic_ai.realtime.RealtimeSession.close] discards pending items and ends every live
 iterator; [`closed`][pydantic_ai.realtime.RealtimeSession.closed] reports the state.
 
-If nothing is iterating the session, the session keeps the most recent 512 audio and transcript
-delta events for a late `async for`; older deltas are discarded. Structural events are always kept.
+If nothing is iterating the session, the session keeps the most recent 512 part delta events
+(audio, transcript, and text) for a late `async for`; older deltas are discarded. Structural events
+are always kept.
 
 ### Live captions
 

--- a/docs/realtime/events.md
+++ b/docs/realtime/events.md
@@ -7,6 +7,9 @@ high-level [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
 [Audio, images, and transcripts](audio.md) are derived from this same stream, so most applications
 iterate the session for control flow and leave media to the views.
 
+If nothing is iterating the session, the session keeps the most recent 512 audio and transcript
+delta events for a late `async for`; older deltas are discarded. Structural events are always kept.
+
 ## Event reference
 
 | Event | Meaning |

--- a/docs/realtime/events.md
+++ b/docs/realtime/events.md
@@ -7,8 +7,9 @@ high-level [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
 [Audio, images, and transcripts](audio.md) are derived from this same stream, so most applications
 iterate the session for control flow and leave media to the views.
 
-If nothing is iterating the session, the session keeps the most recent 512 audio and transcript
-delta events for a late `async for`; older deltas are discarded. Structural events are always kept.
+If nothing is iterating the session, the session keeps the most recent 512 part delta events
+(audio, transcript, and text) for a late `async for`; older deltas are discarded. Structural events
+are always kept.
 
 ## Event reference
 

--- a/docs/realtime/observability.md
+++ b/docs/realtime/observability.md
@@ -97,8 +97,8 @@ response.
 The session span also reports `pydantic_ai.audio_chunks_dropped` and
 `pydantic_ai.transcript_items_dropped`, summed across bounded
 [audio and transcript consumers](audio.md#consuming-audio-and-transcripts). These totals are written
-when the session closes. `pydantic_ai.queue_dropped_deltas` counts older audio and transcript delta
-events discarded from the session event queue while nothing was iterating it.
+when the session closes. `pydantic_ai.queue_dropped_deltas` counts older part delta events discarded from the session event
+queue while nothing was iterating it.
 
 See [Debugging and monitoring](../logfire.md) for Logfire setup and privacy controls.
 

--- a/docs/realtime/observability.md
+++ b/docs/realtime/observability.md
@@ -97,7 +97,8 @@ response.
 The session span also reports `pydantic_ai.audio_chunks_dropped` and
 `pydantic_ai.transcript_items_dropped`, summed across bounded
 [audio and transcript consumers](audio.md#consuming-audio-and-transcripts). These totals are written
-when the session closes.
+when the session closes. `pydantic_ai.queue_dropped_deltas` counts older audio and transcript delta
+events discarded from the session event queue while nothing was iterating it.
 
 See [Debugging and monitoring](../logfire.md) for Logfire setup and privacy controls.
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -316,6 +316,9 @@ Key facts for building realtime agents:
   from a tool, await `ctx.realtime_session.close()` for a clean hang-up (the tool does not resume and
   its call is recorded as interrupted), or call `ctx.cancel()` to make the session context raise
   `RunCancelled`.
+- **Late event consumption is bounded**: while nothing is iterating the session, it retains every
+  structural event but only the most recent 512 audio and transcript `PartDeltaEvent`s. An active
+  `async for event in session` remains lossless.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -317,7 +317,7 @@ Key facts for building realtime agents:
   its call is recorded as interrupted), or call `ctx.cancel()` to make the session context raise
   `RunCancelled`.
 - **Late event consumption is bounded**: while nothing is iterating the session, it retains every
-  structural event but only the most recent 512 audio and transcript `PartDeltaEvent`s. An active
+  structural event but only the most recent 512 `PartDeltaEvent`s. An active
   `async for event in session` remains lossless.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's

--- a/pydantic_ai_slim/pydantic_ai/realtime/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_instrumentation.py
@@ -170,6 +170,7 @@ class SessionInstrumentation:
         final_result: str | None,
         audio_chunks_dropped: int,
         transcript_items_dropped: int,
+        queue_dropped_deltas: int,
     ) -> str | None:
         """Finalize and end the session span, returning its traceparent (for `AgentRunResult`).
 
@@ -191,6 +192,7 @@ class SessionInstrumentation:
             **settings.system_instructions_attributes(self.instructions),
             'pydantic_ai.audio_chunks_dropped': audio_chunks_dropped,
             'pydantic_ai.transcript_items_dropped': transcript_items_dropped,
+            'pydantic_ai.queue_dropped_deltas': queue_dropped_deltas,
         }
         schema_properties: dict[str, Any] = {}
         if 'gen_ai.system_instructions' in attributes:

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -981,13 +981,9 @@ class RealtimeSession:
 
     def _trim_queue_deltas(self) -> None:
         while self._queue_delta_count > _SESSION_DELTA_QUEUE_SIZE:
-            if isinstance(self._queue[0], PartDeltaEvent):
-                self._queue.popleft()
-            else:
-                for index, queued in enumerate(self._queue):
-                    if isinstance(queued, PartDeltaEvent):
-                        del self._queue[index]
-                        break
+            # Deltas make up the bulk of a backed-up queue, so the oldest one is normally at the head.
+            oldest = next(index for index, queued in enumerate(self._queue) if isinstance(queued, PartDeltaEvent))
+            del self._queue[oldest]
             self._queue_delta_count -= 1
             self._queue_dropped_deltas += 1
 
@@ -999,9 +995,9 @@ class RealtimeSession:
 
     async def _queue_get(self) -> RealtimeEvent | object:
         while not self._queue:
+            # Nothing can append between the clear and the wait: producers run on this event loop.
             self._queue_event.clear()
-            if not self._queue:
-                await self._queue_event.wait()
+            await self._queue_event.wait()
         return self._queue_get_nowait()
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -7,6 +7,7 @@ import dataclasses
 import io
 import wave
 import weakref
+from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable, Sequence
 from dataclasses import dataclass, replace
 from threading import Lock as ThreadLock
@@ -225,6 +226,7 @@ _FULL_PROFILE = RealtimeModelProfile(
 # audible glitch, so they get a far deeper window for the same trivial cost.
 _AUDIO_TAP_SIZE = 32
 _TRANSCRIPT_TAP_SIZE = 512
+_SESSION_DELTA_QUEUE_SIZE = 512
 _TapItem = TypeVar('_TapItem')
 _Tap = TypeVar('_Tap')
 
@@ -759,7 +761,10 @@ class RealtimeSession:
         # Iteration starts the pump lazily, but never tears it down: an early `break` can abandon the
         # reader generator without affecting resource lifetime, and `__aexit__` still drains everything
         # before the connection and toolset close.
-        self._queue: asyncio.Queue[RealtimeEvent | object] = asyncio.Queue()
+        self._queue: deque[RealtimeEvent | object] = deque()
+        self._queue_event = asyncio.Event()
+        self._queue_delta_count = 0
+        self._queue_dropped_deltas = 0
         self._queue_changed = object()
         self._tap_finished = object()
         self._audio_taps: set[_AudioTap] = set()
@@ -934,6 +939,7 @@ class RealtimeSession:
             final_result=self._final_result_text(),
             audio_chunks_dropped=self._audio_tap_drops,
             transcript_items_dropped=self._transcript_tap_drops,
+            queue_dropped_deltas=self._queue_dropped_deltas,
         )
         self._loop = None
 
@@ -959,10 +965,44 @@ class RealtimeSession:
                 raise self._pump_error
             # A failed tool (or background drain) surfaces through the queue rather than
             # `_pump_error`; with no consumer it would otherwise vanish here.
-            while not self._queue.empty():
-                item = self._queue.get_nowait()
+            while self._queue:
+                item = self._queue_get_nowait()
                 if isinstance(item, BaseException) and not isinstance(item, asyncio.CancelledError):
                     raise item
+
+    def _queue_put(self, item: RealtimeEvent | object) -> None:
+        """Append an item, bounding queued deltas while no session iterator is active."""
+        if isinstance(item, PartDeltaEvent):
+            self._queue_delta_count += 1
+        self._queue.append(item)
+        if not self._iterator_active:
+            self._trim_queue_deltas()
+        self._queue_event.set()
+
+    def _trim_queue_deltas(self) -> None:
+        while self._queue_delta_count > _SESSION_DELTA_QUEUE_SIZE:
+            if isinstance(self._queue[0], PartDeltaEvent):
+                self._queue.popleft()
+            else:
+                for index, queued in enumerate(self._queue):
+                    if isinstance(queued, PartDeltaEvent):
+                        del self._queue[index]
+                        break
+            self._queue_delta_count -= 1
+            self._queue_dropped_deltas += 1
+
+    def _queue_get_nowait(self) -> RealtimeEvent | object:
+        item = self._queue.popleft()
+        if isinstance(item, PartDeltaEvent):
+            self._queue_delta_count -= 1
+        return item
+
+    async def _queue_get(self) -> RealtimeEvent | object:
+        while not self._queue:
+            self._queue_event.clear()
+            if not self._queue:
+                await self._queue_event.wait()
+        return self._queue_get_nowait()
 
     @property
     def closed(self) -> bool:
@@ -1417,7 +1457,7 @@ class RealtimeSession:
         await self._send_frame(CommitAudio())
         self._user_turn_active = True
         for event in self._finalize_untranscribed_user():
-            await self._queue.put(event)
+            self._queue_put(event)
 
     async def clear_audio(self) -> None:
         """Discard buffered, uncommitted input audio."""
@@ -2493,7 +2533,7 @@ class RealtimeSession:
         # of the `chat` spans. The session-level `realtime` span and per-response `chat` spans below
         # stay hand-managed for now — they move onto exchange-level capability hooks when those land.
         async def on_validate(args_valid: bool) -> None:
-            await self._queue.put(FunctionToolCallEvent(part=call_part, args_valid=args_valid))
+            self._queue_put(FunctionToolCallEvent(part=call_part, args_valid=args_valid))
             validation_done.set()
             for prerequisite in execution_prerequisites:
                 await prerequisite.wait()
@@ -2502,8 +2542,8 @@ class RealtimeSession:
             requests: DeferredToolRequests,
             results: DeferredToolResults,
         ) -> None:
-            await self._queue.put(DeferredToolRequestsEvent(requests))
-            await self._queue.put(DeferredToolResultsEvent(results))
+            self._queue_put(DeferredToolRequestsEvent(requests))
+            self._queue_put(DeferredToolResultsEvent(results))
 
         try:
             async with self._tool_manager_lock:
@@ -2613,8 +2653,8 @@ class RealtimeSession:
     def _pending_message_task_done(self, task: asyncio.Task[None]) -> None:
         self._background_tasks.discard(task)
         if not task.cancelled() and (error := task.exception()) is not None:
-            self._queue.put_nowait(error)
-        self._queue.put_nowait(self._queue_changed)
+            self._queue_put(error)
+        self._queue_put(self._queue_changed)
 
     async def _drain_pending_messages(self, priority: PendingMessagePriority) -> None:
         """Deliver queued text prompts of `priority` and record them as normal user turns."""
@@ -2741,7 +2781,7 @@ class RealtimeSession:
             # Surface the failure through the queue so the consumer re-raises it, instead of letting it
             # vanish into `__aexit__`'s cleanup-only drain and hang the session on a completion that
             # never arrives.
-            await self._queue.put(e)
+            self._queue_put(e)
             if not self._stream_consumed and self._pump_task is not None:
                 # Nobody is reading the event stream, so the parked error can only surface from
                 # `close()` — and with the provider still waiting on a tool result it will never get,
@@ -2771,7 +2811,7 @@ class RealtimeSession:
             self._ordered_tool_events[order_index] = events
         else:
             for event in events:
-                await self._queue.put(event)
+                self._queue_put(event)
         if self._asap_drain_deferred and not self._tool_calls_awaiting_usage:
             await self._drain_pending_messages('asap')
 
@@ -2782,10 +2822,10 @@ class RealtimeSession:
         # `_pending_message_task_done`. Otherwise it vanishes with only an "exception was never
         # retrieved" warning at GC, silently losing the enqueued message with no signal to the consumer.
         if not task.cancelled() and (error := task.exception()) is not None:
-            self._queue.put_nowait(error)
+            self._queue_put(error)
         self._release_ordered_tool_events()
         # Wake the queue reader so it can finish once both the pump and the last tool are done.
-        self._queue.put_nowait(self._queue_changed)
+        self._queue_put(self._queue_changed)
 
     def _release_ordered_tool_events(self) -> None:
         """Emit `parallel_ordered_events` results in call order, once nothing is still running.
@@ -2797,7 +2837,7 @@ class RealtimeSession:
             return
         for order_index in sorted(self._ordered_tool_events):
             for event in self._ordered_tool_events[order_index]:
-                self._queue.put_nowait(event)
+                self._queue_put(event)
         self._ordered_tool_events.clear()
 
     async def _handle_pump_event(
@@ -2843,7 +2883,7 @@ class RealtimeSession:
             # `PartEndEvent(SpeechPart)` here rather than on the translation path, and the transcript
             # views would otherwise miss exactly the turns where the assistant speaks and acts.
             self._publish_taps(out)
-            await self._queue.put(out)
+            self._queue_put(out)
         mode = self._tool_manager.get_parallel_execution_mode()
         is_barrier = mode == 'sequential' or self._tool_manager.is_sequential(call_part)
         # `parallel_ordered_events` keeps calls concurrent but hands their result events to the
@@ -2913,7 +2953,7 @@ class RealtimeSession:
                     outcome='interrupted',
                 )
                 for out in self._complete_tool_call(call_part, cancelled_part):
-                    await self._queue.put(out)
+                    self._queue_put(out)
             return False
         if isinstance(event, SessionUsage):
             await self._handle_usage_event(event)
@@ -2924,7 +2964,7 @@ class RealtimeSession:
                 # Before the event reaches the consumer, so the app observes an already-handled
                 # barge-in rather than racing the session to handle it.
                 await self._auto_barge_in(out)
-            await self._queue.put(out)
+            self._queue_put(out)
         if isinstance(event, ResponseDone):
             await self._drain_pending_messages('asap')
             await self._drain_pending_messages('when_idle')
@@ -2943,7 +2983,7 @@ class RealtimeSession:
             self._pump_finished = True
             if not self._closed:
                 self._finish_taps()
-            await self._queue.put(self._queue_changed)
+            self._queue_put(self._queue_changed)
             if token is not None:
                 otel_context.detach(token)
 
@@ -3026,14 +3066,14 @@ class RealtimeSession:
 
         async def queue_events() -> AsyncIterator[RealtimeEvent]:
             while True:
-                item = await self._queue.get()
+                item = await self._queue_get()
                 if item is self._queue_changed:
                     # A pump error takes priority over stuck background tools. Their cancellation and
                     # drain belong to `__aexit__`, which runs as this exception leaves the owner block.
                     if self._pump_error is not None:
                         self._stream_exhausted = True
                         raise self._pump_error
-                    if self._pump_finished and not self._background_tasks and self._queue.empty():
+                    if self._pump_finished and not self._background_tasks and not self._queue:
                         self._stream_exhausted = True
                         return
                     continue
@@ -3054,3 +3094,4 @@ class RealtimeSession:
                 await aclose_all((stream_iterator, stream, source))
             finally:
                 self._iterator_active = False
+                self._trim_queue_deltas()

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -981,7 +981,9 @@ class RealtimeSession:
 
     def _trim_queue_deltas(self) -> None:
         while self._queue_delta_count > _SESSION_DELTA_QUEUE_SIZE:
-            # Deltas make up the bulk of a backed-up queue, so the oldest one is normally at the head.
+            # Deltas make up the bulk of a backed-up queue, so the oldest one is normally near the head.
+            # The scan only crosses the structural events retained ahead of it — a handful per turn, so
+            # negligible next to the audio frame that triggered it even after hundreds of turns.
             oldest = next(index for index, queued in enumerate(self._queue) if isinstance(queued, PartDeltaEvent))
             del self._queue[oldest]
             self._queue_delta_count -= 1
@@ -3091,8 +3093,8 @@ class RealtimeSession:
             async for event in stream_iterator:  # pragma: no branch
                 yield event
         finally:
-            try:
-                await aclose_all((stream_iterator, stream, source))
-            finally:
-                self._iterator_active = False
-                self._trim_queue_deltas()
+            # Nobody reads the queue past this point, so the bound applies again before the wrapper's
+            # cleanup runs, however long that takes.
+            self._iterator_active = False
+            self._trim_queue_deltas()
+            await aclose_all((stream_iterator, stream, source))

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -981,9 +981,11 @@ class RealtimeSession:
 
     def _trim_queue_deltas(self) -> None:
         while self._queue_delta_count > _SESSION_DELTA_QUEUE_SIZE:
-            # Deltas make up the bulk of a backed-up queue, so the oldest one is normally near the head.
-            # The scan only crosses the structural events retained ahead of it — a handful per turn, so
-            # negligible next to the audio frame that triggered it even after hundreds of turns.
+            # Deltas make up the bulk of a backed-up queue, so the oldest one is close to the head: the
+            # scan and the deque deletion are linear only in the structural events kept ahead of it,
+            # some five per turn, which do accumulate over a session nothing iterates. That stays under
+            # a tenth of a millisecond per delta until one session has run thousands of turns, which is
+            # negligible against the audio frame that triggered it.
             oldest = next(index for index, queued in enumerate(self._queue) if isinstance(queued, PartDeltaEvent))
             del self._queue[oldest]
             self._queue_delta_count -= 1

--- a/tests/realtime/test_instrumentation.py
+++ b/tests/realtime/test_instrumentation.py
@@ -1073,6 +1073,24 @@ async def test_session_span_counts_dropped_transcript_deltas() -> None:
     assert sess.attributes['pydantic_ai.transcript_items_dropped'] == 8
 
 
+async def test_session_span_counts_dropped_session_queue_deltas() -> None:
+    settings, exporter = _settings()
+    chunks = [index.to_bytes(2) for index in range(520)]
+    session = RealtimeSession(
+        _Connection([AudioDelta(chunk) for chunk in chunks]),
+        _ok_runner,
+        instrumentation=settings,
+        model_name='gpt-realtime',
+    )
+
+    async with session:
+        _ = [chunk async for chunk in session.stream_audio()]
+
+    sess = next(s for s in exporter.get_finished_spans() if s.name == 'invoke_agent agent')
+    assert sess.attributes is not None
+    assert sess.attributes['pydantic_ai.queue_dropped_deltas'] == 8
+
+
 async def test_session_span_includes_resolved_run_attributes() -> None:
     settings, exporter = _settings()
     agent: Agent[None, str] = Agent(

--- a/tests/realtime/test_instrumentation.py
+++ b/tests/realtime/test_instrumentation.py
@@ -1075,7 +1075,7 @@ async def test_session_span_counts_dropped_transcript_deltas() -> None:
 
 async def test_session_span_counts_dropped_session_queue_deltas() -> None:
     settings, exporter = _settings()
-    chunks = [index.to_bytes(2) for index in range(520)]
+    chunks = [index.to_bytes(2, 'big') for index in range(520)]
     session = RealtimeSession(
         _Connection([AudioDelta(chunk) for chunk in chunks]),
         _ok_runner,

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -4037,6 +4037,91 @@ async def test_concurrent_iteration_raises() -> None:
         await anext(late)
 
 
+def _queued_realtime_events(session: _RealtimeSession) -> list[RealtimeEvent]:
+    return [
+        item
+        for item in session._queue  # pyright: ignore[reportPrivateUsage]
+        if isinstance(
+            item,
+            (
+                PartStartEvent,
+                PartDeltaEvent,
+                PartEndEvent,
+                RealtimeInputSpeechStartEvent,
+                RealtimeInputSpeechEndEvent,
+                RealtimeTurnCompleteEvent,
+            ),
+        )
+    ]
+
+
+async def test_unconsumed_session_queue_keeps_structural_events_and_latest_deltas() -> None:
+    chunks = [index.to_bytes(2) for index in range(2000)]
+    connection = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(),
+            *[AudioDelta(chunk) for chunk in chunks[:1000]],
+            RealtimeInputSpeechEndEvent(),
+            *[AudioDelta(chunk) for chunk in chunks[1000:]],
+            ResponseDone(),
+        ]
+    )
+
+    async with RealtimeSession(connection) as session:
+        assert [chunk async for chunk in session.stream_audio()] == chunks[-32:]
+
+        queued = _queued_realtime_events(session)
+        assert sum(isinstance(event, PartDeltaEvent) for event in queued) == 512
+        assert [type(event) for event in queued if not isinstance(event, PartDeltaEvent)] == [
+            RealtimeInputSpeechStartEvent,
+            PartStartEvent,
+            RealtimeInputSpeechEndEvent,
+            PartEndEvent,
+            RealtimeTurnCompleteEvent,
+        ]
+
+        late_events = [event async for event in session]
+        late_chunks = [
+            event.delta.audio_chunk
+            for event in late_events
+            if isinstance(event, PartDeltaEvent) and isinstance(event.delta, SpeechPartDelta)
+        ]
+        assert late_chunks == chunks[-512:]
+
+
+async def test_active_session_iterator_does_not_drop_deltas() -> None:
+    chunks = [index.to_bytes(2) for index in range(2000)]
+    async with RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks])) as session:
+        events = [event async for event in session]
+        assert [
+            event.delta.audio_chunk
+            for event in events
+            if isinstance(event, PartDeltaEvent) and isinstance(event.delta, SpeechPartDelta)
+        ] == chunks
+        assert session._queue_dropped_deltas == 0  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_closing_session_iterator_bounds_remaining_deltas() -> None:
+    chunks = [index.to_bytes(2) for index in range(2000)]
+    async with RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks])) as session:
+        events = session.__aiter__()
+        assert isinstance(await anext(events), PartStartEvent)
+        await events.aclose()
+
+        assert session._queue_delta_count == 512  # pyright: ignore[reportPrivateUsage]
+        assert session._queue_dropped_deltas == 1488  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_unconsumed_session_queue_keeps_parked_exception() -> None:
+    chunks = [index.to_bytes(2) for index in range(2000)]
+    session = RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks]))
+
+    with pytest.raises(RuntimeError, match='tool failed'):
+        async with session:
+            session._queue_put(RuntimeError('tool failed'))  # pyright: ignore[reportPrivateUsage]
+            _ = [chunk async for chunk in session.stream_audio()]
+
+
 async def test_direct_session_must_be_entered_and_streams_once() -> None:
     session = RealtimeSession(FakeRealtimeConnection([]), _noop_runner)
 
@@ -5915,9 +6000,7 @@ async def test_deferred_asap_drain_failure_after_tool_is_forwarded(monkeypatch: 
     await asyncio.gather(task, return_exceptions=True)
     await asyncio.sleep(0)  # let the done-callback run
 
-    queued: list[Any] = []
-    while not session._queue.empty():  # pyright: ignore[reportPrivateUsage]
-        queued.append(session._queue.get_nowait())  # pyright: ignore[reportPrivateUsage]
+    queued = list(session._queue)  # pyright: ignore[reportPrivateUsage]
     assert any(isinstance(item, RuntimeError) and str(item) == 'drain send failed' for item in queued)
 
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -4080,7 +4080,7 @@ def _queued_realtime_events(session: _RealtimeSession) -> list[RealtimeEvent]:
 
 
 async def test_unconsumed_session_queue_keeps_structural_events_and_latest_deltas() -> None:
-    chunks = [index.to_bytes(2) for index in range(2000)]
+    chunks = [index.to_bytes(2, 'big') for index in range(2000)]
     connection = FakeRealtimeConnection(
         [
             RealtimeInputSpeechStartEvent(),
@@ -4114,7 +4114,7 @@ async def test_unconsumed_session_queue_keeps_structural_events_and_latest_delta
 
 
 async def test_active_session_iterator_does_not_drop_deltas() -> None:
-    chunks = [index.to_bytes(2) for index in range(2000)]
+    chunks = [index.to_bytes(2, 'big') for index in range(2000)]
     async with RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks])) as session:
         events = [event async for event in session]
         assert [
@@ -4126,10 +4126,11 @@ async def test_active_session_iterator_does_not_drop_deltas() -> None:
 
 
 async def test_closing_session_iterator_bounds_remaining_deltas() -> None:
-    chunks = [index.to_bytes(2) for index in range(2000)]
+    chunks = [index.to_bytes(2, 'big') for index in range(2000)]
     async with RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks])) as session:
         events = session.__aiter__()
         assert isinstance(await anext(events), PartStartEvent)
+        assert isinstance(events, AsyncGenerator)
         await events.aclose()
 
         assert session._queue_delta_count == 512  # pyright: ignore[reportPrivateUsage]
@@ -4137,7 +4138,7 @@ async def test_closing_session_iterator_bounds_remaining_deltas() -> None:
 
 
 async def test_unconsumed_session_queue_keeps_parked_exception() -> None:
-    chunks = [index.to_bytes(2) for index in range(2000)]
+    chunks = [index.to_bytes(2, 'big') for index in range(2000)]
     session = RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks]))
 
     with pytest.raises(RuntimeError, match='tool failed'):


### PR DESCRIPTION
`RealtimeSession._queue` was an unbounded `asyncio.Queue` with fifteen producers and two readers: the `async for` iterator and the exception sweep in `close()`. A consumer that only uses `stream_audio()` / `stream_transcripts()` — the quickstart shape, and the shape of the field report behind #8103–#8110 — never reads it, so every `PartDeltaEvent` (one per audio frame) stayed referenced until the session closed. A probe with five minutes of 24 kHz audio held all 14.4 MB in the queue after the audio taps had correctly dropped almost all of it; that is roughly 170 MB per hour of assistant speech.

Now, while nothing is iterating the session, the queue keeps the most recent 512 delta events and discards older ones, oldest first. Structural events (part starts and ends, tool events, turn boundaries, session, reconnect and error events), exceptions parked for the consumer, and internal sentinels are never discarded and keep their order. While a consumer is iterating nothing is dropped, so today's behaviour is unchanged for anyone with an `async for event in session`; closing that iterator trims the backlog. A late iterator sees every structural event and the most recent deltas. The queue is a `deque` plus an `asyncio.Event` so trimming can remove from the middle; discards are counted on the session span as `pydantic_ai.queue_dropped_deltas`, next to the existing tap-drop counters.

Docs: audio.md, events.md, observability.md, and the agent skill.

Found by a taps-only audit of the realtime surface; the design (cap of 512 deltas, structural events always kept) was decided by the maintainer.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

