### PR TITLE
Surface realtime receive-side failures to every consumer shape, and end `send_audio(iterable)` cleanly on close

### DIFF
--- a/docs/api/realtime.md
+++ b/docs/api/realtime.md
@@ -78,6 +78,10 @@ yields finalized speech from both speakers or live deltas with `delta=True`. The
 run concurrently with each other and with the session's raw event iterator.
 [`RealtimeSession.close()`][pydantic_ai.realtime.RealtimeSession.close] ends the session and every
 live view; [`RealtimeSession.closed`][pydantic_ai.realtime.RealtimeSession.closed] exposes its state.
+The session starts receiving when its context is entered. A fatal receive or tool failure is raised
+from active event iteration; without an active iterator, the views end and context exit raises it.
+The next outbound session method raises an already-ended receive side's failure first, and the same
+failure is never delivered twice.
 
 The low-level [`RealtimeConnection.send`][pydantic_ai.realtime.codec.RealtimeConnection.send] accepts the
 normalized [`RealtimeInput`][pydantic_ai.realtime.codec.RealtimeInput] — a `str` text turn, a

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -10,7 +10,9 @@ You send and receive raw audio samples; there is no container or codec in the li
 [`send_audio()`][pydantic_ai.realtime.RealtimeSession.send_audio] accepts raw, signed 16-bit
 little-endian mono PCM — a single chunk, or an async iterable of chunks (a microphone stream, a
 WebSocket receive loop) that it forwards until the iterable ends, so a whole capture loop can be
-one task. [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
+one task. If the session is closed while consuming the iterable, that task returns cleanly; sending
+a single chunk after close still raises [`UserError`][pydantic_ai.exceptions.UserError].
+[`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
 returns the same format. Capture at
 [`session.audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]
 and play at

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -10,8 +10,10 @@ You send and receive raw audio samples; there is no container or codec in the li
 [`send_audio()`][pydantic_ai.realtime.RealtimeSession.send_audio] accepts raw, signed 16-bit
 little-endian mono PCM — a single chunk, or an async iterable of chunks (a microphone stream, a
 WebSocket receive loop) that it forwards until the iterable ends, so a whole capture loop can be
-one task. If the session is closed while consuming the iterable, that task returns cleanly; sending
-a single chunk after close still raises [`UserError`][pydantic_ai.exceptions.UserError].
+one task. If the session is closed while consuming the iterable, that task returns cleanly as soon
+as the source yields again, without sending that chunk. Cancel the task in application code if the
+source can stall indefinitely. Sending a single chunk after close still raises
+[`UserError`][pydantic_ai.exceptions.UserError].
 [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio]
 returns the same format. Capture at
 [`session.audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]

--- a/docs/realtime/lifecycle.md
+++ b/docs/realtime/lifecycle.md
@@ -138,13 +138,10 @@ for provider operations and
 user transcription. The session remains usable after either event.
 
 Failures surface from the responsible call where possible; a failed `send_audio()` raises there.
-Receive-loop and tool failures surface according to how the session is consumed:
-
-- While the event stream is being iterated, the failure is raised from `async for`.
-- When the event stream was never iterated (only the audio or transcript views are consumed), the
-  views end and the failure is raised when the `async with` block exits (from
-  [`close()`][pydantic_ai.realtime.RealtimeSession.close]).
-- A consumer that started iterating and then stopped has chosen to stop listening: a later failure
-  is not raised on its behalf.
+Receive-loop and tool failures are raised from `async for` while the event stream is being
+iterated. Otherwise the audio and transcript views end, and the failure is raised when the `async
+with` block exits (from [`close()`][pydantic_ai.realtime.RealtimeSession.close]). If the receive side
+has already failed, the next outbound session method raises that failure instead; it is delivered
+only once.
 
 For symptom-first debugging, see [Troubleshooting](troubleshooting.md).

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -227,8 +227,9 @@ The session closes cleanly, and `session.result` and its history are settled bef
 exits. The tool does not resume after `close()`: there is no provider left to receive its result, so
 the call is recorded locally with an interrupted result. The code that owns the `session()` context
 does not receive an exception. A concurrent `send_audio()` call consuming a microphone or other
-async iterable returns cleanly when the tool closes the session; sending a single chunk after close
-still raises [`UserError`][pydantic_ai.exceptions.UserError].
+async iterable returns cleanly at the next chunk after the tool closes the session, without sending
+that chunk. If the source can stall indefinitely, cancel the task in application code. Sending a
+single chunk after close still raises [`UserError`][pydantic_ai.exceptions.UserError].
 
 To abort the run instead, [`ctx.cancel()`](../tools-advanced.md#cancelling-the-run-from-a-tool)
 works as in a standard run: the call is likewise recorded as interrupted, and the `session()`

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -12,9 +12,9 @@ When a model calls a tool, the session emits
 result, and emits [`FunctionToolResultEvent`][pydantic_ai.messages.FunctionToolResultEvent]. Parse
 failures and [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] produce a
 [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart], matching a standard agent run. Other tool
-exceptions end the session and propagate from iteration; if the event stream was never iterated,
-they end the audio and transcript views and are raised when the session closes. (A consumer that
-started iterating and then stopped has chosen to stop listening: nothing is raised on its behalf.)
+exceptions are raised from `async for` while the event stream is being iterated. Otherwise they end
+the audio and transcript views and are raised when the session closes. If the receive side has
+already ended, an outbound session method raises the failure instead; it is delivered only once.
 The general
 [`on_tool_execute_error`][pydantic_ai.capabilities.AbstractCapability.on_tool_execute_error]
 capability hook also applies in realtime and can turn an exception into a replacement result or
@@ -226,7 +226,9 @@ async def hang_up(ctx: RunContext[None]) -> None:
 The session closes cleanly, and `session.result` and its history are settled before the context
 exits. The tool does not resume after `close()`: there is no provider left to receive its result, so
 the call is recorded locally with an interrupted result. The code that owns the `session()` context
-does not receive an exception.
+does not receive an exception. A concurrent `send_audio()` call consuming a microphone or other
+async iterable returns cleanly when the tool closes the session; sending a single chunk after close
+still raises [`UserError`][pydantic_ai.exceptions.UserError].
 
 To abort the run instead, [`ctx.cancel()`](../tools-advanced.md#cancelling-the-run-from-a-tool)
 works as in a standard run: the call is likewise recorded as interrupted, and the `session()`

--- a/examples/pydantic_ai_examples/realtime_voice.py
+++ b/examples/pydantic_ai_examples/realtime_voice.py
@@ -71,9 +71,12 @@ async def conversation(session: RealtimeSession) -> None:
         # machine that stutters glitches instead of ending the call. Pulling the next
         # chunk only after the device consumed the previous one also lets the session
         # track the playback position itself, which is what `handle_barge_in=True` uses
-        # to handle interruptions without any code here.
+        # to handle interruptions without any code here. The view is created here rather
+        # than inside the task so that audio arriving before the task first runs is kept.
+        model_audio = session.stream_audio()
+
         async def play_audio() -> None:
-            async for chunk in session.stream_audio():
+            async for chunk in model_audio:
                 await speaker.write(chunk)
 
         tg.start_soon(play_audio)

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -316,9 +316,8 @@ Key facts for building realtime agents:
   An `on_tool_execute_error` capability can return a replacement result or raise `ModelRetry` to keep
   the session running. To end the call from a tool, await `ctx.realtime_session.close()` for a clean
   hang-up (the tool does not resume, its call is recorded as interrupted, and a concurrent
-  `send_audio()` async iterable returns cleanly as soon as its source yields again, without sending
-  that chunk; cancel the task in application code if the source can stall indefinitely), or call
-  `ctx.cancel()` to make the session context raise `RunCancelled`.
+  `send_audio()` async iterable returns cleanly at its next chunk), or call `ctx.cancel()` to make
+  the session context raise `RunCancelled`.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -316,8 +316,9 @@ Key facts for building realtime agents:
   An `on_tool_execute_error` capability can return a replacement result or raise `ModelRetry` to keep
   the session running. To end the call from a tool, await `ctx.realtime_session.close()` for a clean
   hang-up (the tool does not resume, its call is recorded as interrupted, and a concurrent
-  `send_audio()` async iterable returns cleanly), or call `ctx.cancel()` to make the session context
-  raise `RunCancelled`.
+  `send_audio()` async iterable returns cleanly as soon as its source yields again, without sending
+  that chunk; cancel the task in application code if the source can stall indefinitely), or call
+  `ctx.cancel()` to make the session context raise `RunCancelled`.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -310,12 +310,14 @@ Key facts for building realtime agents:
 - **Tools**: every tool runs in the background, so a slow tool never blocks the session. Whether
   the model keeps speaking meanwhile is provider-specific (OpenAI/Azure do; Gemini needs
   `google_async_tool_calls=True` on a native-audio model). An unhandled tool exception is raised
-  from session iteration; when only `stream_audio()` or `stream_transcripts()` is consumed, it ends
-  those views and is raised when the session context closes. An `on_tool_execute_error` capability
-  can return a replacement result or raise `ModelRetry` to keep the session running. To end the call
-  from a tool, await `ctx.realtime_session.close()` for a clean hang-up (the tool does not resume and
-  its call is recorded as interrupted), or call `ctx.cancel()` to make the session context raise
-  `RunCancelled`.
+  from session iteration while it is active; otherwise it ends `stream_audio()` and
+  `stream_transcripts()` and is raised when the session context closes. The next outbound method
+  raises an already-ended receive side's failure instead, and every failure is delivered only once.
+  An `on_tool_execute_error` capability can return a replacement result or raise `ModelRetry` to keep
+  the session running. To end the call from a tool, await `ctx.realtime_session.close()` for a clean
+  hang-up (the tool does not resume, its call is recorded as interrupted, and a concurrent
+  `send_audio()` async iterable returns cleanly), or call `ctx.cancel()` to make the session context
+  raise `RunCancelled`.
 - **Browser WebRTC (OpenAI and Azure OpenAI)**: for browser voice agents, relay the browser's SDP
   offer server-side with `agent.realtime(model).answer_webrtc_offer(sdp_offer)` — the agent's
   resolved instructions and tools are baked in and the API key stays on the server — then attach a

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, replace
 from threading import Lock as ThreadLock
 from time import time_ns
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Never, TypeAlias, TypeVar, cast, overload
 
 from anyio import Lock
 from opentelemetry import context as otel_context
@@ -756,9 +756,9 @@ class RealtimeSession:
         self._input_audio_by_id: dict[str, bytes] = {}
 
         # The session context is the single owner of the receive pump and background tool tasks.
-        # Iteration starts the pump lazily, but never tears it down: an early `break` can abandon the
-        # reader generator without affecting resource lifetime, and `__aexit__` still drains everything
-        # before the connection and toolset close.
+        # It starts the pump on entry and never tears it down before `close()`: an early `break` can
+        # abandon the reader generator without affecting resource lifetime, and `__aexit__` still
+        # drains everything before the connection and toolset close.
         self._queue: asyncio.Queue[RealtimeEvent | object] = asyncio.Queue()
         self._queue_changed = object()
         self._tap_finished = object()
@@ -816,9 +816,8 @@ class RealtimeSession:
         self._pump_finished = False
         self._iterator_active = False
         self._stream_exhausted = False
-        # Whether the event stream was ever consumed, which decides whether a pump error still needs
-        # somewhere to go when the session closes — see `close`.
-        self._stream_consumed = False
+        self._parked_errors: list[BaseException] = []
+        self._delivered_errors: list[BaseException] = []
         self._entered = False
         self._closed = False
         self._closing_error: BaseException | None = None
@@ -840,6 +839,7 @@ class RealtimeSession:
             self._connection.set_message_history(self.all_messages)
 
         self._session_instrumentation.start_session_span()
+        self._start_pump()
 
         return self
 
@@ -870,7 +870,7 @@ class RealtimeSession:
         tool does not resume, and its call is recorded as interrupted.
 
         Raises whatever ended the session — a provider hangup, an exceeded `usage_limits`, or a failed
-        tool — if the event stream was never iterated, since there was nowhere else for it to surface.
+        tool — unless it was already raised by event iteration or an outbound session method.
         """
         if not self._entered or self._closed:
             return
@@ -948,21 +948,10 @@ class RealtimeSession:
             current_task.cancel(msg='Realtime session exited')
             await asyncio.sleep(0)
 
-        # A session that was never iterated has nowhere else to learn that it failed: the pump's error is
-        # normally raised out of `__aiter__`, so a caller using only `send()` and the
-        # `stream_audio()`/`stream_transcripts()` views would otherwise exit *cleanly* from a provider
-        # hangup — or from an exceeded `usage_limits`, silently spending past a cost cap it asked for.
-        # Not raised when the caller did consume the stream (it either saw the error or chose to stop
-        # listening), nor over an exception already on its way out of the `async with` body.
-        if self._closing_error is None and not self._stream_consumed:
-            if self._pump_error is not None:
-                raise self._pump_error
-            # A failed tool (or background drain) surfaces through the queue rather than
-            # `_pump_error`; with no consumer it would otherwise vanish here.
-            while not self._queue.empty():
-                item = self._queue.get_nowait()
-                if isinstance(item, BaseException) and not isinstance(item, asyncio.CancelledError):
-                    raise item
+        # Do not hide the caller's own exception, but make sure every receive-side failure has one
+        # delivery point even when iteration stopped early or was never started.
+        if self._closing_error is None and (error := self._first_undelivered_error()) is not None:
+            self._raise_delivered(error)
 
     @property
     def closed(self) -> bool:
@@ -1198,6 +1187,7 @@ class RealtimeSession:
         [`ToolResult`][pydantic_ai.realtime.codec.ToolResult] is sent by the session itself as each tool
         completes (see `_execute_tool`) — neither is accepted here.
         """
+        self._ensure_can_send()
         if isinstance(content, str):
             solicits_response = respond is not False
             if solicits_response:
@@ -1277,7 +1267,7 @@ class RealtimeSession:
         """
         if not self._entered:
             raise UserError('Enter the realtime session with `async with` before enqueuing content.')
-        self._ensure_not_closed()
+        self._ensure_can_send()
         pending = PendingMessage.from_content(*content, priority=priority)
         if pending is None:
             return None
@@ -1371,7 +1361,9 @@ class RealtimeSession:
 
         Given an async iterable — a microphone stream, a WebSocket receive loop — each chunk is
         forwarded as it arrives and the call returns when the iterable is exhausted, so a whole
-        capture loop can be one task: `asyncio.create_task(session.send_audio(microphone))`.
+        capture loop can be one task: `asyncio.create_task(session.send_audio(microphone))`. If the
+        session is closed while consuming that iterable, the call returns cleanly. Passing a single
+        chunk to a session that is already closed still raises [`UserError`][pydantic_ai.exceptions.UserError].
 
         Resample the audio to
         [`audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]
@@ -1379,9 +1371,17 @@ class RealtimeSession:
         raw bytes carry no rate, so the wrong one is heard as a chipmunk rather than reported.
         """
         self._require_media_ownership('send_audio')
+        self._ensure_can_send()
         if isinstance(data, AsyncIterable):
             async for chunk in data:
-                await self.send_audio(chunk)
+                if self._closed:
+                    return
+                try:
+                    await self.send_audio(chunk)
+                except UserError:
+                    if self._closed:
+                        return
+                    raise
             return
         user_turn_was_active = self._user_turn_active
         if not user_turn_was_active:
@@ -1412,6 +1412,7 @@ class RealtimeSession:
 
     async def commit_audio(self) -> None:
         """Commit buffered input audio as a user turn (manual turn-taking / push-to-talk)."""
+        self._ensure_can_send()
         self._require_media_ownership('commit_audio')
         self._require_capability('supports_manual_turn_control', method='commit_audio', feature='manual turn-taking')
         await self._send_frame(CommitAudio())
@@ -1421,6 +1422,7 @@ class RealtimeSession:
 
     async def clear_audio(self) -> None:
         """Discard buffered, uncommitted input audio."""
+        self._ensure_can_send()
         self._require_media_ownership('clear_audio')
         self._require_capability('supports_manual_turn_control', method='clear_audio', feature='manual turn-taking')
         await self._send_frame(ClearAudio())
@@ -1435,6 +1437,7 @@ class RealtimeSession:
         If a response is already in flight, the request is held until it completes and is dropped if
         the user barges in. Returning does not mean the model has started speaking.
         """
+        self._ensure_can_send()
         self._require_capability('supports_manual_turn_control', method='create_response', feature='manual turn-taking')
         self._reserve_response_request()
         try:
@@ -1484,7 +1487,7 @@ class RealtimeSession:
             played_bytes: Playback position as the total raw PCM bytes actually played from the
                 session's single `stream_audio()` iterator. Mutually exclusive with `played_ms`.
         """
-        self._ensure_not_closed()
+        self._ensure_can_send()
         self._require_capability('supports_interruption', method='interrupt', feature='interruption')
         if played_bytes is not None:
             if played_ms is not None:
@@ -1641,6 +1644,34 @@ class RealtimeSession:
     def _ensure_not_closed(self) -> None:
         if self._closed:
             raise UserError('This realtime session is closed.')
+
+    def _ensure_can_send(self) -> None:
+        self._ensure_not_closed()
+        if self._pump_finished and (error := self._first_undelivered_error()) is not None:
+            self._raise_delivered(error)
+
+    def _error_was_delivered(self, error: BaseException) -> bool:
+        return any(delivered is error for delivered in self._delivered_errors)
+
+    def _raise_delivered(self, error: BaseException) -> Never:
+        if not self._error_was_delivered(error):
+            self._delivered_errors.append(error)
+        raise error
+
+    def _first_undelivered_error(self) -> BaseException | None:
+        if self._pump_error is not None and not self._error_was_delivered(self._pump_error):
+            return self._pump_error
+        for error in self._parked_errors:
+            if not isinstance(error, asyncio.CancelledError) and not self._error_was_delivered(error):
+                return error
+        return None
+
+    def _park_error(self, error: BaseException) -> None:
+        """Park a background failure for iteration or close, ending receive-only views if nobody is iterating."""
+        self._parked_errors.append(error)
+        self._queue.put_nowait(error)
+        if not self._iterator_active and self._pump_task is not None:
+            self._pump_task.cancel()
 
     def _require_capability(self, capability: str, *, method: str, feature: str) -> None:
         """Raise a clear `UserError` before sending when the profile doesn't report `capability`."""
@@ -2613,7 +2644,7 @@ class RealtimeSession:
     def _pending_message_task_done(self, task: asyncio.Task[None]) -> None:
         self._background_tasks.discard(task)
         if not task.cancelled() and (error := task.exception()) is not None:
-            self._queue.put_nowait(error)
+            self._park_error(error)
         self._queue.put_nowait(self._queue_changed)
 
     async def _drain_pending_messages(self, priority: PendingMessagePriority) -> None:
@@ -2741,15 +2772,7 @@ class RealtimeSession:
             # Surface the failure through the queue so the consumer re-raises it, instead of letting it
             # vanish into `__aexit__`'s cleanup-only drain and hang the session on a completion that
             # never arrives.
-            await self._queue.put(e)
-            if not self._stream_consumed and self._pump_task is not None:
-                # Nobody is reading the event stream, so the parked error can only surface from
-                # `close()` — and with the provider still waiting on a tool result it will never get,
-                # the session would sit open but mute until the caller happens to close it. End the
-                # receive side now, exactly as a pump error does: the audio/transcript views finish,
-                # the caller's own playback loop returns, and `close()` raises the error. A consumer
-                # that is iterating gets it from iteration and keeps its views, as before.
-                self._pump_task.cancel()
+            self._park_error(e)
             return
         finally:
             validation_done.set()
@@ -2782,7 +2805,7 @@ class RealtimeSession:
         # `_pending_message_task_done`. Otherwise it vanishes with only an "exception was never
         # retrieved" warning at GC, silently losing the enqueued message with no signal to the consumer.
         if not task.cancelled() and (error := task.exception()) is not None:
-            self._queue.put_nowait(error)
+            self._park_error(error)
         self._release_ordered_tool_events()
         # Wake the queue reader so it can finish once both the pump and the last tool are done.
         self._queue.put_nowait(self._queue_changed)
@@ -3021,7 +3044,6 @@ class RealtimeSession:
             raise UserError('This realtime session event stream has already ended.')
 
         self._iterator_active = True
-        self._stream_consumed = True
         self._start_pump()
 
         async def queue_events() -> AsyncIterator[RealtimeEvent]:
@@ -3032,12 +3054,17 @@ class RealtimeSession:
                     # drain belong to `__aexit__`, which runs as this exception leaves the owner block.
                     if self._pump_error is not None:
                         self._stream_exhausted = True
-                        raise self._pump_error
+                        if not self._error_was_delivered(self._pump_error):
+                            self._raise_delivered(self._pump_error)
                     if self._pump_finished and not self._background_tasks and self._queue.empty():
                         self._stream_exhausted = True
                         return
                     continue
-                yield _as_event(item)  # re-raises if a tool failed
+                if isinstance(item, BaseException):
+                    if self._error_was_delivered(item):
+                        continue
+                    self._raise_delivered(item)
+                yield _as_event(item)
 
         source = queue_events()
         stream: AsyncIterable[RealtimeEvent] = source

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -814,6 +814,7 @@ class RealtimeSession:
         self._pump_task: asyncio.Task[None] | None = None
         self._pump_error: Exception | None = None
         self._pump_finished = False
+        self._receive_ending = False
         self._iterator_active = False
         self._stream_exhausted = False
         self._parked_errors: list[BaseException] = []
@@ -1362,8 +1363,10 @@ class RealtimeSession:
         Given an async iterable — a microphone stream, a WebSocket receive loop — each chunk is
         forwarded as it arrives and the call returns when the iterable is exhausted, so a whole
         capture loop can be one task: `asyncio.create_task(session.send_audio(microphone))`. If the
-        session is closed while consuming that iterable, the call returns cleanly. Passing a single
-        chunk to a session that is already closed still raises [`UserError`][pydantic_ai.exceptions.UserError].
+        session is closed while consuming that iterable, the call returns cleanly at the next chunk
+        the source yields. Cancel the task in application code if the source can stall indefinitely.
+        Passing a single chunk to a session that is already closed still raises
+        [`UserError`][pydantic_ai.exceptions.UserError].
 
         Resample the audio to
         [`audio_input_sample_rate`][pydantic_ai.realtime.RealtimeSession.audio_input_sample_rate]
@@ -1652,7 +1655,7 @@ class RealtimeSession:
 
     def _ensure_can_send(self) -> None:
         self._ensure_not_closed()
-        if self._pump_finished and (error := self._first_undelivered_error()) is not None:
+        if (self._pump_finished or self._receive_ending) and (error := self._first_undelivered_error()) is not None:
             self._raise_delivered(error)
 
     def _error_was_delivered(self, error: BaseException) -> bool:
@@ -1676,6 +1679,7 @@ class RealtimeSession:
         self._parked_errors.append(error)
         self._queue.put_nowait(error)
         if not self._iterator_active and self._pump_task is not None:
+            self._receive_ending = True
             self._pump_task.cancel()
 
     def _require_capability(self, capability: str, *, method: str, feature: str) -> None:
@@ -2967,6 +2971,7 @@ class RealtimeSession:
                     return  # a usage limit tripped: stop reading the upstream
         except Exception as e:
             self._pump_error = e
+            self._receive_ending = True
         finally:
             self._pump_finished = True
             if not self._closed:

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -314,13 +314,6 @@ _TranslatableEvent: TypeAlias = (
 _SettledToolResult: TypeAlias = tuple[ToolReturnPart | RetryPromptPart, str | Sequence[UserContent] | None]
 
 
-def _as_event(item: object) -> RealtimeEvent:
-    """Unwrap a queue item: re-raise a tool's exception, otherwise return the event."""
-    if isinstance(item, BaseException):
-        raise item
-    return cast('RealtimeEvent', item)
-
-
 def _pcm_to_wav(data: bytes, sample_rate: int) -> bytes:
     """Wrap mono 16-bit PCM bytes in a WAV container at `sample_rate`."""
     buffer = io.BytesIO()
@@ -877,10 +870,11 @@ class RealtimeSession:
             return
         self._closed = True
         self._finish_taps(discard_pending=True)
-        if self._pump_task is not None:
-            # Cancelled before state is settled below so the pump can't mutate it mid-settlement;
-            # the task is awaited together with the rest afterwards.
-            self._pump_task.cancel()
+        # The pump runs from `__aenter__` on. Cancelled before state is settled below so it can't
+        # mutate state mid-settlement; the task is awaited together with the rest afterwards.
+        pump_task = self._pump_task
+        assert pump_task is not None
+        pump_task.cancel()
         if (early_error := self._closing_error or self._pump_error) is not None and (
             chat_span := self._session_instrumentation.chat_span
         ) is not None:
@@ -912,10 +906,7 @@ class RealtimeSession:
         current_task = asyncio.current_task()
         closing_from_own_task = current_task is not None and current_task in self._background_tasks
         tasks = [task for task in self._background_tasks if task is not current_task]
-        if self._pump_task is not None:
-            tasks.append(self._pump_task)
-        if tasks:
-            await cancel_and_drain(*tasks, msg='Realtime session exited')
+        await cancel_and_drain(*tasks, pump_task, msg='Realtime session exited')
 
         # Any open `chat` span was closed by the settlement above (an open span counts as a response
         # in flight), with the error — if any — already recorded on it before settlement.
@@ -1379,12 +1370,7 @@ class RealtimeSession:
             async for chunk in data:
                 if self._closed:
                     return
-                try:
-                    await self.send_audio(chunk)
-                except UserError:
-                    if self._closed:
-                        return
-                    raise
+                await self.send_audio(chunk)
             return
         user_turn_was_active = self._user_turn_active
         if not user_turn_was_active:
@@ -1662,8 +1648,8 @@ class RealtimeSession:
         return any(delivered is error for delivered in self._delivered_errors)
 
     def _raise_delivered(self, error: BaseException) -> Never:
-        if not self._error_was_delivered(error):
-            self._delivered_errors.append(error)
+        """Raise an error its callers have already checked is undelivered, recording the delivery."""
+        self._delivered_errors.append(error)
         raise error
 
     def _first_undelivered_error(self) -> BaseException | None:
@@ -3073,7 +3059,7 @@ class RealtimeSession:
                     if self._error_was_delivered(item):
                         continue
                     self._raise_delivered(item)
-                yield _as_event(item)
+                yield cast('RealtimeEvent', item)
 
         source = queue_events()
         stream: AsyncIterable[RealtimeEvent] = source

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -12,12 +12,12 @@ from dataclasses import dataclass, replace
 from threading import Lock as ThreadLock
 from time import time_ns
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal, Never, TypeAlias, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar, cast, overload
 
 from anyio import Lock
 from opentelemetry import context as otel_context
 from opentelemetry.context import Context
-from typing_extensions import TypeAliasType, assert_never
+from typing_extensions import Never, TypeAliasType, assert_never
 
 from .. import _agent_graph
 from .._enqueue import EnqueueContent, PendingMessage, PendingMessagePriority

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -2971,7 +2971,6 @@ class RealtimeSession:
                     return  # a usage limit tripped: stop reading the upstream
         except Exception as e:
             self._pump_error = e
-            self._receive_ending = True
         finally:
             self._pump_finished = True
             if not self._closed:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,10 @@ def pytest_configure(config: pytest.Config) -> None:
         'markers',
         'moves_cache_prefix(reason): recorded conversation deliberately moves the cache prefix; reason required',
     )
+    config.addinivalue_line(
+        'markers',
+        'realtime_ws_hold_open: keep a replay WebSocket open after its last recorded frame',
+    )
 
 
 if TYPE_CHECKING:

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -218,7 +218,7 @@ def _ws_cassette(
         )
     cassette = RealtimeCassette.load(path) if plan == 'replay' else RealtimeCassette()
     try:
-        hold_open = request.node.get_closest_marker('realtime_ws_hold_open') is not None
+        hold_open = request.node.get_closest_marker('realtime_ws_hold_open') is not None  # pyright: ignore[reportUnknownMemberType]
         with patched_ws_connect(provider, cassette, plan, hold_open=hold_open):
             yield cassette
     finally:

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -218,7 +218,8 @@ def _ws_cassette(
         )
     cassette = RealtimeCassette.load(path) if plan == 'replay' else RealtimeCassette()
     try:
-        with patched_ws_connect(provider, cassette, plan):
+        hold_open = request.node.get_closest_marker('realtime_ws_hold_open') is not None
+        with patched_ws_connect(provider, cassette, plan, hold_open=hold_open):
             yield cassette
     finally:
         # Persist recorded frames even if later assertions fail, so cassettes can be recorded first

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -51,7 +51,7 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 
 from ..conftest import IsDatetime, IsSameStr, IsStr, try_import
 from .conftest import REAL_SDP_OFFER
-from .ws_cassettes import RealtimeCassette, ReplayWebSocket
+from .ws_cassettes import RealtimeCassette
 from .ws_helpers import collapse_event_types, sent_frames_containing
 
 with try_import() as imports_successful:
@@ -282,6 +282,7 @@ async def test_image_can_solicit_one_response(
     assert len(responses) == 1
 
 
+@pytest.mark.realtime_ws_hold_open
 async def test_media_views_subscribe_before_iteration(
     openai_ws_cassette: tuple[Provider[Any], RealtimeCassette],
 ) -> None:
@@ -499,6 +500,7 @@ async def test_audio_in_server_vad_turn(
     assert reply.usage.details.get('input_transcription_seconds') is None
 
 
+@pytest.mark.realtime_ws_hold_open
 async def test_input_audio_retention_segments_three_server_vad_turns(
     openai_ws_cassette: tuple[Provider[Any], RealtimeCassette], assets_path: Path
 ) -> None:
@@ -723,20 +725,11 @@ async def test_tool_can_close_session(openai_ws_cassette: tuple[Provider[Any], R
     )
 
 
+@pytest.mark.realtime_ws_hold_open
 async def test_tool_error_ends_transcript_only_session(
     openai_ws_cassette: tuple[Provider[Any], RealtimeCassette],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A raising tool ends a transcript-only consumer instead of leaving the live session mute."""
-    replay_recv = ReplayWebSocket.recv
-
-    async def yielding_replay_recv(self: ReplayWebSocket, *, decode: bool | None = None) -> str | bytes:
-        # A real socket yields between frames; give the spawned tool task the same scheduling chance
-        # during cassette playback before end-of-recording is interpreted as a provider close.
-        await asyncio.sleep(0)
-        return await replay_recv(self, decode=decode)
-
-    monkeypatch.setattr(ReplayWebSocket, 'recv', yielding_replay_recv)
     provider, _ = openai_ws_cassette
     model = OpenAIRealtimeModel(
         'gpt-realtime', provider=provider, settings=OpenAIRealtimeModelSettings(output_modality='text')

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2805,6 +2805,82 @@ async def test_tool_error_leaves_views_open_for_an_iterating_consumer() -> None:
         await anext(audio)
 
 
+@pytest.mark.parametrize('consumer', ['iterating', 'taps_only', 'iterated_then_taps'])
+async def test_pending_message_error_is_delivered_once_to_every_consumer_shape(
+    consumer: Literal['iterating', 'taps_only', 'iterated_then_taps'],
+) -> None:
+    """A failed background enqueue cannot remain parked on an unread event queue."""
+    events = [RealtimeInputSpeechStartEvent()] if consumer == 'iterated_then_taps' else []
+    session = RealtimeSession(
+        BlockingRealtimeConnection(events),
+        usage_limits=UsageLimits(request_limit=0),
+    )
+    await session.__aenter__()
+
+    event_task: asyncio.Task[list[RealtimeEvent]] | None = None
+    if consumer == 'iterating':
+        event_task = asyncio.create_task(drain_events(session))
+        await asyncio.sleep(0)
+    elif consumer == 'iterated_then_taps':
+        iterator = session.__aiter__()
+        assert isinstance(await anext(iterator), RealtimeInputSpeechStartEvent)
+        await iterator.aclose()
+
+    transcripts = session.stream_transcripts()
+    session.enqueue('too expensive')
+
+    if event_task is not None:
+        with pytest.raises(UsageLimitExceeded, match='request_limit of 0'):
+            await asyncio.wait_for(event_task, timeout=1)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(anext(transcripts), timeout=0.05)
+        await session.close()
+    else:
+        assert await asyncio.wait_for(_collect(transcripts), timeout=1) == []
+        with pytest.raises(UsageLimitExceeded, match='request_limit of 0'):
+            await session.close()
+        await session.close()
+    assert session.result is None
+
+
+async def test_receive_failure_is_delivered_by_next_send() -> None:
+    """A send-only bridge exits when the already-ended receive side failed."""
+    session = RealtimeSession(ExplodingConnection())
+    await session.__aenter__()
+    assert session._pump_task is not None  # pyright: ignore[reportPrivateUsage]
+    await session._pump_task  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(RuntimeError, match='connection dropped'):
+        await session.send_audio(b'next microphone chunk')
+    await session.close()
+    assert session.result is None
+
+
+async def test_session_entry_starts_receive_pump() -> None:
+    """Entering alone is enough to observe a fatal provider frame at context exit."""
+    session = RealtimeSession(ExplodingConnection())
+    with pytest.raises(RuntimeError, match='connection dropped'):
+        async with session:
+            await asyncio.sleep(0)
+    await session.close()
+    assert session.result is None
+
+
+async def test_failed_taps_only_agent_session_has_no_result() -> None:
+    agent: Agent[None, str] = Agent()
+    session: _RealtimeSession | None = None
+    with pytest.raises(UsageLimitExceeded, match='request_limit of 0'):
+        async with agent.realtime(
+            FakeRealtimeModel(BlockingRealtimeConnection([])),
+            usage_limits=UsageLimits(request_limit=0),
+        ).session() as session:
+            session.enqueue('too expensive')
+            assert await asyncio.wait_for(_collect(session.stream_transcripts()), timeout=1) == []
+
+    assert session is not None
+    assert session.result is None
+
+
 async def _collect(iterator: AsyncIterator[Any]) -> list[Any]:
     return [item async for item in iterator]
 
@@ -5862,12 +5938,15 @@ async def test_tool_completion_drains_messages_deferred_until_usage_arrives(monk
     assert 'after tool' in conn.sent
 
 
-async def test_deferred_asap_drain_failure_after_tool_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize('consumer', ['iterating', 'taps_only'])
+async def test_deferred_asap_drain_failure_after_tool_is_forwarded(
+    monkeypatch: pytest.MonkeyPatch, consumer: Literal['iterating', 'taps_only']
+) -> None:
     # The post-`finally` deferred `asap` drain in `_run_tool` runs OUTSIDE its try/except. If its
     # `connection.send` fails (e.g. the socket just dropped), `_tool_task_done` must forward the error to
     # the consumer — mirroring `_pending_message_task_done` — instead of letting it vanish as an
     # unretrieved-task-exception warning at GC, silently losing the enqueued follow-up.
-    class _FailingDrain(FakeRealtimeConnection):
+    class _FailingDrain(BlockingRealtimeConnection):
         async def send(self, content: RealtimeInput) -> None:
             if isinstance(content, str):
                 raise RuntimeError('drain send failed')
@@ -5876,6 +5955,10 @@ async def test_deferred_asap_drain_failure_after_tool_is_forwarded(monkeypatch: 
 
     conn = _FailingDrain([])
     session = RealtimeSession(conn)
+    await session.__aenter__()
+    event_task = asyncio.create_task(drain_events(session)) if consumer == 'iterating' else None
+    transcripts = session.stream_transcripts()
+    await asyncio.sleep(0)
     session._asap_drain_deferred = True  # pyright: ignore[reportPrivateUsage]
     session._pending_messages.append(  # pyright: ignore[reportPrivateUsage]
         PendingMessage(messages=[ModelRequest(parts=[UserPromptPart(content='after tool')])], priority='asap')
@@ -5915,10 +5998,15 @@ async def test_deferred_asap_drain_failure_after_tool_is_forwarded(monkeypatch: 
     await asyncio.gather(task, return_exceptions=True)
     await asyncio.sleep(0)  # let the done-callback run
 
-    queued: list[Any] = []
-    while not session._queue.empty():  # pyright: ignore[reportPrivateUsage]
-        queued.append(session._queue.get_nowait())  # pyright: ignore[reportPrivateUsage]
-    assert any(isinstance(item, RuntimeError) and str(item) == 'drain send failed' for item in queued)
+    if event_task is not None:
+        with pytest.raises(RuntimeError, match='drain send failed'):
+            await event_task
+        await session.close()
+    else:
+        assert await asyncio.wait_for(_collect(transcripts), timeout=1) == []
+        with pytest.raises(RuntimeError, match='drain send failed'):
+            await session.close()
+    await session.close()
 
 
 async def test_tool_call_limit_stops_pump_before_later_events() -> None:
@@ -6029,9 +6117,6 @@ async def test_tool_call_limit_counts_in_flight_calls() -> None:
 async def test_iterator_reuses_receive_pump_started_by_session_owner() -> None:
     session = RealtimeSession(FakeRealtimeConnection([ResponseDone()]))
     async with session:
-        session._pump_task = asyncio.create_task(  # pyright: ignore[reportPrivateUsage]
-            session._pump(session._session_instrumentation.context)  # pyright: ignore[reportPrivateUsage]
-        )
         assert [event async for event in session] == [RealtimeTurnCompleteEvent()]
 
 
@@ -6562,6 +6647,48 @@ async def test_tool_can_close_realtime_session_without_iterating(loop_errors: li
         ('tc', 'The tool call was interrupted before a result was produced.', 'interrupted')
     ]
     assert loop_errors == []
+
+
+@pytest.mark.parametrize('consumer', ['iterating', 'taps_only'])
+async def test_tool_close_ends_async_audio_sender_cleanly(
+    loop_errors: list[dict[str, Any]], consumer: Literal['iterating', 'taps_only']
+) -> None:
+    """A microphone task owned by the app does not fail when a tool hangs up."""
+    agent = Agent[None, str](deps_type=type(None))
+    microphone_started = asyncio.Event()
+
+    @agent.tool
+    async def hang_up(ctx: RunContext[None]) -> None:
+        assert ctx.realtime_session is not None
+        await microphone_started.wait()
+        await ctx.realtime_session.close()
+
+    async def microphone() -> AsyncIterator[bytes]:
+        microphone_started.set()
+        while True:
+            yield b'\x00\x00'
+            await asyncio.sleep(0)
+
+    conn = IdleAfterToolConnection(ToolCall(tool_call_id='tc', tool_name='hang_up', args='{}'))
+    with anyio.fail_after(5):
+        async with agent.realtime(FakeRealtimeModel(conn)).session() as session:
+            microphone_task = asyncio.create_task(session.send_audio(microphone()))
+            if consumer == 'iterating':
+                _ = [event async for event in session]
+            else:
+                assert [chunk async for chunk in session.stream_audio()] == []
+            await microphone_task
+
+    assert session.result is not None
+    assert loop_errors == []
+
+
+async def test_single_audio_chunk_still_fails_after_close() -> None:
+    session = RealtimeSession(FakeRealtimeConnection([]))
+    async with session:
+        pass
+    with pytest.raises(UserError, match='session is closed'):
+        await session.send_audio(b'\x00\x00')
 
 
 async def test_tool_that_swallows_the_cancel_after_closing_records_one_return(

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2869,12 +2869,54 @@ async def test_tool_error_does_not_preempt_send_for_an_active_iterator() -> None
         assert isinstance(await anext(events), PartStartEvent)
         assert isinstance(await anext(events), PartEndEvent)
         assert isinstance(await anext(events), FunctionToolCallEvent)
-        while not session._parked_errors:  # pyright: ignore[reportPrivateUsage]
-            await asyncio.sleep(0)
+        # The failure is parked by the tool task itself, so it is there once that task has finished.
+        await asyncio.gather(*session._background_tasks, return_exceptions=True)  # pyright: ignore[reportPrivateUsage]
 
         await session.send('x')
         assert conn.sent[-1] == 'x'
         with pytest.raises(ValueError, match='tool exploded'):
+            await anext(events)
+
+
+async def test_tool_error_delivered_to_send_is_skipped_by_the_iterator() -> None:
+    """Once the receive side has ended, a send raises the parked failure; the iterator then ends cleanly."""
+
+    async def runner(*args: Any) -> str:
+        raise ValueError('tool exploded')
+
+    conn = FakeRealtimeConnection([ToolCall(tool_call_id='tc1', tool_name='noop', args='{}')])
+    session = RealtimeSession(conn, runner=runner)
+    async with session:
+        events = session.__aiter__()
+        assert isinstance(await anext(events), PartStartEvent)
+        assert isinstance(await anext(events), PartEndEvent)
+        assert isinstance(await anext(events), FunctionToolCallEvent)
+        await asyncio.gather(*session._background_tasks, return_exceptions=True)  # pyright: ignore[reportPrivateUsage]
+        assert session._pump_task is not None  # pyright: ignore[reportPrivateUsage]
+        await session._pump_task  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(ValueError, match='tool exploded'):
+            await session.send('x')
+        with pytest.raises(StopAsyncIteration):
+            await anext(events)
+
+
+async def test_pump_error_delivered_to_send_is_not_raised_again_by_the_iterator() -> None:
+    class _DyingConnection(FakeRealtimeConnection):
+        async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            yield RealtimeInputSpeechStartEvent()
+            raise RuntimeError('socket died')
+
+    session = RealtimeSession(_DyingConnection([]))
+    async with session:
+        events = session.__aiter__()
+        assert isinstance(await anext(events), RealtimeInputSpeechStartEvent)
+        assert session._pump_task is not None  # pyright: ignore[reportPrivateUsage]
+        await session._pump_task  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(RuntimeError, match='socket died'):
+            await session.send('x')
+        with pytest.raises(StopAsyncIteration):
             await anext(events)
 
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, TypeVar, cast
 import anyio
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.context import Context
 from pydantic_core import SchemaValidator, core_schema
 
 from pydantic_ai import Agent, ModelRetry, RunContext
@@ -2790,6 +2791,34 @@ async def test_tool_error_ends_views_when_the_stream_was_never_iterated() -> Non
             assert await asyncio.wait_for(_collect(session.stream_transcripts()), timeout=1) == []
 
 
+async def test_tool_error_preempts_send_while_receive_pump_is_ending() -> None:
+    """A send cannot slip between a taps-only tool failure and the cancelled pump finishing."""
+    pump_cancelled = asyncio.Event()
+
+    class SlowPumpSession(_RealtimeSession):
+        async def _pump(self, context: Context | None) -> None:
+            try:
+                await super()._pump(context)
+            except asyncio.CancelledError:
+                pump_cancelled.set()
+                await asyncio.Event().wait()
+
+    async def runner(*args: Any) -> str:
+        raise ValueError('tool exploded')
+
+    session = SlowPumpSession(
+        BlockingRealtimeConnection([ToolCall(tool_call_id='tc1', tool_name='noop', args='{}')]),
+        tool_manager=make_tool_manager(runner),
+    )
+    await session.__aenter__()
+    await asyncio.wait_for(pump_cancelled.wait(), timeout=1)
+    assert session._pump_task is not None and not session._pump_task.done()  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(ValueError, match='tool exploded'):
+        await session.send('x')
+    await session.close()
+
+
 async def test_tool_retry_exhaustion_ends_views_when_the_stream_was_never_iterated() -> None:
     async def runner(*args: Any) -> str:
         raise UnexpectedModelBehavior('retry budget exhausted')
@@ -2827,6 +2856,26 @@ async def test_tool_error_leaves_views_open_for_an_iterating_consumer() -> None:
         assert session._pump_task is not None and not session._pump_task.done()  # pyright: ignore[reportPrivateUsage]
     with pytest.raises(StopAsyncIteration):
         await anext(audio)
+
+
+async def test_tool_error_does_not_preempt_send_for_an_active_iterator() -> None:
+    async def runner(*args: Any) -> str:
+        raise ValueError('tool exploded')
+
+    conn = BlockingRealtimeConnection([ToolCall(tool_call_id='tc1', tool_name='noop', args='{}')])
+    session = RealtimeSession(conn, runner=runner)
+    async with session:
+        events = session.__aiter__()
+        assert isinstance(await anext(events), PartStartEvent)
+        assert isinstance(await anext(events), PartEndEvent)
+        assert isinstance(await anext(events), FunctionToolCallEvent)
+        while not session._parked_errors:  # pyright: ignore[reportPrivateUsage]
+            await asyncio.sleep(0)
+
+        await session.send('x')
+        assert conn.sent[-1] == 'x'
+        with pytest.raises(ValueError, match='tool exploded'):
+            await anext(events)
 
 
 @pytest.mark.parametrize('consumer', ['iterating', 'taps_only', 'iterated_then_taps'])
@@ -3344,6 +3393,29 @@ async def test_send_audio_accepts_async_iterable() -> None:
         BinaryAudio(data=b'\x01\x02', media_type='audio/pcm'),
         BinaryAudio(data=b'\x03\x04', media_type='audio/pcm'),
     ]
+
+
+async def test_send_audio_iterable_waits_for_next_chunk_after_close() -> None:
+    """Closing does not cancel into a caller-owned async iterable that is blocked between chunks."""
+    source_blocked = asyncio.Event()
+    next_chunk = asyncio.Event()
+
+    async def microphone() -> AsyncIterator[bytes]:
+        yield b'first'
+        source_blocked.set()
+        await next_chunk.wait()
+        yield b'after close'
+
+    conn = BlockingRealtimeConnection([])
+    async with RealtimeSession(conn) as session:
+        sender = asyncio.create_task(session.send_audio(microphone()))
+        await source_blocked.wait()
+        await session.close()
+        assert not sender.done()
+        next_chunk.set()
+        await sender
+
+    assert conn.sent == [BinaryAudio(data=b'first', media_type='audio/pcm')]
 
 
 async def test_send_dispatches_through_bookkeeping_helpers() -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2883,7 +2883,7 @@ async def test_pending_message_error_is_delivered_once_to_every_consumer_shape(
     consumer: Literal['iterating', 'taps_only', 'iterated_then_taps'],
 ) -> None:
     """A failed background enqueue cannot remain parked on an unread event queue."""
-    events = [RealtimeInputSpeechStartEvent()] if consumer == 'iterated_then_taps' else []
+    events: list[RealtimeCodecEvent] = [RealtimeInputSpeechStartEvent()] if consumer == 'iterated_then_taps' else []
     session = RealtimeSession(
         BlockingRealtimeConnection(events),
         usage_limits=UsageLimits(request_limit=0),
@@ -2897,6 +2897,7 @@ async def test_pending_message_error_is_delivered_once_to_every_consumer_shape(
     elif consumer == 'iterated_then_taps':
         iterator = session.__aiter__()
         assert isinstance(await anext(iterator), RealtimeInputSpeechStartEvent)
+        assert isinstance(iterator, AsyncGenerator)
         await iterator.aclose()
 
     transcripts = session.stream_transcripts()

--- a/tests/realtime/test_ws_cassettes.py
+++ b/tests/realtime/test_ws_cassettes.py
@@ -243,6 +243,19 @@ async def test_empty_replay_closes_cleanly_and_disconnect_requires_binding() -> 
 
 
 @pytest.mark.anyio
+async def test_replay_can_hold_open_after_last_frame_until_client_closes() -> None:
+    replay = ReplayWebSocket(RealtimeCassette(), hold_open=True)
+
+    receive_task = asyncio.create_task(replay.recv())
+    await asyncio.sleep(0)
+    assert not receive_task.done()
+
+    await replay.close()
+    with pytest.raises(ConnectionClosedOK):
+        await receive_task
+
+
+@pytest.mark.anyio
 async def test_disconnect_delegates_to_the_bound_connection() -> None:
     """Once bound, `disconnect()` drops the active transport so replay reaches the recorded close.
 

--- a/tests/realtime/ws_cassettes.py
+++ b/tests/realtime/ws_cassettes.py
@@ -268,12 +268,14 @@ class ReplayWebSocket:
     consuming a future inbound frame.
     """
 
-    def __init__(self, cassette: RealtimeCassette) -> None:
+    def __init__(self, cassette: RealtimeCassette, *, hold_open: bool = False) -> None:
         self._interactions = cassette.interactions
+        self._hold_open = hold_open
         self._position = 0
         self._normalizer = _SentFrameNormalizer()
         self._condition = asyncio.Condition()
         self._readers = 0
+        self._closed = False
         # Mirrors the `websockets` attributes a connection exposes once closed, so code that inspects
         # the close after iteration ends (a normal close doesn't raise) sees what was recorded.
         self.close_code: int | None = None
@@ -314,6 +316,9 @@ class ReplayWebSocket:
         while True:
             interaction = self._peek()
             if interaction is None:
+                if self._hold_open and not self._closed:
+                    await self._condition.wait()
+                    continue
                 # The recording ran out: the session outlived what was captured, which replays as
                 # the ordinary end-of-conversation close.
                 self.close_code, self.close_reason = 1000, ''
@@ -349,6 +354,9 @@ class ReplayWebSocket:
 
     async def close(self, *args: Any, **kwargs: Any) -> None:
         del args, kwargs
+        async with self._condition:
+            self._closed = True
+            self._condition.notify_all()
 
     def _peek(self) -> RealtimeCassetteInteraction | None:
         if self._position >= len(self._interactions):
@@ -428,11 +436,13 @@ def _connect_target(provider: ProviderName) -> tuple[Any, str]:
 
 
 @contextmanager
-def patched_ws_connect(provider: ProviderName, cassette: RealtimeCassette, plan: CassettePlan) -> Generator[None]:
+def patched_ws_connect(
+    provider: ProviderName, cassette: RealtimeCassette, plan: CassettePlan, *, hold_open: bool = False
+) -> Generator[None]:
     """Patch the provider's WebSocket `connect` to replay from (or record into) `cassette`."""
     target, attr = _connect_target(provider)
     real_connect = getattr(target, attr)
-    replay = ReplayWebSocket(cassette) if plan == 'replay' else None
+    replay = ReplayWebSocket(cassette, hold_open=hold_open) if plan == 'replay' else None
 
     @asynccontextmanager
     async def connect(*args: Any, **kwargs: Any) -> AsyncGenerator[ReplayWebSocket | RecordingWebSocket]:


### PR DESCRIPTION
Follow-up to #8108, which made a failing tool end the audio and transcript views of a session that was never iterated. An audit of every path that parks an error for the consumer found the rest of the picture, all reproduced with fakes:

- **Two other parking sites did nothing for a taps-only session.** A pending-message drain that fails (for example `enqueue()` tripping a `UsageLimitExceeded`, or a non-transport `send` failure) and a tool task's post-result drain both parked the error on the queue and left the pump running: views stayed open, the session sat live and mute, and the enqueued prompt was silently lost. All three sites now go through one `_park_error()` that ends the receive side when nobody is iterating.
- **"Ever iterated" was the wrong predicate.** Every docs example that iterates does so until the first `RealtimeTurnCompleteEvent`, `break`s, and keeps the views. That shape got the pre-#8108 behaviour back: the pump kept running, the views stayed open, the error sat in the queue, `close()` swallowed it, and `session.result` looked successful. The documented rule that such a consumer "has chosen to stop listening" is withdrawn: a failure is raised from `async for` while iteration is active; otherwise the views end and the failure is raised when the `async with` block exits. A failure is delivered exactly once.
- **A send-only bridge kept sending into a dead session.** Once the receive side has ended with a failure nobody received, `send()`, `send_audio()`, `enqueue()`, `create_response()` and the other outbound methods now raise it, so a `send_audio(microphone())` loop exits and the app leaves the block.
- **The pump starts on `__aenter__`.** A session that was entered but never sent to never read a fatal provider frame and closed cleanly.
- **`send_audio(async_iterable)` returns cleanly when the session is closed while consuming it**, mirroring `stream_audio()` ending on close. Before, a tool hanging up with `ctx.realtime_session.close()` made the app's own microphone task die with `UserError('This realtime session is closed.')`, and the quickstart's `await microphone` re-raised it. Sending a single chunk after close still raises.

Docs: lifecycle.md Errors section, tools.md, audio.md, `docs/api/realtime.md`, the `close()` and `send_audio()` docstrings, and the agent skill.

Tests cover each path in the iterating, taps-only, iterated-then-taps, send-only, and entered-only shapes. Two OpenAI cassette tests that `break` on the turn boundary and keep working inside the block used to rely on the replay socket's end-of-recording close being ignored; a real provider keeps the socket open after a turn, so `ReplayWebSocket` gains an opt-in `hold_open` (via a `realtime_ws_hold_open` marker) that those tests use, and the tool-error cassette test no longer needs its `recv` patch.

Because the pump now starts on `__aenter__`, a playback task that calls `stream_audio()` in its own body can miss audio the model produced before the task first ran. The shipped `realtime_voice.py` example creates its audio view before starting the task, as the docs recommend, and its tests are unchanged.

> [!NOTE]
> Behaviour change for a consumer that iterated, stopped, and then hit a receive-side failure before leaving the block: the failure is now raised from `close()` instead of being dropped. This surfaces real failures (including a provider hangup) that were previously invisible; a clean exit stays clean.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->