### PR TITLE
Render `ToolAdditionMode` and `ToolDeferralMode` on the profiles API reference page

### DIFF
--- a/docs/api/profiles.md
+++ b/docs/api/profiles.md
@@ -5,6 +5,8 @@
       members:
         - ModelProfile
         - ModelProfileSpec
+        - ToolAdditionMode
+        - ToolDeferralMode
         - JsonSchemaTransformer
         - InlineDefsJsonSchemaTransformer
         - merge_profile


### PR DESCRIPTION
`ToolAdditionMode` and `ToolDeferralMode` are exported from `pydantic_ai.profiles.__all__`, but neither is in the `members:` filter on `docs/api/profiles.md`, and neither name appears anywhere else under `docs/`. They are the only two `__all__` entries the page is missing. On the rendered page today, `ModelProfile.tool_deferral_mode`, `.tool_addition_mode` and `.tool_additions` show a type name with nothing to resolve to.

Both were added in #7104, which put them in `__all__` without adding them here.

One thing I could not settle from the outside, so please correct me if I have this wrong: #7483 swept this same page for missing public symbols eleven days after #7104 landed, added `JsonSchemaTransformer` and `InlineDefsJsonSchemaTransformer`, and left these two. Its `ToolsetTool` entry used the criterion this PR uses — exported in `__all__`, absent from the page — so I read the gap as one the sweep did not reach rather than a decision. If these are meant to stay off the reference, say so and I will close this.

Neither alias has a docstring, so each renders as its `Literal` values with no prose. Happy to push a follow-up commit documenting both if you would rather they land documented.

Refs: #7483

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
