### PR TITLE
Price realtime responses so `usage.cost` and `UsageLimits.cost_limit` work in a session

### DIFF
--- a/docs/realtime/observability.md
+++ b/docs/realtime/observability.md
@@ -12,7 +12,9 @@ and follow-up text runs share one usage budget and trace.
 Read cumulative usage from
 [`RealtimeSession.usage`][pydantic_ai.realtime.RealtimeSession.usage]. It includes input/output
 tokens, provider audio and cache breakdowns where available, and tool-call counts. Usage updates are
-not emitted as session events. As with a standard run's
+not emitted as session events. When [genai-prices](https://github.com/pydantic/genai-prices) has
+pricing for the model, `session.usage.cost` contains the accumulated USD cost and `cost_limit`
+applies. As with a standard run's
 [usage limits](../agent.md#usage-limits), pass `usage=` to accumulate into a shared object — for
 example one carried across a voice call and its follow-up text runs — and `usage_limits=` to cap a
 session:
@@ -44,10 +46,14 @@ Input-transcription usage is reported separately in `RunUsage.details` under
 `input_transcription_*` keys. It is not included in response token totals or attributed to a
 `ModelResponse`, because transcription can use a separate model and billing meter.
 
-Token and tool-call limits are checked as usage accrues. Request limits are checked before sending
-text, explicitly creating a response, or returning a tool result. With server-side VAD, the provider
-can begin a response without a client request; that limit is checked at the first response event.
-Breaches raise [`UsageLimitExceeded`][pydantic_ai.exceptions.UsageLimitExceeded] from iteration.
+Each recorded `ModelResponse` in `session.new_messages()` carries that response's usage. One
+tool-calling turn can span several responses, so use `session.usage` for the cumulative total.
+
+Token, cost, and tool-call limits are checked as usage accrues. Request limits are checked before
+sending text, explicitly creating a response, or returning a tool result. With server-side VAD, the
+provider can begin a response without a client request; that limit is checked at the first response
+event. Breaches raise [`UsageLimitExceeded`][pydantic_ai.exceptions.UsageLimitExceeded] from
+iteration, or when the session context exits if only an audio or transcript view is consumed.
 
 Provider-specific usage fields belong on the
 [OpenAI](openai.md#feature-support-and-limitations),

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -286,6 +286,8 @@ Key facts for building realtime agents:
   and xAI cannot, and assistant audio is never replayed. Streamed images all reach the provider, but
   history keeps a sampled (`retain_images_every_n`) and bounded (`retain_images_max`, default `100`,
   oldest evicted first) record.
+- **Usage and cost**: each recorded `ModelResponse` carries its response usage, while `session.usage`
+  is cumulative; priced models get a `genai-prices` cost and enforce `UsageLimits.cost_limit`.
 - **No `output_type`**: realtime models don't do structured output. Delegate hard work to a text
   agent behind a tool, or hand off history afterwards.
 - **Check the model profile before calling profile-gated methods**: `model.profile` (a

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1882,6 +1882,9 @@ class RealtimeSession:
         self._pending_provider_response_id = None
         self._pending_finish_reason = None
         self._response_limit_checked = False
+        # Not while closing: a response settled by `close()` is the last thing this session will ever
+        # spend, and raising from teardown would mask the reason the session is closing. Its cost is
+        # still accumulated above, so a shared `usage` object carries it into whatever runs next.
         if response is not None and not self._closed:
             self._check_usage_limits()
 

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -2719,9 +2719,12 @@ class RealtimeSession:
             self._begin_response()
         self.usage.incr(event.usage)
         if event.response_scoped:
+            # Measured before accumulating: a tool-call response is finalized by the accumulation
+            # itself, which resets the accumulator.
+            response_input_tokens = (self._pending_response_usage + event.usage).input_tokens
             self._accumulate_response_usage(event)
             if self._usage_limits is not None:
-                self._usage_limits.check_per_request_input_tokens(self._pending_response_usage.input_tokens)
+                self._usage_limits.check_per_request_input_tokens(response_input_tokens)
         # Response pricing happens at finalization, so cost is provisionally unavailable here.
         self._check_usage_limits(warn_if_cost_unavailable=False)
         if self._asap_drain_ready:

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -21,6 +21,7 @@ from typing_extensions import TypeAliasType, assert_never
 
 from .. import _agent_graph
 from .._enqueue import EnqueueContent, PendingMessage, PendingMessagePriority
+from .._genai_prices import fill_response_cost
 from .._tool_execution import (
     _reject_unloaded_capability_reveals,  # pyright: ignore[reportPrivateUsage]
     build_tool_return_part,
@@ -1848,6 +1849,12 @@ class RealtimeSession:
                 state='interrupted' if interrupted else 'complete',
             )
             fill_run_metadata(response, run_id=self._run_id, conversation_id=self._conversation_id)
+            provider_reported_cost = response.usage.cost
+            fill_response_cost(response)
+            if provider_reported_cost is None:
+                # Tokens were added as `SessionUsage` events arrived; only add the price calculated
+                # at this response boundary. A provider-reported cost arrived in those events too.
+                self.usage.incr(RequestUsage(cost=response.usage.cost))
             self._history.append(response)
             self.usage.requests += 1
             self._tool_run_step += 1
@@ -1870,6 +1877,8 @@ class RealtimeSession:
         self._pending_provider_response_id = None
         self._pending_finish_reason = None
         self._response_limit_checked = False
+        if response is not None and not self._closed:
+            self._check_usage_limits()
 
     def _ensure_chat_span(self) -> None:
         """Begin assembling a response and open its `chat {model}` span if not already open.
@@ -2648,11 +2657,11 @@ class RealtimeSession:
         projected = dataclasses.replace(self.usage, tool_calls=self.usage.tool_calls + self._tool_calls_in_flight + 1)
         self._usage_limits.check_before_tool_call(projected)
 
-    def _check_usage_limits(self) -> None:
+    def _check_usage_limits(self, *, warn_if_cost_unavailable: bool = True) -> None:
         if self._usage_limits is None:
             return
         self._usage_limits.check_tokens(self.usage)
-        self._usage_limits.check_cost(self.usage)
+        self._usage_limits.check_cost(self.usage, warn_if_cost_unavailable=warn_if_cost_unavailable)
 
     def _reserve_response_request(self) -> None:
         """Claim the request budget for a response this session is about to solicit.
@@ -2701,13 +2710,12 @@ class RealtimeSession:
         if event.response_scoped:
             self._begin_response()
         self.usage.incr(event.usage)
-        self._check_usage_limits()
         if event.response_scoped:
-            if self._usage_limits is not None:
-                self._usage_limits.check_per_request_input_tokens(
-                    (self._pending_response_usage + event.usage).input_tokens
-                )
             self._accumulate_response_usage(event)
+            if self._usage_limits is not None:
+                self._usage_limits.check_per_request_input_tokens(self._pending_response_usage.input_tokens)
+        # Response pricing happens at finalization, so cost is provisionally unavailable here.
+        self._check_usage_limits(warn_if_cost_unavailable=False)
         if self._asap_drain_ready:
             self._asap_drain_ready = False
             await self._drain_pending_messages('asap')

--- a/tests/realtime/test_azure_ws.py
+++ b/tests/realtime/test_azure_ws.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations as _annotations
 
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -117,6 +118,7 @@ async def test_text_in_audio_out_turn(
                 'output_text_tokens': 16,
                 'audio_tokens': 82,
             },
+            cost=Decimal('0.005568'),
             requests=1,
         )
     )

--- a/tests/realtime/test_google_ws.py
+++ b/tests/realtime/test_google_ws.py
@@ -11,6 +11,7 @@ Recorded once against the live API with `--record-mode=rewrite`, then replayed o
 from __future__ import annotations as _annotations
 
 import asyncio
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -270,8 +271,9 @@ async def test_tool_call_round(gemini_ws_cassette: tuple[Provider[Any], Realtime
     assert isinstance(tool_response, ModelResponse)
     assert tool_response.parts == [ToolCallPart(tool_name='record_reading', args=IsStr(), tool_call_id=IsStr())]
     # Gemini's tool-call frame carries no usage metadata; the later completed turn owns the only usage
-    # report the provider supplies, so the intermediate response remains honestly empty.
-    assert tool_response.usage == RequestUsage()
+    # report the provider supplies, so the intermediate response remains honestly empty: no tokens, and
+    # therefore a zero price rather than an unknown one.
+    assert tool_response.usage == RequestUsage(cost=Decimal('0'))
     tool_return = messages[2]
     assert isinstance(tool_return, ModelRequest)
     assert tool_return.parts == [
@@ -295,6 +297,7 @@ async def test_tool_call_round(gemini_ws_cassette: tuple[Provider[Any], Realtime
     # must not be collapsed into the output total.
     assert final.usage == (
         RequestUsage(
+            cost=Decimal('0.0016495'),
             input_tokens=1267,
             output_tokens=103,
             input_text_tokens=1267,

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -48,7 +48,7 @@ from pydantic_ai.realtime import (
     RealtimeSession,
     RealtimeTurnCompleteEvent,
 )
-from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai.usage import RunUsage
 
 from ..conftest import IsDatetime, IsSameStr, IsStr, try_import
 from .conftest import REAL_SDP_OFFER

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -13,6 +13,7 @@ import asyncio
 import importlib
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +21,7 @@ import anyio
 import pytest
 from inline_snapshot import snapshot
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RequestUsage, RunContext
 from pydantic_ai.capabilities.instrumentation import Instrumentation
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
@@ -127,6 +128,7 @@ async def test_session_when_idle_enqueue_waits_for_response_boundary(
                     },
                     output_tokens=5,
                     input_tokens=24,
+                    cost=Decimal('0.000176'),
                 ),
                 model_name='gpt-realtime',
                 timestamp=IsDatetime(),
@@ -159,6 +161,7 @@ async def test_session_when_idle_enqueue_waits_for_response_boundary(
                     },
                     output_tokens=9,
                     input_tokens=52,
+                    cost=Decimal('0.000352'),
                 ),
                 model_name='gpt-realtime',
                 timestamp=IsDatetime(),
@@ -354,6 +357,7 @@ async def test_provider_factory_text_turn(
                         'output_text_tokens': 5,
                         'audio_tokens': 0,
                     },
+                    cost=Decimal('0.000128'),
                 ),
                 model_name='gpt-realtime',
                 timestamp=IsDatetime(),
@@ -493,6 +497,7 @@ async def test_audio_in_server_vad_turn(
                 'output_text_tokens': 28,
                 'audio_tokens': 136,
             },
+            cost=Decimal('0.010072'),
             requests=1,
         )
     )
@@ -697,6 +702,7 @@ async def test_tool_can_close_session(openai_ws_cassette: tuple[Provider[Any], R
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='hang_up', args='{}', tool_call_id=(tool_call_id := IsSameStr()))],
+                usage=RequestUsage(cost=Decimal('0.0')),
                 model_name='gpt-realtime',
                 timestamp=IsDatetime(),
                 provider_name='openai',
@@ -772,6 +778,7 @@ async def test_tool_error_ends_transcript_only_session(
                         tool_call_id=IsStr(),
                     )
                 ],
+                usage=RequestUsage(cost=Decimal('0.0')),
                 model_name='gpt-realtime',
                 timestamp=IsDatetime(),
                 provider_name='openai',

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -7156,6 +7156,24 @@ async def test_agent_realtime_session_per_request_input_token_limit_raises() -> 
             _ = [e async for e in session]
 
 
+async def test_agent_realtime_session_per_request_input_token_limit_covers_a_tool_call_response() -> None:
+    """OpenAI reports a tool-call response's usage right before `response.done`, which finalizes the
+    response immediately; the per-request check must see that usage rather than the reset accumulator."""
+    conn = FakeRealtimeConnection(
+        [
+            ToolCall(tool_call_id='tc1', tool_name='noop', args='{}'),
+            SessionUsage(usage=RequestUsage(input_tokens=51), response_scoped=True),
+            ResponseDone(),
+        ]
+    )
+    agent: Agent[None, str] = Agent()
+    async with agent.realtime(
+        FakeRealtimeModel(conn), usage_limits=UsageLimits(per_request_input_tokens_limit=50)
+    ).session() as session:
+        with pytest.raises(UsageLimitExceeded, match='per_request_input_tokens_limit of 50'):
+            _ = [e async for e in session]
+
+
 async def test_agent_realtime_session_request_limit_raises() -> None:
     conn = FakeRealtimeConnection(
         [

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -4849,6 +4849,7 @@ async def test_handoff_to_standard_agent_run() -> None:
             ModelRequest(parts=[SpeechPart(speaker='user', transcript='hello')], timestamp=IsDatetime()),
             ModelResponse(
                 parts=[SpeechPart(speaker='assistant', transcript='hi there')],
+                usage=RequestUsage(cost=Decimal('0.0')),
                 model_name='gpt-realtime',
                 timestamp=IsDatetime(),
                 finish_reason='stop',
@@ -4980,6 +4981,7 @@ async def test_grounding_streams_and_folds_native_tool_parts() -> None:
     assert session.new_messages() == [
         ModelResponse(
             parts=[*grounding, SpeechPart(speaker='assistant', transcript='It is sunny in Rome')],
+            usage=RequestUsage(cost=Decimal('0.0')),
             model_name='gemini-live-2.5-flash',
             timestamp=IsDatetime(),
             finish_reason='stop',
@@ -5033,6 +5035,7 @@ async def test_grounded_history_hands_off_with_native_parts_intact() -> None:
                     ),
                     TextPart(content='It is sunny in Rome'),
                 ],
+                usage=RequestUsage(cost=Decimal('0.0')),
                 model_name='gemini-live-2.5-flash',
                 timestamp=IsDatetime(),
                 finish_reason='stop',
@@ -5111,6 +5114,7 @@ async def test_code_execution_history_hands_off_with_native_parts_intact() -> No
                     ),
                     TextPart(content='The answer is 2.'),
                 ],
+                usage=RequestUsage(cost=Decimal('0.0')),
                 model_name='gemini-live-2.5-flash',
                 timestamp=IsDatetime(),
                 finish_reason='stop',
@@ -6949,6 +6953,47 @@ async def test_agent_realtime_session_external_usage_accumulates() -> None:
     assert usage.output_tokens == 3
 
 
+async def test_agent_realtime_session_prices_response_usage() -> None:
+    usage = RequestUsage(
+        input_tokens=1000,
+        output_tokens=500,
+        input_audio_tokens=800,
+        output_audio_tokens=400,
+    )
+    conn = FakeRealtimeConnection(
+        [OutputTranscript(text='priced response', is_final=True), SessionUsage(usage=usage), ResponseDone()]
+    )
+    agent: Agent[None, str] = Agent()
+    async with agent.realtime(FakeRealtimeModel(conn, model_name='gpt-realtime', system='openai')).session() as session:
+        _ = [event async for event in session]
+
+    response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
+    assert isinstance(response.usage.cost, Decimal) and response.usage.cost > 0
+    assert session.usage.cost == response.usage.cost
+    # The response tokens were already accumulated from `SessionUsage`; pricing must not add them again.
+    assert session.usage.input_tokens == 1000
+    assert session.usage.output_tokens == 500
+    assert session.usage.input_audio_tokens == 800
+    assert session.usage.output_audio_tokens == 400
+
+
+async def test_agent_realtime_session_unpriced_response_keeps_cost_unknown() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            OutputTranscript(text='unpriced response', is_final=True),
+            SessionUsage(usage=RequestUsage(input_tokens=10, output_tokens=5)),
+            ResponseDone(),
+        ]
+    )
+    agent: Agent[None, str] = Agent()
+    async with agent.realtime(FakeRealtimeModel(conn, model_name='unpriced-realtime-model')).session() as session:
+        _ = [event async for event in session]
+
+    response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
+    assert response.usage.cost is None
+    assert session.usage.cost is None
+
+
 async def test_run_level_usage_is_not_attributed_to_or_finalize_response() -> None:
     async def runner(name: str, args: dict[str, Any], call_id: str) -> str:
         return 'done'
@@ -6981,6 +7026,9 @@ async def test_agent_realtime_session_token_limit_raises() -> None:
     async with agent.realtime(model, usage_limits=UsageLimits(total_tokens_limit=50)).session() as session:
         with pytest.raises(UsageLimitExceeded, match='Exceeded the total_tokens_limit of 50'):
             _ = [e async for e in session]
+    response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
+    assert response.state == 'complete'
+    assert response.usage == RequestUsage(input_tokens=100, output_tokens=100)
 
 
 async def test_agent_realtime_session_cost_limit_raises_on_usage() -> None:
@@ -6991,6 +7039,50 @@ async def test_agent_realtime_session_cost_limit_raises_on_usage() -> None:
     ).session() as session:
         with pytest.raises(UsageLimitExceeded, match=r'Exceeded the `cost_limit` of 0.50'):
             _ = [e async for e in session]
+
+
+async def test_agent_realtime_session_priced_cost_limit_raises_at_response_boundary() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            OutputTranscript(text='over budget', is_final=True),
+            SessionUsage(usage=RequestUsage(input_tokens=1000, output_tokens=500)),
+            ResponseDone(),
+        ]
+    )
+    agent: Agent[None, str] = Agent()
+    async with agent.realtime(
+        FakeRealtimeModel(conn, model_name='gpt-realtime', system='openai'),
+        usage_limits=UsageLimits(cost_limit=Decimal('0.0001')),
+    ).session() as session:
+        with pytest.raises(UsageLimitExceeded, match=r'Exceeded the `cost_limit` of 0.0001'):
+            _ = [event async for event in session]
+
+    response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
+    assert response.state == 'complete'
+    assert response.usage.input_tokens == 1000
+    assert response.usage.output_tokens == 500
+    assert response.usage.cost == session.usage.cost
+
+
+async def test_agent_realtime_session_priced_cost_limit_raises_with_only_transcript_view() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            OutputTranscript(text='over budget', is_final=True),
+            SessionUsage(usage=RequestUsage(input_tokens=1000, output_tokens=500)),
+            ResponseDone(),
+        ]
+    )
+    agent: Agent[None, str] = Agent()
+    with pytest.raises(UsageLimitExceeded, match=r'Exceeded the `cost_limit` of 0.0001'):
+        async with agent.realtime(
+            FakeRealtimeModel(conn, model_name='gpt-realtime', system='openai'),
+            usage_limits=UsageLimits(cost_limit=Decimal('0.0001')),
+        ).session() as session:
+            _ = [part async for part in session.stream_transcripts()]
+
+    response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
+    assert response.state == 'complete'
+    assert response.usage.cost == session.usage.cost
 
 
 async def test_when_idle_enqueue_after_pump_finishes_is_delivered() -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -7103,10 +7103,11 @@ async def test_agent_realtime_session_priced_cost_limit_raises_with_only_transcr
             usage_limits=UsageLimits(cost_limit=Decimal('0.0001')),
         ).session() as session:
             _ = [part async for part in session.stream_transcripts()]
-
-    response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
-    assert response.state == 'complete'
-    assert response.usage.cost == session.usage.cost
+            # The view ended because the limit tripped, after the response was finalized and priced;
+            # the error itself is raised when the block exits.
+            response = next(message for message in session.new_messages() if isinstance(message, ModelResponse))
+            assert response.state == 'complete'
+            assert response.usage.cost == session.usage.cost
 
 
 async def test_when_idle_enqueue_after_pump_finishes_is_delivered() -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -7161,7 +7161,7 @@ async def test_agent_realtime_session_per_request_input_token_limit_covers_a_too
     response immediately; the per-request check must see that usage rather than the reset accumulator."""
     conn = FakeRealtimeConnection(
         [
-            ToolCall(tool_call_id='tc1', tool_name='noop', args='{}'),
+            ToolCall(tool_call_id='tc1', tool_name='noop', args='{}', response_usage_follows=True),
             SessionUsage(usage=RequestUsage(input_tokens=51), response_scoped=True),
             ResponseDone(),
         ]

--- a/tests/realtime/test_xai_ws.py
+++ b/tests/realtime/test_xai_ws.py
@@ -11,6 +11,7 @@ cassette is missing offline the `xai_ws_cassette` fixture skips rather than erro
 
 from __future__ import annotations as _annotations
 
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -127,6 +128,7 @@ async def test_text_in_audio_out_turn(xai_ws_cassette: tuple[XaiProvider, Realti
                 'audio_tokens': 39,
                 'billable_audio_seconds': 1,
             },
+            cost=Decimal('0.0'),
             requests=1,
         )
     )


### PR DESCRIPTION
`fill_response_cost` runs at every standard-run response boundary and in the fallback model, but nowhere on the realtime path. The instrumentation computes a price for the `chat` span, so Logfire showed a cost, while `ModelResponse.usage.cost` and `session.usage.cost` stayed `None` and `UsageLimits(cost_limit=...)`, which the session checks after every usage event, could never trip. observability.md says sessions enforce standard usage limits.

`_finalize_response` now prices each recorded response with genai-prices and adds the cost to `session.usage` without re-adding the tokens, which were already accumulated from the `SessionUsage` events; the usage-limit check runs at that boundary so `cost_limit` raises the standard `UsageLimitExceeded`, from iteration or, for a taps-only consumer, when the session context exits. A provider-reported cost is never overwritten, and an unpriced model keeps `cost=None`. The `chat` span's price is unchanged.

Same area, also fixed: the response that trips a token limit was recorded with empty usage and `state='interrupted'` even though the model had finished it, because the limit check raised before the event was accumulated into the pending response. The event is accumulated first, so the settled response carries the usage that tripped the limit.

Docs: observability.md (cost, and that each recorded `ModelResponse` carries its own usage) and the agent skill. Cassette snapshots gain the priced `cost` values.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

