### PR TITLE
Fix Embedder identity equality

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
@@ -139,7 +139,7 @@ def infer_embedding_model(
         raise UserError(f'Unknown embeddings model: {model}')  # pragma: no cover
 
 
-@dataclass(init=False)
+@dataclass(init=False, eq=False)
 class Embedder:
     """High-level interface for generating text embeddings.
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2314,3 +2314,12 @@ async def test_limited_instrumentation(capfire: CaptureLogfire):
             }
         ]
     )
+
+
+def test_embedder_identity_equality():
+    embedder1 = Embedder('openai:text-embedding-3-small')
+    embedder2 = Embedder('openai:text-embedding-3-small')
+
+    assert embedder1 != embedder2
+    assert embedder1 == embedder1
+    assert hash(embedder1) != hash(embedder2)


### PR DESCRIPTION
## Summary

- Set `eq=False` on `Embedder` to use identity-based equality.
- Add a regression test covering identity equality and hashability.

Closes #8144

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

