### PR TITLE
Allow dataclasses.replace on ImageGeneration and XSearch with a fallback model

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
@@ -10,7 +10,7 @@ from pydantic_ai.native_tools import ImageAspectRatio, ImageGenerationModelName,
 from pydantic_ai.tools import AgentDepsT, RunContext, Tool
 from pydantic_ai.toolsets import AbstractToolset
 
-from .native_or_local import NativeOrLocalTool
+from .native_or_local import NativeOrLocalTool, _is_fallback_derived_local, _mark_fallback_derived_local
 
 if TYPE_CHECKING:
     from pydantic_ai.common_tools.image_generation import ImageGenerationFallbackModel, ImageGenerationNativeTool
@@ -166,7 +166,13 @@ class ImageGeneration(NativeOrLocalTool[AgentDepsT]):
         # the local tool would then take effect with `fallback_model` silently ignored. Runs before
         # the base resolves `local`, so it reads what was declared rather than what was
         # materialized.
-        if self.fallback_model is not None and self.local is not None:
+        #
+        # `dataclasses.replace` re-enters with the Tool `_default_local` already stored in `local`.
+        # That is derived, not a user `local=`. Drop it so the base rebuilds from the (possibly
+        # updated) `fallback_model`. See #8095.
+        if _is_fallback_derived_local(self.local):
+            self.local = None
+        elif self.fallback_model is not None and self.local is not None:
             raise UserError(
                 'ImageGeneration: cannot specify both `fallback_model` and `local` — '
                 'use `fallback_model` for the default subagent fallback, or `local` for a custom tool'
@@ -213,4 +219,6 @@ class ImageGeneration(NativeOrLocalTool[AgentDepsT]):
             return None
         from pydantic_ai.common_tools.image_generation import image_generation_tool
 
-        return image_generation_tool(model=self.fallback_model, native_tool=self._resolved_native())
+        return _mark_fallback_derived_local(
+            image_generation_tool(model=self.fallback_model, native_tool=self._resolved_native())
+        )

--- a/pydantic_ai_slim/pydantic_ai/capabilities/native_or_local.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/native_or_local.py
@@ -20,6 +20,20 @@ from .abstract import (
 
 _NativeToolT = TypeVar('_NativeToolT', bound=AbstractNativeTool)
 
+# Stamped onto the Tool `_default_local` builds from `fallback_model`. `dataclasses.replace`
+# reconstructs through `__init__` with that resolved Tool in `local`, and the exclusivity
+# check has to tell that reconstruction apart from a caller who passed `local=` themselves.
+_FALLBACK_DERIVED_ATTR = '_pydantic_ai_fallback_derived'
+
+
+def _mark_fallback_derived_local(local: Tool[AgentDepsT]) -> Tool[AgentDepsT]:
+    object.__setattr__(local, _FALLBACK_DERIVED_ATTR, True)
+    return local
+
+
+def _is_fallback_derived_local(local: object) -> bool:
+    return bool(getattr(local, _FALLBACK_DERIVED_ATTR, False))
+
 
 @dataclass(init=False)
 class NativeOrLocalTool(AbstractCapability[AgentDepsT]):

--- a/pydantic_ai_slim/pydantic_ai/capabilities/x_search.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/x_search.py
@@ -11,7 +11,7 @@ from pydantic_ai.native_tools import XSearchTool
 from pydantic_ai.tools import AgentDepsT, RunContext, Tool
 from pydantic_ai.toolsets import AbstractToolset
 
-from .native_or_local import NativeOrLocalTool
+from .native_or_local import NativeOrLocalTool, _is_fallback_derived_local, _mark_fallback_derived_local
 
 if TYPE_CHECKING:
     from pydantic_ai.common_tools.x_search import XSearchFallbackModel, XSearchNativeTool
@@ -123,7 +123,12 @@ class XSearch(NativeOrLocalTool[AgentDepsT]):
         # the local tool would then take effect with `fallback_model` silently ignored. Runs before
         # the base resolves `local`, so it reads what was declared rather than what was
         # materialized.
-        if self.fallback_model is not None and self.local is not None:
+        # `dataclasses.replace` re-enters with the Tool `_default_local` already stored in `local`.
+        # That is derived, not a user `local=`. Drop it so the base rebuilds from the (possibly
+        # updated) `fallback_model`. See #8095.
+        if _is_fallback_derived_local(self.local):
+            self.local = None
+        elif self.fallback_model is not None and self.local is not None:
             raise UserError(
                 'XSearch: cannot specify both `fallback_model` and `local` — '
                 'use `fallback_model` for the default subagent fallback, or `local` for a custom tool'
@@ -160,7 +165,9 @@ class XSearch(NativeOrLocalTool[AgentDepsT]):
             return None
         from pydantic_ai.common_tools.x_search import x_search_tool
 
-        return x_search_tool(model=self.fallback_model, native_tool=self._resolved_native())
+        return _mark_fallback_derived_local(
+            x_search_tool(model=self.fallback_model, native_tool=self._resolved_native())
+        )
 
     def _requires_native(self) -> bool:
         # Handle constraints can only be enforced by the native XSearchTool.

--- a/tests/test_capability_native_or_local.py
+++ b/tests/test_capability_native_or_local.py
@@ -259,6 +259,24 @@ class TestXSearchCapability:
         with pytest.raises(UserError, match='cannot specify both `fallback_model` and `local`'):
             XSearch(fallback_model='xai:grok-4-1-fast-non-reasoning', local=my_search)
 
+    def test_xsearch_replace_with_fallback_model(self):
+        """`dataclasses.replace` on XSearch(fallback_model=...) must not treat the derived local as user-supplied.
+
+        Regression for #8095.
+        """
+        from pydantic_ai.tools import Tool
+
+        cap = XSearch(fallback_model='xai:grok-4-1-fast-non-reasoning')
+        copied = replace(cap)
+        assert copied is not cap
+        assert isinstance(copied.local, Tool)
+        assert copied.fallback_model == cap.fallback_model
+        assert copied.get_toolset() is not None
+
+        updated = replace(cap, fallback_model='xai:grok-4.3')
+        assert updated.fallback_model == 'xai:grok-4.3'
+        assert isinstance(updated.local, Tool)
+
     def test_xsearch_fallback_model_with_local_false(self):
         """XSearch(fallback_model=..., local=False) raises UserError."""
         with pytest.raises(UserError, match='cannot specify both `fallback_model` and `local`'):
@@ -696,6 +714,35 @@ class TestImageGenerationCapability:
 
         with pytest.raises(UserError, match='cannot specify both `fallback_model` and `local`'):
             ImageGeneration(fallback_model='openai-responses:gpt-5.4', local=my_gen)
+
+    def test_image_generation_replace_with_fallback_model(self):
+        """`dataclasses.replace` on ImageGeneration(fallback_model=...) must not treat the derived local as user-supplied.
+
+        Regression for #8095: after construction `local` holds the fallback Tool, and replace
+        re-enters `__init__` with that value.
+        """
+        from pydantic_ai.tools import Tool
+
+        cap = ImageGeneration(fallback_model='openai-responses:gpt-5.4')
+        copied = replace(cap)
+        assert copied is not cap
+        assert isinstance(copied.local, Tool)
+        assert copied.fallback_model == cap.fallback_model
+        assert copied.get_toolset() is not None
+
+        updated = replace(cap, fallback_model='openai-responses:gpt-5.5')
+        assert updated.fallback_model == 'openai-responses:gpt-5.5'
+        assert isinstance(updated.local, Tool)
+
+    def test_image_generation_replace_still_rejects_user_local(self):
+        """replace must not open a hole for pairing fallback_model with a caller-supplied local."""
+
+        def my_gen(prompt: str) -> str:
+            return 'image_url'  # pragma: no cover
+
+        cap = ImageGeneration(fallback_model='openai-responses:gpt-5.4')
+        with pytest.raises(UserError, match='cannot specify both `fallback_model` and `local`'):
+            replace(cap, local=my_gen)
 
     def test_image_generation_fallback_model_with_local_false(self):
         """ImageGeneration(fallback_model=..., local=False) raises UserError."""


### PR DESCRIPTION
## Summary
- `ImageGeneration(fallback_model=...)` and `XSearch(fallback_model=...)` store the derived subagent `Tool` in `local` after `__post_init__`.
- `dataclasses.replace` reconstructs through `__init__` with that resolved `Tool`, so the fallback-versus-`local` check treats it as a user-supplied `local=` and raises `UserError`.
- Mark the derived tool, skip the exclusivity check for it, and drop it before the base class re-runs `_default_local` so a replace that changes `fallback_model` rebuilds the tool. Real `local=` conflicts still raise.

## Test plan
- [x] `dataclasses.replace(ImageGeneration(fallback_model=...))` and the XSearch equivalent round-trip
- [x] `replace(..., fallback_model=other)` rebuilds the local tool
- [x] `ImageGeneration(..., local=func)` and `local=False` still raise
- [x] `replace(cap, local=func)` still raises

Fixes #8095
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
