### PR TITLE
Add `RealtimeSession.wait_for_playback()` and let the docs examples finish the reply before closing

### DIFF
--- a/docs/api/realtime.md
+++ b/docs/api/realtime.md
@@ -77,7 +77,7 @@ audio chunks ready for playback, while
 yields finalized speech from both speakers or live deltas with `delta=True`. These bounded views can
 run concurrently with each other and with the session's raw event iterator.
 [`RealtimeSession.wait_for_playback()`][pydantic_ai.realtime.RealtimeSession.wait_for_playback]
-waits for the single audio view to consume all audio emitted so far.
+waits until the single audio view has played, or discarded on a barge-in, all audio emitted so far.
 [`RealtimeSession.close()`][pydantic_ai.realtime.RealtimeSession.close] ends the session and every
 live view; [`RealtimeSession.closed`][pydantic_ai.realtime.RealtimeSession.closed] exposes its state.
 

--- a/docs/api/realtime.md
+++ b/docs/api/realtime.md
@@ -76,6 +76,8 @@ audio chunks ready for playback, while
 [`RealtimeSession.stream_transcripts()`][pydantic_ai.realtime.RealtimeSession.stream_transcripts]
 yields finalized speech from both speakers or live deltas with `delta=True`. These bounded views can
 run concurrently with each other and with the session's raw event iterator.
+[`RealtimeSession.wait_for_playback()`][pydantic_ai.realtime.RealtimeSession.wait_for_playback]
+waits for the single audio view to consume all audio emitted so far.
 [`RealtimeSession.close()`][pydantic_ai.realtime.RealtimeSession.close] ends the session and every
 live view; [`RealtimeSession.closed`][pydantic_ai.realtime.RealtimeSession.closed] exposes its state.
 

--- a/docs/api/realtime.md
+++ b/docs/api/realtime.md
@@ -77,7 +77,8 @@ audio chunks ready for playback, while
 yields finalized speech from both speakers or live deltas with `delta=True`. These bounded views can
 run concurrently with each other and with the session's raw event iterator.
 [`RealtimeSession.wait_for_playback()`][pydantic_ai.realtime.RealtimeSession.wait_for_playback]
-waits until the single audio view has played, or discarded on a barge-in, all audio emitted so far.
+waits until the single audio view has accounted for all audio emitted so far, whether it was
+played or discarded.
 [`RealtimeSession.close()`][pydantic_ai.realtime.RealtimeSession.close] ends the session and every
 live view; [`RealtimeSession.closed`][pydantic_ai.realtime.RealtimeSession.closed] exposes its state.
 

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -60,6 +60,8 @@ async def main():
         async for event in session:
             if isinstance(event, RealtimeTurnCompleteEvent):
                 break
+        # Let the speaker consume every generated chunk before closing the session.
+        await session.wait_for_playback()
 
     # Leaving the `async with` block closes the session, which ends every live view.
     await asyncio.gather(audio_task, transcript_task)
@@ -73,6 +75,13 @@ up to its buffer bound.
 An unconsumed view buffers up to its bound, dropping the oldest item when full, until it is collected.
 [`close()`][pydantic_ai.realtime.RealtimeSession.close] discards pending items and ends every live
 iterator; [`closed`][pydantic_ai.realtime.RealtimeSession.closed] reports the state.
+
+After a reply finishes generating, await
+[`wait_for_playback()`][pydantic_ai.realtime.RealtimeSession.wait_for_playback] before closing the
+session or opening the microphone. It returns when the single `stream_audio()` consumer has taken
+all audio emitted so far, using the same one-chunk-lag accounting as
+[`played_audio_bytes`][pydantic_ai.realtime.RealtimeSession.played_audio_bytes]. It requires exactly
+one audio view and also returns if that view or the session closes.
 
 ### Live captions
 

--- a/docs/realtime/audio.md
+++ b/docs/realtime/audio.md
@@ -78,10 +78,11 @@ iterator; [`closed`][pydantic_ai.realtime.RealtimeSession.closed] reports the st
 
 After a reply finishes generating, await
 [`wait_for_playback()`][pydantic_ai.realtime.RealtimeSession.wait_for_playback] before closing the
-session or opening the microphone. It returns when the single `stream_audio()` consumer has taken
-all audio emitted so far, using the same one-chunk-lag accounting as
-[`played_audio_bytes`][pydantic_ai.realtime.RealtimeSession.played_audio_bytes]. It requires exactly
-one audio view and also returns if that view or the session closes.
+session or opening the microphone. It returns once the single `stream_audio()` consumer has accounted
+for all audio emitted so far: played, using the same one-chunk-lag accounting as
+[`played_audio_bytes`][pydantic_ai.realtime.RealtimeSession.played_audio_bytes], or discarded by a
+barge-in or by the view's buffer overflowing. It requires exactly one audio view and also returns if
+that view or the session closes.
 
 ### Live captions
 

--- a/docs/realtime/azure.md
+++ b/docs/realtime/azure.md
@@ -20,21 +20,19 @@ by your Azure deployment name:
 
 ```python
 from pydantic_ai import Agent
-from pydantic_ai.messages import PartEndEvent, SpeechPart
-from pydantic_ai.realtime import RealtimeTurnCompleteEvent
 
 agent = Agent(instructions='You are a helpful voice assistant.')
 
 
 async def main():
     async with agent.realtime('azure:my-realtime-deployment').session() as session:
+        transcripts = session.stream_transcripts()  # subscribe before prompting
         await session.send('Say hello.')
 
-        async for event in session:
-            if isinstance(event, PartEndEvent) and isinstance(event.part, SpeechPart):
-                print(f'{event.part.speaker}: {event.part.transcript}')
-                #> assistant: Hello from the realtime assistant.
-            if isinstance(event, RealtimeTurnCompleteEvent):
+        async for part in transcripts:
+            print(f'{part.speaker}: {part.transcript}')
+            #> assistant: Hello from the realtime assistant.
+            if part.speaker == 'assistant':
                 break  # keep listening in a real call; we stop after one reply
 ```
 

--- a/docs/realtime/azure.md
+++ b/docs/realtime/azure.md
@@ -20,6 +20,8 @@ by your Azure deployment name:
 
 ```python
 from pydantic_ai import Agent
+from pydantic_ai.messages import PartEndEvent, SpeechPart
+from pydantic_ai.realtime import RealtimeTurnCompleteEvent
 
 agent = Agent(instructions='You are a helpful voice assistant.')
 
@@ -28,10 +30,11 @@ async def main():
     async with agent.realtime('azure:my-realtime-deployment').session() as session:
         await session.send('Say hello.')
 
-        async for part in session.stream_transcripts():
-            print(f'{part.speaker}: {part.transcript}')
-            #> assistant: Hello from the realtime assistant.
-            if part.speaker == 'assistant':
+        async for event in session:
+            if isinstance(event, PartEndEvent) and isinstance(event.part, SpeechPart):
+                print(f'{event.part.speaker}: {event.part.transcript}')
+                #> assistant: Hello from the realtime assistant.
+            if isinstance(event, RealtimeTurnCompleteEvent):
                 break  # keep listening in a real call; we stop after one reply
 ```
 
@@ -157,6 +160,7 @@ mixture of the two.
 ```python
 from pydantic_ai import Agent
 from pydantic_ai.providers.azure import AzureProvider
+from pydantic_ai.realtime import RealtimeTurnCompleteEvent
 from pydantic_ai.realtime.azure import AzureRealtimeModel, AzureRealtimeModelSettings
 
 provider = AzureProvider(
@@ -177,7 +181,8 @@ async def main():
     async with agent.realtime(model).session() as session:
         await session.send('Say hello.')
         async for event in session:
-            ...
+            if isinstance(event, RealtimeTurnCompleteEvent):
+                break  # keep listening in a real call; we stop after one reply
 ```
 
 Voice-Live-only knobs use the `azure_voice_live_*` prefix (e.g.

--- a/docs/realtime/deployment.md
+++ b/docs/realtime/deployment.md
@@ -107,19 +107,29 @@ app = FastAPI()
 @app.websocket('/voice')
 async def voice_socket(websocket: WebSocket):
     await websocket.accept()
+
+    async def microphone():
+        while True:
+            yield await websocket.receive_bytes()
+
     async with agent.realtime('openai:gpt-realtime').session() as session:
 
-        async def pump_input():
-            while True:
-                await session.send_audio(await websocket.receive_bytes())
-
-        input_task = asyncio.create_task(pump_input())
-        try:
+        async def playback():
             async for chunk in session.stream_audio():
                 await websocket.send_bytes(chunk)
+
+        playback_task = asyncio.create_task(playback())
+        try:
+            await session.send_audio(microphone())
         finally:
-            input_task.cancel()
+            playback_task.cancel()
 ```
+
+[`send_audio()`][pydantic_ai.realtime.RealtimeSession.send_audio] consumes the async iterator for the
+whole call, so when the browser disconnects, `receive_bytes()` raises, the `finally` stops playback,
+and leaving the `async with` block hangs up the provider session. Driving the input from a bare
+`asyncio.create_task` instead would swallow that error and leave the billed session open with nobody
+listening.
 
 ## SIP/telephony bridge
 

--- a/docs/realtime/overview.md
+++ b/docs/realtime/overview.md
@@ -64,6 +64,8 @@ async def main():
             #> assistant: We do: 7 pm, table for two. Want me to book it?
             if part.speaker == 'assistant':
                 break  # keep listening in a real call; we stop after one exchange
+        # Let the speaker consume every generated chunk before closing the session.
+        await session.wait_for_playback()
 
     # Leaving the `async with` block closes the session, which ends the speaker's audio stream —
     # but the microphone reads an external source, so stop it explicitly.

--- a/docs/realtime/tools.md
+++ b/docs/realtime/tools.md
@@ -60,6 +60,7 @@ is the source of truth.
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import WebSearch
 from pydantic_ai.messages import NativeToolReturnPart, PartEndEvent
+from pydantic_ai.realtime import RealtimeTurnCompleteEvent
 
 agent = Agent(instructions='Answer questions, searching the web when useful.')
 
@@ -73,6 +74,8 @@ async def main():
         async for event in session:
             if isinstance(event, PartEndEvent) and isinstance(event.part, NativeToolReturnPart):
                 print(event.part.content)
+            if isinstance(event, RealtimeTurnCompleteEvent):
+                break  # keep listening in a real call; we stop after one reply
 ```
 
 An unsupported native tool with a configured local fallback is replaced before connection. Without

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -63,16 +63,30 @@ chunk to the device before pulling the next — the session can handle that half
 `handle_barge_in=True` when opening the session:
 
 ```python
+import asyncio
+from collections.abc import AsyncIterator
+
 from pydantic_ai import Agent
+from pydantic_ai.realtime import RealtimeTurnCompleteEvent
 
 agent = Agent(instructions='You are a helpful voice assistant.')
+
+
+async def play_audio(chunks: AsyncIterator[bytes]) -> None:
+    async for chunk in chunks:
+        ...  # write the chunk to your speaker, waiting until the device consumed it
 
 
 async def main():
     realtime = agent.realtime('openai:gpt-realtime')
     async with realtime.session(handle_barge_in=True) as session:
-        async for chunk in session.stream_audio():
-            ...  # write the chunk to your speaker, waiting until the device consumed it
+        playback = asyncio.create_task(play_audio(session.stream_audio()))
+        await session.send('Say hello.')
+        async for event in session:
+            if isinstance(event, RealtimeTurnCompleteEvent):
+                break  # keep listening in a real call; we stop after one reply
+        await session.wait_for_playback()
+    await playback
 ```
 
 When the user speaks over the model, the session discards the buffered audio the user will never
@@ -187,7 +201,7 @@ import asyncio
 from collections.abc import AsyncIterator
 
 from pydantic_ai import Agent
-from pydantic_ai.realtime import RealtimeSession
+from pydantic_ai.messages import PartEndEvent, SpeechPart
 
 agent = Agent(instructions='You are a welcoming museum guide.')
 
@@ -197,20 +211,17 @@ async def play_audio(chunks: AsyncIterator[bytes]) -> None:
         ...  # Write the PCM16 chunk to your speaker or audio output stream.
 
 
-async def wait_for_assistant_speech(session: RealtimeSession) -> None:
-    async for part in session.stream_transcripts():
-        if part.speaker == 'assistant':
-            return
-
-
 async def main():
     async with agent.realtime('openai:gpt-realtime').session() as session:
         playback = asyncio.create_task(play_audio(session.stream_audio()))
-        greeted = asyncio.create_task(wait_for_assistant_speech(session))
         await session.send('Greet the visitor.')
-        await greeted
-        ...  # wait for the speaker to drain, then open the microphone and start sending audio
-        await playback
+        async for event in session:
+            if isinstance(event, PartEndEvent) and isinstance(event.part, SpeechPart):
+                if event.part.speaker == 'assistant':
+                    break
+        await session.wait_for_playback()
+        ...  # open the microphone and start sending audio
+    await playback
 ```
 
 With manual turn control, [`create_response()`][pydantic_ai.realtime.RealtimeSession.create_response]

--- a/docs/realtime/turns.md
+++ b/docs/realtime/turns.md
@@ -67,7 +67,6 @@ import asyncio
 from collections.abc import AsyncIterator
 
 from pydantic_ai import Agent
-from pydantic_ai.realtime import RealtimeTurnCompleteEvent
 
 agent = Agent(instructions='You are a helpful voice assistant.')
 
@@ -81,11 +80,7 @@ async def main():
     realtime = agent.realtime('openai:gpt-realtime')
     async with realtime.session(handle_barge_in=True) as session:
         playback = asyncio.create_task(play_audio(session.stream_audio()))
-        await session.send('Say hello.')
-        async for event in session:
-            if isinstance(event, RealtimeTurnCompleteEvent):
-                break  # keep listening in a real call; we stop after one reply
-        await session.wait_for_playback()
+        ...  # stream the microphone and handle events; barge-in is handled for you
     await playback  # the audio view ends once the session has closed
 ```
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -230,7 +230,8 @@ passing raw microphone bytes to `send_audio`, convert them to mono PCM16 at `ses
 chunks carry no sample-rate metadata.
 After `RealtimeTurnCompleteEvent` (or a greeting's finalized `SpeechPart`), await
 `session.wait_for_playback()` before closing the session or opening the microphone. It waits for the single
-device-paced `stream_audio()` view to consume all audio emitted so far; it requires exactly one audio view.
+device-paced `stream_audio()` view to play (or discard on a barge-in) all audio emitted so far; it requires exactly one
+audio view.
 
 ```python {test="skip"}
 from pydantic_ai import Agent

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -228,6 +228,9 @@ boundary, when generation and tool work are complete. This is not always the end
 on WebRTC sidebands, track playback with `RealtimeOutputSpeechStartEvent` and `RealtimeOutputSpeechEndEvent`. Before
 passing raw microphone bytes to `send_audio`, convert them to mono PCM16 at `session.audio_input_sample_rate`; raw
 chunks carry no sample-rate metadata.
+After `RealtimeTurnCompleteEvent` (or a greeting's finalized `SpeechPart`), await
+`session.wait_for_playback()` before closing the session or opening the microphone. It waits for the single
+device-paced `stream_audio()` view to consume all audio emitted so far; it requires exactly one audio view.
 
 ```python {test="skip"}
 from pydantic_ai import Agent

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -230,8 +230,8 @@ passing raw microphone bytes to `send_audio`, convert them to mono PCM16 at `ses
 chunks carry no sample-rate metadata.
 After `RealtimeTurnCompleteEvent` (or a greeting's finalized `SpeechPart`), await
 `session.wait_for_playback()` before closing the session or opening the microphone. It waits for the single
-device-paced `stream_audio()` view to play (or discard on a barge-in) all audio emitted so far; it requires exactly one
-audio view.
+device-paced `stream_audio()` view to account for all audio emitted so far, whether it was played or discarded; it
+requires exactly one audio view.
 
 ```python {test="skip"}
 from pydantic_ai import Agent

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1737,6 +1737,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
 
         ```python
         from pydantic_ai import Agent
+        from pydantic_ai.realtime import RealtimeTurnCompleteEvent
         from pydantic_ai.realtime.openai import OpenAIRealtimeModel
 
         agent = Agent(instructions='You are a helpful voice assistant.')
@@ -1749,8 +1750,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             model = OpenAIRealtimeModel('gpt-realtime')
             async with agent.realtime(model).session() as session:
                 await session.send_audio(b'...')
-                async for _event in session:
-                    pass
+                async for event in session:
+                    if isinstance(event, RealtimeTurnCompleteEvent):
+                        break  # keep listening in a real call; we stop after one reply
         ```
 
         Args:

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -8,7 +8,7 @@ import io
 import wave
 import weakref
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from threading import Lock as ThreadLock
 from time import time_ns
 from types import TracebackType
@@ -251,9 +251,16 @@ class _TapView(AsyncIterator[_TapItem]):
     collected.
     """
 
-    def __init__(self, iterator: AsyncGenerator[_TapItem, None], taps: set[_Tap], tap: _Tap) -> None:
+    def __init__(
+        self,
+        iterator: AsyncGenerator[_TapItem, None],
+        taps: set[_Tap],
+        tap: _Tap,
+        on_close: Callable[[], None] | None = None,
+    ) -> None:
         self._iterator = iterator
         self._discard = weakref.finalize(self, taps.discard, tap)
+        self._finish = weakref.finalize(self, on_close) if on_close is not None else None
 
     def __aiter__(self) -> AsyncIterator[_TapItem]:
         return self
@@ -263,6 +270,8 @@ class _TapView(AsyncIterator[_TapItem]):
 
     async def aclose(self) -> None:
         self._discard()
+        if self._finish is not None:
+            self._finish()
         await self._iterator.aclose()
 
 
@@ -288,6 +297,13 @@ class _AudioTap:
     """
     played_bytes: int = 0
     """Chunks the consumer finished with — counted when it resumes the iterator for the next one."""
+    progress: asyncio.Event = field(default_factory=asyncio.Event)
+    """Set when playback advances or the view ends, waking `wait_for_playback()`."""
+    ended: bool = False
+
+    def finish(self) -> None:
+        self.ended = True
+        self.progress.set()
 
 
 # The `RealtimeEvent` variants that `_translate_event` handles: the full union minus `ToolCall` and
@@ -1071,10 +1087,44 @@ class RealtimeSession:
                     # next — that is the moment the previous chunk finished playing, which is what
                     # makes `played_audio_bytes` an accurate playback position with no caller counting.
                     tap.played_bytes += len(item)
+                    tap.progress.set()
             finally:
+                tap.finish()
                 self._audio_taps.discard(tap)
 
-        return _TapView(iterate(), self._audio_taps, tap)
+        return _TapView(iterate(), self._audio_taps, tap, tap.finish)
+
+    async def wait_for_playback(self) -> None:
+        """Wait until the session's single audio view has played all audio emitted so far.
+
+        Call this after a reply finishes generating, before closing the session or opening the
+        microphone, so buffered audio is not cut off. Playback advances with the same one-chunk lag
+        as [`played_audio_bytes`][pydantic_ai.realtime.RealtimeSession.played_audio_bytes]: a chunk
+        counts once the consumer requests the next one. The wait also ends if the view is closed or
+        abandoned, or the session closes. Requires exactly one active
+        [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio] iterator.
+        """
+        tap = self._single_audio_tap('`wait_for_playback()`', 'wait for playback from')
+        while not self._closed and not tap.ended:
+            playhead = tap.subscribed_at_bytes + tap.played_bytes + tap.dropped_bytes
+            buffer_empty = tap.queue.empty() or (self._pump_finished and tap.queue.qsize() == 1)
+            if buffer_empty and playhead >= self._emitted_audio_bytes:
+                return
+            tap.progress.clear()
+            playhead = tap.subscribed_at_bytes + tap.played_bytes + tap.dropped_bytes
+            buffer_empty = tap.queue.empty() or (self._pump_finished and tap.queue.qsize() == 1)
+            if buffer_empty and playhead >= self._emitted_audio_bytes:
+                return
+            await tap.progress.wait()
+
+    def _single_audio_tap(self, method: str, purpose: str) -> _AudioTap:
+        if len(self._audio_taps) != 1:
+            raise UserError(
+                f'{method} needs exactly one active `stream_audio()` iterator to {purpose}, '
+                f'not {len(self._audio_taps)}; keep your own accounting instead.'
+            )
+        (tap,) = self._audio_taps
+        return tap
 
     @property
     def played_audio_bytes(self) -> int:
@@ -1090,13 +1140,7 @@ class RealtimeSession:
         [`interrupt(played_bytes=...)`][pydantic_ai.realtime.RealtimeSession.interrupt] on
         barge-in. Requires exactly one active `stream_audio()` iterator, like that call.
         """
-        if len(self._audio_taps) != 1:
-            raise UserError(
-                '`played_audio_bytes` needs exactly one active `stream_audio()` iterator to report '
-                f'the playback position of, not {len(self._audio_taps)}; keep your own accounting instead.'
-            )
-        (tap,) = self._audio_taps
-        return tap.played_bytes
+        return self._single_audio_tap('`played_audio_bytes`', 'report the playback position of').played_bytes
 
     @overload
     def stream_transcripts(self, *, delta: Literal[False] = False) -> AsyncIterator[SpeechPart]: ...
@@ -3002,6 +3046,9 @@ class RealtimeSession:
                         self._transcript_tap_drops += 1
 
     def _finish_taps(self, *, discard_pending: bool = False) -> None:
+        if discard_pending:
+            for tap in self._audio_taps:
+                tap.finish()
         audio_queues = (tap.queue for tap in self._audio_taps)
         for queue in (*audio_queues, *self._transcript_taps, *self._transcript_delta_taps):
             if discard_pending:

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1095,13 +1095,14 @@ class RealtimeSession:
         return _TapView(iterate(), self._audio_taps, tap, tap.finish)
 
     async def wait_for_playback(self) -> None:
-        """Wait until the session's single audio view has played all audio emitted so far.
+        """Wait until the session's single audio view has accounted for all audio emitted so far.
 
         Call this after a reply finishes generating, before closing the session or opening the
         microphone, so buffered audio is not cut off. Playback advances with the same one-chunk lag
         as [`played_audio_bytes`][pydantic_ai.realtime.RealtimeSession.played_audio_bytes]: a chunk
-        counts once the consumer requests the next one. The wait also ends if the view is closed or
-        abandoned, or the session closes. Requires exactly one active
+        counts once the consumer requests the next one. Audio discarded by a barge-in, or by the
+        view's buffer overflowing, counts as accounted for rather than played. The wait also ends if
+        the view is closed or abandoned, or the session closes. Requires exactly one active
         [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio] iterator.
         """
         tap = self._single_audio_tap('`wait_for_playback()`', 'wait for playback from')
@@ -1633,6 +1634,9 @@ class RealtimeSession:
                 break
             assert isinstance(item, bytes)
             tap.dropped_bytes += len(item)
+        # Every change to the playback accounting wakes `wait_for_playback()`, so it re-checks against
+        # the flushed queue rather than waiting for audio that will never come.
+        tap.progress.set()
 
     async def _auto_barge_in(self, event: RealtimeEvent) -> None:
         """The local half of barge-in, run by the session itself under `handle_barge_in=True`.

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1106,12 +1106,10 @@ class RealtimeSession:
         """
         tap = self._single_audio_tap('`wait_for_playback()`', 'wait for playback from')
         while not self._closed and not tap.ended:
-            playhead = tap.subscribed_at_bytes + tap.played_bytes + tap.dropped_bytes
-            buffer_empty = tap.queue.empty() or (self._pump_finished and tap.queue.qsize() == 1)
-            if buffer_empty and playhead >= self._emitted_audio_bytes:
-                return
+            # Clear before checking so that progress made between the check and the wait still wakes us.
             tap.progress.clear()
             playhead = tap.subscribed_at_bytes + tap.played_bytes + tap.dropped_bytes
+            # Once the pump has finished, the only item left in the queue is the completion sentinel.
             buffer_empty = tap.queue.empty() or (self._pump_finished and tap.queue.qsize() == 1)
             if buffer_empty and playhead >= self._emitted_audio_bytes:
                 return

--- a/pydantic_ai_slim/pydantic_ai/realtime/_session.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_session.py
@@ -1100,9 +1100,10 @@ class RealtimeSession:
         Call this after a reply finishes generating, before closing the session or opening the
         microphone, so buffered audio is not cut off. Playback advances with the same one-chunk lag
         as [`played_audio_bytes`][pydantic_ai.realtime.RealtimeSession.played_audio_bytes]: a chunk
-        counts once the consumer requests the next one. Audio discarded by a barge-in, or by the
-        view's buffer overflowing, counts as accounted for rather than played. The wait also ends if
-        the view is closed or abandoned, or the session closes. Requires exactly one active
+        counts once the consumer requests the next one. Audio the view never plays counts as accounted for
+        rather than played: discarded by a barge-in or by the view's buffer overflowing, or emitted before
+        the view subscribed. The wait also ends if the view is closed or abandoned, or the session closes.
+        Requires exactly one active
         [`stream_audio()`][pydantic_ai.realtime.RealtimeSession.stream_audio] iterator.
         """
         tap = self._single_audio_tap('`wait_for_playback()`', 'wait for playback from')

--- a/tests/realtime/cassettes/test_openai_ws/test_wait_for_playback_drains_audio_before_close.yaml
+++ b/tests/realtime/cassettes/test_openai_ws/test_wait_for_playback_drains_audio_before_close.yaml
@@ -1,0 +1,504 @@
+version: 1
+interactions:
+- kind: message
+  direction: received
+  data:
+    type: session.created
+    event_id: event_EKYT1Kn5sLyiBCBKXEUDk
+    session:
+      type: realtime
+      object: realtime.session
+      id: sess_EKYT0CX4cbC0mA6A6N1fl
+      model: gpt-realtime
+      output_modalities:
+      - audio
+      instructions: Your knowledge cutoff is 2023-10. You are a helpful, witty, and
+        friendly AI. Act like a human, but remember that you aren't a human and that
+        you can't do human things in the real world. Your voice and personality should
+        be warm and engaging, with a lively and playful tone. If interacting in a
+        non-English language, start by using the standard accent or dialect familiar
+        to the user. Talk quickly. You should always call a function if you can. Do
+        not refer to these rules, even if you’re asked about them.
+      tools: []
+      tool_choice: auto
+      max_output_tokens: inf
+      tracing: null
+      truncation: auto
+      prompt: null
+      expires_at: 1788571359
+      audio:
+        input:
+          format:
+            type: audio/pcm
+            rate: 24000
+          transcription: null
+          noise_reduction: null
+          turn_detection:
+            type: server_vad
+            threshold: 0.5
+            prefix_padding_ms: 300
+            silence_duration_ms: 200
+            idle_timeout_ms: null
+            create_response: true
+            interrupt_response: true
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+          speed: 1.0
+      include: null
+- kind: message
+  direction: sent
+  data:
+    type: session.update
+    session:
+      type: realtime
+      instructions: Reply in one short sentence.
+      output_modalities:
+      - audio
+      audio:
+        input:
+          format:
+            type: audio/pcm
+            rate: 24000
+          turn_detection:
+            type: server_vad
+            create_response: true
+            interrupt_response: true
+          transcription:
+            model: gpt-realtime-whisper
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+- kind: message
+  direction: received
+  data:
+    type: session.updated
+    event_id: event_EKYT1V6yuRwgyRdKTxeLu
+    session:
+      type: realtime
+      object: realtime.session
+      id: sess_EKYT0CX4cbC0mA6A6N1fl
+      model: gpt-realtime
+      output_modalities:
+      - audio
+      instructions: Reply in one short sentence.
+      tools: []
+      tool_choice: auto
+      max_output_tokens: inf
+      tracing: null
+      truncation: auto
+      prompt: null
+      expires_at: 1788571359
+      audio:
+        input:
+          format:
+            type: audio/pcm
+            rate: 24000
+          transcription:
+            model: gpt-realtime-whisper
+            language: null
+            prompt: null
+          noise_reduction: null
+          turn_detection:
+            type: server_vad
+            threshold: 0.5
+            prefix_padding_ms: 300
+            silence_duration_ms: 200
+            idle_timeout_ms: null
+            create_response: true
+            interrupt_response: true
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+          speed: 1.0
+      include: null
+- kind: message
+  direction: sent
+  data:
+    type: conversation.item.create
+    item:
+      type: message
+      role: user
+      content:
+      - type: input_text
+        text: Say hello.
+- kind: message
+  direction: sent
+  data:
+    type: response.create
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.added
+    event_id: event_EKYT1HMQBNyd0kZKRidxt
+    previous_item_id: null
+    item:
+      id: item_EKYT1B5sKCOAgZyrrC6wv
+      type: message
+      status: completed
+      role: user
+      content:
+      - type: input_text
+        text: Say hello.
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.done
+    event_id: event_EKYT1g4PHIefxrHEFuBBv
+    previous_item_id: null
+    item:
+      id: item_EKYT1B5sKCOAgZyrrC6wv
+      type: message
+      status: completed
+      role: user
+      content:
+      - type: input_text
+        text: Say hello.
+- kind: message
+  direction: received
+  data:
+    type: response.created
+    event_id: event_EKYT1KdSQn7WUmE1hnK8u
+    response:
+      object: realtime.response
+      id: resp_EKYT1vZO9sBexSNM0pHNB
+      status: in_progress
+      status_details: null
+      output: []
+      conversation_id: conv_EKYT0lPn5oMhkMUVbelSO
+      output_modalities:
+      - audio
+      max_output_tokens: inf
+      audio:
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+      usage: null
+      metadata: null
+- kind: message
+  direction: received
+  data:
+    type: response.output_item.added
+    event_id: event_EKYT1n5YEppqumsvCKOIC
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    output_index: 0
+    item:
+      id: item_EKYT1l7qWK3MEv5CCFabU
+      type: message
+      status: in_progress
+      role: assistant
+      content: []
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.added
+    event_id: event_EKYT1IlG1G2Swj1tl7vMj
+    previous_item_id: item_EKYT1B5sKCOAgZyrrC6wv
+    item:
+      id: item_EKYT1l7qWK3MEv5CCFabU
+      type: message
+      status: in_progress
+      role: assistant
+      content: []
+- kind: message
+  direction: received
+  data:
+    type: response.content_part.added
+    event_id: event_EKYT1deejkKXeb0zwi7cP
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    part:
+      type: audio
+      transcript: ''
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1T2szzlkW7kfDdeXC
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: Hello
+    obfuscation: UkBgZ2ONau5
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1FAQabAFaH7corlgT
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: '!'
+    obfuscation: ztPGfTsHUs2sAb0
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1xmRqYcYRPRv5bkR8
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: AAACAAcAAQD8/wQAAwADAP7/AwADAAIAAgD9/wcAAAAC
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1mDlTmfgKWdApqPjS
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: GQnXCIUIvgj/CIAJZgsPDzIT7RjmHeMhIyVHJ+Qq7i3a
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1m86vb40Ulhsc5y2G
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: ' Great'
+    obfuscation: 1lXPxoD4f0
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1g2tjatTcKAjnPXwm
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: XxiwGAAX4xQJFNAUexWMFmgY5BkVHL4csBw3HJ0bWBss
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1E6uBHye2AjQ93pg0
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: ' to'
+    obfuscation: e7FkGPnnPs0JB
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1ewviT2VMye96mRZq
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: ' connect'
+    obfuscation: O4cufvFN
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1Sszoird4Fmeh8CQF
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: 7f/g/+f/8P/s//L/8f/w/+//8v/8/wQABwAJABIADwAH
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1GH7OMFpmb29sziNJ
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: +/8IAAAACQD+/w0AAQAJAAoABQAKAAsACAAHABEABAAS
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1he702VKFUiY9u7vy
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: ' with'
+    obfuscation: hhFy7lQVmve
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1kC2qwBcm0loxJmAD
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: ' you'
+    obfuscation: QzZuzuGit8ne
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.delta
+    event_id: event_EKYT1cXEU3SXvPROazsZO
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: .
+    obfuscation: 5vBmRcklrVB4Q5L
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1PryAQTOqkVFXe16z
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: agBrAGoAcABsAGwAbgBqAG0AZwBrAGcAZwBqAGcAaABk
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT19k2NVCIp1GKgPJ3j
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: PRUuFrEW8RezGJEZJBs9G9Ab0xtCG5EarRkSGKEWJRW8
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT1agaoahw4YzbgSJVO
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: eP74/2gAmP9h/kT/3gGdAQ8C0QFwAeIBqwA4/3/9W/9L
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.delta
+    event_id: event_EKYT15R9ZsYKh2ucwishi
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    delta: 0QJuBUgH/wg7CxMNog5YD5cPQRAPEE4Q7w8/DzUOMA05
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio.done
+    event_id: event_EKYT1gH9jBGamWyuHx2LT
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+- kind: message
+  direction: received
+  data:
+    type: response.output_audio_transcript.done
+    event_id: event_EKYT1Rl9kDdw4sy3PaGIB
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    transcript: Hello! Great to connect with you.
+- kind: message
+  direction: received
+  data:
+    type: response.content_part.done
+    event_id: event_EKYT1tv9iaG3nCEdKg5rt
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    item_id: item_EKYT1l7qWK3MEv5CCFabU
+    output_index: 0
+    content_index: 0
+    part:
+      type: audio
+      transcript: Hello! Great to connect with you.
+- kind: message
+  direction: received
+  data:
+    type: conversation.item.done
+    event_id: event_EKYT1avfvNzmJ4YrN6gfc
+    previous_item_id: null
+    item:
+      id: item_EKYT1l7qWK3MEv5CCFabU
+      type: message
+      status: completed
+      role: assistant
+      content:
+      - type: output_audio
+        transcript: Hello! Great to connect with you.
+- kind: message
+  direction: received
+  data:
+    type: response.output_item.done
+    event_id: event_EKYT1asxxfuwCSr5xH3ZI
+    response_id: resp_EKYT1vZO9sBexSNM0pHNB
+    output_index: 0
+    item:
+      id: item_EKYT1l7qWK3MEv5CCFabU
+      type: message
+      status: completed
+      role: assistant
+      content:
+      - type: output_audio
+        transcript: Hello! Great to connect with you.
+- kind: message
+  direction: received
+  data:
+    type: response.done
+    event_id: event_EKYT148DyLr082zROZHY2
+    response:
+      object: realtime.response
+      id: resp_EKYT1vZO9sBexSNM0pHNB
+      status: completed
+      status_details: null
+      output:
+      - id: item_EKYT1l7qWK3MEv5CCFabU
+        type: message
+        status: completed
+        role: assistant
+        content:
+        - type: output_audio
+          transcript: Hello! Great to connect with you.
+      conversation_id: conv_EKYT0lPn5oMhkMUVbelSO
+      output_modalities:
+      - audio
+      max_output_tokens: inf
+      audio:
+        output:
+          format:
+            type: audio/pcm
+            rate: 24000
+          voice: alloy
+      usage:
+        total_tokens: 79
+        input_tokens: 13
+        output_tokens: 66
+        input_token_details:
+          text_tokens: 13
+          audio_tokens: 0
+          image_tokens: 0
+          cached_tokens: 0
+          cached_tokens_details:
+            text_tokens: 0
+            audio_tokens: 0
+            image_tokens: 0
+        output_token_details:
+          text_tokens: 18
+          audio_tokens: 48
+      metadata: null

--- a/tests/realtime/test_openai_ws.py
+++ b/tests/realtime/test_openai_ws.py
@@ -319,6 +319,42 @@ async def test_media_views_subscribe_before_iteration(
     assert transcript_parts[0].transcript
 
 
+async def test_wait_for_playback_drains_audio_before_close(
+    openai_ws_cassette: tuple[Provider[Any], RealtimeCassette],
+) -> None:
+    """A generation boundary does not let session teardown cut off device-paced playback."""
+    provider, _ = openai_ws_cassette
+    model = OpenAIRealtimeModel('gpt-realtime', provider=provider)
+    agent = Agent(instructions='Reply in one short sentence.')
+    emitted: list[bytes] = []
+    played: list[bytes] = []
+
+    async with agent.realtime(model).session() as session:
+        audio = session.stream_audio()
+
+        async def play_audio() -> None:
+            async for chunk in audio:
+                await asyncio.sleep(0.005)
+                played.append(chunk)
+
+        playback = asyncio.create_task(play_audio())
+        await session.send('Say hello.')
+        with anyio.fail_after(30):
+            async for event in session:  # pragma: no branch
+                if (
+                    isinstance(event, PartDeltaEvent)
+                    and isinstance(event.delta, SpeechPartDelta)
+                    and event.delta.audio_chunk
+                ):
+                    emitted.append(event.delta.audio_chunk)
+                if isinstance(event, RealtimeTurnCompleteEvent):
+                    break
+            await session.wait_for_playback()
+        assert played == emitted
+
+    await playback
+
+
 async def test_provider_factory_text_turn(
     openai_ws_cassette: tuple[Provider[Any], RealtimeCassette], openai_api_key: str
 ) -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1783,6 +1783,7 @@ async def test_wait_for_playback_returns_immediately_without_audio() -> None:
     async with session:
         stream = session.stream_audio()
         await session.wait_for_playback()
+        assert isinstance(stream, _TapView)
         await stream.aclose()
 
 
@@ -1796,6 +1797,7 @@ async def test_wait_for_playback_requires_exactly_one_audio_stream() -> None:
         second = session.stream_audio()
         with pytest.raises(UserError, match=r'`wait_for_playback\(\)` needs exactly one active.*not 2'):
             await session.wait_for_playback()
+        assert isinstance(first, _TapView) and isinstance(second, _TapView)
         await first.aclose()
         await second.aclose()
 
@@ -1833,6 +1835,7 @@ async def test_wait_for_playback_returns_when_view_is_closed() -> None:
         waiting = asyncio.create_task(session.wait_for_playback())
         await asyncio.sleep(0)
         assert not waiting.done()
+        assert isinstance(stream, _TapView)
         await stream.aclose()
         await waiting
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1729,6 +1729,90 @@ async def test_played_audio_bytes_requires_exactly_one_audio_stream() -> None:
         _ = session.played_audio_bytes
 
 
+async def test_wait_for_playback_waits_for_device_paced_consumer() -> None:
+    chunks = [bytes([index]) * _CHUNK for index in range(20)]
+    session = RealtimeSession(BlockingRealtimeConnection([AudioDelta(chunk) for chunk in chunks]), _noop_runner)
+    played: list[bytes] = []
+
+    async with session:
+        stream = session.stream_audio()
+
+        async def play() -> None:
+            async for chunk in stream:
+                await asyncio.sleep(0.005)
+                played.append(chunk)
+
+        playback = asyncio.create_task(play())
+        await asyncio.sleep(0)
+        waiting = asyncio.create_task(session.wait_for_playback())
+        await asyncio.sleep(0.005)
+        assert not waiting.done()
+        await waiting
+        assert played == chunks
+        playback.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await playback
+
+
+async def test_wait_for_playback_returns_immediately_without_audio() -> None:
+    session = RealtimeSession(BlockingRealtimeConnection([]), _noop_runner)
+    async with session:
+        stream = session.stream_audio()
+        await session.wait_for_playback()
+        await stream.aclose()
+
+
+async def test_wait_for_playback_requires_exactly_one_audio_stream() -> None:
+    session = RealtimeSession(FakeRealtimeConnection([]), _noop_runner)
+    async with session:
+        with pytest.raises(UserError, match=r'`wait_for_playback\(\)` needs exactly one active.*not 0'):
+            await session.wait_for_playback()
+
+        first = session.stream_audio()
+        second = session.stream_audio()
+        with pytest.raises(UserError, match=r'`wait_for_playback\(\)` needs exactly one active.*not 2'):
+            await session.wait_for_playback()
+        await first.aclose()
+        await second.aclose()
+
+
+async def test_wait_for_playback_returns_when_session_closes() -> None:
+    session = RealtimeSession(BlockingRealtimeConnection([AudioDelta(b'audio')]), _noop_runner)
+    await session.__aenter__()
+    stream = session.stream_audio()
+    assert await anext(stream) == b'audio'
+    waiting = asyncio.create_task(session.wait_for_playback())
+    await asyncio.sleep(0)
+    assert not waiting.done()
+    await session.close()
+    await waiting
+
+
+async def test_wait_for_playback_drains_after_pump_finishes() -> None:
+    chunks = [b'first', b'second']
+    session = RealtimeSession(FakeRealtimeConnection([AudioDelta(chunk) for chunk in chunks]), _noop_runner)
+    async with session:
+        stream = session.stream_audio()
+        await asyncio.sleep(0)
+        waiting = asyncio.create_task(session.wait_for_playback())
+        await asyncio.sleep(0)
+        assert not waiting.done()
+        assert [chunk async for chunk in stream] == chunks
+        await waiting
+
+
+async def test_wait_for_playback_returns_when_view_is_closed() -> None:
+    session = RealtimeSession(BlockingRealtimeConnection([AudioDelta(b'audio')]), _noop_runner)
+    async with session:
+        stream = session.stream_audio()
+        await asyncio.sleep(0)
+        waiting = asyncio.create_task(session.wait_for_playback())
+        await asyncio.sleep(0)
+        assert not waiting.done()
+        await stream.aclose()
+        await waiting
+
+
 async def test_handle_barge_in_interrupts_automatically_on_speech_start() -> None:
     """With `handle_barge_in=True` the session runs the whole local half of barge-in itself.
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -175,6 +175,10 @@ class MockRealtimeConnection(RealtimeConnection):
     def __init__(self, function_tool_names: Sequence[str] = ()) -> None:
         self._function_tool_names = function_tool_names
         self._tool_result_received = asyncio.Event()
+        self._closed = asyncio.Event()
+
+    async def aclose(self) -> None:
+        self._closed.set()
 
     async def send(self, content: RealtimeInput) -> None:
         if isinstance(content, ToolResult):
@@ -196,6 +200,7 @@ class MockRealtimeConnection(RealtimeConnection):
             yield AudioDelta(data=b'\x00\x00')
             yield OutputTranscript(text='Hello from the realtime assistant.', is_final=True)
             yield ResponseDone()
+        await self._closed.wait()
 
 
 @asynccontextmanager
@@ -205,7 +210,11 @@ async def _mock_realtime_connect(
     model_request_parameters: ModelRequestParameters,
     **kwargs: Any,
 ) -> AsyncGenerator[RealtimeConnection]:
-    yield MockRealtimeConnection([tool.name for tool in model_request_parameters.function_tools])
+    connection = MockRealtimeConnection([tool.name for tool in model_request_parameters.function_tools])
+    try:
+        yield connection
+    finally:
+        await connection.aclose()
 
 
 def _patch_realtime_models(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Follow-up to #8132 from the realtime usage-surface audit.

Closing a session discards buffered audio, so every example that reads a reply and then leaves the `async with` block could cut the speaker off mid-sentence, and there was no session-level way to know when device-paced playback had caught up. Users had to count bytes themselves or sleep.

- Adds `RealtimeSession.wait_for_playback()`: waits until the session's single `stream_audio()` consumer has taken every chunk emitted so far, with the same one-chunk lag as `played_audio_bytes` (a chunk counts as played once the consumer comes back for the next one). It returns early if the view or the session closes, and raises `UserError` without exactly one audio view, like `played_audio_bytes`.
- The quickstart, media-views, barge-in and "Speaking first" examples await it before closing or opening the microphone; "Speaking first" no longer needs a helper task for the greeting.
- The docs-test `MockRealtimeConnection` now stays connected until the session closes it, like a real provider. That exposed a few examples that only terminated because the mock hung up; they now break on the turn boundary (including the `Agent.realtime()` docstring example), and the Azure example subscribes to its transcript view before prompting, since a reply can otherwise be pumped before a view created after `send()` exists.
- One recorded OpenAI cassette test checks that a turn boundary no longer lets teardown cut off playback.

Follow-up: a session-owned background task helper for the playback/microphone tasks these examples create, once #8138 has landed.

- Closes #<none>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->