### PR TITLE
Keep late realtime input transcripts attached to the user turn they belong to

### DIFF
--- a/docs/realtime/history.md
+++ b/docs/realtime/history.md
@@ -143,7 +143,12 @@ sends one frame per second — so for camera and screen streams, use both delibe
 ## Transcription and history edge cases
 
 Input transcription defaults to `'auto'`; see [Input transcription](audio.md#input-transcription)
-and each provider page for configuration. With transcription disabled:
+and each provider page for configuration. Transcripts are recorded with the user turn they describe,
+even when they arrive after that turn's response or overlap the following turn. If a reported speech
+segment never receives a transcript, the session still records its retained audio or a content-less
+`SpeechPart` when the session closes.
+
+With transcription disabled:
 
 - retained input audio creates an audio-only user `SpeechPart`;
 - without input retention, the session records a content-less user `SpeechPart`;

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -282,7 +282,10 @@ Key facts for building realtime agents:
   image. Never pair `session.send('...')` with `session.create_response()`, because that asks twice.
 - **History handoff is the marquee integration**: `session.all_messages()` / `session.new_messages()`
   return real `ModelMessage`s; seed with `realtime(model, message_history=...).session()`. Transcripts
-  are what carry over; OpenAI and Azure can also replay retained transcript-less *user* audio, Gemini
+  stay attached to the user turn they describe even when they arrive after its response. A reported
+  speech segment whose transcript never arrives remains represented by retained audio or a content-less
+  `SpeechPart` when the session closes. Transcripts are what carry over; OpenAI and Azure can also
+  replay retained transcript-less *user* audio, Gemini
   and xAI cannot, and assistant audio is never replayed. Streamed images all reach the provider, but
   history keeps a sampled (`retain_images_every_n`) and bounded (`retain_images_max`, default `100`,
   oldest evicted first) record.

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -2244,55 +2244,20 @@ class RealtimeSession:
 
     def _finalize_failed_user_item(self, item_id: str | None) -> list[RealtimeEvent]:
         """Finalize a user item whose transcription failed without retaining unreliable partial text."""
-        start_emitted = False
         if item_id is not None:
             # Same guard as `_handle_input_transcript`: once an item is closed, a stray duplicate or
             # late error event must not re-open it and record a second (blank) user turn.
             if item_id in self._finalized_user_item_ids:
                 return []
-            turn = self._user_turns.get(item_id)
-            start_emitted = turn is not None
-            part = replace(turn.part, transcript=None) if turn is not None else SpeechPart(speaker='user')
-            index = turn.index if turn is not None else self._take_part_index()
-            if turn is None:
-                turn = self._user_turns[item_id] = _UserTurn(part, '', index)
-            if item_id not in self._user_turn_anchors:
-                # The failure is the first we hear of this item, so its turn is only placed now.
-                self._claim_user_turn_anchor(item_id)
-            self._finalized_user_item_ids.add(item_id)
+        turn = self._user_turns.get(item_id)
+        if turn is None:
+            part = SpeechPart(speaker='user')
+            turn = self._user_turns[item_id] = _UserTurn(part, '', self._take_part_index(), start_emitted=False)
+            self._claim_user_turn_anchor(item_id)
         else:
-            turn = self._user_turns.get(None)
-            start_emitted = turn is not None
-            part = replace(turn.part, transcript=None) if turn is not None else SpeechPart(speaker='user')
-            index = turn.index if turn is not None else self._take_part_index()
-
-        if self._retain_input:
-            segment = self._input_audio_by_id.pop(item_id, None) if item_id is not None else None
-            if segment is None:
-                segment = bytes(self._input_audio) if self._input_audio else None
-                self._input_audio.clear()
-            if segment:
-                part = replace(
-                    part,
-                    audio=BinaryContent(
-                        data=_pcm_to_wav(segment, self.audio_input_sample_rate),
-                        media_type=_WAV_MEDIA_TYPE,
-                    ),
-                )
-
-        # Recompute like `_finalize_user`: with overlapping user items, one item's failure must not mark
-        # the whole user side idle while another item is still active.
-        self._user_turn_active = any(not current.finalized for current in self._user_turns.values())
-        if item_id is None:
-            self._record_user_request(None, self._new_request([part]))
-            self._user_turns.pop(None, None)
-        else:
-            assert turn is not None
-            turn.part = part
-            turn.finalized = True
-            self._flush_finalized_user_prefix()
-        end = PartEndEvent(index=index, part=part)
-        return [end] if start_emitted else [PartStartEvent(index=index, part=part), end]
+            turn.part = replace(turn.part, transcript=None)
+            turn.transcript = ''
+        return self._finalize_user(item_id=item_id)
 
     def _flush_pending_users(self) -> None:
         """Preserve transcript-bearing user items that never received an explicit final event."""

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -196,6 +196,8 @@ class _UserTurn:
     transcript: str
     index: int
     finalized: bool = False
+    speech_ended: bool = False
+    start_emitted: bool = True
 
 
 # Realtime providers stream raw PCM audio, but retained history uses a WAV container so the sample
@@ -738,15 +740,16 @@ class RealtimeSession:
 
         # In-flight user request being assembled from input-transcript events.
         self._user_turn_active = False
+        self._anonymous_user_turn_ended = False
         # Insertion order is provider item order. `None` is the single anonymous turn used by
         # providers that do not identify input transcript items.
         self._user_turns: dict[str | None, _UserTurn] = {}
         self._finalized_user_item_ids: set[str] = set()
         # Where in history each user turn belongs, remembered when the turn *starts* — see
-        # `_open_user_turn_anchor`. `_pending_user_turn_anchor` holds the anchor of a turn that has begun
-        # but whose transcript hasn't identified it yet; `_user_turn_anchors` keys them by item id (`None`
-        # for id-less providers) once it has.
+        # `_open_user_turn_anchor`. Provider item IDs keep overlapping turns paired with their own
+        # anchors; `_pending_user_turn_anchor` is only for providers whose events carry no item ID.
         self._pending_user_turn_anchor: tuple[ModelMessage | None] | None = None
+        self._pending_user_turn_anchors: dict[str, tuple[ModelMessage | None]] = {}
         self._user_turn_anchors: dict[str | None, ModelMessage | None] = {}
         # Retained input audio (`audio_retention='input_audio'`/`'all'`). `_input_audio` is the rolling buffer
         # of audio sent since the last turn boundary; on providers that report a per-item speech-stopped
@@ -1383,6 +1386,10 @@ class RealtimeSession:
             async for chunk in data:
                 await self.send_audio(chunk)
             return
+        if (turn := self._user_turns.get(None)) is not None and turn.speech_ended:
+            for event in self._finalize_user():
+                await self._queue.put(event)
+            self._anonymous_user_turn_ended = False
         user_turn_was_active = self._user_turn_active
         if not user_turn_was_active:
             # Audio starting is the earliest sign of a user turn, and the only one on a provider that
@@ -1723,7 +1730,10 @@ class RealtimeSession:
     def _handle_assistant_transcript(
         self, text: str, *, output_text: bool = False, item_id: str | None = None
     ) -> list[RealtimeEvent]:
-        events = self._ensure_active_assistant(output_text=output_text, item_id=item_id)
+        # An id-less provider cannot associate transcripts with overlapping input items. Its first
+        # output frame is therefore the boundary that closes the anonymous user turn before the reply.
+        events = self._finalize_anonymous_user_before_output()
+        events.extend(self._ensure_active_assistant(output_text=output_text, item_id=item_id))
         active = self._active_assistant
         assert active is not None
         self._assistant_transcript, appended = _accumulate_transcript(self._assistant_transcript, text)
@@ -1740,7 +1750,8 @@ class RealtimeSession:
         return events
 
     def _handle_assistant_audio(self, data: bytes, *, item_id: str | None = None) -> list[RealtimeEvent]:
-        events = self._ensure_active_assistant(item_id=item_id)
+        events = self._finalize_anonymous_user_before_output()
+        events.extend(self._ensure_active_assistant(item_id=item_id))
         if self._retain_output:
             self._output_audio.extend(data)
         events.append(
@@ -1964,8 +1975,9 @@ class RealtimeSession:
         frame has no per-response usage to wait for; it is finalized immediately with zero usage, while
         the later completed turn keeps the usage Gemini reports for that turn.
         """
+        events = self._finalize_anonymous_user_before_output()
         self._ensure_chat_span()
-        events = self._finalize_assistant_part()
+        events.extend(self._finalize_assistant_part())
         index = self._take_part_index()
         events.append(PartStartEvent(index=index, part=call_part))
         events.append(PartEndEvent(index=index, part=call_part))
@@ -2043,6 +2055,9 @@ class RealtimeSession:
                 turn = self._user_turns[item_id] = _UserTurn(part, '', self._take_part_index())
                 events.append(PartStartEvent(index=turn.index, part=part))
             turn = self._user_turns[item_id]
+            if not turn.start_emitted:
+                events.append(PartStartEvent(index=turn.index, part=turn.part))
+                turn.start_emitted = True
             transcript, delta = _user_transcript_update(turn.transcript, text, cumulative=cumulative)
             turn.transcript = transcript
             turn.part = replace(turn.part, transcript=transcript)
@@ -2057,15 +2072,34 @@ class RealtimeSession:
             self._user_turn_active = True
             part = SpeechPart(speaker='user', transcript='')
             self._claim_user_turn_anchor(None)
-            turn = self._user_turns[None] = _UserTurn(part, '', self._take_part_index())
+            turn = self._user_turns[None] = _UserTurn(
+                part, '', self._take_part_index(), speech_ended=self._anonymous_user_turn_ended
+            )
             events.append(PartStartEvent(index=turn.index, part=part))
         turn = self._user_turns[None]
+        if not turn.start_emitted:
+            events.append(PartStartEvent(index=turn.index, part=turn.part))
+            turn.start_emitted = True
         turn.transcript, delta = _user_transcript_update(turn.transcript, text, cumulative=cumulative)
         turn.part = replace(turn.part, transcript=turn.transcript)
         if delta is not None:
             events.append(PartDeltaEvent(index=turn.index, delta=delta))
         if is_final:
             events.extend(self._finalize_user())
+        return events
+
+    def _finalize_anonymous_user_before_output(self) -> list[RealtimeEvent]:
+        """Close an id-less user turn when the model begins replying to it."""
+        if not self._input_transcription_enabled:
+            return []
+        events = self._finalize_user()
+        if events:
+            self._anonymous_user_turn_ended = False
+        elif self._user_turn_active:
+            # The transcript can lag behind the output that marks its boundary. Remember that the
+            # anonymous turn is already over so the next audio segment can close it after it arrives.
+            self._anonymous_user_turn_ended = True
+            self._user_turn_active = False
         return events
 
     def _finalize_user(self, *, item_id: str | None = None) -> list[RealtimeEvent]:
@@ -2102,13 +2136,27 @@ class RealtimeSession:
         if item_id is None:
             self._record_user_request(None, self._new_request([part]))
             self._user_turns.pop(None)
+            self._anonymous_user_turn_ended = False
         else:
             turn.part = part
             turn.finalized = True
-            self._flush_finalized_user_prefix()
-        return [PartEndEvent(index=index, part=part)]
+            blocked_by_started_turn = False
+            for current_id, current in self._user_turns.items():
+                if current_id == item_id:
+                    break
+                if current.start_emitted and not current.finalized:
+                    blocked_by_started_turn = True
+                    break
+            if blocked_by_started_turn:
+                self._flush_finalized_user_prefix()
+            else:
+                self._user_turns.pop(item_id)
+                self._record_user_request(item_id, self._new_request([part]))
+                self._flush_finalized_user_prefix()
+        end = PartEndEvent(index=index, part=part)
+        return [end] if turn.start_emitted else [PartStartEvent(index=index, part=part), end]
 
-    def _open_user_turn_anchor(self) -> None:
+    def _open_user_turn_anchor(self, item_id: str | None = None) -> None:
         """Remember where a starting user turn belongs in history, before its transcript arrives.
 
         Input transcription is asynchronous, and its final event can land after the response the speech
@@ -2118,11 +2166,18 @@ class RealtimeSession:
         unprompted. So the turn's position is taken when it starts (audio begins flowing, or the provider
         reports speech started), and `_record_user_request` inserts there however late the transcript is.
         """
-        self._pending_user_turn_anchor = (self._history[-1] if self._history else None,)
+        anchor = self._history[-1] if self._history else None
+        if item_id is None:
+            self._pending_user_turn_anchor = (anchor,)
+        else:
+            self._pending_user_turn_anchors[item_id] = (anchor,)
 
     def _claim_user_turn_anchor(self, item_id: str | None) -> None:
         """Attach the starting turn's remembered position to the item the transcript identified it as."""
-        anchor, self._pending_user_turn_anchor = self._pending_user_turn_anchor, None
+        if item_id is None:
+            anchor, self._pending_user_turn_anchor = self._pending_user_turn_anchor, None
+        else:
+            anchor = self._pending_user_turn_anchors.pop(item_id, None)
         # No anchor when the first thing we ever hear about the turn is its transcript (text-only sessions
         # seeded with audio, or a provider that reports nothing before it); the turn starts here instead.
         self._user_turn_anchors[item_id] = (
@@ -2245,6 +2300,7 @@ class RealtimeSession:
         assert not self._user_turns, 'every pending user turn should have been recorded'
         self._user_turn_anchors.clear()
         self._pending_user_turn_anchor = None
+        self._pending_user_turn_anchors.clear()
         # Drop any input-audio segments whose transcript never arrived, so they can't leak across a
         # long-lived session (finalized items already popped their own segment above).
         self._input_audio_by_id.clear()
@@ -2383,7 +2439,7 @@ class RealtimeSession:
             return [event]
         # A reported speech start is a turn boundary even mid-stream, so it re-anchors: with a continuously
         # open microphone the previous turn may not have finalized yet, leaving `_user_turn_active` set.
-        self._open_user_turn_anchor()
+        self._open_user_turn_anchor(event.item_id)
         self._user_turn_active = True
         self._user_speech_started_at = time_ns()
         # Whatever response was in flight, the provider's own turn detection is cancelling it now.
@@ -2397,6 +2453,23 @@ class RealtimeSession:
                 self._replayed_item_ids.add(event.item_id)
             if event.tool_call_id is not None:
                 self._replayed_tool_call_ids.add(event.tool_call_id)
+
+    def _handle_input_speech_end(self, event: RealtimeInputSpeechEndEvent) -> list[RealtimeEvent]:
+        """Segment input audio and preserve a placeholder while transcription is pending."""
+        self._provider_segments_input = True
+        self._segment_input_audio(event.item_id)
+        self._record_user_speech_span()
+        events = self._finalize_untranscribed_user()
+        if self._input_transcription_enabled:
+            if event.item_id not in self._user_turns:
+                self._claim_user_turn_anchor(event.item_id)
+                part = SpeechPart(speaker='user', transcript='')
+                self._user_turns[event.item_id] = _UserTurn(
+                    part, '', self._take_part_index(), speech_ended=True, start_emitted=False
+                )
+            else:
+                self._user_turns[event.item_id].speech_ended = True
+        return [*events, event]
 
     def _translate_event(self, event: _TranslatableEvent) -> list[RealtimeEvent]:
         """Translate a low-level codec event into shared session events, building history as a side effect.
@@ -2429,10 +2502,7 @@ class RealtimeSession:
             # retained, cut the rolling buffer into this item's own segment so a later out-of-order
             # transcript still attaches its own audio; with transcription off there's no lagging transcript,
             # so `_finalize_untranscribed_user` consumes the rolling buffer synchronously here instead.
-            self._provider_segments_input = True
-            self._segment_input_audio(event.item_id)
-            self._record_user_speech_span()
-            return [*self._finalize_untranscribed_user(), event]
+            return self._handle_input_speech_end(event)
         if isinstance(event, ResponseDone):
             return self._handle_turn_complete(event)
         if isinstance(event, (PartStartEvent, PartEndEvent)):

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -10,6 +10,7 @@ import weakref
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable, Sequence
 from dataclasses import dataclass, replace
+from itertools import takewhile
 from threading import Lock as ThreadLock
 from time import time_ns
 from types import TracebackType
@@ -2145,13 +2146,11 @@ class RealtimeSession:
         else:
             turn.part = part
             turn.finalized = True
-            blocked_by_started_turn = False
-            for current_id, current in self._user_turns.items():
-                if current_id == item_id:
-                    break
-                if (current.start_emitted or current.speech_ended) and not current.finalized:
-                    blocked_by_started_turn = True
-                    break
+            earlier_turns = takewhile(lambda entry: entry[0] != item_id, self._user_turns.items())
+            blocked_by_started_turn = any(
+                (current.start_emitted or current.speech_ended) and not current.finalized
+                for _, current in earlier_turns
+            )
             if blocked_by_started_turn:
                 self._flush_finalized_user_prefix()
             else:
@@ -2196,11 +2195,6 @@ class RealtimeSession:
 
     def _record_user_request(self, item_id: str | None, request: ModelRequest) -> None:
         """Record a finalized user turn at the position it held when it started."""
-        # A turn that never opened an anchor has no earlier place to hold: only audio reserves one, so
-        # a text turn simply belongs where it is finalized.
-        if item_id not in self._user_turn_anchors:
-            self._history.append(request)
-            return
         anchor = self._user_turn_anchors.pop(item_id)
         insert_at = 0
         if anchor is not None:

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -7,6 +7,7 @@ import dataclasses
 import io
 import wave
 import weakref
+from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable, Sequence
 from dataclasses import dataclass, replace
 from threading import Lock as ThreadLock
@@ -740,15 +741,16 @@ class RealtimeSession:
 
         # In-flight user request being assembled from input-transcript events.
         self._user_turn_active = False
-        self._anonymous_user_turn_ended = False
+        self._anonymous_user_turns_ended = 0
         # Insertion order is provider item order. `None` is the single anonymous turn used by
         # providers that do not identify input transcript items.
         self._user_turns: dict[str | None, _UserTurn] = {}
         self._finalized_user_item_ids: set[str] = set()
         # Where in history each user turn belongs, remembered when the turn *starts* — see
         # `_open_user_turn_anchor`. Provider item IDs keep overlapping turns paired with their own
-        # anchors; `_pending_user_turn_anchor` is only for providers whose events carry no item ID.
-        self._pending_user_turn_anchor: tuple[ModelMessage | None] | None = None
+        # anchors; `_pending_anonymous_user_turn_anchors` is only for providers whose events carry no
+        # item ID. It is a queue because a transcript can arrive after the next audio turn starts.
+        self._pending_anonymous_user_turn_anchors: deque[ModelMessage | None] = deque()
         self._pending_user_turn_anchors: dict[str, tuple[ModelMessage | None]] = {}
         self._user_turn_anchors: dict[str | None, ModelMessage | None] = {}
         # Retained input audio (`audio_retention='input_audio'`/`'all'`). `_input_audio` is the rolling buffer
@@ -1388,8 +1390,8 @@ class RealtimeSession:
             return
         if (turn := self._user_turns.get(None)) is not None and turn.speech_ended:
             for event in self._finalize_user():
+                self._publish_taps(event)
                 await self._queue.put(event)
-            self._anonymous_user_turn_ended = False
         user_turn_was_active = self._user_turn_active
         if not user_turn_was_active:
             # Audio starting is the earliest sign of a user turn, and the only one on a provider that
@@ -2078,8 +2080,10 @@ class RealtimeSession:
             part = SpeechPart(speaker='user', transcript='')
             self._claim_user_turn_anchor(None)
             turn = self._user_turns[None] = _UserTurn(
-                part, '', self._take_part_index(), speech_ended=self._anonymous_user_turn_ended
+                part, '', self._take_part_index(), speech_ended=self._anonymous_user_turns_ended > 0
             )
+            if turn.speech_ended:
+                self._anonymous_user_turns_ended -= 1
             events.append(PartStartEvent(index=turn.index, part=part))
         turn = self._user_turns[None]
         if not turn.start_emitted:
@@ -2098,12 +2102,10 @@ class RealtimeSession:
         if not self._input_transcription_enabled:
             return []
         events = self._finalize_user()
-        if events:
-            self._anonymous_user_turn_ended = False
-        elif self._user_turn_active:
+        if not events and self._user_turn_active:
             # The transcript can lag behind the output that marks its boundary. Remember that the
             # anonymous turn is already over so the next audio segment can close it after it arrives.
-            self._anonymous_user_turn_ended = True
+            self._anonymous_user_turns_ended += 1
             self._user_turn_active = False
         return events
 
@@ -2115,7 +2117,6 @@ class RealtimeSession:
         index = turn.index
         if item_id is not None:
             self._finalized_user_item_ids.add(item_id)
-        self._user_turn_active = any(not current.finalized for current in self._user_turns.values())
         # Strip surrounding whitespace at finalization: providers whose transcripts arrive as a cumulative
         # or final snapshot (OpenAI/xAI) already reconcile leading-space drift via `_accumulate_transcript`,
         # but a partial-only stream (Gemini) concatenates deltas verbatim and would otherwise keep the
@@ -2141,7 +2142,6 @@ class RealtimeSession:
         if item_id is None:
             self._record_user_request(None, self._new_request([part]))
             self._user_turns.pop(None)
-            self._anonymous_user_turn_ended = False
         else:
             turn.part = part
             turn.finalized = True
@@ -2149,7 +2149,7 @@ class RealtimeSession:
             for current_id, current in self._user_turns.items():
                 if current_id == item_id:
                     break
-                if current.start_emitted and not current.finalized:
+                if (current.start_emitted or current.speech_ended) and not current.finalized:
                     blocked_by_started_turn = True
                     break
             if blocked_by_started_turn:
@@ -2158,6 +2158,10 @@ class RealtimeSession:
                 self._user_turns.pop(item_id)
                 self._record_user_request(item_id, self._new_request([part]))
                 self._flush_finalized_user_prefix()
+        self._user_turn_active = (
+            any(not current.finalized for current in self._user_turns.values())
+            or len(self._pending_anonymous_user_turn_anchors) > self._anonymous_user_turns_ended
+        )
         end = PartEndEvent(index=index, part=part)
         return [end] if turn.start_emitted else [PartStartEvent(index=index, part=part), end]
 
@@ -2173,21 +2177,22 @@ class RealtimeSession:
         """
         anchor = self._history[-1] if self._history else None
         if item_id is None:
-            self._pending_user_turn_anchor = (anchor,)
+            self._pending_anonymous_user_turn_anchors.append(anchor)
         else:
             self._pending_user_turn_anchors[item_id] = (anchor,)
 
     def _claim_user_turn_anchor(self, item_id: str | None) -> None:
         """Attach the starting turn's remembered position to the item the transcript identified it as."""
         if item_id is None:
-            anchor, self._pending_user_turn_anchor = self._pending_user_turn_anchor, None
+            has_anchor = bool(self._pending_anonymous_user_turn_anchors)
+            anchor = self._pending_anonymous_user_turn_anchors.popleft() if has_anchor else None
         else:
-            anchor = self._pending_user_turn_anchors.pop(item_id, None)
+            pending_anchor = self._pending_user_turn_anchors.pop(item_id, None)
+            anchor = pending_anchor[0] if pending_anchor is not None else None
+            has_anchor = pending_anchor is not None
         # No anchor when the first thing we ever hear about the turn is its transcript (text-only sessions
         # seeded with audio, or a provider that reports nothing before it); the turn starts here instead.
-        self._user_turn_anchors[item_id] = (
-            anchor[0] if anchor is not None else (self._history[-1] if self._history else None)
-        )
+        self._user_turn_anchors[item_id] = anchor if has_anchor else (self._history[-1] if self._history else None)
 
     def _record_user_request(self, item_id: str | None, request: ModelRequest) -> None:
         """Record a finalized user turn at the position it held when it started."""
@@ -2269,7 +2274,8 @@ class RealtimeSession:
         # Finalizing the last blocked item flushed the whole finalized prefix, so nothing remains.
         assert not self._user_turns, 'every pending user turn should have been recorded'
         self._user_turn_anchors.clear()
-        self._pending_user_turn_anchor = None
+        self._pending_anonymous_user_turn_anchors.clear()
+        self._anonymous_user_turns_ended = 0
         self._pending_user_turn_anchors.clear()
         # Drop any input-audio segments whose transcript never arrived, so they can't leak across a
         # long-lived session (finalized items already popped their own segment above).
@@ -2431,6 +2437,8 @@ class RealtimeSession:
         self._record_user_speech_span()
         events = self._finalize_untranscribed_user()
         if self._input_transcription_enabled:
+            if event.item_id is not None and event.item_id in self._finalized_user_item_ids:
+                return [*events, event]
             if event.item_id not in self._user_turns:
                 self._claim_user_turn_anchor(event.item_id)
                 part = SpeechPart(speaker='user', transcript='')

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -2176,7 +2176,14 @@ class RealtimeSession:
         """
         anchor = self._history[-1] if self._history else None
         if item_id is None:
-            self._pending_anonymous_user_turn_anchors.append(anchor)
+            anchors = self._pending_anonymous_user_turn_anchors
+            if len(anchors) > self._anonymous_user_turns_ended:
+                # An anonymous turn is still open — local audio reserved its place already — so a
+                # speech start now is the provider confirming that turn, not a new one: re-anchor it
+                # rather than reserving a second place the next turn would then inherit.
+                anchors[-1] = anchor
+            else:
+                anchors.append(anchor)
         else:
             self._pending_user_turn_anchors[item_id] = (anchor,)
 

--- a/tests/realtime/test_google_ws.py
+++ b/tests/realtime/test_google_ws.py
@@ -83,6 +83,7 @@ async def test_audio_in_server_vad_turn(
         [
             'PartStartEvent',
             'PartDeltaEvent',
+            'PartEndEvent',
             'PartStartEvent',
             'PartDeltaEvent',
             'PartEndEvent',

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2594,6 +2594,44 @@ async def test_idless_next_audio_turn_keeps_anchor_when_output_precedes_transcri
     )
 
 
+async def test_idless_speech_start_reanchors_the_turn_local_audio_opened() -> None:
+    """Local audio reserves the turn's place; an id-less speech start for the same turn must not reserve a second one."""
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(),
+            InputTranscript(text='question one', is_final=True),
+            OutputTranscript(text='answer one', is_final=True),
+            ResponseDone(),
+            RealtimeInputSpeechStartEvent(),
+            InputTranscript(text='question two', is_final=True),
+            OutputTranscript(text='answer two', is_final=True),
+            ResponseDone(),
+        ]
+    )
+    session = RealtimeSession(conn, _noop_runner)
+    async with session:
+        await session.send_audio(b'first')
+        await drain_events(session)
+
+    assert not session._user_turn_active  # pyright: ignore[reportPrivateUsage]
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer two')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
 async def test_idless_late_transcript_does_not_merge_with_next_audio_turn() -> None:
     second_audio_sent = asyncio.Event()
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -571,6 +571,42 @@ async def test_final_transcripts_survive_a_flood_of_deltas() -> None:
     ]
 
 
+async def test_send_audio_finalizes_late_anonymous_transcript_for_transcript_view() -> None:
+    late_transcript_processed = asyncio.Event()
+    next_audio_sent = asyncio.Event()
+
+    class _LateTranscriptBeforeNextAudio(FakeRealtimeConnection):
+        async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            for event in [
+                OutputTranscript(text='answer one', is_final=True),
+                ResponseDone(),
+                InputTranscript(text='question one'),
+            ]:
+                yield event
+            late_transcript_processed.set()
+            await next_audio_sent.wait()
+
+        async def send(self, content: RealtimeInput) -> None:
+            await super().send(content)
+            if len(self.sent) == 2:
+                next_audio_sent.set()
+
+    session = RealtimeSession(_LateTranscriptBeforeNextAudio([]), _noop_runner)
+
+    async with session:
+        await session.send_audio(b'first')
+        transcript_task = asyncio.create_task(aiter_to_list(session.stream_transcripts()))
+        await late_transcript_processed.wait()
+        await session.send_audio(b'second')
+        transcripts = await transcript_task
+
+    assert transcripts == snapshot(
+        [
+            SpeechPart(speaker='user', transcript='question one'),
+        ]
+    )
+
+
 async def test_send_only_session_still_runs_tools() -> None:
     # Tool execution, turn tracking, and usage limits all run off the receive loop, and a caller who
     # sends a prompt and then goes off to do something else has no reason to think iterating is what
@@ -2346,6 +2382,75 @@ async def test_late_overlapping_input_transcripts_keep_their_speech_start_anchor
     )
 
 
+async def test_repeated_speech_end_for_finalized_item_does_not_duplicate_user_turn() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            InputTranscript(text='question one', is_final=True, item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            OutputTranscript(text='answer one', is_final=True),
+            ResponseDone(),
+        ]
+    )
+    session = RealtimeSession(conn, _noop_runner)
+
+    events = await collect_events(session)
+
+    assert events == snapshot(
+        [
+            RealtimeInputSpeechStartEvent(item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            PartStartEvent(index=0, part=SpeechPart(speaker='user', transcript='')),
+            PartDeltaEvent(
+                index=0,
+                delta=SpeechPartDelta(speaker='user', transcript_delta='question one', transcript='question one'),
+            ),
+            PartEndEvent(index=0, part=SpeechPart(speaker='user', transcript='question one')),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            PartStartEvent(index=1, part=SpeechPart(speaker='assistant', transcript='')),
+            PartDeltaEvent(
+                index=1,
+                delta=SpeechPartDelta(speaker='assistant', transcript_delta='answer one', transcript='answer one'),
+            ),
+            PartEndEvent(index=1, part=SpeechPart(speaker='assistant', transcript='answer one')),
+            RealtimeTurnCompleteEvent(),
+        ]
+    )
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
+async def test_later_transcript_waits_for_earlier_speech_end_placeholder() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            RealtimeInputSpeechStartEvent(item_id='u2'),
+            InputTranscript(text='question two', is_final=True, item_id='u2'),
+            InputTranscript(text='question one', is_final=True, item_id='u1'),
+        ]
+    )
+    session = RealtimeSession(conn, _noop_runner)
+
+    await collect_events(session)
+
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+        ]
+    )
+
+
 async def test_missing_input_transcript_keeps_a_contentless_user_turn() -> None:
     conn = FakeRealtimeConnection(
         [
@@ -2415,6 +2520,108 @@ async def test_idless_late_transcript_closes_before_the_next_audio_turn() -> Non
         await session.send_audio(b'first')
         events_task = asyncio.create_task(drain_events(session))
         await first_transcript_processed.wait()
+        await session.send_audio(b'second')
+        await events_task
+
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer two')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
+async def test_idless_next_audio_turn_keeps_anchor_when_output_precedes_transcript() -> None:
+    first_transcript_processed = asyncio.Event()
+    second_audio_sent = asyncio.Event()
+
+    class _OutputBeforeSecondTranscript(FakeRealtimeConnection):
+        async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            for event in [
+                OutputTranscript(text='answer one', is_final=True),
+                ResponseDone(),
+                InputTranscript(text='question one'),
+            ]:
+                yield event
+            first_transcript_processed.set()
+            await second_audio_sent.wait()
+            for event in [
+                OutputTranscript(text='answer two', is_final=True),
+                ResponseDone(),
+                InputTranscript(text='question two', is_final=True),
+            ]:
+                yield event
+
+        async def send(self, content: RealtimeInput) -> None:
+            await super().send(content)
+            if len(self.sent) == 2:
+                second_audio_sent.set()
+
+    session = RealtimeSession(_OutputBeforeSecondTranscript([]), _noop_runner)
+
+    async with session:
+        await session.send_audio(b'first')
+        events_task = asyncio.create_task(drain_events(session))
+        await first_transcript_processed.wait()
+        await session.send_audio(b'second')
+        await events_task
+
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer two')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
+async def test_idless_late_transcript_does_not_merge_with_next_audio_turn() -> None:
+    second_audio_sent = asyncio.Event()
+
+    class _LateTranscriptAfterNextAudio(FakeRealtimeConnection):
+        async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            for event in [OutputTranscript(text='answer one', is_final=True), ResponseDone()]:
+                yield event
+            await second_audio_sent.wait()
+            for event in [
+                InputTranscript(text='question one', is_final=True),
+                InputTranscript(text='question two', is_final=True),
+                OutputTranscript(text='answer two', is_final=True),
+                ResponseDone(),
+            ]:
+                yield event
+
+        async def send(self, content: RealtimeInput) -> None:
+            await super().send(content)
+            if len(self.sent) == 2:
+                second_audio_sent.set()
+
+    session = RealtimeSession(_LateTranscriptAfterNextAudio([]), _noop_runner)
+
+    async with session:
+        await session.send_audio(b'first')
+        events_task = asyncio.create_task(drain_events(session))
+        while len(session.all_messages()) < 1:
+            await asyncio.sleep(0)
         await session.send_audio(b'second')
         await events_task
 
@@ -4818,11 +5025,11 @@ async def test_input_audio_segmented_by_item_id_across_overlapping_turns() -> No
     assert session.new_messages() == snapshot(
         [
             ModelRequest(
-                parts=[SpeechPart(speaker='user', transcript='second', audio=_wav_content(b'\xbb'))],
+                parts=[SpeechPart(speaker='user', transcript='first', audio=_wav_content(b'\xaa'))],
                 timestamp=IsDatetime(),
             ),
             ModelRequest(
-                parts=[SpeechPart(speaker='user', transcript='first', audio=_wav_content(b'\xaa'))],
+                parts=[SpeechPart(speaker='user', transcript='second', audio=_wav_content(b'\xbb'))],
                 timestamp=IsDatetime(),
             ),
         ]

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2248,6 +2248,133 @@ async def test_late_input_transcript_anchors_from_sent_audio_without_speech_boun
     )
 
 
+async def test_late_overlapping_input_transcripts_keep_their_speech_start_anchors() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            OutputTranscript(text='answer one', is_final=True),
+            ResponseDone(),
+            RealtimeInputSpeechStartEvent(item_id='u2'),
+            InputTranscript(text='question one', is_final=True, item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u2'),
+            InputTranscript(text='question two', is_final=True, item_id='u2'),
+            OutputTranscript(text='answer two', is_final=True),
+            ResponseDone(),
+        ]
+    )
+    session = RealtimeSession(conn, _noop_runner)
+
+    await collect_events(session)
+
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer two')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
+async def test_missing_input_transcript_keeps_a_contentless_user_turn() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(item_id='u1'),
+            RealtimeInputSpeechEndEvent(item_id='u1'),
+            OutputTranscript(text='answer one', is_final=True),
+            ResponseDone(),
+            RealtimeInputSpeechStartEvent(item_id='u2'),
+            RealtimeInputSpeechEndEvent(item_id='u2'),
+            InputTranscript(text='question two', is_final=True, item_id='u2'),
+            OutputTranscript(text='answer two', is_final=True),
+            ResponseDone(),
+        ]
+    )
+    session = RealtimeSession(conn, _noop_runner)
+
+    await collect_events(session)
+
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer two')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
+async def test_idless_late_transcript_closes_before_the_next_audio_turn() -> None:
+    first_transcript_processed = asyncio.Event()
+    second_audio_sent = asyncio.Event()
+
+    class _LateIdlessTranscript(FakeRealtimeConnection):
+        async def __aiter__(self) -> AsyncIterator[RealtimeCodecEvent]:
+            for event in [
+                OutputTranscript(text='answer one', is_final=True),
+                ResponseDone(),
+                InputTranscript(text='question one'),
+            ]:
+                yield event
+            first_transcript_processed.set()
+            await second_audio_sent.wait()
+            for event in [
+                InputTranscript(text='question two'),
+                OutputTranscript(text='answer two', is_final=True),
+                ResponseDone(),
+            ]:
+                yield event
+
+        async def send(self, content: RealtimeInput) -> None:
+            await super().send(content)
+            if len(self.sent) == 2:
+                second_audio_sent.set()
+
+    conn = _LateIdlessTranscript([])
+    session = RealtimeSession(conn, _noop_runner)
+
+    async with session:
+        await session.send_audio(b'first')
+        events_task = asyncio.create_task(drain_events(session))
+        await first_transcript_processed.wait()
+        await session.send_audio(b'second')
+        await events_task
+
+    assert session.all_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question one')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer one')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='question two')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='answer two')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
 async def test_tool_response_finalized_on_usage_is_not_duplicated_at_terminal() -> None:
     conn = FakeRealtimeConnection(
         [

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2618,10 +2618,10 @@ async def test_idless_late_transcript_does_not_merge_with_next_audio_turn() -> N
     session = RealtimeSession(_LateTranscriptAfterNextAudio([]), _noop_runner)
 
     async with session:
+        transcripts = session.stream_transcripts()
         await session.send_audio(b'first')
         events_task = asyncio.create_task(drain_events(session))
-        while len(session.all_messages()) < 1:
-            await asyncio.sleep(0)
+        assert (await anext(transcripts)).transcript == 'answer one'  # the first reply is in history
         await session.send_audio(b'second')
         await events_task
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1114,6 +1114,43 @@ async def test_input_transcription_failure_passes_through_and_session_continues(
     )
 
 
+async def test_input_transcription_failure_finalizes_speech_end_placeholder() -> None:
+    conn = FakeRealtimeConnection(
+        [
+            RealtimeInputSpeechStartEvent(item_id='user-1'),
+            RealtimeInputSpeechEndEvent(item_id='user-1'),
+            RealtimeInputTranscriptionErrorEvent(message='transcription failed', item_id='user-1'),
+            OutputTranscript(text='I could not hear you.', is_final=True),
+            ResponseDone(),
+        ]
+    )
+    session = RealtimeSession(conn, _noop_runner)
+
+    events = await collect_events(session)
+
+    assert [type(event).__name__ for event in events] == [
+        'RealtimeInputSpeechStartEvent',
+        'RealtimeInputSpeechEndEvent',
+        'PartStartEvent',
+        'PartEndEvent',
+        'RealtimeInputTranscriptionErrorEvent',
+        'PartStartEvent',
+        'PartDeltaEvent',
+        'PartEndEvent',
+        'RealtimeTurnCompleteEvent',
+    ]
+    assert session.new_messages() == snapshot(
+        [
+            ModelRequest(parts=[SpeechPart(speaker='user')], timestamp=IsDatetime()),
+            ModelResponse(
+                parts=[SpeechPart(speaker='assistant', transcript='I could not hear you.')],
+                timestamp=IsDatetime(),
+                finish_reason='stop',
+            ),
+        ]
+    )
+
+
 async def test_input_transcription_failure_after_partial_does_not_block_later_turns() -> None:
     # Item A streams a partial transcript, item B finalizes out of order, then A's transcription fails.
     # A's placeholder must unblock the ordered prefix so both turns reach history in provider order.


### PR DESCRIPTION
Three history-fidelity defects in how a realtime session places user turns, found by replaying event orderings modelled on the recorded OpenAI and Gemini cassettes through fakes:

- **A late transcript filed after the reply it prompted.** The pending turn anchor was a single slot with no item id, overwritten by every speech-start event, and handed to whichever transcript arrived first. With `SpeechStart(u1), SpeechEnd(u1), reply, ResponseDone, SpeechStart(u2), InputTranscript(u1), ...` the history came out as `Res[a1], Req[u1], Req[u2], Res[a2]`, so a text-model handoff saw the answer before the question. Pending anchors are now keyed by the speech-start item id (OpenAI, Azure and xAI send one); the anonymous slot remains for id-less providers.
- **A VAD segment whose transcript never arrived vanished.** Speech start and end only set flags, so with neither a completed nor a failed transcript nothing was ever finalized and the reply read as unprompted. Speech end now registers a placeholder turn for the item, finalized at close or the next boundary as a content-less or retained-audio `SpeechPart`, matching the transcription-off path. The transcription-failure path delegates to the same finalizer, so a placeholder gets its part-start and completes the turn (the Azure transcription-error cassette pins this).
- **Gemini merged a transcript arriving after `turnComplete` into the next user turn.** Id-less transcripts fold into one anonymous turn that was only closed by `ResponseDone`. An id-less user turn is now closed when the model starts producing output, so a transcript landing between `turnComplete` and the next output still belongs to the previous exchange. The recorded Gemini cassettes, where transcripts arrive before the model turn, keep their history; one gains an earlier user `PartEndEvent`.

Docs: history.md says transcripts are recorded with the turn they describe even when late, and that a segment with no transcript is still recorded at close.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

