### PR TITLE
Document per-provider behavior for refusals and `content_filter` finish reasons

### DIFF
--- a/docs/capabilities/raise-content-filter-error.md
+++ b/docs/capabilities/raise-content-filter-error.md
@@ -35,13 +35,13 @@ By default, Pydantic AI only raises [`ContentFilterError`][pydantic_ai.exception
 
 ## Per-provider behavior {#per-provider-behavior}
 
-Whether a refusal arrives as an error or as ordinary output therefore depends on whether the adapter keeps the provider's text. The adapters differ:
+Whether a refusal arrives as an error or as ordinary output therefore depends on whether the response ends up with any text: the OpenAI adapters drop the parts, while the Anthropic and Google adapters keep whatever text the provider sent, and an empty `content_filter` response raises for every provider. The adapters differ:
 
 | Provider | Refusal / safety wire event | Adapter behavior | Default outcome |
 |---|---|---|---|
 | OpenAI (Chat Completions, streaming and not) | `choice.message.refusal` / refusal delta | Response parts are emptied, `finish_reason='content_filter'` is set, the refusal string is kept in `provider_details['refusal']` | Response is empty, so [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
 | OpenAI Responses | refusal output item | Same as above | [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
-| Anthropic | `stop_reason='refusal'` | `finish_reason='content_filter'` is set and the stop explanation is kept in `provider_details['refusal']`, but the text block is preserved as a part | Refusal text is returned as ordinary output, no error |
-| Google | Safety-family `finishReason` values (`SAFETY`, `RECITATION`, `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `MODEL_ARMOR`) | `finish_reason='content_filter'` is set, but any text parts are preserved | Refusal text is returned as ordinary output, no error |
+| Anthropic | `stop_reason='refusal'` | `finish_reason='content_filter'` is set and the stop explanation is kept in `provider_details['refusal']`, but any text block is preserved as a part | Responses with text parts are returned as ordinary output; empty responses raise [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] |
+| Google | Safety-family `finishReason` values (`SAFETY`, `RECITATION`, `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `MODEL_ARMOR`) | `finish_reason='content_filter'` is set, and any text parts are preserved | Responses with text parts are returned as ordinary output; empty responses raise [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] |
 
 Adding [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] makes all providers behave the same way: every response with `finish_reason='content_filter'` raises, including Anthropic and Google responses that would otherwise flow the refusal text through as output.

--- a/docs/capabilities/raise-content-filter-error.md
+++ b/docs/capabilities/raise-content-filter-error.md
@@ -32,3 +32,16 @@ _(This example is complete, it can be run "as is")_
 It declares a default `id` of `'raise_content_filter_error'`, so two instances merge instead of raising a duplicate-id error — see [building custom capabilities](custom.md) for the merge rules.
 
 By default, Pydantic AI only raises [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] when a `content_filter` response is *empty*: if the provider returns partial text or refusal text alongside `finish_reason='content_filter'`, that text becomes ordinary agent output and no error is raised (see [finish reason handling](../models/overview.md#finish-reason-example)). This capability extends the check to *every* `content_filter` response, so partial and refusal text raise too. When it raises, the full [`ModelResponse`][pydantic_ai.messages.ModelResponse] is serialized into [`ContentFilterError.body`][pydantic_ai.exceptions.UnexpectedModelBehavior.body] so the partial text remains inspectable.
+
+## Per-provider behavior {#per-provider-behavior}
+
+Whether a refusal arrives as an error or as ordinary output therefore depends on whether the adapter keeps the provider's text. The adapters differ:
+
+| Provider | Refusal / safety wire event | Adapter behavior | Default outcome |
+|---|---|---|---|
+| OpenAI (Chat Completions, streaming and not) | `choice.message.refusal` / refusal delta | Response parts are emptied, `finish_reason='content_filter'` is set, the refusal string is kept in `provider_details['refusal']` | Response is empty, so [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
+| OpenAI Responses | refusal output item | Same as above | [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
+| Anthropic | `stop_reason='refusal'` | `finish_reason='content_filter'` is set and the stop explanation is kept in `provider_details['refusal']`, but the text block is preserved as a part | Refusal text is returned as ordinary output, no error |
+| Google | Safety-family `finishReason` values (`SAFETY`, `RECITATION`, `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `MODEL_ARMOR`) | `finish_reason='content_filter'` is set, but any text parts are preserved | Refusal text is returned as ordinary output, no error |
+
+Adding [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] makes all providers behave the same way: every response with `finish_reason='content_filter'` raises, including Anthropic and Google responses that would otherwise flow the refusal text through as output.

--- a/docs/capabilities/raise-content-filter-error.md
+++ b/docs/capabilities/raise-content-filter-error.md
@@ -39,8 +39,9 @@ Whether a refusal arrives as an error or as ordinary output therefore depends on
 
 | Provider | Refusal / safety wire event | Adapter behavior | Default outcome |
 |---|---|---|---|
-| OpenAI (Chat Completions, streaming and not) | `choice.message.refusal` / refusal delta | Response parts are emptied, `finish_reason='content_filter'` is set, the refusal string is kept in `provider_details['refusal']` | Response is empty, so [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
-| OpenAI Responses | refusal output item | Same as above | [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
+| OpenAI (Chat Completions, not streaming) | `choice.message.refusal` | Response parts are emptied, `finish_reason='content_filter'` is set, the refusal string is kept in `provider_details['refusal']` | Response is empty, so [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
+| OpenAI (Chat Completions, streaming) | refusal delta | The refusal itself is withheld (no part is emitted for it), `finish_reason='content_filter'` is set and the refusal string kept in `provider_details['refusal']`; any text emitted before the refusal delta is retained | Raises when no text preceded the refusal; otherwise the retained text is returned as ordinary output |
+| OpenAI Responses | refusal output item | Same as non-streaming Chat Completions | [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] is raised |
 | Anthropic | `stop_reason='refusal'` | `finish_reason='content_filter'` is set and the stop explanation is kept in `provider_details['refusal']`, but any text block is preserved as a part | Responses with text parts are returned as ordinary output; empty responses raise [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] |
 | Google | Safety-family `finishReason` values (`SAFETY`, `RECITATION`, `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `MODEL_ARMOR`) | `finish_reason='content_filter'` is set, and any text parts are preserved | Responses with text parts are returned as ordinary output; empty responses raise [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] |
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -482,7 +482,9 @@ print(result.output)
     being raised. Note that it rejects *every* response with that finish reason, including non-empty
     ones the agent loop would have accepted. To instead raise on `content_filter` responses that still
     carry partial or refusal text, add the
-    [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] capability.
+    [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] capability; whether a
+    given provider's refusals raise by default is summarized in
+    [per-provider refusal and safety-filter behavior](../capabilities/raise-content-filter-error.md#per-provider-behavior).
 
 #### Native Tool Failure Example
 


### PR DESCRIPTION
Closes #N/A (docs-only; follow-up to the investigation in #8176)

# Description

While investigating #8176 (refusal handling divergence across providers), the
behavior turned out to be the documented default contract, but what each
provider's refusal wire-event becomes was not written down anywhere. This adds
a "Per-provider behavior" section to the `RaiseContentFilterError` docs, with a
table covering:

- OpenAI Chat Completions (streaming and not) and OpenAI Responses: the adapter
  empties the response parts and sets `finish_reason='content_filter'`, so the
  default empty-response guard raises `ContentFilterError`
- Anthropic (`stop_reason='refusal'`): finish reason is mapped and the stop
  explanation kept in `provider_details['refusal']`, but the text block is
  preserved, so the refusal text flows through as ordinary output
- Google (safety-family `finishReason` values): same as Anthropic

Each row was verified against the current adapters
(`models/openai.py`, `models/anthropic.py`, `models/google.py`). Also links the
finish-reason note in `docs/models/overview.md` to the new section.

## Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it (docs-only change; no code)
- [x] There are no breaking changes (docs only)
- [ ] (n/a) Permitted compatibility impact
- [x] PR title fit for the release changelog


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

