### PR TITLE
Correct what `ModelAPIError` covers in the `FallbackModel` default

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -251,8 +251,10 @@ in sequence until one succeeds. Pydantic AI can switch to the next model when th
 raises an exception (like a 4xx/5xx API error) **or** when the response content indicates a semantic
 failure (like a truncated response or a failed native tool call).
 
-By default, fallback triggers on [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError] (4xx/5xx API errors),
-so you don't need to configure anything for the most common use case.
+By default, fallback triggers on [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError], which covers both
+4xx/5xx responses (raised as [`ModelHTTPError`][pydantic_ai.exceptions.ModelHTTPError]) and transport
+failures such as timeouts and connection errors, so you don't need to configure anything for the most
+common use case.
 
 This behavior is controlled by the `fallback_on` parameter (see
 [`FallbackModel`][pydantic_ai.models.fallback.FallbackModel]), which accepts exception types,


### PR DESCRIPTION
`docs/models/overview.md:253` says fallback triggers on `ModelAPIError` "(4xx/5xx API errors)". That parenthetical describes `ModelHTTPError`, which is the subclass, not the parent that is actually the default trigger.

The distinction matters for the decision the sentence is helping the reader make. `ModelAPIError` is documented as "Raised when a model provider API request fails" and `ModelHTTPError` as "status code of 4xx or 5xx", and several adapters raise the parent directly for non-HTTP failures: `models/bedrock.py:152` and `:155`, `models/anthropic.py:359` and `:361`, `models/groq.py:101` and `:103`. #8xxx (`Wrap botocore transport errors in ModelAPIError`) just added timeouts and connection errors to that set for Bedrock.

So a reader who takes the parenthetical literally may add a `fallback_on` handler for connection errors that the default already catches. This widens the parenthetical to say what the parent actually covers, and names `ModelHTTPError` so the 4xx/5xx case is still findable.

Ran `uv run pytest tests/test_examples.py -k "overview or fallback"` (36 passed, 10 skipped).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

---

About me: I'm a freshman in college. I checked the class hierarchy and grepped for `raise ModelAPIError` across the adapters rather than assuming the parenthetical was simply sloppy, since it could have been a deliberate simplification. I used Claude Code to check my reasoning and read the diff myself. If you meant it as a plain-language gloss on the common case and would rather keep it short, closing this is completely fine.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

