### PR TITLE
fix: deduplicate complex inputs in tool-call retries to prevent context growth

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1768,7 +1768,19 @@ class RetryPromptPart:
                     i: {'ctx', 'input'} if len(e.get('loc', ())) <= 1 else {'ctx'} for i, e in enumerate(self.content)
                 }
             else:
-                exclude = {'__all__': {'ctx'}}
+                exclude = {}
+                seen_input_ids = set()
+                for i, e in enumerate(self.content):
+                    exc_set = {'ctx'}
+                    inp = e.get('input')
+                    # Deduplicate complex inputs (dicts/lists) to prevent multiplicative context growth
+                    if isinstance(inp, (dict, list)):
+                        inp_id = id(inp)
+                        if inp_id in seen_input_ids:
+                            exc_set.add('input')
+                        else:
+                            seen_input_ids.add(inp_id)
+                    exclude[i] = exc_set
             json_errors = error_details_ta.dump_json(self.content, exclude=exclude, indent=2)
             plural = isinstance(self.content, list) and len(self.content) != 1
             description = (

--- a/tests/test_retry_deduplication.py
+++ b/tests/test_retry_deduplication.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import BaseModel
+from pydantic_ai.messages import RetryPromptPart
+from pydantic_core import ValidationError
+
+def test_tool_call_retry_deduplicates_root_input():
+    class MultiErrorModel(BaseModel):
+        a: int
+        b: int
+        c: int
+
+    # Missing fields cause input to be the root dictionary exactly
+    invalid_args = {'d': 'some-extra-arg'}
+    
+    try:
+        MultiErrorModel.model_validate(invalid_args)
+    except ValidationError as e:
+        error = e
+
+    part = RetryPromptPart.from_error(error, tool_name='my_tool')
+    msg = part.model_response()
+    
+    # The root invalid_args object should be included exactly once, even though there are 3 errors
+    # In JSON, it appears as "input": { "d": "some-extra-arg" }
+    # So we count the occurrences of "input"
+    assert msg.count('"input": {') == 1
+    # Check that there are 3 validation errors
+    assert '3 validation errors:' in msg
+


### PR DESCRIPTION
- Closes #7171

### Summary
Fixes a bug where validation retries for `ToolOutput` with multiple top-level errors (e.g. `missing` fields) duplicate the entire root invalid argument object once per error. This caused multiplicative context window growth (`O(errors * object_size)`).

### Fix
In `RetryPromptPart.model_response()`, when `tool_name` is present, the logic now deduplicates complex inputs (dictionaries and lists) by their `id()`. This preserves small string/integer inputs for individual field errors (critical for model self-correction, per #5181), but ensures the massive root object is injected at most once.

### Tests
- Added `test_tool_call_retry_deduplicates_root_input` to assert that an object missing multiple fields only includes the root `input` dictionary exactly once.
- Verified existing `NativeOutput` and `ToolOutput` snapshot tests pass without regression.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

