### PR TITLE
Add AI Token King provider

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -64,6 +64,8 @@
 
 ::: pydantic_ai.providers.ovhcloud.OVHcloudProvider
 
+::: pydantic_ai.providers.aitokenking.AITokenKingProvider
+
 ::: pydantic_ai.providers.crusoe.CrusoeProvider
 
 ::: pydantic_ai.providers.alibaba.AlibabaProvider

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -1057,6 +1057,45 @@ print(result.output)
 #> The capital of France is Paris.
 ```
 
+### AI Token King
+
+[AI Token King](https://aitokenking.com.tw) is an OpenAI-compatible gateway that serves models from several
+labs behind a single API key. Create a key in the platform console, then set the `AITOKENKING_API_KEY`
+environment variable and use [`AITokenKingProvider`][pydantic_ai.providers.aitokenking.AITokenKingProvider]
+by name:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('aitokenking:gpt-5.6-terra')
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+#> The capital of France is Paris.
+```
+
+If you need to configure the provider, you can use the
+[`AITokenKingProvider`][pydantic_ai.providers.aitokenking.AITokenKingProvider] class:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.aitokenking import AITokenKingProvider
+
+model = OpenAIChatModel(
+    'gpt-5.6-terra',
+    provider=AITokenKingProvider(api_key='your-api-key'),
+)
+agent = Agent(model)
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+#> The capital of France is Paris.
+```
+
+Model ids are passed through to the gateway unchanged. The provider maps each model family it
+recognises (`claude-`, `deepseek-`, `gemini-`, `glm-`, `gpt-`, `kimi-`, `qwen`) onto the matching
+Pydantic AI model profile; families without an upstream profile fall back to the OpenAI-compatible
+defaults.
+
 ### OVHcloud AI Endpoints
 
 To use OVHcloud AI Endpoints, you need to create a new API key. To do so, go to the [OVHcloud manager](https://ovh.com/manager), then in Public Cloud > AI Endpoints > API keys. Click on `Create a new API key` and copy your new key.

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -21,6 +21,7 @@ Pydantic AI is model-agnostic and has built-in support for multiple model provid
 
 In addition, many providers are compatible with the OpenAI API, and can be used with `OpenAIChatModel` in Pydantic AI:
 
+- [AI Token King](openai.md#ai-token-king)
 - [Alibaba Cloud Model Studio (DashScope)](openai.md#alibaba-cloud-model-studio-dashscope)
 - [Azure AI Foundry](openai.md#azure-ai-foundry)
 - [DeepSeek](openai.md#deepseek)

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -186,7 +186,7 @@ Need deterministic, fast tests?
 | Snowflake Cortex | `snowflake:` | `snowflake:claude-sonnet-4-6` |
 | Crusoe | `crusoe:` | `crusoe:zai/GLM-5.2` |
 
-**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `moonshotai:`. For any other OpenAI-compatible endpoint, point `OpenAIChatModel` at it with `provider=OpenAIProvider(base_url=..., api_key=...)`. For anything that isn't OpenAI-compatible, subclass `Model`.
+**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `moonshotai:`, `aitokenking:`. For any other OpenAI-compatible endpoint, point `OpenAIChatModel` at it with `provider=OpenAIProvider(base_url=..., api_key=...)`. For anything that isn't OpenAI-compatible, subclass `Model`.
 
 ### Tool Decorator Comparison
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -123,6 +123,7 @@ def known_model_names() -> tuple[str, ...]:
 OpenAIChatCompatibleProvider = TypeAliasType(
     'OpenAIChatCompatibleProvider',
     Literal[
+        'aitokenking',
         'alibaba',
         'azure',
         'cerebras',

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -257,6 +257,10 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .ovhcloud import OVHcloudProvider
 
         return OVHcloudProvider
+    elif provider == 'aitokenking':
+        from .aitokenking import AITokenKingProvider
+
+        return AITokenKingProvider
     elif provider == 'alibaba':
         from .alibaba import AlibabaProvider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/aitokenking.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/aitokenking.py
@@ -1,0 +1,109 @@
+from __future__ import annotations as _annotations
+
+import os
+from typing import overload
+
+from pydantic_ai import ModelProfile
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles import merge_profile
+from pydantic_ai.profiles.anthropic import anthropic_model_profile
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import google_model_profile
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
+from pydantic_ai.profiles.qwen import qwen_model_profile
+from pydantic_ai.profiles.zai import zai_model_profile
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:
+    raise ImportError(
+        'Please install the `openai` package to use the AI Token King provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+else:
+    from ._openai_compatible import (
+        AsyncHTTPClient as _OpenAIHTTPClient,
+        OpenAICompatibleProvider as _OpenAICompatibleProvider,
+    )
+
+
+class AITokenKingProvider(_OpenAICompatibleProvider):
+    """Provider for the AI Token King gateway."""
+
+    @property
+    def name(self) -> str:
+        return 'aitokenking'
+
+    @property
+    def base_url(self) -> str:
+        return 'https://api.aitokenking.com.tw/api/v1'
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    @staticmethod
+    def model_profile(model_name: str) -> ModelProfile | None:
+        model_name = model_name.lower()
+
+        prefix_to_profile = {
+            'claude-': anthropic_model_profile,
+            'deepseek-': deepseek_model_profile,
+            'gemini-': google_model_profile,
+            'glm-': zai_model_profile,
+            'gpt-': openai_model_profile,
+            'kimi-': moonshotai_model_profile,
+            'qwen': qwen_model_profile,
+        }
+
+        profile = None
+        for prefix, profile_func in prefix_to_profile.items():
+            if model_name.startswith(prefix):
+                profile = profile_func(model_name)
+                break
+
+        # Model families the gateway serves that have no upstream profile in Pydantic AI (for example
+        # MiniMax and Seed) fall through with `profile is None` and get the OpenAI-compatible defaults.
+        # As `AITokenKingProvider` is always used with `OpenAIChatModel`, which used to unconditionally use
+        # `OpenAIJsonSchemaTransformer`, we keep that as the base and let the family profile win on top.
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str, http_client: _OpenAIHTTPClient) -> None: ...
+
+    @overload
+    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: _OpenAIHTTPClient | None = None,
+    ) -> None:
+        """Create a new AI Token King provider.
+
+        Args:
+            api_key: The API key to use for authentication, if not provided, the `AITOKENKING_API_KEY` environment
+                variable will be used if available.
+            openai_client: An existing `AsyncOpenAI` client to use. If provided, `api_key` and `http_client` must be `None`.
+            http_client: An existing `httpx2.AsyncClient` or legacy `httpx.AsyncClient` to use for making HTTP requests.
+        """
+        api_key = api_key or os.getenv('AITOKENKING_API_KEY')
+        if not api_key and openai_client is None:
+            raise UserError(
+                'Set the `AITOKENKING_API_KEY` environment variable or pass it via '
+                '`AITokenKingProvider(api_key=...)` to use the AI Token King provider.'
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+        else:
+            self._client = self._create_openai_client(base_url=self.base_url, api_key=api_key, http_client=http_client)

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -1636,6 +1636,26 @@ def test_ovhcloud_llama():
     assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
 
 
+def test_aitokenking_qwen():
+    from pydantic_ai.providers.aitokenking import AITokenKingProvider
+
+    profile = AITokenKingProvider.model_profile('qwen3.8-max')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'ignore_streamed_leading_whitespace': True,
+        }
+    )
+
+
+def test_aitokenking_unknown_family():
+    """Families the gateway serves that have no upstream profile still get the OpenAI-compatible base."""
+    from pydantic_ai.providers.aitokenking import AITokenKingProvider
+
+    profile = AITokenKingProvider.model_profile('minimax-m3')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': OpenAIJsonSchemaTransformer})
+
+
 def test_alibaba_qwen():
     from pydantic_ai.providers.alibaba import AlibabaProvider
 

--- a/tests/providers/test_aitokenking.py
+++ b/tests/providers/test_aitokenking.py
@@ -1,0 +1,122 @@
+import re
+
+import httpx2
+import pytest
+from pytest_mock import MockerFixture
+
+from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles.anthropic import anthropic_model_profile
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import google_model_profile
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
+from pydantic_ai.profiles.qwen import qwen_model_profile
+from pydantic_ai.profiles.zai import zai_model_profile
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    import openai
+
+    from pydantic_ai.providers.aitokenking import AITokenKingProvider
+
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
+    pytest.mark.vcr,
+    pytest.mark.anyio,
+]
+
+
+def test_aitokenking_provider():
+    provider = AITokenKingProvider(api_key='your-api-key')
+    assert provider.name == 'aitokenking'
+    assert provider.base_url == 'https://api.aitokenking.com.tw/api/v1'
+    assert isinstance(provider.client, openai.AsyncOpenAI)
+    assert provider.client.api_key == 'your-api-key'
+
+
+def test_aitokenking_provider_need_api_key(env: TestEnv) -> None:
+    env.remove('AITOKENKING_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'Set the `AITOKENKING_API_KEY` environment variable or pass it via '
+            '`AITokenKingProvider(api_key=...)` to use the AI Token King provider.'
+        ),
+    ):
+        AITokenKingProvider()
+
+
+def test_aitokenking_pass_openai_client() -> None:
+    openai_client = openai.AsyncOpenAI(api_key='your-api-key')
+    provider = AITokenKingProvider(openai_client=openai_client)
+    assert provider.client == openai_client
+
+
+def test_aitokenking_pass_http_client():
+    http_client = httpx2.AsyncClient()
+    provider = AITokenKingProvider(api_key='your-api-key', http_client=http_client)
+    assert isinstance(provider.client, openai.AsyncOpenAI)
+    assert provider.client.api_key == 'your-api-key'
+
+
+def test_aitokenking_model_profile(mocker: MockerFixture):
+    provider = AITokenKingProvider(api_key='your-api-key')
+
+    ns = 'pydantic_ai.providers.aitokenking'
+
+    anthropic_mock = mocker.patch(f'{ns}.anthropic_model_profile', wraps=anthropic_model_profile)
+    deepseek_mock = mocker.patch(f'{ns}.deepseek_model_profile', wraps=deepseek_model_profile)
+    google_mock = mocker.patch(f'{ns}.google_model_profile', wraps=google_model_profile)
+    moonshotai_mock = mocker.patch(f'{ns}.moonshotai_model_profile', wraps=moonshotai_model_profile)
+    openai_mock = mocker.patch(f'{ns}.openai_model_profile', wraps=openai_model_profile)
+    qwen_mock = mocker.patch(f'{ns}.qwen_model_profile', wraps=qwen_model_profile)
+    zai_mock = mocker.patch(f'{ns}.zai_model_profile', wraps=zai_model_profile)
+
+    profile = provider.model_profile('claude-opus-5')
+    anthropic_mock.assert_called_with('claude-opus-5')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    profile = provider.model_profile('deepseek-v3.2')
+    deepseek_mock.assert_called_with('deepseek-v3.2')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    profile = provider.model_profile('gemini-3.1-pro-preview')
+    google_mock.assert_called_with('gemini-3.1-pro-preview')
+    assert profile is not None
+
+    profile = provider.model_profile('kimi-k2.7-code')
+    moonshotai_mock.assert_called_with('kimi-k2.7-code')
+    assert profile is not None
+
+    profile = provider.model_profile('gpt-5.6-terra')
+    openai_mock.assert_called_with('gpt-5.6-terra')
+    assert profile is not None
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    qwen_profile = provider.model_profile('qwen3.8-max')
+    qwen_mock.assert_called_with('qwen3.8-max')
+    assert qwen_profile is not None
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+
+    profile = provider.model_profile('glm-5.3')
+    zai_mock.assert_called_with('glm-5.3')
+    assert profile is not None
+
+    # The model name is lower-cased before the prefix match, so a mixed-case id still resolves.
+    provider.model_profile('Claude-Opus-5')
+    anthropic_mock.assert_called_with('claude-opus-5')
+
+    # Families the gateway serves that Pydantic AI has no profile for (MiniMax, Seed) must still return
+    # a usable OpenAI-compatible profile rather than `None`.
+    minimax_profile = provider.model_profile('minimax-m3')
+    assert minimax_profile is not None
+    assert minimax_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    unknown_profile = provider.model_profile('unknown-model')
+    assert unknown_profile is not None
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_openai_compatible_http_clients.py
+++ b/tests/providers/test_openai_compatible_http_clients.py
@@ -20,6 +20,7 @@ with try_import() as imports_successful:
     from openai import AsyncOpenAI
 
     from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
+    from pydantic_ai.providers.aitokenking import AITokenKingProvider
     from pydantic_ai.providers.alibaba import AlibabaProvider
     from pydantic_ai.providers.azure import AzureProvider
     from pydantic_ai.providers.bedrock_mantle import BedrockMantleProvider
@@ -57,6 +58,11 @@ class Case:
 
 
 CASES = [
+    Case(
+        'aitokenking',
+        lambda: AITokenKingProvider(api_key='test'),
+        lambda http_client: AITokenKingProvider(api_key='test', http_client=http_client),
+    ),
     Case(
         'alibaba',
         lambda: AlibabaProvider(api_key='test'),
@@ -176,6 +182,7 @@ CASES = [
 ]
 
 IMPORT_GUARD_CASES = [
+    ('aitokenking', 'use the AI Token King provider'),
     ('alibaba', 'use the Alibaba provider'),
     ('azure', 'use the Azure provider'),
     ('bedrock_mantle', 'use the Bedrock Mantle provider'),

--- a/tests/providers/test_provider_names.py
+++ b/tests/providers/test_provider_names.py
@@ -15,6 +15,7 @@ with try_import() as imports_successful:
     from google.auth.exceptions import DefaultCredentialsError, GoogleAuthError
     from openai import OpenAIError
 
+    from pydantic_ai.providers.aitokenking import AITokenKingProvider
     from pydantic_ai.providers.anthropic import AnthropicProvider
     from pydantic_ai.providers.azure import AzureProvider
     from pydantic_ai.providers.bedrock import BedrockProvider
@@ -66,6 +67,7 @@ with try_import() as imports_successful:
         ('crusoe', CrusoeProvider, 'CRUSOE_API_KEY'),
         ('nebius', NebiusProvider, 'NEBIUS_API_KEY'),
         ('ovhcloud', OVHcloudProvider, 'OVHCLOUD_API_KEY'),
+        ('aitokenking', AITokenKingProvider, 'AITOKENKING_API_KEY'),
         ('snowflake', SnowflakeProvider, 'SNOWFLAKE_ACCOUNT'),
         ('gateway/chat', OpenAIProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('gateway/groq', GroqProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -100,6 +100,7 @@ from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDef
 from pydantic_graph import End
 
 if TYPE_CHECKING:
+    from pydantic_ai.providers.aitokenking import AITokenKingProvider
     from pydantic_ai.providers.alibaba import AlibabaProvider
     from pydantic_ai.providers.anthropic import AnthropicProvider
     from pydantic_ai.providers.azure import AzureProvider
@@ -126,6 +127,7 @@ if TYPE_CHECKING:
     from pydantic_ai.providers.vllm import VLLMProvider
 else:
     try:
+        from pydantic_ai.providers.aitokenking import AITokenKingProvider
         from pydantic_ai.providers.alibaba import AlibabaProvider
         from pydantic_ai.providers.azure import AzureProvider
         from pydantic_ai.providers.cerebras import CerebrasProvider
@@ -149,7 +151,7 @@ else:
         CrusoeProvider = FireworksProvider = GitHubProvider = HerokuProvider = None
         MoonshotAIProvider = NebiusProvider = OllamaProvider = OpenAIProvider = None
         OpenRouterProvider = OVHcloudProvider = SambaNovaProvider = None
-        TogetherProvider = VercelProvider = VLLMProvider = None
+        TogetherProvider = VercelProvider = VLLMProvider = AITokenKingProvider = None
 
     try:
         from pydantic_ai.providers.anthropic import AnthropicProvider
@@ -9149,6 +9151,7 @@ async def test_azure_provider_lifecycle_closes_client():
         pytest.param(lambda: TogetherProvider(api_key='t'), marks=[requires_openai], id='together'),
         pytest.param(lambda: VercelProvider(api_key='t'), marks=[requires_openai], id='vercel'),
         pytest.param(lambda: AlibabaProvider(api_key='t'), marks=[requires_openai], id='alibaba'),
+        pytest.param(lambda: AITokenKingProvider(api_key='t'), marks=[requires_openai], id='aitokenking'),
         pytest.param(lambda: VLLMProvider(base_url='http://localhost:8000/v1'), marks=[requires_openai], id='vllm'),
     ],
 )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -308,6 +308,7 @@ def test_docs_examples(
     env.set('MOONSHOTAI_API_KEY', 'testing')
     env.set('DEEPSEEK_API_KEY', 'testing')
     env.set('OVHCLOUD_API_KEY', 'testing')
+    env.set('AITOKENKING_API_KEY', 'testing')
     env.set('ALIBABA_API_KEY', 'testing')
     env.set('SAMBANOVA_API_KEY', 'testing')
     env.set('PYDANTIC_AI_GATEWAY_API_KEY', 'testing')


### PR DESCRIPTION
AI Token King (https://aitokenking.com.tw) is an OpenAI-compatible gateway that serves models from several labs behind a single API key.

`AITokenKingProvider` follows the `OVHcloudProvider` shape: an `OpenAICompatibleProvider` subclass with a constant base URL, an `AITOKENKING_API_KEY` environment variable, and a prefix-based model profile map. Model ids are passed through unchanged, so `claude-`, `deepseek-`, `gemini-`, `glm-`, `gpt-`, `kimi-` and `qwen` resolve to the matching Pydantic AI family profile; families with no upstream profile (MiniMax, Seed) fall back to the OpenAI-compatible defaults rather than returning `None`.

No new optional dependency group: the provider rides the existing `openai` extra, so `.github/scripts/check_http_dependencies.py` is unchanged.

Tests: unit tests for the provider, entries in the shared provider-name, HTTP-client and agent-reentry suites, and two profile-resolution cases (one family with a profile, one without).

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://pydantic.dev/docs/ai/project/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- For a version-policy-permitted compatibility impact, add the `compatibility impact` label -->
<!-- and place this warning immediately after the PR's opening explanation: -->
<!-- > [!WARNING] -->
<!-- > **Compatibility impact:** Existing code that ... may ... -->
<!-- > -->
<!-- > **Why this can ship in a minor release:** ... -->
<!-- > -->
<!-- > **Migration:** ... -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#when-do-you-need-the-harness -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

