### PR TITLE
Record a failed `ToolReturnPart` when a realtime tool raises, and keep a tool call and its speech in one `ModelResponse`

### DIFF
--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -15,6 +15,8 @@ failures and [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] produce a
 exceptions end the session and propagate from iteration; if the event stream was never iterated,
 they end the audio and transcript views and are raised when the session closes. (A consumer that
 started iterating and then stopped has chosen to stop listening: nothing is raised on its behalf.)
+The failed call is recorded with `outcome='failed'`, so the settled history can be passed to
+[`Agent.run(message_history=...)`][pydantic_ai.agent.AbstractAgent.run].
 The general
 [`on_tool_execute_error`][pydantic_ai.capabilities.AbstractCapability.on_tool_execute_error]
 capability hook also applies in realtime and can turn an exception into a replacement result or

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -311,11 +311,12 @@ Key facts for building realtime agents:
   the model keeps speaking meanwhile is provider-specific (OpenAI/Azure do; Gemini needs
   `google_async_tool_calls=True` on a native-audio model). An unhandled tool exception is raised
   from session iteration; when only `stream_audio()` or `stream_transcripts()` is consumed, it ends
-  those views and is raised when the session context closes. An `on_tool_execute_error` capability
-  can return a replacement result or raise `ModelRetry` to keep the session running. To end the call
-  from a tool, await `ctx.realtime_session.close()` for a clean hang-up (the tool does not resume and
-  its call is recorded as interrupted), or call `ctx.cancel()` to make the session context raise
-  `RunCancelled`.
+  those views and is raised when the session context closes. Its call is recorded with
+  `outcome='failed'`, leaving history valid for a standard-agent handoff. An
+  `on_tool_execute_error` capability can return a replacement result or raise `ModelRetry` to keep
+  the session running. To end the call from a tool, await `ctx.realtime_session.close()` for a clean
+  hang-up (the tool does not resume and its call is recorded as interrupted), or call `ctx.cancel()`
+  to make the session context raise `RunCancelled`.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -2927,10 +2927,10 @@ class RealtimeSession:
                     await self._queue.put(out)
             return False
         if isinstance(event, SessionUsage):
+            # Only part and response boundaries come out of a usage report, never a speech-start
+            # or interruption signal, so there is nothing for `_auto_barge_in` to do here.
             for out in await self._handle_usage_event(event):
                 self._publish_taps(out)
-                if self._handle_barge_in:
-                    await self._auto_barge_in(out)
                 await self._queue.put(out)
             return False
         for out in self._translate_event(event):

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -425,19 +425,17 @@ def _build_session_tool_return(
     return result_part, user_content
 
 
-def _unsettled_call_return(call: ToolCallPart, error: ApprovalRequired | CallDeferred | RunCancelled) -> ToolReturnPart:
-    """The failed return a session answers with when a tool call couldn't settle normally.
+def _unsettled_call_return(call: ToolCallPart, error: BaseException) -> ToolReturnPart:
+    """The return a session records when a tool call couldn't settle normally.
 
-    Both cases are ones the graph resolves by ending or isolating the run, which a live conversation
-    can't do — so each becomes a deliberate explanation the model can voice, marked `'failed'` rather
-    than left at the default `'success'`. Recording a refusal as a successful return would be a
-    misleading audit trail: `all_messages()` handed to `Agent.run` would read it as a tool that ran.
+    These are cases the graph resolves by ending or isolating the run, which a live conversation
+    can't do — so each gets a deliberate local settlement rather than leaving a dangling call.
     """
     if isinstance(error, RunCancelled):
         # Exactly the graph path's settlement (this session's own cancellation arrives as
         # `CancelledError`, which `_run_tool` re-raises untouched) — shared so the two can't drift.
         return cancelled_sub_agent_return(call, error)
-    else:
+    elif isinstance(error, (ApprovalRequired, CallDeferred)):
         # `handle_call` already gave the `HandleDeferredToolCalls` capability handler the chance to
         # resolve the deferral inline (approve, deny, retry, or substitute a result); reaching here
         # means no handler resolved it. The graph's fallback — pausing the run with a
@@ -445,6 +443,8 @@ def _unsettled_call_return(call: ToolCallPart, error: ApprovalRequired | CallDef
         # out-of-band result, and the provider expects an answer on the string-only tool channel).
         reason = 'requires approval' if isinstance(error, ApprovalRequired) else 'runs externally'
         content = f'Error: The {call.tool_name!r} tool {reason} and cannot be completed during a realtime session.'
+    else:
+        content = 'The tool raised an unhandled error and the session ended.'
     return ToolReturnPart(
         tool_name=call.tool_name,
         content=content,
@@ -2684,11 +2684,13 @@ class RealtimeSession:
             self._usage_limits.check_before_request(self.usage)
         self._response_limit_checked = True
 
-    def _accumulate_response_usage(self, event: SessionUsage) -> None:
+    def _accumulate_response_usage(self, event: SessionUsage) -> list[RealtimeEvent]:
+        events: list[RealtimeEvent] = []
         self._pending_response_usage = self._pending_response_usage + event.usage
         self._pending_provider_response_id = event.provider_response_id or self._pending_provider_response_id
         self._pending_finish_reason = event.finish_reason or self._pending_finish_reason
         if self._tool_calls_awaiting_usage:
+            events.extend(self._finalize_assistant_part())
             self._finalize_response(
                 provider_response_id=event.provider_response_id,
                 finish_reason=event.finish_reason,
@@ -2696,8 +2698,10 @@ class RealtimeSession:
             # OpenAI emits this usage immediately before `response.done`; the response is complete
             # already, so that terminal must not append a second, empty `ModelResponse`.
             self._response_finalized_before_terminal = True
+        return events
 
-    async def _handle_usage_event(self, event: SessionUsage) -> None:
+    async def _handle_usage_event(self, event: SessionUsage) -> list[RealtimeEvent]:
+        events: list[RealtimeEvent] = []
         if event.response_scoped:
             self._begin_response()
         self.usage.incr(event.usage)
@@ -2707,10 +2711,11 @@ class RealtimeSession:
                 self._usage_limits.check_per_request_input_tokens(
                     (self._pending_response_usage + event.usage).input_tokens
                 )
-            self._accumulate_response_usage(event)
+            events.extend(self._accumulate_response_usage(event))
         if self._asap_drain_ready:
             self._asap_drain_ready = False
             await self._drain_pending_messages('asap')
+        return events
 
     async def _run_tool(
         self,
@@ -2738,6 +2743,7 @@ class RealtimeSession:
         except asyncio.CancelledError:
             raise
         except BaseException as e:
+            self._complete_tool_call(call_part, _unsettled_call_return(call_part, e))
             # Surface the failure through the queue so the consumer re-raises it, instead of letting it
             # vanish into `__aexit__`'s cleanup-only drain and hang the session on a completion that
             # never arrives.
@@ -2916,7 +2922,11 @@ class RealtimeSession:
                     await self._queue.put(out)
             return False
         if isinstance(event, SessionUsage):
-            await self._handle_usage_event(event)
+            for out in await self._handle_usage_event(event):
+                self._publish_taps(out)
+                if self._handle_barge_in:
+                    await self._auto_barge_in(out)
+                await self._queue.put(out)
             return False
         for out in self._translate_event(event):
             self._publish_taps(out)

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -780,6 +780,20 @@ async def test_tool_error_ends_transcript_only_session(
                 conversation_id=IsStr(),
                 state='interrupted',
             ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='get_weather',
+                        content='The tool raised an unhandled error and the session ended.',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                        outcome='failed',
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
         ]
     )
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2257,6 +2257,7 @@ async def test_tool_response_finalized_on_usage_is_not_duplicated_at_terminal() 
                 args='{}',
                 response_usage_follows=True,
             ),
+            OutputTranscript(text='I will check that now.', is_final=True),
             SessionUsage(
                 usage=RequestUsage(output_tokens=1),
                 provider_response_id='response-tool',
@@ -2274,11 +2275,20 @@ async def test_tool_response_finalized_on_usage_is_not_duplicated_at_terminal() 
         return 'done'
 
     session = RealtimeSession(conn, runner)
-    _ = await collect_events(session)
+    events = await collect_events(session)
 
     responses = [message for message in session.new_messages() if isinstance(message, ModelResponse)]
     assert len(responses) == 1
-    assert isinstance(responses[0].parts[0], ToolCallPart)
+    assert responses[0].parts == [
+        ToolCallPart(tool_name='noop', args='{}', tool_call_id='tc-1'),
+        SpeechPart(speaker='assistant', transcript='I will check that now.'),
+    ]
+    assert responses[0].provider_response_id == 'response-tool'
+    assert responses[0].usage == RequestUsage(output_tokens=1)
+    assert session.usage.requests == 1
+    assert [
+        event.part for event in events if isinstance(event, PartEndEvent) and isinstance(event.part, SpeechPart)
+    ] == [SpeechPart(speaker='assistant', transcript='I will check that now.')]
 
 
 async def test_tool_call_events_carry_real_parts() -> None:
@@ -2764,6 +2774,22 @@ async def test_tool_error_ends_views_when_the_stream_was_never_iterated() -> Non
             assert await asyncio.wait_for(_collect(session.stream_audio()), timeout=1) == []
             # A view subscribed after the failure also ends immediately.
             assert await asyncio.wait_for(_collect(session.stream_transcripts()), timeout=1) == []
+
+    response, request = session.all_messages()
+    assert isinstance(response, ModelResponse)
+    assert response.parts == [ToolCallPart(tool_name='noop', args='{}', tool_call_id='tc1')]
+    assert isinstance(request, ModelRequest)
+    assert request.parts == snapshot(
+        [
+            ToolReturnPart(
+                tool_name='noop',
+                content='The tool raised an unhandled error and the session ended.',
+                tool_call_id='tc1',
+                timestamp=IsDatetime(),
+                outcome='failed',
+            )
+        ]
+    )
 
 
 async def test_tool_retry_exhaustion_ends_views_when_the_stream_was_never_iterated() -> None:
@@ -5297,6 +5323,32 @@ async def test_agent_realtime_session_tool_exception() -> None:
         with pytest.raises(ValueError, match='nope'):
             _ = [e async for e in session]
     assert conn.sent == []
+    assert [(type(message).__name__, message.parts) for message in session.all_messages()] == snapshot(
+        [
+            (
+                'ModelResponse',
+                [ToolCallPart(tool_name='explode', args='{}', tool_call_id='tc')],
+            ),
+            (
+                'ModelRequest',
+                [
+                    ToolReturnPart(
+                        tool_name='explode',
+                        content='The tool raised an unhandled error and the session ended.',
+                        tool_call_id='tc',
+                        timestamp=IsDatetime(),
+                        outcome='failed',
+                    )
+                ],
+            ),
+        ]
+    )
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(content='continued')])
+
+    result = await Agent(FunctionModel(respond)).run('continue', message_history=session.all_messages())
+    assert result.output == 'continued'
 
 
 async def test_agent_realtime_session_tool_failed_returns_error_result() -> None:


### PR DESCRIPTION
Two history-fidelity defects found by auditing `session.all_messages()` shapes against `Agent.run(message_history=...)`.

**A raising tool left a dangling `ToolCallPart`.** `_run_tool`'s `except BaseException` path parked the error for the consumer and popped the call from the pending set without recording a return, and `close()`'s settlement only covers calls still pending. So after the one tool-failure path that ends a session, `all_messages()` ended on a `ToolCallPart` with no return, and handing it to `Agent.run('continue', message_history=...)` raised `UserError: Cannot provide a new user prompt when the message history contains unprocessed tool calls.` `ctx.cancel()` and `close()` from a tool already record an `outcome='interrupted'` return, and the realtime AGENTS.md promises history never ends on a dangling call. The failing call is now settled locally with `outcome='failed'` and the content "The tool raised an unhandled error and the session ended." before the error surfaces; no `ToolResult` goes to the provider, since the session is ending.

**A response whose usage arrived while an assistant part was still streaming was split in two.** `_accumulate_response_usage` finalized the response for a call awaiting usage without first finalizing the open assistant part, so the trailing `ResponseDone` recorded the leftover speech as a second `ModelResponse` with the same `provider_response_id`, empty usage, and a second `requests` increment. The assistant part is now finalized first, mirroring `_handle_turn_complete`, and the part-boundary events it produces go through the same tap and barge-in path as translated events. The recorded OpenAI cassettes only ever show function-call-only responses followed by separate audio responses, so this was reproduced with a fake; the protocol allows the mixed ordering.

Docs: tools.md and the agent skill say the failed call is recorded so the settled history can be handed off. The `test_tool_error_ends_transcript_only_session` cassette expectation gains the failed return.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

