### PR TITLE
Fix InstructionPart round-trip through ModelMessagesTypeAdapter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2653,6 +2653,7 @@ def _model_request_part_discriminator(v: Any) -> str | None:
 ModelRequestPart = Annotated[
     Annotated[SystemPromptPart, pydantic.Tag('system-prompt')]
     | Annotated[UserPromptPart, pydantic.Tag('user-prompt')]
+    | Annotated[InstructionPart, pydantic.Tag('instruction')]
     | Annotated[SpeechPart, pydantic.Tag('speech')]
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
     | Annotated[LoadCapabilityReturnPart, pydantic.Tag('capability-load-return')]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -804,6 +804,20 @@ def test_builtin_tool_call_part_has_content_empty(args: dict[str, object] | str 
     assert not part.has_content()
 
 
+def test_instruction_part_serialization_roundtrip():
+    # `InstructionPart` advertises itself as deserializable via `part_kind`; the
+    # `ModelRequestPart` union must include it so stored message history containing
+    # instruction parts round-trips instead of raising a ValidationError (#8143).
+    messages: list[ModelMessage] = [ModelRequest(parts=[InstructionPart(content='be brief', dynamic=False)])]
+    serialized = ModelMessagesTypeAdapter.dump_python(messages, mode='json')
+    reloaded = ModelMessagesTypeAdapter.validate_python(serialized)
+    assert reloaded == messages
+    part = cast(InstructionPart, reloaded[0].parts[0])
+    assert isinstance(part, InstructionPart)
+    assert part.content == 'be brief'
+    assert part.dynamic is False
+
+
 def test_file_part_serialization_roundtrip():
     # Verify that a serialized BinaryImage doesn't come back as a BinaryContent.
     messages: list[ModelMessage] = [


### PR DESCRIPTION
Fixes #8143

## Problem

`InstructionPart` is a public dataclass whose own docstring says `part_kind` is "used as a discriminator for deserialization", but it was missing from the `ModelRequestPart` tagged union — so round-tripping a stored message list containing an instruction part through `ModelMessagesTypeAdapter` raised a `ValidationError` and lost the message (dump succeeds, validate fails).

## Fix

Add the missing union arm:

```python
| Annotated[InstructionPart, pydantic.Tag('instruction')]
```

The callable discriminator already handles it via its base-`part_kind` fallthrough (dicts: returns `'instruction'`; instances: `getattr(v, 'part_kind')`), so no discriminator changes are needed — serialization and deserialization now both resolve the `'instruction'` tag.

## Test

`test_instruction_part_serialization_roundtrip` in `tests/test_messages.py`, following the existing roundtrip test pattern: dump → validate → equality + type/content/dynamic assertions. The issue's exact repro now round-trips cleanly.

`tests/test_messages.py` full run: 211 passed, 2 skipped (pre-existing skips).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

