### PR TITLE
Reduce capability traceback depth and exception-local serialization overhead

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -412,6 +412,16 @@ Agent.instrument_all(instrumentation_settings)
 
 This setting is particularly useful in production environments where compliance requirements or data sensitivity concerns make it necessary to limit what content is sent to your observability platform.
 
+### Exception capture and telemetry content
+
+Exception-local capture, traceback retention, and OpenTelemetry content recording are separate concerns:
+
+- An error reporter such as Sentry may format local variables from every traceback frame. Set Sentry's `include_local_variables=False` to disable that formatting. This is the immediate workaround when exception capture is using substantial memory.
+- Pydantic AI preserves normal Python tracebacks so application debugging remains intact. A live traceback can still keep objects reachable until the exception is released; bounded representations reduce formatting work but do not clear traceback frames or mutate your run state.
+- [`InstrumentationSettings.include_content`][pydantic_ai.models.instrumented.InstrumentationSettings] controls message and tool content recorded on OpenTelemetry spans. It does not disable exception-local capture, and disabling it does not release objects retained by a live traceback.
+
+For example, configure Sentry independently of Pydantic AI instrumentation with `sentry_sdk.init(include_local_variables=False)`.
+
 ### Excluding model request parameters
 
 By default, each model request span carries a `model_request_parameters` attribute that serializes the full [`ModelRequestParameters`][pydantic_ai.models.ModelRequestParameters], including the output configuration and every tool definition. Tools that carry large output schemas (some MCP toolsets, for example) can make this attribute big enough to strain span export and inflate memory use. Set `include_model_request_parameters=False` to omit it entirely:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -304,7 +304,9 @@ def resolve_run_id(
 class GraphAgentState:
     """State kept across the execution of the agent graph."""
 
-    message_history: list[_messages.ModelMessage] = dataclasses.field(default_factory=list[_messages.ModelMessage])
+    message_history: list[_messages.ModelMessage] = dataclasses.field(
+        default_factory=list[_messages.ModelMessage], repr=False
+    )
     usage: _usage.RunUsage = dataclasses.field(default_factory=_usage.RunUsage)
     output_retries_used: int = 0
     run_step: int = 0
@@ -385,11 +387,11 @@ class GraphAgentState:
 class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     """Dependencies/config passed to the agent graph."""
 
-    user_deps: DepsT
+    user_deps: DepsT = dataclasses.field(repr=False)
 
-    prompt: str | Sequence[_messages.UserContent] | None
+    prompt: str | Sequence[_messages.UserContent] | None = dataclasses.field(repr=False)
     new_message_index: int
-    resumed_request: _messages.ModelRequest | None
+    resumed_request: _messages.ModelRequest | None = dataclasses.field(repr=False)
     resumed_request_index: int | None
 
     model: models.Model
@@ -1948,9 +1950,9 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
             inner = dispatch_event_stream(
                 run_context, _with_event_stream_buffer(self._run_stream(ctx), ctx.state.event_stream_buffer)
             )
-            self._wrapped_events_iterator = aiter(
-                ctx.deps.root_capability.wrap_run_event_stream(run_context, stream=inner)
-            )
+            if ctx.deps.root_capability.has_wrap_run_event_stream:
+                inner = ctx.deps.root_capability.wrap_run_event_stream(run_context, stream=inner)
+            self._wrapped_events_iterator = aiter(inner)
         return self._wrapped_events_iterator
 
     async def _run_stream(  # noqa: C901

--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -145,21 +145,27 @@ async def run_output_validate_hooks(
         output = await capability.before_output_validate(run_context, output_context=output_context, output=output)
 
         try:
-            validated = await capability.wrap_output_validate(
-                run_context, output_context=output_context, output=output, handler=do_validate
-            )
+            if capability._has_wrap_output_validate:  # pyright: ignore[reportPrivateUsage]
+                validated = await capability.wrap_output_validate(
+                    run_context, output_context=output_context, output=output, handler=do_validate
+                )
+            else:
+                validated = await do_validate(output)
         except (ValidationError, ModelRetry) as e:
             if allow_partial:
                 if wrap_validation_errors and isinstance(e, ValidationError):  # pragma: no cover
                     raise _make_retry_prompt(e, run_context) from e
                 raise
-            try:
-                validated = await capability.on_output_validate_error(
-                    run_context, output_context=output_context, output=output, error=e
-                )
-            except (ValidationError, ModelRetry) as hook_error:
-                if wrap_validation_errors:
-                    raise _make_retry_prompt(hook_error, run_context) from hook_error
+            if capability._has_on_output_validate_error:  # pyright: ignore[reportPrivateUsage]
+                try:
+                    validated = await capability.on_output_validate_error(
+                        run_context, output_context=output_context, output=output, error=e
+                    )
+                except (ValidationError, ModelRetry) as hook_error:
+                    if wrap_validation_errors:
+                        raise _make_retry_prompt(hook_error, run_context) from hook_error
+                    raise
+            else:
                 raise
 
         return await capability.after_output_validate(run_context, output_context=output_context, output=validated)
@@ -195,9 +201,12 @@ async def run_output_process_hooks(
         output = await capability.before_output_process(run_context, output_context=output_context, output=output)
 
         try:
-            result = await capability.wrap_output_process(
-                run_context, output_context=output_context, output=output, handler=do_process
-            )
+            if capability._has_wrap_output_process:  # pyright: ignore[reportPrivateUsage]
+                result = await capability.wrap_output_process(
+                    run_context, output_context=output_context, output=output, handler=do_process
+                )
+            else:
+                result = await do_process(output)
         except ToolRetryError:
             raise  # Control flow, not error
         except ModelRetry:
@@ -205,9 +214,12 @@ async def run_output_process_hooks(
         except Exception as e:
             # If the error hook itself raises ValidationError/ModelRetry, it propagates out
             # to the outer handler below, where it's wrapped as ToolRetryError if needed.
-            result = await capability.on_output_process_error(
-                run_context, output_context=output_context, output=output, error=e
-            )
+            if capability._has_on_output_process_error:  # pyright: ignore[reportPrivateUsage]
+                result = await capability.on_output_process_error(
+                    run_context, output_context=output_context, output=output, error=e
+                )
+            else:
+                raise
 
         return await capability.after_output_process(run_context, output_context=output_context, output=result)
     except ToolRetryError:

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -126,7 +126,7 @@ class AnchoredEvidence:
 class RunContext(Generic[RunContextAgentDepsT]):
     """Information about the current call."""
 
-    deps: RunContextAgentDepsT
+    deps: RunContextAgentDepsT = field(repr=False)
     """Dependencies for the agent."""
     model: AbstractModel
     """The active model, which is a `RealtimeModel` during a realtime session."""
@@ -150,9 +150,9 @@ class RunContext(Generic[RunContextAgentDepsT]):
     agent: Agent[RunContextAgentDepsT, Any] | None = field(default=None, repr=False)
     """The agent running this context, or `None` if not set."""
 
-    prompt: str | Sequence[_messages.UserContent] | None = None
+    prompt: str | Sequence[_messages.UserContent] | None = field(default=None, repr=False)
     """The original user prompt passed to the run."""
-    messages: list[_messages.ModelMessage] = field(default_factory=list[_messages.ModelMessage])
+    messages: list[_messages.ModelMessage] = field(default_factory=list[_messages.ModelMessage], repr=False)
     """Messages exchanged in the conversation so far."""
     validation_context: Any = None
     """Pydantic [validation context](https://docs.pydantic.dev/latest/concepts/validators/#validation-context) for tool args and run outputs."""

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -264,7 +264,10 @@ async def _run_lifecycle_hooks(  # noqa: C901
         return build_result()
 
     outer_context = contextvars.copy_context()
-    _wrap_task = asyncio.create_task(run_capability.wrap_run(run_ctx, handler=_do_run))
+    if run_capability._has_wrap_run:  # pyright: ignore[reportPrivateUsage]
+        _wrap_task = asyncio.create_task(run_capability.wrap_run(run_ctx, handler=_do_run))
+    else:
+        _wrap_task = asyncio.create_task(_do_run())
     # Wait for handler to start or wrap_run to complete (short-circuit).
     _ready_waiter = asyncio.create_task(_run_ready.wait())
     try:
@@ -353,7 +356,7 @@ async def _run_lifecycle_hooks(  # noqa: C901
                         pass
 
         # If wrap_run didn't recover, give on_run_error a chance.
-        if _run_error is not None:
+        if _run_error is not None and run_capability._has_on_run_error:  # pyright: ignore[reportPrivateUsage]
             try:
                 result = await run_capability.on_run_error(run_ctx, error=_run_error)
             except BaseException as on_error_exc:
@@ -3688,15 +3691,25 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                     AsyncIterable[_messages.AgentStreamEvent],
                 ]
                 | None
-            ) = (
-                (
-                    lambda stream: run_capability.wrap_run_event_stream(
+            ) = None
+            if run_capability.has_wrap_run_event_stream:
+
+                def wrap_with_capability(
+                    stream: AsyncIterable[_messages.AgentStreamEvent],
+                ) -> AsyncIterable[_messages.AgentStreamEvent]:
+                    return run_capability.wrap_run_event_stream(
                         run_context, stream=dispatch_event_stream(run_context, stream)
                     )
-                )
-                if run_capability.has_wrap_run_event_stream or run_capability.has_on_event
-                else None
-            )
+
+                wrap_event_stream = wrap_with_capability
+            elif run_capability.has_on_event:
+
+                def dispatch_events(
+                    stream: AsyncIterable[_messages.AgentStreamEvent],
+                ) -> AsyncIterable[_messages.AgentStreamEvent]:
+                    return dispatch_event_stream(run_context, stream)
+
+                wrap_event_stream = dispatch_events
 
             resolution = _RealtimeSessionResolution(
                 model=model,

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -395,6 +395,46 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         return type(self).on_model_request_error is not AbstractCapability.on_model_request_error
 
     @property
+    def _has_wrap_run(self) -> bool:
+        return type(self).wrap_run is not AbstractCapability.wrap_run
+
+    @property
+    def _has_on_run_error(self) -> bool:
+        return type(self).on_run_error is not AbstractCapability.on_run_error
+
+    @property
+    def _has_wrap_tool_validate(self) -> bool:
+        return type(self).wrap_tool_validate is not AbstractCapability.wrap_tool_validate
+
+    @property
+    def _has_on_tool_validate_error(self) -> bool:
+        return type(self).on_tool_validate_error is not AbstractCapability.on_tool_validate_error
+
+    @property
+    def _has_wrap_tool_execute(self) -> bool:
+        return type(self).wrap_tool_execute is not AbstractCapability.wrap_tool_execute
+
+    @property
+    def _has_on_tool_execute_error(self) -> bool:
+        return type(self).on_tool_execute_error is not AbstractCapability.on_tool_execute_error
+
+    @property
+    def _has_wrap_output_validate(self) -> bool:
+        return type(self).wrap_output_validate is not AbstractCapability.wrap_output_validate
+
+    @property
+    def _has_on_output_validate_error(self) -> bool:
+        return type(self).on_output_validate_error is not AbstractCapability.on_output_validate_error
+
+    @property
+    def _has_wrap_output_process(self) -> bool:
+        return type(self).wrap_output_process is not AbstractCapability.wrap_output_process
+
+    @property
+    def _has_on_output_process_error(self) -> bool:
+        return type(self).on_output_process_error is not AbstractCapability.on_output_process_error
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         """Whether this capability (or any sub-capability) overrides wrap_run_event_stream."""
         return type(self).wrap_run_event_stream is not AbstractCapability.wrap_run_event_stream

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -221,8 +221,68 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         return any(c._has_on_model_request_error for c in self.capabilities)
 
     @property
+    def _has_wrap_run(self) -> bool:
+        return type(self).wrap_run is not CombinedCapability.wrap_run or any(c._has_wrap_run for c in self.capabilities)
+
+    @property
+    def _has_on_run_error(self) -> bool:
+        return type(self).on_run_error is not CombinedCapability.on_run_error or any(
+            c._has_on_run_error for c in self.capabilities
+        )
+
+    @property
+    def _has_wrap_tool_validate(self) -> bool:
+        return type(self).wrap_tool_validate is not CombinedCapability.wrap_tool_validate or any(
+            c._has_wrap_tool_validate for c in self.capabilities
+        )
+
+    @property
+    def _has_on_tool_validate_error(self) -> bool:
+        return type(self).on_tool_validate_error is not CombinedCapability.on_tool_validate_error or any(
+            c._has_on_tool_validate_error for c in self.capabilities
+        )
+
+    @property
+    def _has_wrap_tool_execute(self) -> bool:
+        return type(self).wrap_tool_execute is not CombinedCapability.wrap_tool_execute or any(
+            c._has_wrap_tool_execute for c in self.capabilities
+        )
+
+    @property
+    def _has_on_tool_execute_error(self) -> bool:
+        return type(self).on_tool_execute_error is not CombinedCapability.on_tool_execute_error or any(
+            c._has_on_tool_execute_error for c in self.capabilities
+        )
+
+    @property
+    def _has_wrap_output_validate(self) -> bool:
+        return type(self).wrap_output_validate is not CombinedCapability.wrap_output_validate or any(
+            c._has_wrap_output_validate for c in self.capabilities
+        )
+
+    @property
+    def _has_on_output_validate_error(self) -> bool:
+        return type(self).on_output_validate_error is not CombinedCapability.on_output_validate_error or any(
+            c._has_on_output_validate_error for c in self.capabilities
+        )
+
+    @property
+    def _has_wrap_output_process(self) -> bool:
+        return type(self).wrap_output_process is not CombinedCapability.wrap_output_process or any(
+            c._has_wrap_output_process for c in self.capabilities
+        )
+
+    @property
+    def _has_on_output_process_error(self) -> bool:
+        return type(self).on_output_process_error is not CombinedCapability.on_output_process_error or any(
+            c._has_on_output_process_error for c in self.capabilities
+        )
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
-        return any(c.has_wrap_run_event_stream for c in self.capabilities)
+        return type(self).wrap_run_event_stream is not CombinedCapability.wrap_run_event_stream or any(
+            c.has_wrap_run_event_stream for c in self.capabilities
+        )
 
     @property
     def has_on_event(self) -> bool:
@@ -506,7 +566,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> AgentRunResult[Any]:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_active_cap(capability, ctx) is not None:
+            if capability._has_wrap_run and _ctx_for_active_cap(capability, ctx) is not None:
                 chain = _make_run_wrap(capability, ctx, chain)
         return await chain()
 
@@ -517,6 +577,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: BaseException,
     ) -> AgentRunResult[Any]:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_run_error:
+                continue
             cap_ctx = _ctx_for_active_cap(capability, ctx)
             if cap_ctx is None:
                 continue
@@ -608,7 +670,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> AsyncIterable[AgentStreamEvent]:
         wrapped_streams = [stream]
         for capability in reversed(self.capabilities):
-            if (cap_ctx := _ctx_for_active_cap(capability, ctx)) is not None:
+            if capability.has_wrap_run_event_stream and (cap_ctx := _ctx_for_active_cap(capability, ctx)) is not None:
                 stream = capability.wrap_run_event_stream(cap_ctx, stream=stream)
                 wrapped_streams.append(stream)
         try:
@@ -714,7 +776,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> dict[str, Any]:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_active_cap(capability, ctx) is not None:
+            if capability._has_wrap_tool_validate and _ctx_for_active_cap(capability, ctx) is not None:
                 chain = _make_tool_validate_wrap(capability, ctx, call, tool_def, chain)
         return await chain(args)
 
@@ -728,6 +790,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: ValidationError | ModelRetry,
     ) -> dict[str, Any]:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_tool_validate_error:
+                continue
             cap_ctx = _ctx_for_active_cap(capability, ctx)
             if cap_ctx is None:
                 continue
@@ -783,7 +847,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> Any:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_active_cap(capability, ctx) is not None:
+            if capability._has_wrap_tool_execute and _ctx_for_active_cap(capability, ctx) is not None:
                 chain = _make_tool_execute_wrap(capability, ctx, call, tool_def, chain)
         return await chain(args)
 
@@ -797,6 +861,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: Exception,
     ) -> Any:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_tool_execute_error:
+                continue
             cap_ctx = _ctx_for_active_cap(capability, ctx)
             if cap_ctx is None:
                 continue
@@ -844,7 +910,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> Any:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_active_cap(capability, ctx) is not None:
+            if capability._has_wrap_output_validate and _ctx_for_active_cap(capability, ctx) is not None:
                 chain = _make_output_validate_wrap(capability, ctx, output_context, chain)
         return await chain(output)
 
@@ -857,6 +923,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: ValidationError | ModelRetry,
     ) -> Any:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_output_validate_error:
+                continue
             cap_ctx = _ctx_for_active_cap(capability, ctx)
             if cap_ctx is None:
                 continue
@@ -907,7 +975,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     ) -> Any:
         chain = handler
         for capability in reversed(self.capabilities):
-            if _ctx_for_active_cap(capability, ctx) is not None:
+            if capability._has_wrap_output_process and _ctx_for_active_cap(capability, ctx) is not None:
                 chain = _make_output_process_wrap(capability, ctx, output_context, chain)
         return await chain(output)
 
@@ -920,6 +988,8 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         error: Exception,
     ) -> Any:
         for capability in reversed(self.capabilities):
+            if not capability._has_on_output_process_error:
+                continue
             cap_ctx = _ctx_for_active_cap(capability, ctx)
             if cap_ctx is None:
                 continue

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -918,6 +918,56 @@ class Hooks(AbstractCapability[AgentDepsT]):
         )
 
     @property
+    def _has_wrap_run(self) -> bool:
+        return type(self).wrap_run is not Hooks.wrap_run or bool(self._get('wrap_run'))
+
+    @property
+    def _has_on_run_error(self) -> bool:
+        return type(self).on_run_error is not Hooks.on_run_error or bool(self._get('on_run_error'))
+
+    @property
+    def _has_wrap_tool_validate(self) -> bool:
+        return type(self).wrap_tool_validate is not Hooks.wrap_tool_validate or bool(self._get('wrap_tool_validate'))
+
+    @property
+    def _has_on_tool_validate_error(self) -> bool:
+        return type(self).on_tool_validate_error is not Hooks.on_tool_validate_error or bool(
+            self._get('on_tool_validate_error')
+        )
+
+    @property
+    def _has_wrap_tool_execute(self) -> bool:
+        return type(self).wrap_tool_execute is not Hooks.wrap_tool_execute or bool(self._get('wrap_tool_execute'))
+
+    @property
+    def _has_on_tool_execute_error(self) -> bool:
+        return type(self).on_tool_execute_error is not Hooks.on_tool_execute_error or bool(
+            self._get('on_tool_execute_error')
+        )
+
+    @property
+    def _has_wrap_output_validate(self) -> bool:
+        return type(self).wrap_output_validate is not Hooks.wrap_output_validate or bool(
+            self._get('wrap_output_validate')
+        )
+
+    @property
+    def _has_on_output_validate_error(self) -> bool:
+        return type(self).on_output_validate_error is not Hooks.on_output_validate_error or bool(
+            self._get('on_output_validate_error')
+        )
+
+    @property
+    def _has_wrap_output_process(self) -> bool:
+        return type(self).wrap_output_process is not Hooks.wrap_output_process or bool(self._get('wrap_output_process'))
+
+    @property
+    def _has_on_output_process_error(self) -> bool:
+        return type(self).on_output_process_error is not Hooks.on_output_process_error or bool(
+            self._get('on_output_process_error')
+        )
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         return (
             bool(self._get('wrap_run_event_stream'))

--- a/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
@@ -161,6 +161,70 @@ class WrapperCapability(AbstractCapability[AgentDepsT]):
         )
 
     @property
+    def _has_wrap_run(self) -> bool:
+        return type(self).wrap_run is not WrapperCapability.wrap_run or self.wrapped._has_wrap_run
+
+    @property
+    def _has_on_run_error(self) -> bool:
+        return type(self).on_run_error is not WrapperCapability.on_run_error or self.wrapped._has_on_run_error
+
+    @property
+    def _has_wrap_tool_validate(self) -> bool:
+        return (
+            type(self).wrap_tool_validate is not WrapperCapability.wrap_tool_validate
+            or self.wrapped._has_wrap_tool_validate
+        )
+
+    @property
+    def _has_on_tool_validate_error(self) -> bool:
+        return (
+            type(self).on_tool_validate_error is not WrapperCapability.on_tool_validate_error
+            or self.wrapped._has_on_tool_validate_error
+        )
+
+    @property
+    def _has_wrap_tool_execute(self) -> bool:
+        return (
+            type(self).wrap_tool_execute is not WrapperCapability.wrap_tool_execute
+            or self.wrapped._has_wrap_tool_execute
+        )
+
+    @property
+    def _has_on_tool_execute_error(self) -> bool:
+        return (
+            type(self).on_tool_execute_error is not WrapperCapability.on_tool_execute_error
+            or self.wrapped._has_on_tool_execute_error
+        )
+
+    @property
+    def _has_wrap_output_validate(self) -> bool:
+        return (
+            type(self).wrap_output_validate is not WrapperCapability.wrap_output_validate
+            or self.wrapped._has_wrap_output_validate
+        )
+
+    @property
+    def _has_on_output_validate_error(self) -> bool:
+        return (
+            type(self).on_output_validate_error is not WrapperCapability.on_output_validate_error
+            or self.wrapped._has_on_output_validate_error
+        )
+
+    @property
+    def _has_wrap_output_process(self) -> bool:
+        return (
+            type(self).wrap_output_process is not WrapperCapability.wrap_output_process
+            or self.wrapped._has_wrap_output_process
+        )
+
+    @property
+    def _has_on_output_process_error(self) -> bool:
+        return (
+            type(self).on_output_process_error is not WrapperCapability.on_output_process_error
+            or self.wrapped._has_on_output_process_error
+        )
+
+    @property
     def has_wrap_run_event_stream(self) -> bool:
         return (
             type(self).wrap_run_event_stream is not WrapperCapability.wrap_run_event_stream

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable, Iterator
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable, Iterator
 from contextlib import AbstractAsyncContextManager, aclosing
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
@@ -394,11 +394,10 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
             )
             # Wrap once, so a capability's `wrap_run_event_stream` sees each event exactly once no
             # matter how many times this stream is iterated (e.g. `stream_text()` then a drain).
-            self._events_iterator = aiter(
-                self._root_capability.wrap_run_event_stream(
-                    self._run_ctx, stream=dispatch_event_stream(self._run_ctx, self._events_iter(base_iter))
-                )
-            )
+            events: AsyncIterable[AgentStreamEvent] = dispatch_event_stream(self._run_ctx, self._events_iter(base_iter))
+            if self._root_capability.has_wrap_run_event_stream:
+                events = self._root_capability.wrap_run_event_stream(self._run_ctx, stream=events)
+            self._events_iterator = aiter(events)
 
         return self._pull_shared(self._events_iterator)
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -389,9 +389,12 @@ class ToolManager(Generic[AgentDepsT]):
             # wrap_tool_validate wraps the validation; on_tool_validate_error on failure
             deferral: _ValidationDeferral | None = None
             try:
-                validated_args = await cap.wrap_tool_validate(
-                    ctx, call=call, tool_def=tool_def, args=raw_args, handler=do_validate
-                )
+                if cap._has_wrap_tool_validate:  # pyright: ignore[reportPrivateUsage]
+                    validated_args = await cap.wrap_tool_validate(
+                        ctx, call=call, tool_def=tool_def, args=raw_args, handler=do_validate
+                    )
+                else:
+                    validated_args = await do_validate(raw_args)
             except _ValidationDeferral as e:
                 # The `args_validator` deferred the call. Hold the deferral rather than letting it
                 # escape: `after_tool_validate` is a policy gate on validated arguments and has to
@@ -408,13 +411,16 @@ class ToolManager(Generic[AgentDepsT]):
                 deferral = _ValidationDeferral(e, handler_validated_args)
                 validated_args = handler_validated_args
             except (ValidationError, ModelRetry) as e:
-                try:
-                    validated_args = await cap.on_tool_validate_error(
-                        ctx, call=call, tool_def=tool_def, args=raw_args, error=e
-                    )
-                except (CallDeferred, ApprovalRequired) as hook_deferral:
-                    # Only reached because validation failed, so there are no validated arguments.
-                    raise _validate_hook_deferral_error('on_tool_validate_error', hook_deferral) from hook_deferral
+                if cap._has_on_tool_validate_error:  # pyright: ignore[reportPrivateUsage]
+                    try:
+                        validated_args = await cap.on_tool_validate_error(
+                            ctx, call=call, tool_def=tool_def, args=raw_args, error=e
+                        )
+                    except (CallDeferred, ApprovalRequired) as hook_deferral:
+                        # Only reached because validation failed, so there are no validated arguments.
+                        raise _validate_hook_deferral_error('on_tool_validate_error', hook_deferral) from hook_deferral
+                else:
+                    raise
 
             # after_tool_validate gates validated arguments, so it runs even when the call has
             # already been deferred, and may still reject or defer it itself.
@@ -466,15 +472,23 @@ class ToolManager(Generic[AgentDepsT]):
 
                 # wrap_tool_execute wraps the execution; on_tool_execute_error on failure
                 try:
-                    tool_result = await cap.wrap_tool_execute(
-                        ctx, call=call, tool_def=tool_def, args=args, handler=do_execute
-                    )
+                    if cap._has_wrap_tool_execute:  # pyright: ignore[reportPrivateUsage]
+                        tool_result = await cap.wrap_tool_execute(
+                            ctx, call=call, tool_def=tool_def, args=args, handler=do_execute
+                        )
+                    else:
+                        tool_result = await do_execute(args)
                 except (SkipToolExecution, CallDeferred, ApprovalRequired, ToolRetryError, ToolFailedError):
                     raise  # Control flow, not errors
                 except (ToolFailed, ModelRetry):
                     raise  # Propagate to outer handler
                 except Exception as e:
-                    tool_result = await cap.on_tool_execute_error(ctx, call=call, tool_def=tool_def, args=args, error=e)
+                    if cap._has_on_tool_execute_error:  # pyright: ignore[reportPrivateUsage]
+                        tool_result = await cap.on_tool_execute_error(
+                            ctx, call=call, tool_def=tool_def, args=args, error=e
+                        )
+                    else:
+                        raise
 
                 # after_tool_execute
                 tool_result = await cap.after_tool_execute(

--- a/tests/durable_exec/test_durable_operation.py
+++ b/tests/durable_exec/test_durable_operation.py
@@ -76,7 +76,7 @@ from pydantic_ai.durable_exec._toolset import (
 )
 from pydantic_ai.durable_exec._utils import DurableModel, StreamedActivityResult
 from pydantic_ai.exceptions import ModelRetry, UserError
-from pydantic_ai.messages import RetryPromptPart, ToolCallPart, ToolReturnPart, UserPromptPart
+from pydantic_ai.messages import PartStartEvent, RetryPromptPart, ToolCallPart, ToolReturnPart, UserPromptPart
 from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
@@ -212,6 +212,18 @@ async def test_durability_forces_sequential_tools_inside_durable_context() -> No
         return cast(AgentRunResult[Any], object())
 
     await bound.wrap_run(ctx, handler=handler)
+
+
+async def test_durability_stream_without_handler_is_passthrough() -> None:
+    durability = JournalDurability()
+    ctx = RunContext[None](deps=None, model=TestModel(), usage=RunUsage())
+
+    async def stream() -> AsyncIterable[AgentStreamEvent]:
+        yield PartStartEvent(index=0, part=TextPart('hello'))
+
+    events = [event async for event in durability.wrap_run_event_stream(ctx, stream=stream())]
+
+    assert events == [PartStartEvent(index=0, part=TextPart('hello'))]
 
 
 def test_prepare_run_context_without_agent() -> None:

--- a/tests/realtime/test_capabilities.py
+++ b/tests/realtime/test_capabilities.py
@@ -20,7 +20,14 @@ import pytest
 
 from pydantic_ai import Agent
 from pydantic_ai._instrumentation import get_instructions
-from pydantic_ai.capabilities import Hooks, NativeTool, ProcessEventStream, WebSearch
+from pydantic_ai.capabilities import (
+    CombinedCapability,
+    Hooks,
+    NativeTool,
+    ProcessEventStream,
+    WebSearch,
+    WrapperCapability,
+)
 from pydantic_ai.capabilities.abstract import AbstractCapability, WrapRunHandler
 from pydantic_ai.exceptions import RunCancelled, UserError
 from pydantic_ai.messages import (
@@ -758,6 +765,24 @@ async def test_on_event_hook_receives_session_events() -> None:
 
     assert any(isinstance(event, PartStartEvent) for event in observed)
     assert any(isinstance(event, RealtimeTurnCompleteEvent) for event in observed)
+
+
+async def test_nested_on_event_hook_receives_session_events() -> None:
+    """Nested dynamic event hooks still dispatch when no stream wrapper is registered."""
+    observed: list[AgentStreamEvent] = []
+    hooks = Hooks()
+
+    @hooks.on.event
+    async def observe(ctx: RunContext[None], event: AgentStreamEvent) -> None:
+        observed.append(event)
+
+    capability = WrapperCapability(wrapped=CombinedCapability([hooks]))
+    await _drain(
+        Agent(capabilities=[capability], deps_type=type(None)),
+        _RecordingModel(connection_events=[OutputTranscript(text='hello'), ResponseDone()]),
+    )
+
+    assert any(isinstance(event, PartStartEvent) for event in observed)
 
 
 async def test_session_stream_wrapper_closes_after_early_break() -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 
 import anyio
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from pydantic_ai import _agent_graph
 from pydantic_ai._run_context import RunContext
@@ -57,6 +57,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    PartStartEvent,
     TextPart,
     ToolCallPart,
     ToolReturn,
@@ -532,6 +533,57 @@ class _NoopCap(AbstractCapability):
 
 
 @dataclass
+class _InactiveErrorHookCap(_NoopCap):
+    id: str | None = 'inactive'
+    defer_loading: bool = True
+
+    async def on_run_error(self, ctx: RunContext[Any], *, error: BaseException) -> AgentRunResult[Any]:
+        return await super().on_run_error(ctx, error=error)
+
+    async def on_tool_validate_error(
+        self,
+        ctx: RunContext[Any],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: str | dict[str, Any],
+        error: ValidationError | ModelRetry,
+    ) -> dict[str, Any]:
+        return await super().on_tool_validate_error(ctx, call=call, tool_def=tool_def, args=args, error=error)
+
+    async def on_tool_execute_error(
+        self,
+        ctx: RunContext[Any],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+        error: Exception,
+    ) -> Any:
+        return await super().on_tool_execute_error(ctx, call=call, tool_def=tool_def, args=args, error=error)
+
+    async def on_output_validate_error(
+        self,
+        ctx: RunContext[Any],
+        *,
+        output_context: OutputContext,
+        output: str | dict[str, Any],
+        error: ValidationError | ModelRetry,
+    ) -> Any:
+        return await super().on_output_validate_error(ctx, output_context=output_context, output=output, error=error)
+
+    async def on_output_process_error(
+        self,
+        ctx: RunContext[Any],
+        *,
+        output_context: OutputContext,
+        output: Any,
+        error: Exception,
+    ) -> Any:
+        return await super().on_output_process_error(ctx, output_context=output_context, output=output, error=error)
+
+
+@dataclass
 class _NodeModelHookCap(AbstractCapability[Any]):
     log: list[str] = field(default_factory=lambda: [])
 
@@ -595,6 +647,159 @@ async def test_default_node_and_model_hooks_remain_directly_callable() -> None:
     with pytest.raises(RuntimeError, match='provider failure') as model_exc_info:
         await _NoopCap().on_model_request_error(ctx, request_context=request_context, error=error)
     assert model_exc_info.value is error
+
+
+async def test_default_lifecycle_hooks_remain_directly_callable() -> None:
+    ctx = _build_run_context()
+    call = ToolCallPart('tool', {}, tool_call_id='call')
+    tool_def = ToolDefinition(name='tool')
+    output_context = _output_context()
+    capability = _NoopCap()
+
+    async def run_handler() -> AgentRunResult[str]:
+        return AgentRunResult(output='run')
+
+    async def validate_tool(args: str | dict[str, Any]) -> dict[str, Any]:
+        return args if isinstance(args, dict) else {}
+
+    async def execute_tool(args: dict[str, Any]) -> str:
+        return str(args)
+
+    async def validate_output(output: str | dict[str, Any]) -> str | dict[str, Any]:
+        return output
+
+    async def process_output(output: Any) -> Any:
+        return output
+
+    assert (await capability.wrap_run(ctx, handler=run_handler)).output == 'run'
+
+    run_error = RuntimeError('run')
+    with pytest.raises(RuntimeError) as run_exc_info:
+        await capability.on_run_error(ctx, error=run_error)
+    assert run_exc_info.value is run_error
+
+    async def event_stream() -> AsyncIterator[AgentStreamEvent]:
+        yield PartStartEvent(index=0, part=TextPart(content='event'))
+
+    assert len([event async for event in capability.wrap_run_event_stream(ctx, stream=event_stream())]) == 1
+    assert await capability.wrap_tool_validate(ctx, call=call, tool_def=tool_def, args={}, handler=validate_tool) == {}
+    assert await capability.wrap_tool_execute(ctx, call=call, tool_def=tool_def, args={}, handler=execute_tool) == '{}'
+    assert (
+        await capability.wrap_output_validate(ctx, output_context=output_context, output='raw', handler=validate_output)
+        == 'raw'
+    )
+    assert (
+        await capability.wrap_output_process(
+            ctx, output_context=output_context, output='parsed', handler=process_output
+        )
+        == 'parsed'
+    )
+    assert await capability.handle_deferred_tool_calls(ctx, requests=DeferredToolRequests(calls=[call])) is None
+
+    validate_error = ModelRetry('validate')
+    with pytest.raises(ModelRetry) as validate_exc_info:
+        await capability.on_tool_validate_error(ctx, call=call, tool_def=tool_def, args={}, error=validate_error)
+    assert validate_exc_info.value is validate_error
+
+    execute_error = RuntimeError('execute')
+    with pytest.raises(RuntimeError) as execute_exc_info:
+        await capability.on_tool_execute_error(ctx, call=call, tool_def=tool_def, args={}, error=execute_error)
+    assert execute_exc_info.value is execute_error
+
+    output_validate_error = ModelRetry('output validate')
+    with pytest.raises(ModelRetry) as output_validate_exc_info:
+        await capability.on_output_validate_error(
+            ctx, output_context=output_context, output='raw', error=output_validate_error
+        )
+    assert output_validate_exc_info.value is output_validate_error
+
+    output_process_error = RuntimeError('output process')
+    with pytest.raises(RuntimeError) as output_process_exc_info:
+        await capability.on_output_process_error(
+            ctx, output_context=output_context, output='parsed', error=output_process_error
+        )
+    assert output_process_exc_info.value is output_process_error
+
+    hooks = Hooks()
+    assert (await hooks.wrap_run(ctx, handler=run_handler)).output == 'run'
+    assert await hooks.wrap_tool_validate(ctx, call=call, tool_def=tool_def, args={}, handler=validate_tool) == {}
+    assert await hooks.wrap_tool_execute(ctx, call=call, tool_def=tool_def, args={}, handler=execute_tool) == '{}'
+    assert (
+        await hooks.wrap_output_validate(ctx, output_context=output_context, output='raw', handler=validate_output)
+        == 'raw'
+    )
+    assert (
+        await hooks.wrap_output_process(ctx, output_context=output_context, output='parsed', handler=process_output)
+        == 'parsed'
+    )
+    with pytest.raises(RuntimeError) as hooks_exc_info:
+        await hooks.on_output_process_error(
+            ctx, output_context=output_context, output='parsed', error=output_process_error
+        )
+    assert hooks_exc_info.value is output_process_error
+
+    wrapper = WrapperCapability(wrapped=_NoopCap())
+    assert await wrapper.wrap_tool_validate(ctx, call=call, tool_def=tool_def, args={}, handler=validate_tool) == {}
+    assert (
+        await wrapper.wrap_output_validate(ctx, output_context=output_context, output='raw', handler=validate_output)
+        == 'raw'
+    )
+    assert (
+        await wrapper.wrap_output_process(ctx, output_context=output_context, output='parsed', handler=process_output)
+        == 'parsed'
+    )
+
+
+async def test_combined_capability_skips_inactive_implemented_reverse_hooks() -> None:
+    capability = _InactiveErrorHookCap()
+    combined = CombinedCapability([capability])
+    ctx = _build_run_context()
+    call = ToolCallPart('tool', {}, tool_call_id='call')
+    tool_def = ToolDefinition(name='tool')
+    output_context = _output_context()
+
+    run_error = RuntimeError('run')
+    with pytest.raises(RuntimeError) as run_exc_info:
+        await combined.on_run_error(ctx, error=run_error)
+    assert run_exc_info.value is run_error
+    with pytest.raises(RuntimeError):
+        await capability.on_run_error(ctx, error=run_error)
+
+    validate_error = ModelRetry('validate')
+    with pytest.raises(ModelRetry) as validate_exc_info:
+        await combined.on_tool_validate_error(ctx, call=call, tool_def=tool_def, args={}, error=validate_error)
+    assert validate_exc_info.value is validate_error
+    with pytest.raises(ModelRetry):
+        await capability.on_tool_validate_error(ctx, call=call, tool_def=tool_def, args={}, error=validate_error)
+
+    execute_error = RuntimeError('execute')
+    with pytest.raises(RuntimeError) as execute_exc_info:
+        await combined.on_tool_execute_error(ctx, call=call, tool_def=tool_def, args={}, error=execute_error)
+    assert execute_exc_info.value is execute_error
+    with pytest.raises(RuntimeError):
+        await capability.on_tool_execute_error(ctx, call=call, tool_def=tool_def, args={}, error=execute_error)
+
+    output_validate_error = ModelRetry('output validate')
+    with pytest.raises(ModelRetry) as output_validate_exc_info:
+        await combined.on_output_validate_error(
+            ctx, output_context=output_context, output='raw', error=output_validate_error
+        )
+    assert output_validate_exc_info.value is output_validate_error
+    with pytest.raises(ModelRetry):
+        await capability.on_output_validate_error(
+            ctx, output_context=output_context, output='raw', error=output_validate_error
+        )
+
+    output_process_error = RuntimeError('output process')
+    with pytest.raises(RuntimeError) as output_process_exc_info:
+        await combined.on_output_process_error(
+            ctx, output_context=output_context, output='parsed', error=output_process_error
+        )
+    assert output_process_exc_info.value is output_process_error
+    with pytest.raises(RuntimeError):
+        await capability.on_output_process_error(
+            ctx, output_context=output_context, output='parsed', error=output_process_error
+        )
 
 
 async def test_inherited_noop_capability_hooks_are_absent_from_traceback() -> None:

--- a/tests/test_capability_hooks.py
+++ b/tests/test_capability_hooks.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import threading
+import traceback
 import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -120,6 +121,32 @@ class SingleBaseModelArg(BaseModel):
 
 
 class TestRunHooks:
+    async def test_empty_capabilities_do_not_add_hook_frames_to_tool_errors(self):
+        """Empty capabilities do not wrap or re-raise a tool error just because they are present."""
+        agent = Agent(
+            TestModel(),
+            deps_type=type(None),
+            capabilities=[Hooks(id=f'empty-{i}') for i in range(3)],
+        )
+
+        @agent.tool
+        async def explode(ctx: RunContext[None]) -> str:
+            raise ValueError('small error')
+
+        with pytest.raises(ValueError) as exc_info:
+            await agent.run('go')
+
+        frame_names = [frame.f_code.co_name for frame, _ in traceback.walk_tb(exc_info.value.__traceback__)]
+        assert 'explode' in frame_names
+        assert not {
+            'wrap_run',
+            'on_run_error',
+            'wrap_tool_validate',
+            'on_tool_validate_error',
+            'wrap_tool_execute',
+            'on_tool_execute_error',
+        } & set(frame_names)
+
     async def test_before_run(self):
         cap = LoggingCapability()
         agent = Agent(FunctionModel(simple_model_function), capabilities=[cap])

--- a/tests/test_capability_hooks.py
+++ b/tests/test_capability_hooks.py
@@ -25,7 +25,9 @@ from pydantic_ai.capabilities import (
     UseThreadExecutor,
 )
 from pydantic_ai.capabilities.abstract import AbstractCapability
+from pydantic_ai.capabilities.combined import CombinedCapability
 from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.capabilities.wrapper import WrapperCapability
 from pydantic_ai.exceptions import (
     ApprovalRequired,
     CallDeferred,
@@ -146,6 +148,53 @@ class TestRunHooks:
             'wrap_tool_execute',
             'on_tool_execute_error',
         } & set(frame_names)
+
+    async def test_dynamic_hooks_survive_capability_composition(self):
+        hooks = Hooks()
+        calls: list[str] = []
+
+        @hooks.on.tool_execute
+        async def wrap_tool_execute(
+            ctx: RunContext[Any],
+            *,
+            call: ToolCallPart,
+            tool_def: ToolDefinition,
+            args: dict[str, Any],
+            handler: Any,
+        ) -> Any:
+            calls.append('before')
+            result = await handler(args)
+            calls.append('after')
+            return result
+
+        capability = WrapperCapability(wrapped=CombinedCapability([hooks]))
+        agent = Agent(FunctionModel(tool_calling_model), capabilities=[capability])
+
+        @agent.tool_plain
+        def my_tool() -> str:
+            return 'tool result'
+
+        await agent.run('call tool')
+        assert calls == ['before', 'after']
+
+    async def test_dynamic_event_hooks_survive_classic_stream_composition(self):
+        hooks = Hooks()
+        observed: list[AgentStreamEvent] = []
+
+        @hooks.on.event
+        async def observe(ctx: RunContext[Any], event: AgentStreamEvent) -> None:
+            observed.append(event)
+
+        capability = WrapperCapability(wrapped=CombinedCapability([hooks]))
+        agent = Agent(
+            FunctionModel(simple_model_function, stream_function=simple_stream_function),
+            capabilities=[capability],
+        )
+
+        async with agent.run_stream('hello') as stream:
+            await stream.get_output()
+
+        assert any(isinstance(event, PartStartEvent) for event in observed)
 
     async def test_before_run(self):
         cap = LoggingCapability()

--- a/tests/test_capability_output_hooks.py
+++ b/tests/test_capability_output_hooks.py
@@ -25,6 +25,7 @@ from pydantic_ai.exceptions import (
     ApprovalRequired,
     CallDeferred,
     ModelRetry,
+    UnexpectedModelBehavior,
     UserError,
 )
 from pydantic_ai.messages import (
@@ -2779,6 +2780,38 @@ class TestDefaultOutputErrorHooks:
 
 class TestStreamingOutputHooks:
     """Output hooks fire during streaming (partial and final validation)."""
+
+    async def test_streaming_output_validate_error_hook_reraises_without_wrapping(self):
+        """A streaming validation error hook preserves its raw validation error."""
+
+        async def stream_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[DeltaToolCalls]:
+            assert info.output_tools is not None
+            yield {0: DeltaToolCall(name=info.output_tools[0].name, json_args='not valid json')}
+
+        seen_errors: list[ValidationError | ModelRetry] = []
+
+        @dataclass
+        class ReraiseCap(AbstractCapability[Any]):
+            async def on_output_validate_error(
+                self,
+                ctx: RunContext[Any],
+                *,
+                output_context: OutputContext,
+                output: str | dict[str, Any],
+                error: ValidationError | ModelRetry,
+            ) -> Any:
+                seen_errors.append(error)
+                raise error
+
+        agent = Agent(
+            FunctionModel(stream_function=stream_fn),
+            output_type=MyOutput,
+            capabilities=[ReraiseCap()],
+        )
+        with pytest.raises(UnexpectedModelBehavior) as exc_info:
+            async with agent.run_stream('hello') as result:
+                await result.get_output()
+        assert exc_info.value.__cause__ is seen_errors[0]
 
     async def test_output_hooks_fire_during_streaming(self):
         """Validate hooks fire on partial attempts; execute hooks fire only when partial validation succeeds."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1167,7 +1167,7 @@ def test_run_and_graph_state_repr_do_not_expand_user_data():
 
     class LargeRepr:
         def __repr__(self) -> str:
-            return 'D' * 4096
+            return 'D' * 4096  # pragma: no cover
 
     deps = LargeRepr()
     messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content='H' * 4096)])]
@@ -1192,7 +1192,7 @@ async def test_graph_run_context_repr_does_not_expand_dependencies():
 
     class LargeRepr:
         def __repr__(self) -> str:
-            return 'D' * 4096
+            return 'D' * 4096  # pragma: no cover
 
     deps = LargeRepr()
     agent = Agent(TestModel(), deps_type=LargeRepr)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,8 @@ import anyio
 import pytest
 
 import pydantic_ai._utils as utils_module
-from pydantic_ai import Agent, UserError
+from pydantic_ai import Agent, RunContext, UserError
+from pydantic_ai._agent_graph import GraphAgentState
 from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
@@ -35,7 +36,9 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
+from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
 
 from ._inline_snapshot import snapshot
 from .conftest import undrivable_event_loop
@@ -1157,6 +1160,48 @@ def test_dataclasses_no_defaults_repr_omits_defaults():
     _items_factory.calls = 0
     assert repr(instance) == '_HasMixedFields(required=1, flag=True, items=[])'
     assert _items_factory.calls == 0
+
+
+def test_run_and_graph_state_repr_do_not_expand_user_data():
+    """Run and graph contexts keep user data accessible without formatting it in `repr`."""
+
+    class LargeRepr:
+        def __repr__(self) -> str:
+            return 'D' * 4096
+
+    deps = LargeRepr()
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content='H' * 4096)])]
+    context = RunContext(deps=deps, model=TestModel(), usage=RunUsage(), prompt='P' * 4096, messages=messages)
+    state = GraphAgentState(message_history=messages)
+
+    context_repr = repr(context)
+    state_repr = repr(state)
+    assert len(context_repr) < 1024
+    assert len(state_repr) < 1024
+    assert 'D' * 64 not in context_repr
+    assert 'H' * 64 not in context_repr
+    assert 'P' * 64 not in context_repr
+    assert 'H' * 64 not in state_repr
+    assert context.deps is deps
+    assert context.messages is messages
+    assert state.message_history is messages
+
+
+async def test_graph_run_context_repr_does_not_expand_dependencies():
+    """The graph context used by `AgentRun.ctx` also omits user dependencies from its repr."""
+
+    class LargeRepr:
+        def __repr__(self) -> str:
+            return 'D' * 4096
+
+    deps = LargeRepr()
+    agent = Agent(TestModel(), deps_type=LargeRepr)
+    async with agent.iter('P' * 4096, deps=deps) as agent_run:
+        context_repr = repr(agent_run.ctx)
+
+    assert len(context_repr) < 4096
+    assert 'D' * 64 not in context_repr
+    assert 'P' * 64 not in context_repr
 
 
 def test_format_inlined_text_file() -> None:


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-luna on behalf of David.

Slack ref: https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1788797235355719

## Why we make these changes

Issue [#8184](https://github.com/pydantic/pydantic-ai/issues/8184) identified avoidable traceback frames from no-op capabilities and unbounded formatting of run state during exception-local capture. This PR removes the confirmed library-side overhead while keeping Sentry integration changes and broader OTel content budgets out of scope.

## New public surface

none

## User-visible behavior

```diff
pydantic_ai_slim/pydantic_ai/agent/__init__.py :: Agent.run()
└─ pydantic_ai_slim/pydantic_ai/capabilities/combined.py :: CombinedCapability.wrap_run()
-   └─ empty capability wrappers and error hooks add traceback frames
+   └─ no-op capabilities bypass middleware; implemented and dynamic hooks keep ordering and recovery
```

`RunContext` and related state representations remain live and accessible, but no longer expand dependencies, prompts, resumed requests, or message history without bound.

## Verification

- [No-op tool-error frames](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_capability_hooks.py#L126), [default lifecycle hooks](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_capabilities.py#L652), and [inactive reverse hooks](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_capabilities.py#L753).
- [Dynamic hook composition](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_capability_hooks.py#L152), [classic streaming events](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_capability_hooks.py#L180), [durable streaming](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/durable_exec/test_durable_operation.py#L217), and [realtime nested events](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/realtime/test_capabilities.py#L770).
- [Streaming output error propagation](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_capability_output_hooks.py#L2784), [bounded RunContext representation](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_utils.py#L1165), and [bounded graph-state representation](https://github.com/pydantic/pydantic-ai/blob/983a6e6113f8c18141c08cf435387a0fe7b052b7/tests/test_utils.py#L1190).
- `uv run pytest ...`: 1,098 passed, 3 xfailed; `make format`, `make lint`, and targeted Pyright checks passed.
- Synthetic MRE: context representation 524,754 → 307 bytes; traceback frames 90 → 39; hook frames 17 → 0.
- `docs/logfire.md` documents exception-local capture, traceback retention, and OTel content recording as separate mechanisms.

## What changes for existing users

No new arguments or public API changes are required; no-op capabilities take a shorter path, while implemented and dynamically registered hooks preserve their existing behavior and live debugging state remains available.

- Closes #8184

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
