### PR TITLE
Automate `pre-commit` setup and correct contributor guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,19 @@
 .uv: ## Check that uv is installed
 	@uv --version || echo 'Please install uv: https://docs.astral.sh/uv/getting-started/installation/'
 
-.PHONY: .pre-commit
-.pre-commit: ## Check that pre-commit is installed
-	@pre-commit -V || echo 'Please install pre-commit: https://pre-commit.com/'
-
 .PHONY: install
-install: .uv .pre-commit ## Install the package, dependencies, and pre-commit for local development
+install: .uv ## Install the package, dependencies, and pre-commit for local development
 	uv sync --frozen --all-extras --no-extra mcp-tasks --all-packages --group lint
 	# pyright typechecks the gh-aw shim, which imports pydantic-ai-harness. The
 	# harness is kept out of the lock (its pydantic-ai-slim dep collides with the
 	# workspace member under lowest-direct), so install it out-of-band; --no-deps
 	# because pydantic-ai-slim is already present. See .github/workflows/ci.yml.
 	uv pip install --no-deps "pydantic-ai-harness==0.7.0"
-	pre-commit install --install-hooks
+	@if command -v pre-commit >/dev/null 2>&1; then \
+		pre-commit install --install-hooks; \
+	else \
+		uv tool install pre-commit && "$$(uv tool dir --bin)/pre-commit" install --install-hooks; \
+	fi
 
 .PHONY: install-all-python
 install-all-python: ## Install and synchronize an interpreter for every python version

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -118,7 +118,7 @@
 ## General
 
 <!-- rule:449 -->
-- Use `make install` to regenerate lock files (e.g., `uv.lock`) after dependency changes — Ensures reproducible builds and keeps lock file diffs minimal. Update the package manager (uv, npm, pip-tools) to latest first and start from clean state. If diffs are unexpectedly large, reset to base branch and regenerate to isolate actual changes — prevents spurious conflicts and version drift.
+- Update Python dependencies with `uv` so the dependency change also updates `uv.lock`. Use `make sync` to regenerate the lockfile when needed. `make install` installs the existing lockfile and development hooks; it does not regenerate `uv.lock`. Investigate unrelated lockfile changes before committing.
 <!-- rule:717 -->
 - Override profile properties in model/provider classes, not in shared profile functions — Prevents provider-specific logic from leaking into shared utilities like `anthropic_model_profile()` that multiple providers (OpenAI, Bedrock, etc.) depend on — keeps profiles reusable and avoids cross-provider bugs
 <!-- rule:-3 -->

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -103,7 +103,7 @@ git clone git@github.com:<your username>/pydantic-ai.git
 cd pydantic-ai
 ```
 
-Install `uv` (version 0.4.30 or later) and `pre-commit`:
+Install `uv` and `pre-commit`. The minimum supported `uv` version is set by `tool.uv.required-version` in the repository's [`pyproject.toml`](https://github.com/pydantic/pydantic-ai/blob/main/pyproject.toml):
 
 - [`uv` install docs](https://docs.astral.sh/uv/getting-started/installation/)
 - [`pre-commit` install docs](https://pre-commit.com/#install)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -103,18 +103,9 @@ git clone git@github.com:<your username>/pydantic-ai.git
 cd pydantic-ai
 ```
 
-Install `uv` and `pre-commit`. The minimum supported `uv` version is set by `tool.uv.required-version` in the repository's [`pyproject.toml`](https://github.com/pydantic/pydantic-ai/blob/main/pyproject.toml):
+[Install `uv`](https://docs.astral.sh/uv/getting-started/installation/). The minimum supported `uv` version is set by `tool.uv.required-version` in the repository's [`pyproject.toml`](https://github.com/pydantic/pydantic-ai/blob/main/pyproject.toml).
 
-- [`uv` install docs](https://docs.astral.sh/uv/getting-started/installation/)
-- [`pre-commit` install docs](https://pre-commit.com/#install)
-
-To install `pre-commit` you can run the following command:
-
-```bash
-uv tool install pre-commit
-```
-
-Install `pydantic-ai`, all dependencies and pre-commit hooks
+Install `pydantic-ai`, all dependencies, and pre-commit hooks. If `pre-commit` is not available, this also installs it with `uv`:
 
 ```bash
 make install

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -185,8 +185,9 @@ All routes in `docs/navigation.yml` are relative to the Pydantic AI documentatio
 page its complete canonical route in `slug`; use `aliases` only for redirect sources. Do not prefix
 either value with `/ai` or a leading slash.
 
-For the rendered site, use the documentation preview attached to a pull request after a maintainer
-adds the `trigger:docs` label.
+To validate navigation changes, ask a maintainer to add the `trigger:docs` label to the pull request.
+This checks the navigation manifest, referenced Markdown files, routes, aliases, and redirects in
+`pydantic/unified-docs` and posts the result on the PR. It does not build a rendered preview.
 
 CI checks that every link between doc pages resolves, anchor included, and fails on `Cannot find
 fragment`. A heading's anchor is generated from its text, so renaming one silently breaks every link


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-6-astra on behalf of David.

`make install` installs `pre-commit` through `uv` when it is missing, then installs the Git hooks. Existing installations are reused, and a newly installed tool works even when uv's tool directory is absent from `PATH`. Setup remains noninteractive.

The contributor guide now needs only `uv` installed beforehand and links its minimum version to `tool.uv.required-version`. Correct the coding guide's claim that frozen installation regenerates `uv.lock`, and describe the navigation validation performed by `trigger:docs` without promising a rendered preview.

Verification: isolated `make install` checks cover existing and missing tools, a tool directory outside `PATH`, and installation failure. A real `uv tool install` in an isolated Git fixture created the pre-commit hook successfully. The stale-lock reproduction and documentation-navigation check pass. The contributor page was rendered locally with `pydantic/unified-docs`. Formatting, linting, and commit hooks pass. No project dependency or runtime API changes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
