### PR TITLE
Correct realtime docs: event inventories, muting, ending a call, relay barge-in, Gemini and Azure specifics

### DIFF
--- a/docs/api/realtime.md
+++ b/docs/api/realtime.md
@@ -102,8 +102,15 @@ vocabulary yielded by a connection:
 [`ResponseDone`][pydantic_ai.realtime.codec.ResponseDone],
 [`RealtimeInputSpeechStartEvent`][pydantic_ai.realtime.RealtimeInputSpeechStartEvent],
 [`RealtimeInputSpeechEndEvent`][pydantic_ai.realtime.RealtimeInputSpeechEndEvent],
+[`RealtimeOutputSpeechStartEvent`][pydantic_ai.realtime.RealtimeOutputSpeechStartEvent],
+[`RealtimeOutputSpeechEndEvent`][pydantic_ai.realtime.RealtimeOutputSpeechEndEvent],
+[`RealtimeInputTranscriptionErrorEvent`][pydantic_ai.realtime.RealtimeInputTranscriptionErrorEvent],
 [`RealtimeResponseInterruptedEvent`][pydantic_ai.realtime.RealtimeResponseInterruptedEvent],
 [`RealtimeSessionReconnectEvent`][pydantic_ai.realtime.RealtimeSessionReconnectEvent],
+[`ConversationCreated`][pydantic_ai.realtime.codec.ConversationCreated],
+[`ConversationItemCreated`][pydantic_ai.realtime.codec.ConversationItemCreated],
+[`PartStartEvent`][pydantic_ai.messages.PartStartEvent],
+[`PartEndEvent`][pydantic_ai.messages.PartEndEvent],
 [`SessionUsage`][pydantic_ai.realtime.codec.SessionUsage],
 and [`RealtimeSessionErrorEvent`][pydantic_ai.realtime.RealtimeSessionErrorEvent].
 
@@ -112,14 +119,16 @@ session. The session translates codec events into the shared vocabulary from
 [`pydantic_ai.messages`][pydantic_ai.messages]: content streams as
 [`PartStartEvent`][pydantic_ai.messages.PartStartEvent] /
 [`PartDeltaEvent`][pydantic_ai.messages.PartDeltaEvent] /
-[`PartEndEvent`][pydantic_ai.messages.PartEndEvent] (carrying
-[`SpeechPart`][pydantic_ai.messages.SpeechPart]s and
-[`ToolCallPart`][pydantic_ai.messages.ToolCallPart]s), tool execution as
+[`PartEndEvent`][pydantic_ai.messages.PartEndEvent] (carrying shared message parts including
+[`SpeechPart`][pydantic_ai.messages.SpeechPart], [`TextPart`][pydantic_ai.messages.TextPart],
+[`ToolCallPart`][pydantic_ai.messages.ToolCallPart], and
+[`NativeToolReturnPart`][pydantic_ai.messages.NativeToolReturnPart]), tool execution as
 [`FunctionToolCallEvent`][pydantic_ai.messages.FunctionToolCallEvent] /
 [`FunctionToolResultEvent`][pydantic_ai.messages.FunctionToolResultEvent], inline deferred handling as
 [`DeferredToolRequestsEvent`][pydantic_ai.messages.DeferredToolRequestsEvent] /
 [`DeferredToolResultsEvent`][pydantic_ai.messages.DeferredToolResultsEvent], and the rest as the
 control-plane events above (`RealtimeInputSpeechStartEvent`, `RealtimeInputSpeechEndEvent`,
+`RealtimeOutputSpeechStartEvent`, `RealtimeOutputSpeechEndEvent`, `RealtimeInputTranscriptionErrorEvent`,
 `RealtimeResponseInterruptedEvent`, `RealtimeSessionReconnectEvent`, and `RealtimeSessionErrorEvent`), plus
 [`RealtimeTurnCompleteEvent`][pydantic_ai.realtime.RealtimeTurnCompleteEvent], which the
 session synthesizes rather than reading off the wire. Usage updates are accumulated on the session and are not yielded.

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -69,7 +69,9 @@ Each view is independently bounded; a slow consumer drops its oldest item rather
 tools, turn tracking, or other consumers.
 A subscription begins when `stream_audio()` or `stream_transcripts()` is called, so a view handed to
 a task with `asyncio.create_task` misses nothing while it waits for its first turn on the event loop,
-up to its buffer bound.
+up to its buffer bound. Call the method where the task is created and pass the iterator in, as
+above: an `async for chunk in session.stream_audio()` inside the task body subscribes only once the
+task first runs, so audio emitted before then is never seen.
 An unconsumed view buffers up to its bound, dropping the oldest item when full, until it is collected.
 [`close()`][pydantic_ai.realtime.RealtimeSession.close] discards pending items and ends every live
 iterator; [`closed`][pydantic_ai.realtime.RealtimeSession.closed] reports the state.

--- a/docs/realtime/azure.md
+++ b/docs/realtime/azure.md
@@ -182,6 +182,13 @@ async def main():
 
 Voice-Live-only knobs use the `azure_voice_live_*` prefix (e.g.
 [`azure_voice_live_turn_detection`][pydantic_ai.realtime.azure.AzureRealtimeModelSettings.azure_voice_live_turn_detection]).
+Voice Live defaults input transcription to `whisper-1` when the deployment name starts with
+`gpt-realtime`, and to `azure-speech` otherwise. This is a name match, so a custom-named
+`gpt-realtime` deployment routed through `profile=` receives the `azure-speech` default; set
+`input_transcription_model` explicitly when that is not the intended deployment.
+
+Voice Live silently ignores the inherited `openai_*` settings plus `thinking` and
+`parallel_tool_calls`. Use Voice-Live-specific settings where available.
 
 ### Which models use which API
 

--- a/docs/realtime/capabilities.md
+++ b/docs/realtime/capabilities.md
@@ -52,11 +52,13 @@ a realtime model. Pass [`RealtimeModelSettings`][pydantic_ai.realtime.RealtimeMo
 | --- | --- |
 | [`ctx.model_settings`][pydantic_ai.tools.RunContext.model_settings] | The merged [`RealtimeModelSettings`][pydantic_ai.realtime.RealtimeModelSettings] the session was connected with. |
 | [`ctx.realtime`][pydantic_ai.tools.RunContext.realtime] | `True` from `before_run` onward. |
-| [`ctx.realtime_session`][pydantic_ai.tools.RunContext.realtime_session] | The live [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] once it is connected. |
+| [`ctx.realtime_session`][pydantic_ai.tools.RunContext.realtime_session] | The live [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] in tool and `on_event` contexts; `None` in run hooks. |
 
 !!! note
-    `ctx.realtime_session` is still `None` in `before_run`, in instruction functions, and in the
-    pre-handler part of `wrap_run`, which all run before the connection is established.
+    `ctx.realtime_session` is `None` throughout `wrap_run`, both before and after `handler()`, because
+    the hook keeps the context copy captured before the session exists. It is also `None` in
+    `before_run` and instruction functions. Use tool hooks or `on_event` when a capability needs the
+    live session.
 
 ## Seeded history is not processed
 

--- a/docs/realtime/deployment.md
+++ b/docs/realtime/deployment.md
@@ -140,9 +140,11 @@ listening.
 
 `handle_barge_in=True` is a no-op for this relay: `played_audio_bytes` counts a chunk as played when
 the relay forwards it, before the browser has actually played it, so the session sees no unplayed
-audio to flush. The relay must obtain the browser's real playback position and call
-[`interrupt(played_bytes=...)`][pydantic_ai.realtime.RealtimeSession.interrupt] with that count.
-Passing `played_ms=` records the provider-side cutoff but never flushes audio queued by the session.
+audio to flush. The relay must obtain the browser's real playback position, call
+[`interrupt(played_bytes=...)`][pydantic_ai.realtime.RealtimeSession.interrupt] with that count, and
+tell the browser to stop playback and clear its own buffer: the session can only drop what it has
+not forwarded yet. Passing `played_ms=` records the provider-side cutoff but never flushes audio
+queued by the session or buffered in the browser.
 
 ## SIP/telephony bridge
 

--- a/docs/realtime/deployment.md
+++ b/docs/realtime/deployment.md
@@ -121,6 +121,12 @@ async def voice_socket(websocket: WebSocket):
             input_task.cancel()
 ```
 
+`handle_barge_in=True` is a no-op for this relay: `played_audio_bytes` counts a chunk as played when
+the relay forwards it, before the browser has actually played it, so the session sees no unplayed
+audio to flush. The relay must obtain the browser's real playback position and call
+[`interrupt(played_bytes=...)`][pydantic_ai.realtime.RealtimeSession.interrupt] with that count.
+Passing `played_ms=` records the provider-side cutoff but never flushes audio queued by the session.
+
 ## SIP/telephony bridge
 
 Terminate the phone call with a telephony provider such as Twilio, then build the service that

--- a/docs/realtime/gemini.md
+++ b/docs/realtime/gemini.md
@@ -34,8 +34,8 @@ the Gemini Developer API:
 
 | API | Model ID | Location |
 | --- | --- | --- |
-| Gemini Developer API | `gemini-2.5-flash-native-audio-latest` | Developer API configuration |
-| Gemini Developer API | `gemini-3.1-flash-live-preview` | Developer API configuration |
+| Gemini Developer API | `gemini-2.5-flash-native-audio-latest` | n/a (no location) |
+| Gemini Developer API | `gemini-3.1-flash-live-preview` | n/a (no location) |
 | Vertex AI / gateway | `gemini-live-2.5-flash` | `global` |
 | Vertex AI / gateway | `gemini-live-2.5-flash-native-audio` | `us-central1` |
 

--- a/docs/realtime/gemini.md
+++ b/docs/realtime/gemini.md
@@ -29,6 +29,20 @@ asynchronous tools, and output behavior. Use the
 [official Gemini Live documentation](https://ai.google.dev/gemini-api/docs/live) as the canonical
 model and availability source.
 
+Vertex AI and the [Pydantic AI Gateway](../gateway.md) use different model IDs and locations from
+the Gemini Developer API:
+
+| API | Model ID | Location |
+| --- | --- | --- |
+| Gemini Developer API | `gemini-2.5-flash-native-audio-latest` | Developer API configuration |
+| Gemini Developer API | `gemini-3.1-flash-live-preview` | Developer API configuration |
+| Vertex AI / gateway | `gemini-live-2.5-flash` | `global` |
+| Vertex AI / gateway | `gemini-live-2.5-flash-native-audio` | `us-central1` |
+
+The Developer API IDs are not available on Vertex AI. Configure the matching Vertex location on
+[`GoogleCloudProvider`][pydantic_ai.providers.google_cloud.GoogleCloudProvider] or in the gateway;
+the gateway example below uses `gemini-live-2.5-flash` and therefore requires `global`.
+
 ## Settings
 
 [`GoogleRealtimeModelSettings`][pydantic_ai.realtime.google.GoogleRealtimeModelSettings] — the
@@ -101,6 +115,10 @@ facts with [`profile=`](overview.md#provider-support), which resolves like a
 [standard model profile](../models/overview.md#inspecting-a-models-profile), e.g.
 `GoogleRealtimeModel('gemini-robotics-er-2-streaming-preview', profile={'supports_text_output': True})`.
 
+The Vertex half-cascade model `gemini-live-2.5-flash` is another exception: it accepts `TEXT`, but
+the built-in speech-to-speech profile rejects `output_modality='text'` before connecting for every
+Gemini ID. Opt in explicitly with `profile={'supports_text_output': True}`.
+
 ## Feature support and limitations
 
 | Feature | Support | Notes |
@@ -130,7 +148,7 @@ realtime = agent.realtime('gateway/google:gemini-live-2.5-flash')
 ```
 
 The gateway proxies Gemini Live through the Vertex upstream, so configure a region that supports
-the Live API. `gateway/google-cloud` is an alias. See
+the selected model as listed in [Model names](#model-names). `gateway/google-cloud` is an alias. See
 [Gateway trace propagation](observability.md#gateway-trace-propagation).
 
 ## Session resumption
@@ -149,6 +167,9 @@ Reconnection uses the latest in-memory server handle and emits `state_restored=T
 
 ## Provider-specific quirks
 
+- A text turn sent while a reply is in flight is answered in order on Gemini 2.5. On Gemini 3.1 it
+  interrupts the active reply, emits `RealtimeResponseInterruptedEvent`, and records any partial
+  reply as interrupted before answering the text turn.
 - Gemini reports response interruption but not user speech-start/end events, so local playback is
   flushed on `RealtimeResponseInterruptedEvent`, and Gemini sessions record no `user speech` span (see
   [Logfire instrumentation](observability.md#logfire-instrumentation)).

--- a/docs/realtime/lifecycle.md
+++ b/docs/realtime/lifecycle.md
@@ -117,6 +117,45 @@ those limits. Exact limits and provider behavior can change, so provider pages a
 Gemini sends `GoAway` shortly before its cap but Pydantic AI currently reconnects only after the
 connection drops, so a long call can briefly drop mid-turn.
 
+## Ending a call
+
+A model-controlled hang-up is a [tool that closes the session](tools.md#ending-the-session-from-a-tool).
+For external policy such as an idle timeout or maximum call duration, run a watchdog task that calls
+[`close()`][pydantic_ai.realtime.RealtimeSession.close]. Closing from another task is safe while the
+session is being iterated: the loop ends, leaving the `async with` block does not raise, and
+[`session.result`][pydantic_ai.realtime.RealtimeSession.result] is settled.
+
+```python
+import asyncio
+
+from pydantic_ai import Agent
+from pydantic_ai.realtime import RealtimeSession
+
+agent = Agent(instructions='You are a helpful voice assistant.')
+
+
+async def close_after(session: RealtimeSession, seconds: float) -> None:
+    await asyncio.sleep(seconds)
+    await session.close()
+
+
+async def main():
+    async with agent.realtime('openai:gpt-realtime').session() as session:
+        watchdog = asyncio.create_task(close_after(session, 300))
+        try:
+            async for event in session:
+                print(event)
+        finally:
+            watchdog.cancel()
+```
+
+For an idle rather than absolute timeout, reset the watchdog on
+[`RealtimeInputSpeechStartEvent`][pydantic_ai.realtime.RealtimeInputSpeechStartEvent] and
+[`RealtimeInputSpeechEndEvent`][pydantic_ai.realtime.RealtimeInputSpeechEndEvent] on OpenAI, Azure
+OpenAI, and xAI. Gemini emits neither event; use assistant
+[`PartDeltaEvent`][pydantic_ai.messages.PartDeltaEvent] activity and
+[`RealtimeTurnCompleteEvent`][pydantic_ai.realtime.RealtimeTurnCompleteEvent] instead.
+
 ## Errors
 
 Realtime sessions use the standard Pydantic AI exception hierarchy:
@@ -124,7 +163,7 @@ Realtime sessions use the standard Pydantic AI exception hierarchy:
 | Exception | Raised when |
 | --- | --- |
 | [`UserError`][pydantic_ai.exceptions.UserError] | The application requests an unsupported operation, passes incompatible settings, lacks credentials, or misuses the session. |
-| [`ModelHTTPError`][pydantic_ai.exceptions.ModelHTTPError] | The provider rejects the WebSocket upgrade with an HTTP status. |
+| [`ModelHTTPError`][pydantic_ai.exceptions.ModelHTTPError] | The provider rejects the WebSocket upgrade with an HTTP status; Gemini also maps WebSocket close codes such as `1007` and `1008` to `status_code`, while OpenAI-protocol providers use `RealtimeError` for an in-handshake rejection. |
 | [`RealtimeError`][pydantic_ai.realtime.RealtimeError] | The connection fails, times out, closes unexpectedly, returns an invalid frame, or exhausts reconnect attempts. |
 | [`UsageLimitExceeded`][pydantic_ai.exceptions.UsageLimitExceeded] | A configured [usage limit](observability.md#usage-and-limits) is exceeded. |
 

--- a/docs/realtime/lifecycle.md
+++ b/docs/realtime/lifecycle.md
@@ -146,7 +146,7 @@ async def main():
         watchdog = asyncio.create_task(close_after(session, 300))
         try:
             async for event in session:
-                print(event)
+                ...  # handle events as usual; the loop ends when the watchdog closes the session
         finally:
             watchdog.cancel()
 ```

--- a/docs/realtime/lifecycle.md
+++ b/docs/realtime/lifecycle.md
@@ -154,9 +154,12 @@ async def main():
 For an idle rather than absolute timeout, reset the watchdog on
 [`RealtimeInputSpeechStartEvent`][pydantic_ai.realtime.RealtimeInputSpeechStartEvent] and
 [`RealtimeInputSpeechEndEvent`][pydantic_ai.realtime.RealtimeInputSpeechEndEvent] on OpenAI, Azure
-OpenAI, and xAI. Gemini emits neither event; use assistant
+OpenAI, and xAI. Gemini emits neither event, so reset it from your own input path as well — whenever
+you send audio that is not silence — plus assistant
 [`PartDeltaEvent`][pydantic_ai.messages.PartDeltaEvent] activity and
-[`RealtimeTurnCompleteEvent`][pydantic_ai.realtime.RealtimeTurnCompleteEvent] instead.
+[`RealtimeTurnCompleteEvent`][pydantic_ai.realtime.RealtimeTurnCompleteEvent]; resetting on output
+alone would hang up on a person mid-sentence. With input transcription enabled, user parts from
+[`stream_transcripts()`][pydantic_ai.realtime.RealtimeSession.stream_transcripts] work too.
 
 ## Errors
 

--- a/docs/realtime/observability.md
+++ b/docs/realtime/observability.md
@@ -45,7 +45,7 @@ Input-transcription usage is reported separately in `RunUsage.details` under
 `ModelResponse`, because transcription can use a separate model and billing meter.
 
 Token and tool-call limits are checked as usage accrues. Request limits are checked before sending
-text, explicitly creating a response, or returning a tool result. With server-side VAD, the provider
+text, sending an image with `respond=True`, explicitly creating a response, or returning a tool result. With server-side VAD, the provider
 can begin a response without a client request; that limit is checked at the first response event.
 Breaches raise [`UsageLimitExceeded`][pydantic_ai.exceptions.UsageLimitExceeded] from iteration.
 
@@ -67,8 +67,9 @@ logfire.instrument_pydantic_ai()
 ```
 
 The session creates an `invoke_agent` span with cumulative usage and conversation content, subject
-to the normal content-redaction setting. Nested `chat {model}` spans represent provider responses,
-and `execute_tool` spans represent tools and delegated agent runs. `model turn complete` and `interrupt`
+to the normal content-redaction setting. Nested provider-response spans have the OpenTelemetry name
+`chat {model}` but display as `response {model}` in Logfire. `execute_tool` spans represent tools;
+a delegated run adds its own `invoke_agent` span inside `execute_tool`. `model turn complete` and `interrupt`
 spans mark those boundaries. A tool round can produce several response spans within one turn.
 
 You may see runs of `model turn complete (interrupted)` spans with no `chat` span between them.
@@ -79,7 +80,7 @@ interrupted response still draws a boundary, displayed as `model turn complete (
 | Attribute | Set on | Meaning |
 | --- | --- | --- |
 | `pydantic_ai.realtime` | Spans the session emits itself (session, response, boundary, and `user speech` spans) | Always `True`; marks spans that belong to a realtime session. `execute_tool` spans come from the [`Instrumentation`][pydantic_ai.capabilities.Instrumentation] capability and don't carry it. |
-| `gen_ai.output.type` | Response spans | `speech` or `text`. |
+| `gen_ai.output.type` | Session and response spans | `speech` or `text`. |
 | `pydantic_ai.response.state` | Interrupted response spans | `'interrupted'`. |
 | Response-level usage | OpenAI, Azure OpenAI, and xAI response spans | Tokens attributed to that response. |
 

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -203,6 +203,11 @@ and may reply, call a tool, or move on. To add context without prompting a turn,
 [`UserPromptPart`][pydantic_ai.messages.UserPromptPart]s in history, as in
 [injecting messages mid-run](../message-history.md#injecting-messages-mid-run).
 
+`enqueue()` does not replace `send()`: it waits for the response in flight to finish, while
+[`send()`][pydantic_ai.realtime.RealtimeSession.send] delivers immediately, even while a tool call or
+response is in progress. Reach for `enqueue()` for a follow-up that should wait its turn, and for
+`send()` to interject into a gap.
+
 Multimodal content and model responses are rejected because the realtime live-input channel cannot
 preserve their standard-run semantics.
 

--- a/docs/realtime/troubleshooting.md
+++ b/docs/realtime/troubleshooting.md
@@ -30,7 +30,9 @@ layer and stop local playback on real [barge-in](turns.md#barge-in).
 ## The greeting never plays, or the model replies twice when the visitor speaks
 
 Speaker echo or microphone transients probably cancelled the greeting while the audio path opened.
-Keep the microphone closed until the greeting has played; see [Speaking first](turns.md#speaking-first).
+Mute microphone capture until the greeting has played, while continuing to send digital silence so
+server VAD can close any open speech segment; see [Muting the microphone](turns.md#muting-the-microphone)
+and [Speaking first](turns.md#speaking-first).
 To confirm the cause, iterate the event stream and look for a
 [`RealtimeResponseInterruptedEvent`][pydantic_ai.realtime.RealtimeResponseInterruptedEvent] on the
 first response and any

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -51,6 +51,21 @@ manual turn control.
 Do not call `create_response()` after `send('...')`: the text turn already asks for a response, so
 the pair asks twice and can make the model say the same thing twice.
 
+When a reply is already in flight, OpenAI-protocol providers queue the text turn and answer it next,
+as does Gemini 2.5. Gemini 3.1 instead interrupts the reply in flight, emits a
+[`RealtimeResponseInterruptedEvent`][pydantic_ai.realtime.RealtimeResponseInterruptedEvent], records
+the partial reply as interrupted, and answers the new text turn.
+
+## Muting the microphone
+
+With server VAD, muting must preserve the audio stream. Simply stopping audio frames can leave the
+provider's current speech segment open indefinitely, so keep sending zero-valued PCM16 frames at the
+normal cadence while muted. If you use [manual turn control](#push-to-talk), stop sending instead and
+call [`clear_audio()`][pydantic_ai.realtime.RealtimeSession.clear_audio] to discard the partial input.
+
+Server VAD recognizes speech, not arbitrary signal energy. A pure tone may never start a speech
+segment, so use recorded speech rather than tones when testing turn detection.
+
 ## Barge-in
 
 With server-side turn detection, providers interrupt the model when they detect new user speech.
@@ -219,8 +234,9 @@ held until that response completes and is dropped if the user barges in, so retu
 `create_response()` does not mean speech has started.
 
 Server VAD enables `interrupt_response` by default, so any detected speech cancels a greeting in flight. This
-includes speaker echo and microphone transients while the audio path opens; keeping the microphone
-closed until the greeting has played avoids that race.
+includes speaker echo and microphone transients while the audio path opens. Until the greeting has
+played, mute microphone capture while continuing to send digital-silence frames as described in
+[Muting the microphone](#muting-the-microphone).
 
 ## Push-to-talk
 

--- a/docs/realtime/xai.md
+++ b/docs/realtime/xai.md
@@ -71,7 +71,7 @@ Other Grok Voice models ignore the setting.
 | --- | --- | --- |
 | Audio format | Full feature support | Mono PCM16, 24 kHz input and output |
 | Text output | Unsupported | Grok Voice always produces audio |
-| Image input | Unsupported | Audio/text input only |
+| Image input | Unsupported | xAI does not document image input; currently accepted frames are silently ignored rather than rejected |
 | Manual turns | Full feature support | `turn_detection=False` plus [commit/create verbs](turns.md#push-to-talk) |
 | Interruption | Limited parameter support | [`interrupt()`](turns.md#barge-in) works; output truncation with `played_ms` does not |
 | Input transcription | Full feature support | [Dedicated provider path](audio.md#input-transcription); `'auto'` by default |
@@ -98,7 +98,8 @@ memory and cannot resume in another process.
 
 - Grok Voice always speaks: its profile reports `supports_text_output=False`, so `output_modality='text'`
   raises a `UserError` before connecting. Read the answer from the transcript on the `SpeechPart`.
-- xAI supports cancellation but not output truncation. Flush local playback and call `interrupt()`
-  without `played_ms`.
+- Pydantic AI reports output truncation as unsupported because xAI does not document it. The API
+  currently accepts `conversation.item.truncate` silently, but does not confirm or document its
+  effect, so flush local playback and call `interrupt()` without `played_ms`.
 - The protocol resembles OpenAI Realtime, but feature support comes from the xAI model profile;
   avoid assuming every OpenAI behavior is available.

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -280,6 +280,9 @@ Key facts for building realtime agents:
 - **A string sent with `session.send()` solicits a response**: use `respond=False` to add passive
   text context. Images are context-only by default; use `respond=True` to ask for a response to an
   image. Never pair `session.send('...')` with `session.create_response()`, because that asks twice.
+  A string sent during a reply queues on OpenAI/Azure/xAI and Gemini 2.5, but interrupts the active
+  reply on Gemini 3.1. Gemini speech models reject text output before connect; the Vertex
+  `gemini-live-2.5-flash` half-cascade can opt in with `profile={'supports_text_output': True}`.
 - **History handoff is the marquee integration**: `session.all_messages()` / `session.new_messages()`
   return real `ModelMessage`s; seed with `realtime(model, message_history=...).session()`. Transcripts
   are what carry over; OpenAI and Azure can also replay retained transcript-less *user* audio, Gemini
@@ -307,6 +310,9 @@ Key facts for building realtime agents:
   down. To keep the trigger yourself, `session.interrupt(played_bytes=session.played_audio_bytes)`
   gets the same treatment on your own signal. A playback layer that buffers ahead of the device
   makes `played_audio_bytes` read too far: count real device consumption and pass `played_ms`.
+- **Mute with server VAD**: keep sending zero-valued PCM16 frames at the normal cadence. Sending
+  nothing can leave an open speech segment open; pure tones do not reliably trigger speech VAD.
+  Under manual turn control, stop sending and call `clear_audio()` instead.
 - **Tools**: every tool runs in the background, so a slow tool never blocks the session. Whether
   the model keeps speaking meanwhile is provider-specific (OpenAI/Azure do; Gemini needs
   `google_async_tool_calls=True` on a native-audio model). An unhandled tool exception is raised
@@ -315,13 +321,17 @@ Key facts for building realtime agents:
   can return a replacement result or raise `ModelRetry` to keep the session running. To end the call
   from a tool, await `ctx.realtime_session.close()` for a clean hang-up (the tool does not resume and
   its call is recorded as interrupted), or call `ctx.cancel()` to make the session context raise
-  `RunCancelled`.
+  `RunCancelled`. An external watchdog may also call `session.close()` while iteration is running;
+  the loop ends cleanly and `session.result` is settled.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a
   control-plane **sideband** with `.session(provider_session=answer.session)`. The browser owns the
   audio; the sideband session runs tools and builds history (its audio methods raise, and
   `audio_retention` must stay `'transcript_only'`).
+- **Browser WebSocket relays**: `handle_barge_in=True` cannot know browser playback position because
+  forwarded chunks count as played. Have the browser report real playback and pass it to
+  `interrupt(played_bytes=...)`; `played_ms=` does not flush session-queued audio.
 
 See the [Realtime guide](https://pydantic.dev/docs/ai/realtime/overview/) for the full walkthrough.
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -56,7 +56,8 @@ Useful `RunContext` fields include:
 - `ctx.messages`
 - `ctx.retry`
 - `ctx.realtime` — whether the run is a realtime session
-- `ctx.realtime_session` — the live `RealtimeSession` once connected (`None` in classic runs and before connect)
+- `ctx.realtime_session` — the live `RealtimeSession` in tools and `on_event` hooks (`None` in
+  classic runs, setup hooks, and throughout `wrap_run`, whose context copy predates the connection)
 
 Inside a realtime tool, `await ctx.realtime_session.close()` hangs up cleanly: the calling tool does
 not resume, and its call is recorded as interrupted. Use `ctx.cancel()` instead when the session

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -286,10 +286,10 @@ class RunContext(Generic[RunContextAgentDepsT]):
     realtime_session: RealtimeSession | None = field(default=None, repr=False)
     """The [`RealtimeSession`][pydantic_ai.realtime.RealtimeSession] this run is, once it is connected.
 
-    `None` in classic runs, and during the parts of a realtime run that precede the connection:
-    `before_run`, `wrap_run` before `handler()` starts the session, and instruction resolution.
-    Use [`realtime`][pydantic_ai.tools.RunContext.realtime] to detect a realtime run in those
-    stages. Tools and hooks that run during the live session can use it to e.g.
+    `None` in classic runs, during setup (`before_run` and instruction resolution), and throughout
+    `wrap_run`: that hook keeps the context copy captured before the session exists, including after
+    `handler()` returns. Use [`realtime`][pydantic_ai.tools.RunContext.realtime] to detect a realtime
+    run in those stages. Tools and `on_event` hooks that run during the live session can use it to e.g.
     [`interrupt()`][pydantic_ai.realtime.RealtimeSession.interrupt] playback or
     [`send()`][pydantic_ai.realtime.RealtimeSession.send] follow-up content, or call
     [`close()`][pydantic_ai.realtime.RealtimeSession.close] to hang up.

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -142,7 +142,9 @@ This is a strict subset of [`AgentStreamEvent`][pydantic_ai.messages.AgentStream
 Content is streamed as the shared [`PartStartEvent`][pydantic_ai.messages.PartStartEvent] /
 [`PartDeltaEvent`][pydantic_ai.messages.PartDeltaEvent] / [`PartEndEvent`][pydantic_ai.messages.PartEndEvent]
 events (carrying [`SpeechPart`][pydantic_ai.messages.SpeechPart]s and
-[`ToolCallPart`][pydantic_ai.messages.ToolCallPart]s), tool execution as
+other shared message parts, including [`TextPart`][pydantic_ai.messages.TextPart],
+[`ToolCallPart`][pydantic_ai.messages.ToolCallPart], and
+[`NativeToolReturnPart`][pydantic_ai.messages.NativeToolReturnPart]), tool execution as
 [`FunctionToolCallEvent`][pydantic_ai.messages.FunctionToolCallEvent] /
 [`FunctionToolResultEvent`][pydantic_ai.messages.FunctionToolResultEvent], inline deferred resolution
 as [`DeferredToolRequestsEvent`][pydantic_ai.messages.DeferredToolRequestsEvent] /


### PR DESCRIPTION
Docs-only corrections from an audit of the realtime docs against the implementation and short live probes. Each item was verified against the code or a live session before writing.

- **Event inventories** (`docs/api/realtime.md`, `RealtimeEvent` docstring): the connection-event list omitted `RealtimeOutputSpeechStartEvent`, `RealtimeOutputSpeechEndEvent`, `RealtimeInputTranscriptionErrorEvent`, `ConversationCreated`, `ConversationItemCreated`, and the part events; the session list omitted three of those and said part events carry only `SpeechPart`s and `ToolCallPart`s, while tools.md's native-tool example relies on `PartEndEvent` carrying a `NativeToolReturnPart` and text output yields `TextPart`s.
- **Muting the microphone** (turns.md): with server VAD, sending nothing leaves the provider's speech segment open. Live on OpenAI, four seconds of silence after half a sentence produced no speech end and no reply, while 1.5 s of zero-valued frames closed the segment within 0.4 s. The recipe is to keep streaming silence at cadence, or `clear_audio()` under manual turn control. The "keep the microphone closed" phrasing in turns.md and troubleshooting.md read as "send nothing" and is rephrased. VAD is not energy-based: a pure tone never trips it, which matters when testing with synthetic audio.
- **Ending a call** (lifecycle.md): hang-up tool, an external watchdog calling `close()` from another task (safe while iterating; the loop ends and the context exits without raising), and which events reset an idle timer per provider, with a runnable example.
- **Relay barge-in** (deployment.md): `handle_barge_in=True` is a no-op over a WebSocket relay because a forwarded chunk counts as played; the relay must report the browser's real playback position via `interrupt(played_bytes=...)`, and `played_ms=` never flushes session-queued audio.
- **Gemini** (gemini.md, turns.md): Vertex and gateway model ids differ from the Developer API ids, and the two Vertex Live ids live in different locations (`gemini-live-2.5-flash` in `global`, `gemini-live-2.5-flash-native-audio` in `us-central1`; the Developer API ids are not found on Vertex). A text turn sent while a reply is in flight is answered in order on Gemini 2.5 but interrupts the reply on Gemini 3.1. The Vertex half-cascade accepts `TEXT` behind `profile={'supports_text_output': True}`. Gemini surfaces WebSocket close codes as `ModelHTTPError(status_code=1007/1008)` where OpenAI-protocol providers raise `RealtimeError` for an in-handshake rejection.
- **xAI** (xai.md): truncation and image input are reported unsupported because xAI does not document them, not because the frames are rejected; live, both are accepted silently.
- **Azure Voice Live** (azure.md): transcription defaults to `whisper-1` for deployments named `gpt-realtime*` and `azure-speech` otherwise, a name match; the inherited `openai_*`, `thinking`, and `parallel_tool_calls` settings are silently ignored.
- **Capabilities** (capabilities.md, `RunContext.realtime_session` docstring): the session is `None` throughout a capability's `wrap_run`, before and after `handler()`, because the hook holds a context copy captured before the session exists.
- **Observability** (observability.md): `chat {model}` spans display as `response {model}` in Logfire, `gen_ai.output.type` is also on the session span, a delegated run adds an `invoke_agent` span inside `execute_tool`, and request limits are also checked before `send(image, respond=True)`.

The agent skill is updated where a stated mechanic changed.

The "Ending a call" watchdog example cancels the watchdog task once the event loop ends. On `main` that can cancel the task while it is inside `close()` and abort the teardown; #8142 makes `close()` finish regardless, so the example stays as written here.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->