### PR TITLE
docs: add The Grid as an OpenAI-compatible provider

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -1167,6 +1167,34 @@ agent = Agent(model)
 ...
 ```
 
+### The Grid
+
+[The Grid](https://thegrid.ai) is a spot market for inference. Model names are market instruments — a task type (`text`, `code`, `agent`) paired with a quality tier (`standard`, `prime`, `max`) — rather than fixed models, so the model that serves a request differs from the instrument requested.
+
+The Grid doesn't have a dedicated provider class, so you can use it with [`OpenAIProvider`][pydantic_ai.providers.openai.OpenAIProvider]. Pass an `AsyncOpenAI` client rather than a `base_url`: The Grid answers inference requests with a [`307` redirect](https://thegrid.ai/docs/api-reference/request-routing-and-redirects) to its routing layer, and the OpenAI SDK's own HTTP client follows redirects, while the default client Pydantic AI builds does not.
+
+```python
+from openai import AsyncOpenAI
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'text-standard',
+    provider=OpenAIProvider(
+        openai_client=AsyncOpenAI(
+            base_url='https://api.thegrid.ai/v1',
+            api_key='your-the-grid-api-key',
+        ),
+    ),
+)
+agent = Agent(model)
+...
+```
+
+Available instruments are listed in [The Grid's documentation](https://thegrid.ai/docs/instrument-specifications/current-instruments).
+
 ### Rapid-MLX (Apple Silicon)
 
 [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an OpenAI-compatible inference server for Apple Silicon, built on Apple's MLX framework.


### PR DESCRIPTION
Adds a "The Grid" section to `docs/models/openai.md`, in the same pattern as the existing Atlas Cloud and Rapid-MLX entries.

**Disclosure:** I work on The Grid, and this was written with AI assistance. Every claim below was verified by running it.

This follows what CONTRIBUTING prescribes:

> "For any other model that's just a custom URL and API key, we're happy to add a one-paragraph description with a link and instructions on the URL to use"

[The Grid](https://thegrid.ai) is a spot market for inference — model names are market instruments (`text-standard`, `code-prime`, `agent-max`) rather than fixed models, and each request is filled by whichever supplier is competitive at the time.

### Why the snippet passes `openai_client` instead of `base_url`

This is the part worth reviewing. The Grid answers inference requests with a [documented `307` redirect](https://thegrid.ai/docs/api-reference/request-routing-and-redirects) to its routing layer. The obvious `OpenAIProvider(base_url=..., api_key=...)` form **fails**, because the client Pydantic AI builds does not follow redirects — you get:

```
pydantic_ai.exceptions.ModelAPIError: <html><body>You are being <a href="...">redirected</a>.</body></html>
```

Passing an `AsyncOpenAI` client works, because the OpenAI SDK sets `follow_redirects=True` on its own httpx client:

```
output -> 'OK'
usage  -> RunUsage(input_tokens=59, output_tokens=51, requests=1)
```

I also tried `http_client=httpx.AsyncClient(follow_redirects=True)`. It works, but emits `PydanticAIDeprecationWarning: httpx.AsyncClient support for OpenAI-compatible providers is deprecated and will be removed in v3`, so the section uses the `openai_client` form instead.

Documenting the working form is the whole point of the section — without it the failure mode is an HTML blob in an exception, which is hard to diagnose.

### Scope

One file, 28 added lines, no deletions. Docs-only, so per CONTRIBUTING this is exempt from the linked-issue requirement. Chat only — The Grid returns `404` for `/v1/embeddings`, so the section says nothing about embeddings.

I did not add a `TheGridProvider` class. Grid's ids encode a tier rather than a model family, so `model_profile()` would have nothing to dispatch on, and CONTRIBUTING points custom-URL-plus-key providers at exactly this paragraph treatment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

