### PR TITLE
Raise `UserError` when a tool is registered while `FunctionToolset` is preparing tool definitions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -148,6 +148,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             for instruction in normalize_instructions(instructions)
         ]
 
+        self._getting_tools = False
         self.tools = {}
         for tool in tools:
             if isinstance(tool, Tool):
@@ -597,6 +598,13 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         Args:
             tool: The tool to add.
         """
+        if self._getting_tools:
+            raise UserError(
+                f'Cannot add tool {tool.name!r} while this toolset is preparing tool definitions.'
+                ' Adding tools from a tool `prepare` callback or tool function is not supported.'
+                ' To add tools dynamically during a run, use a `DynamicToolset`, the agent-level'
+                ' `prepare_tools` hook, or a `DeferredLoadingToolset` for tools that load on demand.'
+            )
         if tool.name in self.tools:
             raise UserError(f'Tool name conflicts with existing tool: {tool.name!r}')
         if tool.max_retries is None and self.max_retries is not None:
@@ -625,6 +633,13 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         return parts or None
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
+        self._getting_tools = True
+        try:
+            return await self._get_tools(ctx)
+        finally:
+            self._getting_tools = False
+
+    async def _get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         tools: dict[str, ToolsetTool[AgentDepsT]] = {}
         for original_name, tool in self.tools.items():
             max_retries = tool.max_retries if tool.max_retries is not None else self.max_retries

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -148,7 +148,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             for instruction in normalize_instructions(instructions)
         ]
 
-        self._getting_tools = False
+        self._getting_tools = 0
         self.tools = {}
         for tool in tools:
             if isinstance(tool, Tool):
@@ -633,11 +633,14 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         return parts or None
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
-        self._getting_tools = True
+        # A counter rather than a flag: the same toolset can be iterated concurrently by
+        # multiple agents, and a flag would let the first caller to finish re-enable
+        # registration while another is still iterating.
+        self._getting_tools += 1
         try:
             return await self._get_tools(ctx)
         finally:
-            self._getting_tools = False
+            self._getting_tools -= 1
 
     async def _get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         tools: dict[str, ToolsetTool[AgentDepsT]] = {}

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -301,6 +301,41 @@ async def test_function_toolset_with_defaults_overridden():
         return a - b  # pragma: no cover
 
 
+async def test_function_toolset_user_error_add_tool_during_get_tools():
+    """Adding a tool from a tool `prepare` callback raises `UserError` instead of `RuntimeError`."""
+    toolset = FunctionToolset()
+
+    def subtract(a: int, b: int) -> int:
+        """Subtract two numbers"""
+        return a - b  # pragma: no cover
+
+    registered = False
+
+    async def prepare_adds_tool(ctx: RunContext, tool_def: ToolDefinition) -> ToolDefinition:
+        nonlocal registered
+        if not registered:
+            registered = True
+            toolset.add_function(subtract)
+        return tool_def
+
+    @toolset.tool_plain(prepare=prepare_adds_tool)
+    def add(a: int, b: int) -> int:
+        """Add two numbers"""
+        return a + b  # pragma: no cover
+
+    with pytest.raises(
+        UserError,
+        match=re.escape("Cannot add tool 'subtract' while this toolset is preparing tool definitions."),
+    ):
+        await toolset.get_tools(build_run_context(None))
+
+    # The guard is reset when `get_tools()` exits, so registration works again between calls...
+    toolset.add_function(subtract)
+    # ...and the next `get_tools()` no longer sees the toolset as mid-iteration.
+    tools = await toolset.get_tools(build_run_context(None))
+    assert list(tools.keys()) == ['add', 'subtract']
+
+
 async def test_prepared_toolset_sync_prepare_func():
     """`PreparedToolset` accepts a synchronous prepare function (no await needed)."""
     base_toolset = FunctionToolset()


### PR DESCRIPTION
Fixes #8058 — this implements **option 1** (raise an actionable `UserError`); happy to adjust or close if option 2 is preferred.

## Problem

`FunctionToolset.get_tools()` iterates `self.tools` while awaiting each tool's `prepare_tool_def()` — which runs the user's `prepare` callback. If that callback registers another tool on the same toolset (via `add_function()` / `add_tool()` / the `tool` decorators), Python raises `RuntimeError: dictionary changed size during iteration`.

Registering tools from within tool-definition preparation is not supported — dynamic registration belongs in `DynamicToolset`, the agent-level `prepare_tools` hook, or `DeferredLoadingToolset` — but the bare `RuntimeError` gives no hint of that. The behavior was also inconsistent: registering a *new* name crashed, while overwriting an *existing* name mid-iteration silently continued.

## Change

- `FunctionToolset` now tracks in-flight `get_tools()` calls with a re-entrancy counter, and `add_tool()` raises an actionable `UserError` while it is non-zero, pointing at the supported dynamic-registration APIs.
- A counter rather than a bool because the same toolset can be iterated concurrently by multiple agents; a flag would let the first caller to finish re-enable registration while another is still iterating.
- `add_tool()` is the single choke point for all mutation paths (`add_function`, `tool`, `tool_plain`, and the agent-level decorators all funnel into it).

## Before / after (the MRE from the issue)

```
# before
RuntimeError: dictionary changed size during iteration

# after
pydantic_ai.exceptions.UserError: Cannot add tool 'second' while this toolset is preparing
tool definitions. Adding tools from a tool `prepare` callback or tool function is not supported.
To add tools dynamically during a run, use a `DynamicToolset`, the agent-level `prepare_tools`
hook, or a `DeferredLoadingToolset` for tools that load on demand.
```

## Test

- New `test_function_toolset_user_error_add_tool_during_get_tools` covers the `UserError` path and that the guard is reset once `get_tools()` exits (including after the exception), so later registration still works.
- `pytest tests/test_toolsets.py tests/test_tools.py`: 269 passed.
- `ruff check` / `ruff format --check` / `pyright` clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Fixes #8058