### PR TITLE
Honour explicit `type` and `disabled` in `load_mcp_toolsets`

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -185,13 +185,24 @@ The configuration file should be a JSON file with an `mcpServers` object contain
 
 Each entry supports `command`, `args`, `env` and `cwd` for a stdio server, or `url` and `headers`
 for an HTTP server. The configuration is validated as it's loaded, so a wrongly-typed field is reported
-straight away instead of failing later at connection time. Unknown keys are ignored, so a file shared with
-another MCP client still loads — but they are only ignored, never honoured. In particular
-`disabled` does not skip a server, and `type` does not choose the transport: that is inferred from
-the URL, as described below.
+straight away instead of failing later at connection time.
+
+Set `disabled` to `true` to skip a server before expanding its environment variables or validating its
+transport fields. `disabled` must be a JSON boolean for enabled entries; omission is equivalent to `false`.
+
+Use `type` to select a transport explicitly:
+
+- `stdio` requires `command` and rejects `url`.
+- `sse` requires `url` and rejects `command`, even when the URL does not end in `/sse`.
+- `http` or `streamableHttp` requires `url` and rejects `command`, even when the URL ends in `/sse`.
+
+Unknown `type` values and conflicting transport fields raise a `ValueError` during loading.
+Without `type`, `command` takes precedence when present; otherwise the transport is inferred from the URL.
+Unknown keys are ignored, so a file shared with another MCP client still loads. Other clients' settings
+such as `envFile`, `headersHelper`, and `oauth` are not applied.
 
 !!! note
-    The MCP server is only inferred to be an SSE server because of the `/sse` suffix. Any other server with the `url` field is treated as a Streamable HTTP server. We made this decision given that the SSE transport is deprecated.
+    When `type` is omitted, the `/sse` suffix selects SSE. Other URLs select Streamable HTTP, since the SSE transport is deprecated.
 
 ### Environment variables
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, Protocol, T
 
 import anyio
 import pydantic_core
-from pydantic import AnyUrl, Field, TypeAdapter
+from pydantic import AnyUrl, BeforeValidator, Field, StrictBool, TypeAdapter
 from typing_extensions import Self, TypedDict, assert_never
 
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
@@ -1922,8 +1922,8 @@ class _MCPServerConfig(TypedDict, total=False):
     """The keys `load_mcp_toolsets` reads from an `mcpServers` entry.
 
     Unknown keys are ignored rather than rejected, so a configuration file shared with another MCP
-    client still loads. They are only ignored, never honoured: `disabled` does not skip a server,
-    and `type` does not select the transport — that is inferred from the URL.
+    client still loads. `disabled: true` skips a server, and an explicit `type` takes precedence
+    over URL-based transport inference.
 
     Optional transport values accept explicit JSON `null` for compatibility with existing shared
     MCP configuration files; loading treats those values the same as omission.
@@ -1935,10 +1935,20 @@ class _MCPServerConfig(TypedDict, total=False):
     cwd: str | None
     url: str
     headers: dict[str, str] | None
+    type: Literal['stdio', 'sse', 'http', 'streamableHttp']
+    disabled: StrictBool
+
+
+def _prepare_mcp_server_config(value: object) -> object:
+    # Disabled entries may contain stale credentials or incomplete transport configuration.
+    if _utils.is_str_dict(value) and value.get('disabled') is True:
+        return {'disabled': True}
+    # Expand before validating, so `${VAR}` references are checked as the values they resolve to.
+    return _expand_env_vars(value)
 
 
 class _MCPConfig(TypedDict):
-    mcpServers: dict[str, _MCPServerConfig]
+    mcpServers: dict[str, Annotated[_MCPServerConfig, BeforeValidator(_prepare_mcp_server_config)]]
 
 
 _MCP_CONFIG_ADAPTER = TypeAdapter(_MCPConfig)
@@ -1948,9 +1958,14 @@ def load_mcp_toolsets(config_path: str | Path) -> list[AbstractToolset[Any]]:
     """Load `MCPToolset`s from a configuration file.
 
     The configuration file uses the same `mcpServers` JSON shape as Claude Desktop, Claude Code,
-    and Cursor. Each server entry produces one [`MCPToolset`][pydantic_ai.mcp.MCPToolset], wrapped
+    and Cursor. Each enabled server entry produces one [`MCPToolset`][pydantic_ai.mcp.MCPToolset], wrapped
     in a [`PrefixedToolset`][pydantic_ai.toolsets.PrefixedToolset] using the server's name as prefix
     to disambiguate tools across multiple servers.
+
+    Entries with `disabled: true` are skipped before environment expansion or transport validation.
+    An explicit `type` selects `stdio` (requires `command` without `url`), `sse`, or
+    `http`/`streamableHttp` (requires `url` without `command`). Without `type`, `command` takes
+    precedence; otherwise a URL ending in `/sse` selects SSE and other URLs select Streamable HTTP.
 
     Environment variables can be referenced in the configuration file using:
 
@@ -1961,27 +1976,36 @@ def load_mcp_toolsets(config_path: str | Path) -> list[AbstractToolset[Any]]:
         config_path: Path to the JSON configuration file.
 
     Returns:
-        A list of toolsets, one per server in the config file, each prefixed with the server name.
+        A list of toolsets, one per enabled server in the config file, each prefixed with the server name.
 
     Raises:
         OSError: If the configuration file does not exist (`FileNotFoundError`), or exists but
             cannot be read — a directory, or a file without read permission.
         ValidationError: If the configuration does not match the `mcpServers` shape above. This is
             a `ValueError` subclass, so catching `ValueError` covers it too.
-        ValueError: If the file is not valid JSON, a server entry has neither `command` nor `url`,
-            or an environment variable referenced in the configuration is not defined and no
-            default is provided.
+        ValueError: If the file is not valid JSON, an enabled server entry has neither `command` nor
+            `url` or conflicts with its explicit `type`, or an environment variable referenced in an
+            enabled entry is not defined and no default is provided.
     """
     config_path = Path(config_path)
     if not config_path.exists():
         raise FileNotFoundError(f'Config file {config_path} not found')
 
     config_data = pydantic_core.from_json(config_path.read_bytes())
-    # Expand before validating, so `${VAR}` references are checked as the values they resolve to.
-    config = _MCP_CONFIG_ADAPTER.validate_python(_expand_env_vars(config_data))
+    config = _MCP_CONFIG_ADAPTER.validate_python(config_data)
 
     toolsets: list[AbstractToolset[Any]] = []
     for name, server in config['mcpServers'].items():
+        if server.get('disabled', False):
+            continue
+        transport_type = server.get('type')
+        if transport_type is not None:
+            if transport_type == 'stdio':
+                valid_shape = 'command' in server and 'url' not in server
+            else:
+                valid_shape = 'url' in server and 'command' not in server
+            if not valid_shape:
+                raise ValueError(f'MCP server config {name!r} has fields incompatible with `type` {transport_type!r}')
         if 'command' in server:
             transport = StdioTransport(
                 command=server['command'],
@@ -1991,7 +2015,11 @@ def load_mcp_toolsets(config_path: str | Path) -> list[AbstractToolset[Any]]:
             )
             toolset = MCPToolset(transport, id=name)
         elif 'url' in server:
-            toolset = MCPToolset(server['url'], id=name, headers=server.get('headers'))
+            if transport_type is None:
+                toolset = MCPToolset(server['url'], id=name, headers=server.get('headers'))
+            else:
+                transport_class = SSETransport if transport_type == 'sse' else StreamableHttpTransport
+                toolset = MCPToolset(transport_class(server['url'], headers=server.get('headers')), id=name)
         else:
             raise ValueError(f'MCP server config {name!r} must have either `command` or `url`')
         toolsets.append(toolset.prefixed(name))

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1770,7 +1770,15 @@ class TestLoadMCPToolsets:
                 'type': 'stdio',
                 'disabled': False,
                 'command': sys.executable,
-                'args': ['-m', 'tests.mcp_server'],
+                # The SDK v1 test server imports `mcp.server.fastmcp`, removed in SDK v2.
+                'args': [
+                    '-c',
+                    'from fastmcp import FastMCP\n'
+                    "mcp = FastMCP('test_server')\n"
+                    "mcp.tool(name='get_weather_forecast')"
+                    "(lambda location: f'The weather in {location} is sunny and 26 degrees Celsius.')\n"
+                    'mcp.run()',
+                ],
             }
         config_path = tmp_path / 'mcp.json'
         config_path.write_text(json.dumps({'mcpServers': servers}), encoding='utf-8')

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import re
 import subprocess
 import sys
@@ -1725,6 +1726,91 @@ class TestResourceMethodErrorPaths:
 
 
 class TestLoadMCPToolsets:
+    @pytest.mark.parametrize(
+        'server,expected_transport',
+        [
+            ({'type': 'sse', 'url': 'https://example.com/mcp'}, 'sse'),
+            ({'type': 'http', 'url': 'https://example.com/sse'}, 'http'),
+            ({'type': 'streamableHttp', 'url': 'https://example.com/sse'}, 'http'),
+            ({'url': 'https://example.com/sse'}, 'sse'),
+            ({'url': 'https://example.com/mcp'}, 'http'),
+        ],
+    )
+    def test_transport_selection(
+        self, tmp_path: Path, server: dict[str, str], expected_transport: Literal['sse', 'http']
+    ):
+        """Inspect selection directly: a successful request alone cannot distinguish the transports."""
+        config_path = tmp_path / 'mcp.json'
+        config_path.write_text(
+            json.dumps({'mcpServers': {'alpha': {**server, 'headers': {'X-Key': 'foo'}}}}), encoding='utf-8'
+        )
+        toolsets = load_mcp_toolsets(config_path)
+        assert len(toolsets) == 1
+        assert isinstance(toolsets[0], PrefixedToolset)
+        wrapped = toolsets[0].wrapped
+        assert isinstance(wrapped, MCPToolset)
+        assert wrapped.id == 'alpha'
+        transport_class = SSETransport if expected_transport == 'sse' else StreamableHttpTransport
+        assert isinstance(wrapped.client.transport, transport_class)
+        assert str(wrapped.client.transport.url) == server['url']
+        assert wrapped.client.transport.headers == {'X-Key': 'foo'}
+
+    @pytest.mark.parametrize('enabled', [False, True])
+    async def test_disabled_entries_are_skipped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, enabled: bool):
+        """Disabled entries need neither valid transport fields nor environment variables, and never start."""
+        monkeypatch.delenv('MCP_TEST_DISABLED_UNDEFINED', raising=False)
+        servers: dict[str, object] = {
+            'disabled-command': {'disabled': True, 'command': 'nonexistent-disabled-mcp-command'},
+            'disabled-invalid': {'disabled': True, 'type': 'invalid', 'url': 123, 'args': 'invalid'},
+            'disabled-env': {'disabled': True, 'command': '${MCP_TEST_DISABLED_UNDEFINED}'},
+            'disabled-empty': {'disabled': True},
+        }
+        if enabled:
+            servers['alpha'] = {
+                'type': 'stdio',
+                'disabled': False,
+                'command': sys.executable,
+                'args': ['-m', 'tests.mcp_server'],
+            }
+        config_path = tmp_path / 'mcp.json'
+        config_path.write_text(json.dumps({'mcpServers': servers}), encoding='utf-8')
+        toolsets = load_mcp_toolsets(config_path)
+        assert len(toolsets) == int(enabled)
+        if enabled:
+            assert isinstance(toolsets[0], PrefixedToolset)
+            assert isinstance(toolsets[0].wrapped, MCPToolset)
+            # Importing the real test server can exceed the default five seconds on busy CI hosts.
+            monkeypatch.setattr(toolsets[0].wrapped.client, '_init_timeout', 30)
+            agent = Agent(TestModel(call_tools=['alpha_get_weather_forecast']), toolsets=toolsets)
+            result = await agent.run('weather')
+            assert result.output == '{"alpha_get_weather_forecast":"The weather in a is sunny and 26 degrees Celsius."}'
+
+    @pytest.mark.parametrize(
+        'server',
+        [
+            {'type': 'stdio', 'url': 'https://example.com/mcp'},
+            {'type': 'stdio'},
+            {'type': 'stdio', 'command': 'python', 'url': 'https://example.com/mcp'},
+            *[{'type': kind, 'command': 'python'} for kind in ('sse', 'http', 'streamableHttp')],
+            *[{'type': kind} for kind in ('sse', 'http', 'streamableHttp')],
+            *[
+                {'type': kind, 'command': 'python', 'url': 'https://example.com/mcp'}
+                for kind in ('sse', 'http', 'streamableHttp')
+            ],
+            {'type': 'unknown', 'command': 'python'},
+            {'type': None, 'command': 'python'},
+            {'disabled': 'true', 'command': 'python'},
+            {'disabled': 1, 'command': 'python'},
+            {'disabled': None, 'command': 'python'},
+        ],
+    )
+    def test_invalid_explicit_transport_config(self, tmp_path: Path, server: dict[str, object]):
+        """Invalid explicit choices must fail during loading, before any connection is attempted."""
+        config_path = tmp_path / 'mcp.json'
+        config_path.write_text(json.dumps({'mcpServers': {'alpha': server}}), encoding='utf-8')
+        with pytest.raises(ValueError, match='alpha'):
+            load_mcp_toolsets(config_path)
+
     async def test_loads_toolsets_from_config_without_env(self):
         """Stdio entries without an `env` field also produce valid toolsets."""
         config = {
@@ -1738,12 +1824,20 @@ class TestLoadMCPToolsets:
             toolsets = load_mcp_toolsets(config_path)
         assert len(toolsets) == 1
 
-    async def test_loads_toolsets_from_config_with_prefix(self):
-        config = {
-            'mcpServers': {
-                'alpha': {'command': 'python', 'args': ['-m', 'tests.mcp_server'], 'env': {'FOO': 'bar'}},
-            }
+    @pytest.mark.parametrize('transport_type', [None, 'stdio'])
+    async def test_loads_toolsets_from_config_with_prefix(self, transport_type: str | None):
+        server: dict[str, object] = {
+            'command': 'python',
+            'args': ['-m', 'tests.mcp_server'],
+            'env': {'FOO': 'bar'},
+            'cwd': '.',
         }
+        if transport_type is None:
+            # Legacy configurations with both fields retain command precedence.
+            server['url'] = 'https://example.com/mcp'
+        else:
+            server['type'] = transport_type
+        config = {'mcpServers': {'alpha': server}}
         with TemporaryDirectory() as tmp:
             config_path = Path(tmp) / 'mcp.json'
             config_path.write_text(json.dumps(config), encoding='utf-8')
@@ -1753,18 +1847,29 @@ class TestLoadMCPToolsets:
         # The wrapped toolset is a `PrefixedToolset`, not an `MCPToolset` directly.
         assert isinstance(toolsets[0], PrefixedToolset)
         assert isinstance(toolsets[0].wrapped, MCPToolset)
+        transport = toolsets[0].wrapped.client.transport
+        assert isinstance(transport, StdioTransport)
+        assert transport.command == 'python'
+        assert transport.args == ['-m', 'tests.mcp_server']
+        assert transport.env == {'FOO': 'bar'}
+        assert transport.cwd == '.'
 
     async def test_load_mcp_toolsets_missing_file_raises(self):
         with pytest.raises(FileNotFoundError):
             load_mcp_toolsets('/nonexistent/path/to/config.json')
 
-    async def test_load_mcp_toolsets_http_entry(self):
-        """A URL-configured toolset completes a real Streamable HTTP tool call."""
+    @pytest.mark.parametrize(
+        'transport_type,path', [(None, '/mcp'), ('sse', '/mcp'), ('http', '/sse'), ('streamableHttp', '/sse')]
+    )
+    async def test_load_mcp_toolsets_http_entry(self, transport_type: str | None, path: str):
+        """Explicit transport choices override contradictory URL suffixes in real MCP tool calls."""
+        server_transport = 'sse' if transport_type == 'sse' else 'streamable-http'
         process = await anyio.open_process(
             [
                 sys.executable,
                 '-c',
                 (
+                    'import asyncio\n'
                     'import socket\n'
                     'import uvicorn\n'
                     'from fastmcp import FastMCP\n'
@@ -1773,9 +1878,12 @@ class TestLoadMCPToolsets:
                     "(lambda location: f'The weather in {location} is sunny and 26 degrees Celsius.')\n"
                     "server_socket = socket.create_server(('127.0.0.1', 0))\n"
                     'print(server_socket.getsockname()[1], flush=True)\n'
-                    "uvicorn.run(mcp.http_app(), fd=server_socket.fileno(), lifespan='on', log_level='warning')"
+                    f'app = mcp.http_app(transport={server_transport!r}, path={path!r})\n'
+                    "server = uvicorn.Server(uvicorn.Config(app, lifespan='on', log_level='warning'))\n"
+                    'asyncio.run(server.serve(sockets=[server_socket]))'
                 ),
             ],
+            env={k: v for k, v in os.environ.items() if not k.startswith('COVERAGE_')},
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -1793,11 +1901,10 @@ class TestLoadMCPToolsets:
                 port = int((await process.stdout.receive()).decode().strip())
             except anyio.EndOfStream:  # pragma: no cover
                 raise AssertionError(f'HTTP MCP test server exited during startup: {await read_stderr()}') from None
-            config = {
-                'mcpServers': {
-                    'beta': {'url': f'http://127.0.0.1:{port}/mcp', 'headers': {'X-Key': 'foo'}},
-                }
-            }
+            server: dict[str, object] = {'url': f'http://127.0.0.1:{port}{path}', 'headers': {'X-Key': 'foo'}}
+            if transport_type is not None:
+                server['type'] = transport_type
+            config = {'mcpServers': {'beta': server}}
             with TemporaryDirectory() as tmp:
                 config_path = Path(tmp) / 'mcp.json'
                 config_path.write_text(json.dumps(config), encoding='utf-8')
@@ -1807,7 +1914,8 @@ class TestLoadMCPToolsets:
             assert isinstance(toolsets[0], PrefixedToolset)
             wrapped = toolsets[0].wrapped
             assert isinstance(wrapped, MCPToolset)
-            assert isinstance(wrapped.client.transport, StreamableHttpTransport)
+            transport_class = SSETransport if transport_type == 'sse' else StreamableHttpTransport
+            assert isinstance(wrapped.client.transport, transport_class)
             assert wrapped.client.transport.headers == {'X-Key': 'foo'}
 
             try:


### PR DESCRIPTION
### Why we make these changes
`load_mcp_toolsets` ignored explicit transport choices and loaded disabled servers. This implements the [approved approach in #7796](https://github.com/pydantic/pydantic-ai/issues/7796#issuecomment-5479819539), including rejecting explicit type/shape conflicts.

> [!WARNING]
> **Compatibility impact:** `type` now selects the transport; `disabled: true` skips the entry before environment expansion and transport validation. Unsupported types, conflicting fields, and non-boolean `disabled` values fail during loading.
>
> **Release targeting:** The issue approves this behavior change, but the existing documentation explicitly described these fields as ignored. Please confirm the appropriate release target; the version-policy checkbox is left open.
>
> **Migration:** Use `stdio` with `command` only, or `sse`/`http`/`streamableHttp` with `url` only. Omit `type` to keep legacy inference; omit `disabled` or set it to `false` to load the server.

Release note: MCP configuration loading now honours explicit transport types and skips disabled servers.

### New public surface
None. No public Python API signature changes; compatibility checks against v2.40.0 pass without a waiver.

### User-visible behavior
```diff
 {"mcpServers": {"weather": {"type": "sse", "url": "https://example.com/mcp"}}}
- Streamable HTTP transport inferred from the URL
+ SSE transport selected by the explicit type
```

### Verification
- [Transport selection](https://github.com/tahakotil/pydantic-ai/blob/d56d41079bae96256648b15cba2eb15749adcb70/tests/test_mcp.py#L1739), [disabled entries with a real stdio tool call](https://github.com/tahakotil/pydantic-ai/blob/d56d41079bae96256648b15cba2eb15749adcb70/tests/test_mcp.py#L1759), [invalid combinations](https://github.com/tahakotil/pydantic-ai/blob/d56d41079bae96256648b15cba2eb15749adcb70/tests/test_mcp.py#L1815), and [real SSE/HTTP tool calls overriding URL suffixes](https://github.com/tahakotil/pydantic-ai/blob/d56d41079bae96256648b15cba2eb15749adcb70/tests/test_mcp.py#L1872).
- Windows / Python 3.12: 265 MCP/CLI tests pass; 49 loader tests pass on both FastMCP 3.4.2 and 4.0.0b2. The loader and its new validator have no uncovered lines or branches in the focused coverage run.
- One existing CLI directory-error test is excluded: it expects Linux's `Is a directory` text and fails identically with the unmodified baseline on Windows.
- Repository-wide Ruff lint/format, targeted Pyright, `git diff --check`, and the public API compatibility check pass. The HTTP fixture passes its bound socket directly to Uvicorn so the transport tests can run on Windows.

### What changes for existing users
Enabled entries without `type` keep command precedence and URL-based inference; entries using `type` or `disabled` now follow their declared configuration.

AI disclosure: An AI coding assistant helped implement, review, and test this change.

- Closes #7796

### Checklist
- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
