### PR TITLE
Stop `pyright` solving a `TypeVar` in the deprecated `fallback_model` helper

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/_deprecated_fallback_model.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_deprecated_fallback_model.py
@@ -20,29 +20,26 @@ from pydantic_ai.exceptions import UserError
 def check_deprecated_fallback_model(
     cls_name: str,
     *,
-    # Keyword-only so the two can't be swapped by position, which would make the new name warn
-    # and the deprecated one win.
-    fallback_subagent_model: object,
-    fallback_model: object,
+    # Keyword-only: two booleans swapped by position would make the new name warn and the
+    # deprecated one win, with nothing for a type checker to catch.
+    fallback_subagent_model_passed: bool,
+    fallback_model_passed: bool,
 ) -> None:
     """Warn on the deprecated `fallback_model` argument and refuse when both spellings are passed.
 
-    Does nothing when `fallback_model` is omitted (`None`). When it is passed, emits a
-    [`PydanticAIDeprecationWarning`][pydantic_ai.exceptions.PydanticAIDeprecationWarning]; passing
-    both refuses rather than picking one silently. The exception depends on the entry path: direct
-    construction raises [`UserError`][pydantic_ai.exceptions.UserError], while through
+    Takes only whether each argument was supplied, not the values: the caller keeps the value it
+    wants (`fallback_model if fallback_model is not None else fallback_subagent_model`) and this
+    only decides whether to warn or raise. Does nothing when `fallback_model` is omitted. When it is
+    passed, emits a [`PydanticAIDeprecationWarning`][pydantic_ai.exceptions.PydanticAIDeprecationWarning];
+    passing both refuses rather than picking one silently. The exception depends on the entry path:
+    direct construction raises [`UserError`][pydantic_ai.exceptions.UserError], while through
     [`Agent.from_spec`][pydantic_ai.agent.Agent.from_spec] the same refusal surfaces as a
     `ValueError` carrying that `UserError` as its `__cause__`, because `_spec.load_from_registry`
     wraps every capability-constructor error.
-
-    The caller picks the value itself (`fallback_model if fallback_model is not None else
-    fallback_subagent_model`). This deliberately takes `object` rather than a `TypeVar`: solving a
-    type variable from two arguments of the callers' large `Model | KnownModelName | str | Callable
-    | None` union cost pyright ~100s per call site and doubled the CI type check.
     """
-    if fallback_model is None:
+    if not fallback_model_passed:
         return
-    if fallback_subagent_model is not None:
+    if fallback_subagent_model_passed:
         raise UserError(
             f'{cls_name}: cannot specify both `fallback_model` and `fallback_subagent_model` — '
             '`fallback_model` is the deprecated spelling of `fallback_subagent_model`, so pass only the latter'

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_deprecated_fallback_model.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_deprecated_fallback_model.py
@@ -12,35 +12,36 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from typing import TypeVar
 
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.exceptions import UserError
 
-FallbackSubagentModelT = TypeVar('FallbackSubagentModelT')
 
-
-def resolve_fallback_subagent_model(
+def check_deprecated_fallback_model(
     cls_name: str,
     *,
-    # Keyword-only because the two share a type variable, so swapping them would make the new name
-    # warn and the deprecated one win, with nothing for a type checker to catch.
-    fallback_subagent_model: FallbackSubagentModelT,
-    fallback_model: FallbackSubagentModelT,
-) -> FallbackSubagentModelT:
-    """Map the deprecated `fallback_model` argument onto `fallback_subagent_model`.
+    # Keyword-only so the two can't be swapped by position, which would make the new name warn
+    # and the deprecated one win.
+    fallback_subagent_model: object,
+    fallback_model: object,
+) -> None:
+    """Warn on the deprecated `fallback_model` argument and refuse when both spellings are passed.
 
-    Returns `fallback_subagent_model` unchanged when `fallback_model` is omitted (`None`). When
-    `fallback_model` is passed, emits a
-    [`PydanticAIDeprecationWarning`][pydantic_ai.exceptions.PydanticAIDeprecationWarning] and returns
-    its value; passing both refuses rather than picking one silently. The exception depends on the
-    entry path: direct construction raises [`UserError`][pydantic_ai.exceptions.UserError], while
-    through [`Agent.from_spec`][pydantic_ai.agent.Agent.from_spec] the same refusal surfaces
-    as a `ValueError` carrying that `UserError` as its `__cause__`, because `_spec.load_from_registry`
+    Does nothing when `fallback_model` is omitted (`None`). When it is passed, emits a
+    [`PydanticAIDeprecationWarning`][pydantic_ai.exceptions.PydanticAIDeprecationWarning]; passing
+    both refuses rather than picking one silently. The exception depends on the entry path: direct
+    construction raises [`UserError`][pydantic_ai.exceptions.UserError], while through
+    [`Agent.from_spec`][pydantic_ai.agent.Agent.from_spec] the same refusal surfaces as a
+    `ValueError` carrying that `UserError` as its `__cause__`, because `_spec.load_from_registry`
     wraps every capability-constructor error.
+
+    The caller picks the value itself (`fallback_model if fallback_model is not None else
+    fallback_subagent_model`). This deliberately takes `object` rather than a `TypeVar`: solving a
+    type variable from two arguments of the callers' large `Model | KnownModelName | str | Callable
+    | None` union cost pyright ~100s per call site and doubled the CI type check.
     """
     if fallback_model is None:
-        return fallback_subagent_model
+        return
     if fallback_subagent_model is not None:
         raise UserError(
             f'{cls_name}: cannot specify both `fallback_model` and `fallback_subagent_model` — '
@@ -59,4 +60,3 @@ def resolve_fallback_subagent_model(
         PydanticAIDeprecationWarning,
         stacklevel=stacklevel,
     )
-    return fallback_model

--- a/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
@@ -159,8 +159,8 @@ class ImageGeneration(NativeOrLocalTool[AgentDepsT]):
         self.local = local
         check_deprecated_fallback_model(
             type(self).__name__,
-            fallback_subagent_model=fallback_subagent_model,
-            fallback_model=fallback_model,
+            fallback_subagent_model_passed=fallback_subagent_model is not None,
+            fallback_model_passed=fallback_model is not None,
         )
         self.fallback_subagent_model = fallback_model if fallback_model is not None else fallback_subagent_model
         self.action = action

--- a/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
@@ -13,7 +13,7 @@ from pydantic_ai.native_tools import ImageAspectRatio, ImageGenerationModelName,
 from pydantic_ai.tools import AgentDepsT, RunContext, Tool
 from pydantic_ai.toolsets import AbstractToolset
 
-from ._deprecated_fallback_model import resolve_fallback_subagent_model
+from ._deprecated_fallback_model import check_deprecated_fallback_model
 from .native_or_local import NativeOrLocalTool
 
 if TYPE_CHECKING:
@@ -157,11 +157,12 @@ class ImageGeneration(NativeOrLocalTool[AgentDepsT]):
         self.defer_loading = defer_loading
         self.native = native
         self.local = local
-        self.fallback_subagent_model = resolve_fallback_subagent_model(
+        check_deprecated_fallback_model(
             type(self).__name__,
             fallback_subagent_model=fallback_subagent_model,
             fallback_model=fallback_model,
         )
+        self.fallback_subagent_model = fallback_model if fallback_model is not None else fallback_subagent_model
         self.action = action
         self.background = background
         self.input_fidelity = input_fidelity

--- a/pydantic_ai_slim/pydantic_ai/capabilities/x_search.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/x_search.py
@@ -121,8 +121,8 @@ class XSearch(NativeOrLocalTool[AgentDepsT]):
         self.local = local
         check_deprecated_fallback_model(
             type(self).__name__,
-            fallback_subagent_model=fallback_subagent_model,
-            fallback_model=fallback_model,
+            fallback_subagent_model_passed=fallback_subagent_model is not None,
+            fallback_model_passed=fallback_model is not None,
         )
         self.fallback_subagent_model = fallback_model if fallback_model is not None else fallback_subagent_model
         self.allowed_x_handles = allowed_x_handles

--- a/pydantic_ai_slim/pydantic_ai/capabilities/x_search.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/x_search.py
@@ -14,7 +14,7 @@ from pydantic_ai.native_tools import XSearchTool
 from pydantic_ai.tools import AgentDepsT, RunContext, Tool
 from pydantic_ai.toolsets import AbstractToolset
 
-from ._deprecated_fallback_model import resolve_fallback_subagent_model
+from ._deprecated_fallback_model import check_deprecated_fallback_model
 from .native_or_local import NativeOrLocalTool
 
 if TYPE_CHECKING:
@@ -119,11 +119,12 @@ class XSearch(NativeOrLocalTool[AgentDepsT]):
         self.defer_loading = defer_loading
         self.native = native
         self.local = local
-        self.fallback_subagent_model = resolve_fallback_subagent_model(
+        check_deprecated_fallback_model(
             type(self).__name__,
             fallback_subagent_model=fallback_subagent_model,
             fallback_model=fallback_model,
         )
+        self.fallback_subagent_model = fallback_model if fallback_model is not None else fallback_subagent_model
         self.allowed_x_handles = allowed_x_handles
         self.excluded_x_handles = excluded_x_handles
         self.from_date = from_date


### PR DESCRIPTION
Fixes the [Main CI duration regression alert](https://logfire-eu.pydantic.info/logfire/pydantic-ai/alerts/b84a3323-8ba4-46d3-aadb-9a3abcad2562?alertRunId=1090e0a2-ba9c-4cbc-9f83-79c750b5f34a) that fired on 2026-09-07 (median run on `main` went from ~325s to ~513s).

### What caused the regression

#8077 added a tiny helper, `resolve_fallback_subagent_model`, to map the deprecated `fallback_model` argument onto `fallback_subagent_model`. It typed both arguments and its return with a single bare `TypeVar`. Its two callers, `ImageGeneration.__init__` and `XSearch.__init__`, pass it two arguments of the large `Model | KnownModelName | str | Callable[...] | None` union, and pyright takes roughly 100 seconds **per call site** to solve that type variable.

That's the whole regression. Nothing else changed: same runner image, same pyright 1.1.411, same command. Every test job, coverage, mypy and every other pre-commit hook stayed flat.

| | before #8077 | after #8077 |
|---|---|---|
| pyright check phase (local) | 36s | 360s |
| `typecheck` pre-commit hook in CI | 76s | 330–490s |
| `quality checks` job in CI | ~220s | ~500s |
| whole CI run on `main` | ~310s | ~550s |

The `quality checks` job is the last thing the final `check` gate waits on, so its growth lands 1:1 on the total.

Two notes for context:

- The slowdown was already visible on #8077's own PR run on 2026-09-05 (pre-commit step: 472s vs 124s on `main` that day), so a per-hook time budget on the `typecheck` hook would have caught it before merge.
- #8075 measured its `--threads` numbers on the evening of 2026-09-06, on top of this regression, so its 475–636s figures reflect #8077 rather than the threads flag.

### The fix

The helper is now `check_deprecated_fallback_model`. It takes only whether each argument was passed (two booleans) and decides whether to warn or raise; it never sees the values. Each caller keeps the value with a plain `fallback_model if fallback_model is not None else fallback_subagent_model`, so the attribute assignment is typed directly from the `__init__` parameters and there is nothing for pyright to solve.

Runtime behavior is unchanged: the deprecation warning, the both-arguments `UserError`, and the `stacklevel` attribution all work as before.

Verified locally on this branch: full `pyright` back to **35s** with 0 errors, the four test files #8077 touched pass (392 tests), pre-commit clean.

I bisected the mechanism before settling on this: typing the helper with `Any` also fixes it (0.1s), removing the `KnownModelName` literals from the callers does not (94s), and removing the `Callable` member only partly (63s). So it's the type-variable solve against the union, not the size of the literal union.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KYQXPNPDYPczakELNju21
