### PR TITLE
fix: preserve undrivable event loops in sync helpers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -1067,11 +1067,19 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
         return ()
 
 
+def _implements_run_until_complete(loop: asyncio.AbstractEventLoop) -> bool:
+    """Whether `loop` actually implements `run_until_complete()`."""
+    return getattr(loop.run_until_complete, '__func__', None) is not asyncio.AbstractEventLoop.run_until_complete
+
+
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:
         event_loop = None
+
+    if event_loop is not None and not _implements_run_until_complete(event_loop):
+        return event_loop
 
     if event_loop is None or event_loop.is_closed():
         event_loop = asyncio.new_event_loop()

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -79,11 +79,19 @@ _P = ParamSpec('_P')
 _R = TypeVar('_R')
 
 
+def _implements_run_until_complete(loop: asyncio.AbstractEventLoop) -> bool:
+    """Whether `loop` actually implements `run_until_complete()`."""
+    return getattr(loop.run_until_complete, '__func__', None) is not asyncio.AbstractEventLoop.run_until_complete
+
+
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:
         event_loop = None
+
+    if event_loop is not None and not _implements_run_until_complete(event_loop):
+        return event_loop
 
     if event_loop is None or event_loop.is_closed():
         event_loop = asyncio.new_event_loop()

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -17,7 +17,7 @@ from dirty_equals import HasRepr, IsNumber, IsOneOf
 from pydantic import BaseModel, TypeAdapter
 
 from .._inline_snapshot import snapshot
-from ..conftest import IsStr, try_import
+from ..conftest import IsStr, try_import, undrivable_event_loop
 from .utils import render_table
 
 with try_import() as imports_successful:
@@ -128,6 +128,14 @@ def test_evaluate_sync_creates_missing_event_loop(missing_event_loop: asyncio.Ab
     assert replacement_loop is not missing_event_loop
     assert not replacement_loop.is_closed()
     assert not asyncio.all_tasks(replacement_loop)
+
+
+def test_evaluate_sync_keeps_undrivable_event_loop():
+    """`evaluate_sync` should preserve runtime-owned loops that it cannot drive itself."""
+    dataset = Dataset(name='test', cases=[Case(name='case', inputs='input')])
+
+    with undrivable_event_loop(), pytest.raises(NotImplementedError):
+        dataset.evaluate_sync(lambda value: value, progress=False)
 
 
 class TaskMetadata(BaseModel):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -99,6 +99,8 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDefinition, ToolDenied
 from pydantic_graph import End
 
+from .conftest import undrivable_event_loop
+
 if TYPE_CHECKING:
     from pydantic_ai.providers.alibaba import AlibabaProvider
     from pydantic_ai.providers.anthropic import AnthropicProvider
@@ -236,6 +238,14 @@ def test_run_sync_creates_missing_event_loop(missing_event_loop: asyncio.Abstrac
     assert replacement_loop is not missing_event_loop
     assert not replacement_loop.is_closed()
     assert not asyncio.all_tasks(replacement_loop)
+
+
+def test_run_sync_keeps_undrivable_event_loop():
+    """`run_sync` should preserve runtime-owned loops that it cannot drive itself."""
+    agent = Agent(TestModel(custom_output_text='success'))
+
+    with undrivable_event_loop(), pytest.raises(UserError, match='does not implement `run_until_complete\\(\\)`'):
+        agent.run_sync('Hello')
 
 
 def test_result_tuple():


### PR DESCRIPTION
## Problem
`pydantic_graph.get_event_loop()` already preserves event loops that do not implement `run_until_complete()`, such as runtime-owned workflow loops, so the sync wrapper can report the supported error path instead of replacing the loop or calling unimplemented loop methods.

The equivalent sync helpers in `pydantic_ai` and `pydantic_evals` still call `is_closed()` on any current loop. For an `asyncio.AbstractEventLoop` subclass that inherits the abstract `is_closed()` / `run_until_complete()` implementations, that can raise a bare `NotImplementedError` before the existing sync-wrapper handling gets a chance to run.

## Before / after
Before, `Agent.run_sync()` and `Dataset.evaluate_sync()` could trip over `is_closed()` when the thread-current loop is owned by another runtime and cannot be driven by the caller.

After, both helpers preserve those loops, matching `pydantic_graph` behavior. `Agent.run_sync()` continues to surface the existing `UserError`, and `Dataset.evaluate_sync()` surfaces the unsupported loop from the graph utility instead of replacing the loop.

## Verification
- `uv run pytest tests/test_agent.py::test_run_sync_keeps_undrivable_event_loop tests/evals/test_dataset.py::test_evaluate_sync_keeps_undrivable_event_loop`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_utils.py pydantic_evals/pydantic_evals/_utils.py tests/test_agent.py tests/evals/test_dataset.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




Closes #8161

