### PR TITLE
Isolate backend context in `run_sync()` and synchronous streams

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_sync_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/_sync_stream.py
@@ -28,6 +28,8 @@ import anyio
 import anyio.streams.memory
 from typing_extensions import TypeIs, TypeVar, TypeVarTuple, Unpack
 
+from pydantic_graph._utils import get_asyncio_context
+
 from . import _utils
 
 T = TypeVar('T')
@@ -215,7 +217,7 @@ class SyncStreamBridge(Generic[StreamT]):
         caller_context = copy_context()
         entered: asyncio.Future[tuple[StreamT, Context]] = loop.create_future()
         exit_requested: asyncio.Future[_ExitInfo] = loop.create_future()
-        owner_task = loop.create_task(_hold_context_manager(cm, entered, exit_requested))
+        owner_task = get_asyncio_context().run(loop.create_task, _hold_context_manager(cm, entered, exit_requested))
         try:
             stream, run_context = loop.run_until_complete(entered)
         except BaseException:
@@ -244,7 +246,7 @@ class SyncStreamBridge(Generic[StreamT]):
 
     def _task_context(self) -> Context:
         """Merge run-owned context changes into the sync caller's current context."""
-        context = copy_context()
+        context = get_asyncio_context()
         for var in self._run_context:
             value = self._run_context[var]
             if var not in self._caller_context or self._caller_context[var] is not value:

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -6,9 +6,11 @@ import types
 import warnings
 from collections.abc import Awaitable, Generator
 from contextlib import contextmanager, suppress
+from contextvars import Context, copy_context
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, get_args, get_origin
 
 from logfire_api import Logfire, LogfireSpan
+from sniffio import current_async_library_cvar
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
@@ -85,6 +87,13 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
 _T = TypeVar('_T')
 
 
+def get_asyncio_context() -> Context:
+    """Copy caller context with backend detection matching the asyncio task that will use it."""
+    context = copy_context()
+    context.run(current_async_library_cvar.set, 'asyncio')
+    return context
+
+
 def run_until_complete(coro: Awaitable[_T]) -> _T:
     """Run `coro` to completion on the event loop, cleaning up after itself if interrupted.
 
@@ -110,7 +119,7 @@ def run_until_complete(coro: Awaitable[_T]) -> _T:
             'Use the asynchronous method instead, e.g. `await agent.run()` rather than `agent.run_sync()`.'
         )
 
-    task = asyncio.ensure_future(coro, loop=loop)
+    task = get_asyncio_context().run(asyncio.ensure_future, coro, loop=loop)
     try:
         return loop.run_until_complete(task)
     except BaseException:

--- a/pydantic_graph/pyproject.toml
+++ b/pydantic_graph/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "anyio>=4.7.0",
     "logfire-api>=3.14.1",
     "pydantic>=2.12",
+    "sniffio>=1.3.0",
     "typing-inspection>=0.4.0",
 ]
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -5,11 +5,14 @@ import sys
 from collections import defaultdict
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager, nullcontext
+from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, Union
 
+import anyio
 import pytest
+import sniffio
 from dirty_equals import IsJson
 from pydantic import BaseModel, TypeAdapter, field_validator
 from pydantic_core import ErrorDetails, to_json
@@ -236,6 +239,34 @@ def test_run_sync_creates_missing_event_loop(missing_event_loop: asyncio.Abstrac
     assert replacement_loop is not missing_event_loop
     assert not replacement_loop.is_closed()
     assert not asyncio.all_tasks(replacement_loop)
+
+
+@pytest.mark.parametrize('fail', [False, True])
+def test_run_sync_uses_its_own_backend_context(fail: bool) -> None:
+    caller_value: ContextVar[str] = ContextVar('caller_value', default='caller')
+    loops: list[asyncio.AbstractEventLoop] = []
+
+    async def respond(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        assert sniffio.current_async_library() == 'asyncio'
+        assert caller_value.get() == 'caller'
+        caller_value.set('run')
+        loops.append(asyncio.get_running_loop())
+        await anyio.sleep(0)
+        if fail:
+            raise ValueError('model failed')
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(respond))
+    token = sniffio.current_async_library_cvar.set('trio')
+    try:
+        for _ in range(2):
+            with pytest.raises(ValueError, match='model failed') if fail else nullcontext():
+                assert agent.run_sync('Hello').output == 'done'
+            assert sniffio.current_async_library_cvar.get() == 'trio'
+            assert caller_value.get() == 'caller'
+        assert loops[0] is loops[1]
+    finally:
+        sniffio.current_async_library_cvar.reset(token)
 
 
 def test_result_tuple():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1349,7 +1349,8 @@ def test_sync_stream_bridge_pump_propagates_base_exception_without_hanging(error
 
 
 @pytest.mark.parametrize('fail', [False, True])
-def test_run_stream_sync_uses_its_own_backend_context(fail: bool) -> None:
+@pytest.mark.parametrize('initial_backend', ['asyncio', 'trio'])
+def test_run_stream_sync_uses_its_own_backend_context(fail: bool, initial_backend: Literal['asyncio', 'trio']) -> None:
     caller_value: contextvars.ContextVar[str] = contextvars.ContextVar('caller_value', default='caller')
     closed: list[str] = []
 
@@ -1368,13 +1369,18 @@ def test_run_stream_sync_uses_its_own_backend_context(fail: bool) -> None:
             closed.append(sniffio.current_async_library())
 
     agent = Agent(FunctionModel(stream_function=stream_function))
-    token = sniffio.current_async_library_cvar.set('trio')
+    token = sniffio.current_async_library_cvar.set(initial_backend)
     try:
         with pytest.raises(ValueError, match='stream failed') if fail else nullcontext():
             with agent.run_stream_sync('Hello') as result:
-                assert sniffio.current_async_library_cvar.get() == 'trio'
-                assert list(result.stream_text(debounce_by=None)) == ['hello ', 'hello world']
-        assert sniffio.current_async_library_cvar.get() == 'trio'
+                assert sniffio.current_async_library_cvar.get() == initial_backend
+                consumption_token = sniffio.current_async_library_cvar.set('trio')
+                try:
+                    assert list(result.stream_text(debounce_by=None)) == ['hello ', 'hello world']
+                finally:
+                    assert sniffio.current_async_library_cvar.get() == 'trio'
+                    sniffio.current_async_library_cvar.reset(consumption_token)
+        assert sniffio.current_async_library_cvar.get() == initial_backend
         assert caller_value.get() == 'caller'
         assert closed == ['asyncio']
     finally:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -11,7 +11,7 @@ import threading
 import warnings
 import weakref
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable, Generator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import datetime as _datetime, timezone
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 import anyio
 import httpx2
 import pytest
+import sniffio
 from pydantic import BaseModel
 from pydantic_core import ErrorDetails
 
@@ -1345,6 +1346,39 @@ def test_sync_stream_bridge_pump_propagates_base_exception_without_hanging(error
         assert loop.run_until_complete(asyncio.sleep(0)) is None
     finally:
         stop_handle.cancel()
+
+
+@pytest.mark.parametrize('fail', [False, True])
+def test_run_stream_sync_uses_its_own_backend_context(fail: bool) -> None:
+    caller_value: contextvars.ContextVar[str] = contextvars.ContextVar('caller_value', default='caller')
+    closed: list[str] = []
+
+    async def stream_function(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        assert sniffio.current_async_library() == 'asyncio'
+        assert caller_value.get() == 'caller'
+        caller_value.set('run')
+        try:
+            await anyio.sleep(0)
+            yield 'hello '
+            await anyio.sleep(0)
+            if fail:
+                raise ValueError('stream failed')
+            yield 'world'
+        finally:
+            closed.append(sniffio.current_async_library())
+
+    agent = Agent(FunctionModel(stream_function=stream_function))
+    token = sniffio.current_async_library_cvar.set('trio')
+    try:
+        with pytest.raises(ValueError, match='stream failed') if fail else nullcontext():
+            with agent.run_stream_sync('Hello') as result:
+                assert sniffio.current_async_library_cvar.get() == 'trio'
+                assert list(result.stream_text(debounce_by=None)) == ['hello ', 'hello world']
+        assert sniffio.current_async_library_cvar.get() == 'trio'
+        assert caller_value.get() == 'caller'
+        assert closed == ['asyncio']
+    finally:
+        sniffio.current_async_library_cvar.reset(token)
 
 
 def test_run_stream_sync_preserves_capability_contextvars():

--- a/uv.lock
+++ b/uv.lock
@@ -5882,6 +5882,7 @@ dependencies = [
     { name = "anyio" },
     { name = "logfire-api" },
     { name = "pydantic" },
+    { name = "sniffio" },
     { name = "typing-inspection" },
 ]
 
@@ -5890,6 +5891,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.7.0" },
     { name = "logfire-api", specifier = ">=3.14.1" },
     { name = "pydantic", specifier = ">=2.12" },
+    { name = "sniffio", specifier = ">=1.3.0" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 


### PR DESCRIPTION
Stacked on [#8171](https://github.com/pydantic/pydantic-ai/pull/8171), as part of [issue #7112](https://github.com/pydantic/pydantic-ai/issues/7112).

Synchronous agent calls and streams can inherit a Trio backend marker from the AnyIO pytest runner while executing on an asyncio loop. Copy the caller's context and set the asyncio marker when creating the sync runner's tasks. Preserve the caller-owned loop required for pooled-client compatibility in [#6454](https://github.com/pydantic/pydantic-ai/pull/6454).

The base branch mirrors the parent PR head. Retarget this PR to `main` after the parent merges.

### New public surface

None.

### User-visible behavior

This opt-in command previously failed in synchronous agent calls and streams; it now passes:

```sh
uv run pytest tests/test_agent.py::test_result_tuple tests/test_direct.py --anyio-backend=trio --record-mode=none
```

Async `Agent.run()` under Trio still needs the separate orchestration migration. Ordinary CI continues to use asyncio; the new regression tests reproduce an inherited context marker without starting a Trio runner.

### Verification

- Six [sync-call](https://github.com/pydantic/pydantic-ai/pull/8173/files#diff-359c72157a993d9c94d8e17fd4591e8403abcfbe4b87507bfba7958e4edf8f7aR244) and [streaming](https://github.com/pydantic/pydantic-ai/pull/8173/files#diff-d960bb61fde148c9fabda1375f3cb82be40ccc75ac1260cb4353d26cfcedb5d1R1351) regression cases cover caller-context preservation, loop reuse, backend-marker changes between stream construction and consumption, cleanup, and propagated model errors. The failures were reproduced before the relevant task-context changes.
- Opt-in Trio checks: 24 passed. Asyncio compatibility checks: 265 passed, 3 expected failures.

### What changes for existing users

Public signatures, caller-owned loops, and other context variables stay unchanged. `pydantic-graph` declares `sniffio>=1.3.0` to use its backend context variable; [AnyIO 4.12 removed it as a dependency](https://anyio.readthedocs.io/en/stable/versionhistory.html).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
