### PR TITLE
Skip unchanged `tests/` files in `make typecheck-changed` and add a `PYRIGHT_TIME_BUDGET` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,11 @@ jobs:
           # CI opts back in.
           PYRIGHT_THREADS: auto
           # Fail a passing pyright run that outlasts this many seconds, so a change that makes
-          # pyright itself slow fails its own PR instead of `main` (#8077 took the hook from
-          # ~85 s to 330-490 s and nothing caught it, see #8177). 110 is 1.1x the p99 of the
-          # hook's own duration over the 60 `main` runs before that regression (mean 84 s,
-          # p99 98 s, max 99 s); the derivation is in #8182.
+          # pyright itself slow fails its own PR instead of `main`, as #8077 did (see #8177): the
+          # hook ran 328 to 490 s over the five `main` runs between those two. 110 is 1.1x the p99
+          # (98.4 s) of the hook's own duration over the 60 successful `main` push runs before that
+          # regression (mean 83.8 s, max 99.2 s), rounded up to a round number; the derivation is in
+          # a comment on https://github.com/pydantic/pydantic-ai/issues/8182.
           PYRIGHT_TIME_BUDGET: "110"
           # pre-commit hooks shell out via `uv run`; without this they would
           # re-sync the venv and drop the out-of-band harness install above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,11 +253,11 @@ jobs:
           # CI opts back in.
           PYRIGHT_THREADS: auto
           # Fail a passing pyright run that outlasts this many seconds, so a change that makes
-          # pyright itself slow fails its own PR instead of `main`, as #8077 did (see #8177): the
-          # hook ran 328 to 490 s over the five `main` runs between those two. 110 is 1.1x the p99
-          # (98.4 s) of the hook's own duration over the 60 successful `main` push runs before that
-          # regression (mean 83.8 s, max 99.2 s), rounded up to a round number; the derivation is in
-          # a comment on https://github.com/pydantic/pydantic-ai/issues/8182.
+          # pyright itself slow fails its own PR instead of `main`. #8077 made pyright slow and
+          # nothing caught it (see #8177): the hook ran 328 to 490 s over the five `main` runs
+          # between those two. 110 is 1.1x the p99 (98.4 s) of the hook's own duration over the 60
+          # successful `main` push runs before that regression (mean 83.8 s, max 99.2 s), rounded up;
+          # derived in https://github.com/pydantic/pydantic-ai/issues/8182#issuecomment-5575016259.
           PYRIGHT_TIME_BUDGET: "110"
           # pre-commit hooks shell out via `uv run`; without this they would
           # re-sync the venv and drop the out-of-band harness install above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,12 @@ jobs:
           # per core swaps. A runner has the memory, and this step is the longest in the job, so
           # CI opts back in.
           PYRIGHT_THREADS: auto
+          # Fail a passing pyright run that outlasts this many seconds, so a change that makes
+          # pyright itself slow fails its own PR instead of `main` (#8077 took the hook from
+          # ~85 s to 330-490 s and nothing caught it, see #8177). 110 is 1.1x the p99 of the
+          # hook's own duration over the 60 `main` runs before that regression (mean 84 s,
+          # p99 98 s, max 99 s); the derivation is in #8182.
+          PYRIGHT_TIME_BUDGET: "110"
           # pre-commit hooks shell out via `uv run`; without this they would
           # re-sync the venv and drop the out-of-band harness install above.
           UV_NO_SYNC: "1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,8 +83,10 @@ repos:
       - id: typecheck
         name: Typecheck
         entry: make
-        # Narrows the run to the files a change can reach, and falls back to the full
-        # `make typecheck` whenever it cannot. CI skips this hook by id when nothing
+        # Narrows the run to the files a change can reach; when it cannot, it checks every
+        # tracked file Pyright reports on, minus the unchanged `tests/` files. Only `CI`, an
+        # interpreter older than 3.11 and a Pyright configuration it cannot reproduce hand the
+        # whole project to `make typecheck-pyright`. CI skips this hook by id when nothing
         # Pyright reads has changed, and runs the full check otherwise.
         args: [typecheck-changed]
         language: system

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ The project uses:
 
 ## When to verify
 
-Pre-commit runs `make lint`, `make format`, and `make typecheck-changed` automatically on every commit; that last one skips `tests/` files you did not change, and CI additionally runs the whole type check and test suite. While iterating, only run targeted checks on the files/tests you have a specific reason to suspect:
+Pre-commit runs `make lint`, `make format`, and `make typecheck-changed` automatically on every commit; that last one skips `tests/` files you did not change since it last passed (the first run checks every file), and CI additionally runs the whole type check and test suite. While iterating, only run targeted checks on the files/tests you have a specific reason to suspect:
 
 - typecheck a single file: `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright path/to/file.py`
 - run a single test: `uv run pytest path/to/test.py::test_name`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ The project uses:
 
 ## When to verify
 
-Pre-commit runs `make lint`, `make format`, and `make typecheck` automatically on every commit; CI additionally runs the full test suite. While iterating, only run targeted checks on the files/tests you have a specific reason to suspect:
+Pre-commit runs `make lint`, `make format`, and `make typecheck-changed` automatically on every commit; that last one skips `tests/` files you did not change, and CI additionally runs the whole type check and test suite. While iterating, only run targeted checks on the files/tests you have a specific reason to suspect:
 
 - typecheck a single file: `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright path/to/file.py`
 - run a single test: `uv run pytest path/to/test.py::test_name`

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,10 @@ typecheck-pyright:
 
 .PHONY: typecheck-changed
 typecheck-changed: ## Run static type checking on the files reached by changes since it last passed
-	@# The pre-commit hook's entry point. Falls back to `typecheck-pyright` whenever the
-	@# narrowed set is not provably the same answer; see scripts/typecheck_changed.py
+	@# The pre-commit hook's entry point. Whenever the narrowed set is not provably the same answer, it
+	@# runs pyright over every tracked file it reports on, minus the unchanged `tests/` files. Only `CI`, an
+	@# interpreter older than 3.11 and a pyright configuration it cannot reproduce hand the whole project to
+	@# `typecheck-pyright`; see scripts/typecheck_changed.py
 	uv run python scripts/typecheck_changed.py
 
 .PHONY: typecheck-mypy

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -176,16 +176,16 @@ not, stays single-process.
 export PYRIGHT_THREADS=auto
 ```
 
-Export it rather than setting it per command, so every full run picks it up. Every worker is a full
-Node process, so they pay for themselves only on a machine with the memory to hold them; one already
-near its limit swaps and comes out slower than the default. Unset the variable or set it to `1` to go
-back to a single process: anything Pyright cannot read as a positive integer, `0` and `off` included,
-means `auto`.
+Export it rather than setting it per command, so every `make typecheck` picks it up. Every worker is
+a full Node process, so they pay for themselves only on a machine with the memory to hold them; one
+already near its limit swaps and comes out slower than the default. Unset the variable or set it to
+`1` to go back to a single process: anything Pyright cannot read as a positive integer, `0` and
+`off` included, means `auto`.
 
 `PYRIGHT_TIME_BUDGET` caps how long the check may take: set it to a number of seconds, and a run that
 passes but takes longer than that fails anyway. CI sets it, so a change that makes Pyright itself slow
-fails its own pull request rather than landing on `main`. Anything but a positive number of seconds
-fails the run outright rather than being ignored.
+fails its own pull request rather than landing on `main`. Any value that is not a positive number of
+seconds fails the run outright rather than being ignored; leaving it unset or empty means no budget.
 
 ## Documentation Changes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -149,30 +149,41 @@ and on seeing it `make typecheck-changed` narrows nothing and hands the whole pr
 `make typecheck-pyright`. A fresh runner has no record to narrow against in the first place. CI still
 skips the hook outright on a pull request that touches nothing Pyright reads, as it did before.
 
-Locally it follows the imports Pyright resolves statically, and falls back to the full run whenever
-something could leave that set incomplete: a first run; an interpreter older than Python 3.11, which
-is what it needs to read `pyproject.toml`; a new Pyright or Python version, including one asked for
-through `PYRIGHT_PYTHON`; a change to
+Locally it follows the imports Pyright resolves statically, and never checks a file under `tests/`
+that did not itself change. Tests are two thirds of the project's lines and most of them import
+`pydantic_ai`, so checking them here would put the whole project back on the command line for any
+change to the library; CI is the gate for a source change that breaks a test file's typing.
+
+It gives up on narrowing whenever something could leave that set incomplete: a first run; a new
+Pyright or Python version, including one asked for through `PYRIGHT_PYTHON`; a change to
 `pyproject.toml`, `uv.lock` or the `Makefile`; an import that would now resolve to a different file
 or a new top-level module that could shadow an installed one; or a change reaching more than half the
-project. A narrowed run only ever considers tracked files, so run `make typecheck` yourself before
-relying on a green hook for a file you have not added; a fallback run hands Pyright the whole project
-and picks untracked files up with it.
+project. It then runs Pyright over every tracked file Pyright reports on, minus the `tests/` files
+that did not change. Only three things hand the whole project to `make typecheck-pyright`: `CI`, an
+interpreter older than Python 3.11, which is what it needs to read `pyproject.toml`, and a Pyright
+configuration it cannot reproduce. Every other run considers tracked files only, so run
+`make typecheck` yourself before relying on a green hook for a file you have not added.
 
 A full run is single-process unless `PYRIGHT_THREADS` says otherwise, and CI sets it to `auto`.
 The variable turns on Pyright's parallel check phase, which reaches the same diagnostics in less
-wall time: `auto` is up to one worker per logical core, and a positive integer caps them. A narrowed
-run stays single-process either way.
+wall time: `auto` is up to one worker per logical core, and a positive integer caps them. Only
+`make typecheck-pyright` reads it; every run `make typecheck-changed` decides for itself, narrowed or
+not, stays single-process.
 
 ```bash
 export PYRIGHT_THREADS=auto
 ```
 
-Export it rather than setting it per command, so a hook run that falls back to the full check picks
-it up too. Every worker is a full Node process, so they pay for themselves only on a machine with
-the memory to hold them; one already near its limit swaps and comes out slower than the default.
-Unset the variable or set it to `1` to go back to a single process: anything Pyright cannot read as
-a positive integer, `0` and `off` included, means `auto`.
+Export it rather than setting it per command, so every full run picks it up. Every worker is a full
+Node process, so they pay for themselves only on a machine with the memory to hold them; one already
+near its limit swaps and comes out slower than the default. Unset the variable or set it to `1` to go
+back to a single process: anything Pyright cannot read as a positive integer, `0` and `off` included,
+means `auto`.
+
+`PYRIGHT_TIME_BUDGET` caps how long the check may take: set it to a number of seconds, and a run that
+passes but takes longer than that fails anyway. CI sets it, so a change that makes Pyright itself slow
+fails its own pull request rather than landing on `main`. Anything but a positive number of seconds
+fails the run outright rather than being ignored.
 
 ## Documentation Changes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,19 +150,21 @@ and on seeing it `make typecheck-changed` narrows nothing and hands the whole pr
 skips the hook outright on a pull request that touches nothing Pyright reads, as it did before.
 
 Locally it follows the imports Pyright resolves statically, and never checks a file under `tests/`
-that did not itself change. Tests are two thirds of the project's lines and most of them import
-`pydantic_ai`, so checking them here would put the whole project back on the command line for any
-change to the library; CI is the gate for a source change that breaks a test file's typing.
+that did not itself change since the run it recorded. Tests are two thirds of the project's lines
+and most of them import `pydantic_ai`, so checking them here would put the whole project back on the
+command line for any change to the library; CI is the gate for a source change that breaks a test
+file's typing.
 
 It gives up on narrowing whenever something could leave that set incomplete: a first run; a new
 Pyright or Python version, including one asked for through `PYRIGHT_PYTHON`; a change to
 `pyproject.toml`, `uv.lock` or the `Makefile`; an import that would now resolve to a different file
 or a new top-level module that could shadow an installed one; or a change reaching more than half the
 project. It then runs Pyright over every tracked file Pyright reports on, minus the `tests/` files
-that did not change. Only three things hand the whole project to `make typecheck-pyright`: `CI`, an
-interpreter older than Python 3.11, which is what it needs to read `pyproject.toml`, and a Pyright
-configuration it cannot reproduce. Every other run considers tracked files only, so run
-`make typecheck` yourself before relying on a green hook for a file you have not added.
+that did not change; a first run has no record to compare them against, so it checks all of them.
+Only three things hand the whole project to `make typecheck-pyright`: `CI`, an interpreter older
+than Python 3.11, which is what it needs to read `pyproject.toml`, and a Pyright configuration it
+cannot reproduce. Every other run considers tracked files only, so run `make typecheck` yourself
+before relying on a green hook for a file you have not added.
 
 A full run is single-process unless `PYRIGHT_THREADS` says otherwise, and CI sets it to `auto`.
 The variable turns on Pyright's parallel check phase, which reaches the same diagnostics in less

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -169,8 +169,9 @@ before relying on a green hook for a file you have not added.
 A full run is single-process unless `PYRIGHT_THREADS` says otherwise, and CI sets it to `auto`.
 The variable turns on Pyright's parallel check phase, which reaches the same diagnostics in less
 wall time: `auto` is up to one worker per logical core, and a positive integer caps them. Only
-`make typecheck-pyright` reads it; every run `make typecheck-changed` decides for itself, narrowed or
-not, stays single-process.
+`make typecheck-pyright` reads it, so the hook picks it up only on a run that hands the whole
+project over: `CI`, an interpreter older than Python 3.11, or a Pyright configuration it cannot
+reproduce. A run it narrows, or runs itself over the reduced set, stays single-process.
 
 ```bash
 export PYRIGHT_THREADS=auto
@@ -184,8 +185,9 @@ already near its limit swaps and comes out slower than the default. Unset the va
 
 `PYRIGHT_TIME_BUDGET` caps how long the check may take: set it to a number of seconds, and a run that
 passes but takes longer than that fails anyway. CI sets it, so a change that makes Pyright itself slow
-fails its own pull request rather than landing on `main`. Any value that is not a positive number of
-seconds fails the run outright rather than being ignored; leaving it unset or empty means no budget.
+fails its own pull request rather than landing on `main`. Any value that is not a finite positive
+number of seconds fails the run outright rather than being ignored; leaving it unset or empty means
+no budget.
 
 ## Documentation Changes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -183,12 +183,6 @@ already near its limit swaps and comes out slower than the default. Unset the va
 `1` to go back to a single process: anything Pyright cannot read as a positive integer, `0` and
 `off` included, means `auto`.
 
-`PYRIGHT_TIME_BUDGET` caps how long the check may take: set it to a number of seconds, and a run that
-passes but takes longer than that fails anyway. CI sets it, so a change that makes Pyright itself slow
-fails its own pull request rather than landing on `main`. Any value that is not a finite positive
-number of seconds fails the run outright rather than being ignored; leaving it unset or empty means
-no budget.
-
 ## Documentation Changes
 
 [`docs/navigation.yml`](https://github.com/pydantic/pydantic-ai/blob/main/docs/navigation.yml)

--- a/scripts/test_typecheck_changed.py
+++ b/scripts/test_typecheck_changed.py
@@ -486,14 +486,21 @@ def test_a_run_over_the_time_budget_fails_and_records_nothing(
     assert not _checkpoint(project).exists()
 
 
-def test_a_run_without_a_time_budget_says_nothing_about_time(project: Path, capsys: pytest.CaptureFixture[str]):
+@pytest.mark.parametrize('empty', [True, False], ids=['empty', 'unset'])
+def test_a_run_without_a_time_budget_says_nothing_about_time(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], empty: bool
+):
+    # An explicitly empty `PYRIGHT_TIME_BUDGET` means what leaving it unset means.
+    if empty:
+        monkeypatch.setenv('PYRIGHT_TIME_BUDGET', '')
+
     recorder = _typecheck(seconds=99.0)
 
     assert recorder.exit_code == 0
     assert 'PYRIGHT_TIME_BUDGET' not in capsys.readouterr().out
 
 
-@pytest.mark.parametrize('setting', ['soon', '0', '-1'])
+@pytest.mark.parametrize('setting', ['soon', '0', '-1', 'nan'])
 def test_a_time_budget_that_is_not_positive_seconds_runs_nothing(
     project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], setting: str
 ):

--- a/scripts/test_typecheck_changed.py
+++ b/scripts/test_typecheck_changed.py
@@ -22,9 +22,17 @@ _MODULES = {
     **{f'pkg_src/pkg/spare{index}.py': f'SPARE = {index}\n' for index in range(4)},
 }
 
+# `tests/` is the one prefix the script treats specially, so the project needs files under it.
+_TESTS = {
+    'tests/__init__.py': '',
+    'tests/test_leaf.py': 'from pkg.leaf import VALUE\n\nCHECKED = VALUE == 1\n',
+}
+
+_TRACKED = {**_MODULES, **_TESTS}
+
 _PYPROJECT = """\
 [tool.pyright]
-include = ["pkg_src"]
+include = ["pkg_src", "tests"]
 
 [tool.uv.workspace]
 members = ["pkg_src"]
@@ -41,10 +49,14 @@ extraPaths = ["pkg_src"]
 # `middle.py` sits between `leaf.py` and `top.py`, so excluding it puts a file Pyright
 # reports nothing about in the middle of an import chain.
 _EXCLUDING_PYPROJECT = _PYPROJECT.replace(
-    'include = ["pkg_src"]', 'include = ["pkg_src"]\nexclude = ["pkg_src/pkg/middle.py"]'
+    'include = ["pkg_src", "tests"]', 'include = ["pkg_src", "tests"]\nexclude = ["pkg_src/pkg/middle.py"]'
 )
 
 _FULL_RUN = [['make', 'typecheck-pyright']]
+
+# What a fallback decided locally checks: every file Pyright reports on, minus the `tests/`
+# files that did not change.
+_EVERY_FILE_OUTSIDE_TESTS = sorted(_MODULES)
 
 
 class _Recorder:
@@ -66,9 +78,21 @@ class _Recorder:
         return command[3:]
 
 
+class _Clock:
+    """A monotonic clock that advances by the same number of seconds every time it is read."""
+
+    def __init__(self, seconds: float) -> None:
+        self.seconds = seconds
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        self.now += self.seconds
+        return self.now
+
+
 @pytest.fixture
 def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    for name, source in _MODULES.items():
+    for name, source in _TRACKED.items():
         _write(tmp_path, name, source)
     _write(tmp_path, 'pyproject.toml', _PYPROJECT)
     _write(tmp_path, 'uv.lock', 'version = 1\n')
@@ -80,6 +104,7 @@ def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # Both are read from the environment, and both are set while this suite runs in CI.
     monkeypatch.delenv('CI', raising=False)
     monkeypatch.delenv('PYRIGHT_PYTHON', raising=False)
+    monkeypatch.delenv('PYRIGHT_TIME_BUDGET', raising=False)
     return tmp_path
 
 
@@ -99,9 +124,9 @@ def _stage(project: Path) -> None:
     subprocess.run(['git', 'add', '--all'], cwd=project, check=True, capture_output=True)
 
 
-def _typecheck(*, fails: bool = False) -> _Recorder:
+def _typecheck(*, fails: bool = False, seconds: float = 0.0) -> _Recorder:
     recorder = _Recorder(1 if fails else 0)
-    recorder.exit_code = typecheck_changed.main(recorder)
+    recorder.exit_code = typecheck_changed.main(recorder, _Clock(seconds))
     return recorder
 
 
@@ -110,12 +135,13 @@ def _checkpoint(project: Path) -> Path:
 
 
 def test_the_first_run_checks_every_tracked_file(project: Path):
+    # Nothing is stored yet, so every test file counts as changed and is checked with the rest.
     recorder = _typecheck()
 
-    assert recorder.commands == _FULL_RUN
+    assert recorder.checked == sorted(_TRACKED)
     assert recorder.exit_code == 0
     checkpoint = json.loads(_checkpoint(project).read_text(encoding='utf-8'))
-    assert sorted(checkpoint['files']) == sorted(_MODULES)
+    assert sorted(checkpoint['files']) == sorted(_TRACKED)
 
 
 def test_a_run_on_unchanged_files_checks_nothing(project: Path):
@@ -139,6 +165,29 @@ def test_an_edit_checks_everything_that_imports_it(project: Path):
     _edit(project, 'pkg_src/pkg/leaf.py')
 
     assert _typecheck().checked == ['pkg_src/pkg/leaf.py', 'pkg_src/pkg/middle.py', 'pkg_src/pkg/top.py']
+
+
+def test_an_edit_leaves_a_test_file_that_imports_it_alone(project: Path):
+    # `tests/test_leaf.py` imports `leaf.py`, and waits for CI rather than being checked here.
+    _typecheck()
+    _edit(project, 'pkg_src/pkg/leaf.py')
+
+    assert 'tests/test_leaf.py' not in _typecheck().checked
+
+
+def test_an_edit_to_a_test_file_checks_it(project: Path):
+    _typecheck()
+    _edit(project, 'tests/test_leaf.py')
+
+    assert _typecheck().checked == ['tests/test_leaf.py']
+
+
+def test_a_new_test_file_is_checked(project: Path):
+    _typecheck()
+    _write(project, 'tests/test_extra.py', 'from pkg.aside import ASIDE\n\nCHECKED = ASIDE\n')
+    _stage(project)
+
+    assert _typecheck().checked == ['tests/test_extra.py']
 
 
 @pytest.mark.parametrize('staged', [True, False], ids=['staged', 'unstaged'])
@@ -198,7 +247,8 @@ def test_a_stub_stands_in_for_the_module_beside_it(project: Path):
 
 def test_a_dot_directory_is_checked_when_exclude_is_set(project: Path):
     # Pyright's built-in `**/.*` exclusion only applies while `exclude` is unset.
-    _write(project, 'pyproject.toml', _PYPROJECT.replace('["pkg_src"]', '["pkg_src"]\nexclude = ["nothing.py"]', 1))
+    include = 'include = ["pkg_src", "tests"]'
+    _write(project, 'pyproject.toml', _PYPROJECT.replace(include, f'{include}\nexclude = ["nothing.py"]'))
     _write(project, 'pkg_src/pkg/.skill/helper.py', 'HELPER = 1\n')
     _stage(project)
     _typecheck()
@@ -218,7 +268,7 @@ def test_a_dot_directory_is_skipped_when_exclude_is_unset(project: Path):
 
 @pytest.mark.parametrize('include', ['.', './pkg_src/', 'pkg_src/'])
 def test_relative_include_path_spellings_are_checked(project: Path, include: str):
-    _write(project, 'pyproject.toml', _PYPROJECT.replace('include = ["pkg_src"]', f'include = ["{include}"]'))
+    _write(project, 'pyproject.toml', _PYPROJECT.replace('include = ["pkg_src", "tests"]', f'include = ["{include}"]'))
     _typecheck()
     _edit(project, 'pkg_src/pkg/aside.py')
 
@@ -232,21 +282,22 @@ def test_a_file_that_does_not_parse_is_still_checked(project: Path):
     assert _typecheck().checked == ['pkg_src/pkg/middle.py', 'pkg_src/pkg/top.py']
 
 
-def test_a_new_top_level_module_checks_everything(project: Path):
+def test_a_new_top_level_module_checks_every_file_outside_tests(project: Path):
     _typecheck()
     _write(project, 'pkg_src/shadow.py', 'SHADOW = 1\n')
     _stage(project)
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == sorted([*_EVERY_FILE_OUTSIDE_TESTS, 'pkg_src/shadow.py'])
 
 
-def test_a_module_that_becomes_a_package_checks_everything(project: Path):
+def test_a_module_that_becomes_a_package_checks_every_file_outside_tests(project: Path):
     _typecheck()
     (project / 'pkg_src/pkg/leaf.py').unlink()
     _write(project, 'pkg_src/pkg/leaf/__init__.py', 'VALUE = 1\n')
     _stage(project)
 
-    assert _typecheck().commands == _FULL_RUN
+    moved = [path for path in _EVERY_FILE_OUTSIDE_TESTS if path != 'pkg_src/pkg/leaf.py']
+    assert _typecheck().checked == sorted([*moved, 'pkg_src/pkg/leaf/__init__.py'])
 
 
 def test_a_module_that_moved_still_reaches_its_importers_afterwards(project: Path):
@@ -267,7 +318,7 @@ def test_a_module_that_moved_still_reaches_its_importers_afterwards(project: Pat
     ]
 
 
-def test_a_new_module_under_an_execution_environment_root_checks_everything(project: Path):
+def test_a_new_module_under_an_execution_environment_root_checks_files_outside_tests(project: Path):
     # Pyright resolves a file directly under an environment root as a top-level module
     # inside that environment, so `pkg/pytest.py` shadows the installed `pytest` there.
     _write(project, 'pyproject.toml', f'{_PYPROJECT}\n[[tool.pyright.executionEnvironments]]\nroot = "pkg_src/pkg"\n')
@@ -275,15 +326,15 @@ def test_a_new_module_under_an_execution_environment_root_checks_everything(proj
     _write(project, 'pkg_src/pkg/pytest.py', 'FAKE = 1\n')
     _stage(project)
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == sorted([*_EVERY_FILE_OUTSIDE_TESTS, 'pkg_src/pkg/pytest.py'])
 
 
 @pytest.mark.parametrize('name', ['pyproject.toml', 'uv.lock', 'Makefile'])
-def test_a_configuration_change_checks_everything(project: Path, name: str):
+def test_a_configuration_change_checks_every_file_outside_tests(project: Path, name: str):
     _typecheck()
     _edit(project, name)
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == _EVERY_FILE_OUTSIDE_TESTS
 
 
 def test_an_interpreter_without_tomllib_checks_everything(project: Path, monkeypatch: pytest.MonkeyPatch):
@@ -293,28 +344,30 @@ def test_an_interpreter_without_tomllib_checks_everything(project: Path, monkeyp
     assert _typecheck().commands == _FULL_RUN
 
 
-def test_a_new_interpreter_checks_everything(project: Path, monkeypatch: pytest.MonkeyPatch):
+def test_a_new_interpreter_checks_every_file_outside_tests(project: Path, monkeypatch: pytest.MonkeyPatch):
     _typecheck()
     monkeypatch.setattr(typecheck_changed.platform, 'python_version', lambda: '9.9.9')
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == _EVERY_FILE_OUTSIDE_TESTS
 
 
-def test_asking_pyright_for_another_python_version_checks_everything(project: Path, monkeypatch: pytest.MonkeyPatch):
+def test_asking_pyright_for_another_python_version_rechecks_the_files_outside_tests(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+):
     # `PYRIGHT_PYTHON` becomes `--pythonversion`, so what passed under one value says
     # nothing about another.
     _typecheck()
     monkeypatch.setenv('PYRIGHT_PYTHON', '3.10')
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == ['--pythonversion', '3.10', *_EVERY_FILE_OUTSIDE_TESTS]
 
 
-def test_a_change_reaching_most_of_the_project_checks_everything(project: Path):
+def test_a_change_reaching_most_of_the_project_checks_every_file_outside_tests(project: Path):
     _typecheck()
     for name in ['aside', 'spare0', 'spare1', 'spare2', 'spare3']:
         _edit(project, f'pkg_src/pkg/{name}.py')
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == _EVERY_FILE_OUTSIDE_TESTS
 
 
 def test_a_change_reaching_half_the_project_stays_narrowed(project: Path):
@@ -346,8 +399,8 @@ def test_editing_an_excluded_file_checks_what_imports_it(project: Path):
 @pytest.mark.parametrize(
     'pyproject',
     [
-        _PYPROJECT.replace('["pkg_src"]', '["pkg_src/**"]'),
-        _PYPROJECT.replace('include = ["pkg_src"]\n', ''),
+        _PYPROJECT.replace('include = ["pkg_src", "tests"]', 'include = ["pkg_src/**"]'),
+        _PYPROJECT.replace('include = ["pkg_src", "tests"]\n', ''),
         _PYPROJECT.replace('[tool.pyright]\n', '[tool.pyright]\nextends = "base.json"\n'),
     ],
     ids=['glob', 'no-include', 'extends'],
@@ -372,11 +425,11 @@ def test_a_pyrightconfig_json_checks_everything(project: Path):
     assert _typecheck().commands == _FULL_RUN
 
 
-def test_an_unreadable_checkpoint_checks_everything(project: Path):
+def test_an_unreadable_checkpoint_checks_every_tracked_file(project: Path):
     _typecheck()
     _checkpoint(project).write_text('not a checkpoint', encoding='utf-8')
 
-    assert _typecheck().commands == _FULL_RUN
+    assert _typecheck().checked == sorted(_TRACKED)
 
 
 def test_ci_checks_everything_and_records_nothing(project: Path, monkeypatch: pytest.MonkeyPatch):
@@ -410,3 +463,45 @@ def test_pyright_reports_an_error_only_the_closure_reveals(project: Path, capsys
 
     assert typecheck_changed.main() == 1
     assert 'Type-checking 3 of 9 files' in capsys.readouterr().out
+
+
+def test_a_run_inside_the_time_budget_passes(project: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('PYRIGHT_TIME_BUDGET', '10')
+
+    recorder = _typecheck(seconds=9.5)
+
+    assert recorder.exit_code == 0
+    assert _checkpoint(project).exists()
+
+
+def test_a_run_over_the_time_budget_fails_and_records_nothing(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    monkeypatch.setenv('PYRIGHT_TIME_BUDGET', '10')
+
+    recorder = _typecheck(seconds=10.5)
+
+    assert recorder.exit_code == 1
+    assert 'Pyright passed in 10.5s, over the 10.0s `PYRIGHT_TIME_BUDGET`.' in capsys.readouterr().out
+    assert not _checkpoint(project).exists()
+
+
+def test_a_run_without_a_time_budget_says_nothing_about_time(project: Path, capsys: pytest.CaptureFixture[str]):
+    recorder = _typecheck(seconds=99.0)
+
+    assert recorder.exit_code == 0
+    assert 'PYRIGHT_TIME_BUDGET' not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize('setting', ['soon', '0', '-1'])
+def test_a_time_budget_that_is_not_positive_seconds_runs_nothing(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], setting: str
+):
+    monkeypatch.setenv('PYRIGHT_TIME_BUDGET', setting)
+
+    recorder = _typecheck()
+
+    assert recorder.exit_code == 2
+    assert recorder.commands == []
+    message = f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a positive number of seconds.'
+    assert message in capsys.readouterr().out

--- a/scripts/test_typecheck_changed.py
+++ b/scripts/test_typecheck_changed.py
@@ -134,12 +134,13 @@ def _checkpoint(project: Path) -> Path:
     return project / '.git' / CHECKPOINT_NAME
 
 
-def test_the_first_run_checks_every_tracked_file(project: Path):
+def test_the_first_run_checks_every_tracked_file(project: Path, capsys: pytest.CaptureFixture[str]):
     # Nothing is stored yet, so every test file counts as changed and is checked with the rest.
     recorder = _typecheck()
 
     assert recorder.checked == sorted(_TRACKED)
     assert recorder.exit_code == 0
+    assert f'Type-checking every one of the {len(_TRACKED)} files' in capsys.readouterr().out
     checkpoint = json.loads(_checkpoint(project).read_text(encoding='utf-8'))
     assert sorted(checkpoint['files']) == sorted(_TRACKED)
 
@@ -172,7 +173,7 @@ def test_an_edit_leaves_a_test_file_that_imports_it_alone(project: Path):
     _typecheck()
     _edit(project, 'pkg_src/pkg/leaf.py')
 
-    assert 'tests/test_leaf.py' not in _typecheck().checked
+    assert _typecheck().checked == ['pkg_src/pkg/leaf.py', 'pkg_src/pkg/middle.py', 'pkg_src/pkg/top.py']
 
 
 def test_an_edit_to_a_test_file_checks_it(project: Path):
@@ -318,7 +319,7 @@ def test_a_module_that_moved_still_reaches_its_importers_afterwards(project: Pat
     ]
 
 
-def test_a_new_module_under_an_execution_environment_root_checks_files_outside_tests(project: Path):
+def test_a_new_module_under_an_execution_environment_root_checks_every_file_outside_tests(project: Path):
     # Pyright resolves a file directly under an environment root as a top-level module
     # inside that environment, so `pkg/pytest.py` shadows the installed `pytest` there.
     _write(project, 'pyproject.toml', f'{_PYPROJECT}\n[[tool.pyright.executionEnvironments]]\nroot = "pkg_src/pkg"\n')
@@ -337,6 +338,18 @@ def test_a_configuration_change_checks_every_file_outside_tests(project: Path, n
     assert _typecheck().checked == _EVERY_FILE_OUTSIDE_TESTS
 
 
+def test_a_fallback_checks_the_test_files_that_changed(project: Path, capsys: pytest.CaptureFixture[str]):
+    # A fallback still leaves out the `tests/` files that did not change, so it names both counts.
+    _typecheck()
+    _edit(project, 'uv.lock')
+    _edit(project, 'tests/test_leaf.py')
+
+    recorder = _typecheck()
+
+    assert recorder.checked == sorted([*_EVERY_FILE_OUTSIDE_TESTS, 'tests/test_leaf.py'])
+    assert 'and the 1 changed inside it' in capsys.readouterr().out
+
+
 def test_an_interpreter_without_tomllib_checks_everything(project: Path, monkeypatch: pytest.MonkeyPatch):
     # Reading Pyright's file list out of pyproject.toml needs `tomllib`, added in 3.11.
     monkeypatch.setattr(typecheck_changed.sys, 'version_info', (3, 10, 18))
@@ -351,7 +364,7 @@ def test_a_new_interpreter_checks_every_file_outside_tests(project: Path, monkey
     assert _typecheck().checked == _EVERY_FILE_OUTSIDE_TESTS
 
 
-def test_asking_pyright_for_another_python_version_rechecks_the_files_outside_tests(
+def test_asking_pyright_for_another_python_version_checks_every_file_outside_tests(
     project: Path, monkeypatch: pytest.MonkeyPatch
 ):
     # `PYRIGHT_PYTHON` becomes `--pythonversion`, so what passed under one value says

--- a/scripts/test_typecheck_changed.py
+++ b/scripts/test_typecheck_changed.py
@@ -513,8 +513,8 @@ def test_a_run_without_a_time_budget_says_nothing_about_time(
     assert 'PYRIGHT_TIME_BUDGET' not in capsys.readouterr().out
 
 
-@pytest.mark.parametrize('setting', ['soon', '0', '-1', 'nan'])
-def test_a_time_budget_that_is_not_positive_seconds_runs_nothing(
+@pytest.mark.parametrize('setting', ['soon', '0', '-1', 'nan', 'inf', '-inf'])
+def test_a_time_budget_that_is_not_finite_positive_seconds_runs_nothing(
     project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], setting: str
 ):
     monkeypatch.setenv('PYRIGHT_TIME_BUDGET', setting)
@@ -523,5 +523,5 @@ def test_a_time_budget_that_is_not_positive_seconds_runs_nothing(
 
     assert recorder.exit_code == 2
     assert recorder.commands == []
-    message = f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a positive number of seconds.'
+    message = f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a finite positive number of seconds.'
     assert message in capsys.readouterr().out

--- a/scripts/test_typecheck_changed.py
+++ b/scripts/test_typecheck_changed.py
@@ -169,11 +169,13 @@ def test_an_edit_checks_everything_that_imports_it(project: Path):
 
 
 def test_an_edit_leaves_a_test_file_that_imports_it_alone(project: Path):
-    # `tests/test_leaf.py` imports `leaf.py`, and waits for CI rather than being checked here.
+    # The recorded edge proves `tests/test_leaf.py` reaches `leaf.py`, and it waits for CI anyway.
     _typecheck()
     _edit(project, 'pkg_src/pkg/leaf.py')
 
     assert _typecheck().checked == ['pkg_src/pkg/leaf.py', 'pkg_src/pkg/middle.py', 'pkg_src/pkg/top.py']
+    checkpoint = json.loads(_checkpoint(project).read_text(encoding='utf-8'))
+    assert 'pkg_src/pkg/leaf.py' in checkpoint['files']['tests/test_leaf.py']['imports']
 
 
 def test_an_edit_to_a_test_file_checks_it(project: Path):
@@ -495,6 +497,35 @@ def test_a_run_over_the_time_budget_fails_and_records_nothing(
     recorder = _typecheck(seconds=10.5)
 
     assert recorder.exit_code == 1
+    assert 'Pyright passed in 10.5s, over the 10.0s `PYRIGHT_TIME_BUDGET`.' in capsys.readouterr().out
+    assert not _checkpoint(project).exists()
+
+
+def test_a_failing_run_over_the_time_budget_reports_the_failure_not_the_time(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    # Pyright's own exit code is the answer; how long it took to reach it says nothing more.
+    monkeypatch.setenv('PYRIGHT_TIME_BUDGET', '10')
+
+    recorder = _typecheck(fails=True, seconds=10.5)
+
+    assert recorder.exit_code == 1
+    assert 'PYRIGHT_TIME_BUDGET' not in capsys.readouterr().out
+    assert not _checkpoint(project).exists()
+
+
+def test_ci_over_the_time_budget_fails_and_records_nothing(
+    project: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    # The pre-commit step that sets `PYRIGHT_TIME_BUDGET` sets `CI` too, so the full run handed
+    # to the Makefile is the only one production measures.
+    monkeypatch.setenv('CI', 'true')
+    monkeypatch.setenv('PYRIGHT_TIME_BUDGET', '10')
+
+    recorder = _typecheck(seconds=10.5)
+
+    assert recorder.exit_code == 1
+    assert recorder.commands == _FULL_RUN
     assert 'Pyright passed in 10.5s, over the 10.0s `PYRIGHT_TIME_BUDGET`.' in capsys.readouterr().out
     assert not _checkpoint(project).exists()
 

--- a/scripts/typecheck_changed.py
+++ b/scripts/typecheck_changed.py
@@ -7,10 +7,11 @@ one on every commit, so the pre-commit hook runs this instead: it narrows the ru
 files whose content changed since Pyright last passed, plus everything that transitively
 imports them.
 
-Locally that set never holds a file under `tests/` that did not itself change. Tests are two
-thirds of this project's lines and most of them import `pydantic_ai`, so keeping them would put
-the whole project back on the command line for any core edit. CI checks every file, and is the
-gate for a source change that breaks a test file's typing.
+Locally that set never holds a file under `tests/` that did not itself change since Pyright last
+passed. A run with no record of that -- the first one, or one after a record this cannot read --
+checks every file instead. Tests are two thirds of this project's lines and most of them import
+`pydantic_ai`, so keeping them would put the whole project back on the command line for any core
+edit. CI checks every file, and is the gate for a source change that breaks a test file's typing.
 
 What passed is recorded in a checkpoint under the git directory, so it is per-worktree and
 never committed. Anything the checkpoint cannot account for -- a first run, a dependency or
@@ -178,6 +179,7 @@ def main(run: Runner = run_command, clock: Clock = time.monotonic) -> int:
         except ValueError:
             budget = None
         # A misconfigured budget has to be loud, so nothing runs until this one reads as seconds.
+        # `nan` compares false either way, which is why this is `not budget > 0` and not `budget <= 0`.
         if budget is None or not budget > 0:
             print(f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a positive number of seconds.')
             return 2
@@ -234,14 +236,19 @@ def main(run: Runner = run_command, clock: Clock = time.monotonic) -> int:
         print(f'Type-checking {len(affected)} of {len(checkable)} files, reached from {len(changed)} changed.')
     else:
         paths = checkable
-        tests = sum(1 for path in checkable if path.startswith(_TESTS_PREFIX))
-        print(
-            f'Type-checking {len(checkable)} files -- every file outside `{_TESTS_PREFIX}`, '
-            f'and the {tests} changed inside it: {reason}.'
-        )
+        if stored:
+            tests = sum(1 for path in checkable if path.startswith(_TESTS_PREFIX))
+            print(
+                f'Type-checking {len(checkable)} files -- every file outside `{_TESTS_PREFIX}`, '
+                f'and the {tests} changed inside it: {reason}.'
+            )
+        else:
+            # With no record to compare against, every file counts as changed, tests included.
+            print(f'Type-checking every one of the {len(checkable)} files: {reason}.')
     # No `--threads`, even with `PYRIGHT_THREADS` set. A fallback reaches most of the project
     # outside `tests/`, but every worker is a full Node process that redoes the shared parse and
-    # bind, and on a laptop they swap and come out slower than the single process; see #8075.
+    # bind, and on a laptop they swap and come out slower than the single process; see
+    # https://github.com/pydantic/pydantic-ai/pull/8075.
     code = runner([sys.executable, '-m', 'pyright', *options, *paths])
 
     if code != 0:

--- a/scripts/typecheck_changed.py
+++ b/scripts/typecheck_changed.py
@@ -171,17 +171,23 @@ class _BudgetedRunner:
 
 
 def main(run: Runner = run_command, clock: Clock = time.monotonic) -> int:
-    """Type-check the files the working tree's changes can reach, and return Pyright's exit code."""
+    """Type-check the files the working tree's changes can reach, and return an exit code.
+
+    Pyright's own, or `0` when no change reaches a file it reports on; `1` for a run that passed
+    but outlasted `PYRIGHT_TIME_BUDGET`; `2` for a budget that does not read as seconds, which
+    runs nothing.
+    """
     budget: float | None = None
     setting = os.environ.get('PYRIGHT_TIME_BUDGET', '')
     if setting:
         try:
             budget = float(setting)
         except ValueError:
-            budget = None
+            budget = math.nan
         # A misconfigured budget has to be loud, so nothing runs until this one reads as seconds.
-        # `nan` and `inf` are rejected here because neither is a budget a run can be measured against.
-        if budget is None or not (math.isfinite(budget) and budget > 0):
+        # A value that is not a number at all becomes `nan`, and `nan` and `inf` are both rejected
+        # here because neither is a budget a run can be measured against.
+        if not (math.isfinite(budget) and budget > 0):
             print(f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a finite positive number of seconds.')
             return 2
     runner = _BudgetedRunner(run, clock, budget)
@@ -476,8 +482,11 @@ def _tracked_files() -> list[str]:
 
     The import graph is a property of the source tree, not of Pyright's file list: a file
     Pyright reports nothing about is still read for whoever imports it, so it belongs in the
-    graph even though it never belongs on the command line. A narrowed run never sees an
-    untracked file; a fallback run does, because Pyright walks the project itself.
+    graph even though it never belongs on the command line. Neither a narrowed run nor a fallback
+    this script decides for itself ever sees an untracked file, because both hand Pyright a file
+    list built from this one. Only the runs handed to `make typecheck-pyright` -- `CI`, an
+    interpreter older than 3.11, and a Pyright configuration this cannot reproduce -- walk the
+    project themselves and pick untracked files up.
     """
     listed = _git('ls-files', '-z').split('\0')
     # A file removed from the working tree but not yet from the index is still listed, and

--- a/scripts/typecheck_changed.py
+++ b/scripts/typecheck_changed.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import importlib.metadata
+import math
 import os
 import platform
 import posixpath
@@ -179,9 +180,9 @@ def main(run: Runner = run_command, clock: Clock = time.monotonic) -> int:
         except ValueError:
             budget = None
         # A misconfigured budget has to be loud, so nothing runs until this one reads as seconds.
-        # `nan` compares false either way, which is why this is `not budget > 0` and not `budget <= 0`.
-        if budget is None or not budget > 0:
-            print(f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a positive number of seconds.')
+        # `nan` and `inf` are rejected here because neither is a budget a run can be measured against.
+        if budget is None or not (math.isfinite(budget) and budget > 0):
+            print(f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a finite positive number of seconds.')
             return 2
     runner = _BudgetedRunner(run, clock, budget)
 

--- a/scripts/typecheck_changed.py
+++ b/scripts/typecheck_changed.py
@@ -7,12 +7,21 @@ one on every commit, so the pre-commit hook runs this instead: it narrows the ru
 files whose content changed since Pyright last passed, plus everything that transitively
 imports them.
 
+Locally that set never holds a file under `tests/` that did not itself change. Tests are two
+thirds of this project's lines and most of them import `pydantic_ai`, so keeping them would put
+the whole project back on the command line for any core edit. CI checks every file, and is the
+gate for a source change that breaks a test file's typing.
+
 What passed is recorded in a checkpoint under the git directory, so it is per-worktree and
-never committed. Anything the checkpoint cannot account for falls back to
-`make typecheck-pyright`, the same full run CI performs: a first run, a dependency or
-configuration change, an import that would resolve somewhere new, an interpreter older than
-the 3.11 this needs to read `pyproject.toml`, or a change large enough that narrowing stops
-paying for itself.
+never committed. Anything the checkpoint cannot account for -- a first run, a dependency or
+configuration change, an import that would resolve somewhere new, or a change large enough that
+narrowing stops paying for itself -- falls back to every file Pyright reports on, minus those
+unchanged tests. Only what leaves this script without a file list at all falls back to
+`make typecheck-pyright`, the same full run CI performs: `CI` itself, an interpreter older than
+the 3.11 this needs to read `pyproject.toml`, and a Pyright configuration this cannot reproduce.
+
+`PYRIGHT_TIME_BUDGET` fails a passing run that took longer than that many seconds, so a change
+that makes Pyright itself slow fails its own pull request rather than `main`.
 
 Usage:
     python scripts/typecheck_changed.py
@@ -28,6 +37,7 @@ import platform
 import posixpath
 import subprocess
 import sys
+import time
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -39,6 +49,9 @@ from typing_extensions import TypedDict
 
 Runner = Callable[[Sequence[str]], int]
 """Runs a command, streams its output, and returns its exit code."""
+
+Clock = Callable[[], float]
+"""Reads a monotonic clock, in seconds."""
 
 # The checkpoint lives in the git directory, which is per-worktree and never tracked.
 CHECKPOINT_NAME = 'pyright-checkpoint.json'
@@ -53,6 +66,13 @@ _CONFIGURATION_FILES = ('pyproject.toml', 'uv.lock', 'Makefile')
 _SKIPPED_DIRECTORIES = frozenset({'__pycache__', 'node_modules'})
 
 _GLOB_CHARACTERS = frozenset('*?[')
+
+# Pyright's execution environment for tests is rooted here, so this prefix is the whole set.
+# Tests are 314 of the 739 files Pyright checks but 337k of its 490k lines, and 263 of them
+# import `pydantic_ai`, so a core edit reaches every one of those. Locally they are checked only
+# when they changed themselves, which leaves CI as the gate for the rest; the profile behind
+# that trade is https://github.com/pydantic/pydantic-ai/issues/8182.
+_TESTS_PREFIX = 'tests/'
 
 
 class _FileState(TypedDict):
@@ -125,25 +145,57 @@ def run_command(command: Sequence[str]) -> int:
     return subprocess.run(command, env={**os.environ, 'PYRIGHT_PYTHON_IGNORE_WARNINGS': '1'}).returncode
 
 
-def main(run: Runner = run_command) -> int:
+@dataclass(frozen=True)
+class _BudgetedRunner:
+    """Runs commands, and fails a passing run that took longer than the budget allows."""
+
+    run: Runner
+    clock: Clock
+    budget: float | None
+
+    def __call__(self, command: Sequence[str]) -> int:
+        started = self.clock()
+        code = self.run(command)
+        elapsed = self.clock() - started
+        if code != 0 or self.budget is None or elapsed <= self.budget:
+            return code
+        print(
+            f'Pyright passed in {elapsed:.1f}s, over the {self.budget:.1f}s `PYRIGHT_TIME_BUDGET`.\n'
+            'A jump like this is usually a new generic signature Pyright cannot solve cheaply, as in '
+            'https://github.com/pydantic/pydantic-ai/pull/8177.\n'
+            'https://github.com/pydantic/pydantic-ai/issues/8182 has the profile of where the time goes.'
+        )
+        return 1
+
+
+def main(run: Runner = run_command, clock: Clock = time.monotonic) -> int:
     """Type-check the files the working tree's changes can reach, and return Pyright's exit code."""
+    budget: float | None = None
+    setting = os.environ.get('PYRIGHT_TIME_BUDGET', '')
+    if setting:
+        try:
+            budget = float(setting)
+        except ValueError:
+            budget = None
+        # A misconfigured budget has to be loud, so nothing runs until this one reads as seconds.
+        if budget is None or not budget > 0:
+            print(f'`PYRIGHT_TIME_BUDGET` is `{setting}`, which is not a positive number of seconds.')
+            return 2
+    runner = _BudgetedRunner(run, clock, budget)
+
     if os.environ.get('CI'):
         # CI keeps no checkpoint between runs, so there is nothing to narrow against.
-        return _check_everything(run, 'CI is set')
+        return _check_everything(runner, 'CI is set')
 
     if sys.version_info < (3, 11):
         # Reading Pyright's file list out of pyproject.toml needs `tomllib`, added in 3.11.
-        return _check_everything(run, 'this interpreter is older than Python 3.11')
+        return _check_everything(runner, 'this interpreter is older than Python 3.11')
 
     project = _load_project()
     if project is None:
-        return _check_everything(run, 'the Pyright file list is not one this script can reproduce')
+        return _check_everything(runner, 'the Pyright file list is not one this script can reproduce')
 
     universe = _tracked_files()
-    # `exclude` silences a file's own diagnostics and `include` bounds what Pyright looks
-    # at, but either file is still read for whoever imports it. So both stay in the graph
-    # and neither is ever a check target.
-    checkable = [path for path in universe if _is_checked(path, project)]
     hashes = {path: _file_hash(path) for path in universe}
     # The Makefile turns this into `--pythonversion`, so it decides what Pyright answers.
     requested_version = os.environ.get('PYRIGHT_PYTHON', '')
@@ -151,7 +203,15 @@ def main(run: Runner = run_command) -> int:
     checkpoint_path = Path(_git('rev-parse', '--absolute-git-dir').strip()) / CHECKPOINT_NAME
     checkpoint = _load_checkpoint(checkpoint_path)
     stored: dict[str, _FileState] = checkpoint['files'] if checkpoint is not None else {}
-    changed = [path for path in universe if path not in stored or stored[path]['hash'] != hashes[path]]
+    changed = {path for path in universe if path not in stored or stored[path]['hash'] != hashes[path]}
+    # `exclude` silences a file's own diagnostics and `include` bounds what Pyright looks
+    # at, but either file is still read for whoever imports it. So both stay in the graph
+    # and neither is ever a check target.
+    checkable = [
+        path
+        for path in universe
+        if _is_checked(path, project) and (not path.startswith(_TESTS_PREFIX) or path in changed)
+    ]
 
     reason = _reason_to_check_everything(checkpoint, keys, stored, universe, project)
     imports: dict[str, list[str]] | None = None
@@ -168,15 +228,21 @@ def main(run: Runner = run_command) -> int:
         if len(affected) * 2 > len(checkable):
             reason = f'{len(affected)} of {len(checkable)} files are affected, so a full run costs no more'
 
-    if reason is not None:
-        code = _check_everything(run, reason)
-    else:
-        options = ['--pythonversion', requested_version] if requested_version else []
+    options = ['--pythonversion', requested_version] if requested_version else []
+    if reason is None:
+        paths = affected
         print(f'Type-checking {len(affected)} of {len(checkable)} files, reached from {len(changed)} changed.')
-        # No `--threads`, even with `PYRIGHT_THREADS` set: the narrowed set is at most half the
-        # project, and at that size the workers do not pay for themselves. Measured on this repo,
-        # 31 files take 5 seconds single-process.
-        code = run([sys.executable, '-m', 'pyright', *options, *affected])
+    else:
+        paths = checkable
+        tests = sum(1 for path in checkable if path.startswith(_TESTS_PREFIX))
+        print(
+            f'Type-checking {len(checkable)} files -- every file outside `{_TESTS_PREFIX}`, '
+            f'and the {tests} changed inside it: {reason}.'
+        )
+    # No `--threads`, even with `PYRIGHT_THREADS` set. A fallback reaches most of the project
+    # outside `tests/`, but every worker is a full Node process that redoes the shared parse and
+    # bind, and on a laptop they swap and come out slower than the single process; see #8075.
+    code = runner([sys.executable, '-m', 'pyright', *options, *paths])
 
     if code != 0:
         # The checkpoint records what Pyright accepted, so a failing run leaves it alone.
@@ -187,6 +253,9 @@ def main(run: Runner = run_command) -> int:
         # unchanged file's stored edges can point at a path that no longer answers to that
         # module name. Only the narrowed path has established that they still hold.
         imports = _parse_imports(universe, universe, project.import_roots)
+    # The whole universe is recorded, unchanged test files included, so the next run reaches
+    # only the ones edited after this point. Recording a file this run did not check is the
+    # trade `_TESTS_PREFIX` describes, and CI is what checks it.
     files = {
         path: _FileState(hash=hashes[path], imports=imports[path] if path in imports else stored[path]['imports'])
         for path in universe
@@ -233,7 +302,7 @@ def _reason_to_check_everything(
 
 
 def _affected(
-    changed: Sequence[str],
+    changed: Iterable[str],
     deleted: Sequence[str],
     stored: Mapping[str, _FileState],
     imports: Mapping[str, list[str]],
@@ -258,7 +327,7 @@ def _affected(
     return sorted(reached.intersection(checkable))
 
 
-def _parse_imports(paths: Sequence[str], universe: Sequence[str], roots: Sequence[str]) -> dict[str, list[str]]:
+def _parse_imports(paths: Iterable[str], universe: Sequence[str], roots: Sequence[str]) -> dict[str, list[str]]:
     modules = _module_map(universe, roots)
     return {path: _imports_of(path, modules, roots) for path in paths}
 


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5-1 on behalf of David.

David set the direction and the budget rule (1.1 × p99 of the hook's history); he has not reviewed the code line by line.

- Part of #8182 (items 1 and 3 of "What would shrink it")

### Why we make these changes

Locally, `make typecheck-changed` (#8076) cannot narrow a core edit: 263 of the 635 files reached from `pydantic_ai/__init__.py` are under `tests/`, and tests are 337k of the 490k lines pyright checks, so every such edit fell back to the full 739-file run at 3.6 to 4 GB RSS. The hook now checks a `tests/` file only when that file itself changed since it last passed (a first run has no record, so it still checks every file), and every fallback it decides for itself runs on that reduced set. CI still checks everything, so a source change that breaks a test file's typing surfaces there.

Separately, #8077 made pyright about ten times slower and nothing caught it before `main` (#8177). `PYRIGHT_TIME_BUDGET` is a number of seconds: a pyright run that passes but takes longer fails anyway. CI sets it to 110: 1.1 × the p99 of the hook's own duration over the 60 successful `main` runs before that regression (mean 83.8 s, p99 98.4 s, max 99.2 s), rounded up; during the regression the hook ran 328 to 490 s. The profile and the derivation are in #8182.

### New public surface

none

### User-visible behavior

On `main`, a one-line edit to `pydantic_ai_slim/pydantic_ai/usage.py` prints `Type-checking every file: … files are affected, so a full run costs no more.` and hands all 739 files to `make typecheck-pyright`. On this branch, measured in the worktree, single process:

```console
$ make typecheck-changed   # after the usage.py edit
Type-checking 425 files -- every file outside `tests/`, and the 0 changed inside it: 371 of 425 files are affected, so a full run costs no more.
# 15.8 s wall
$ make typecheck-changed   # after editing tests/test_cost.py instead
Type-checking 1 of 426 files, reached from 1 changed.
# 3.1 s wall
$ PYRIGHT_TIME_BUDGET=1 make typecheck-changed
Pyright passed in 14.1s, over the 1.0s `PYRIGHT_TIME_BUDGET`.
# exit 1, checkpoint left unchanged
```

### Verification

- Unchanged tests are skipped, changed and new ones are checked, and a first run checks them all: [`test_an_edit_leaves_a_test_file_that_imports_it_alone`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L171), which asserts the recorded `tests/test_leaf.py` → `leaf.py` import edge, so the skipped file was reachable; [`test_an_edit_to_a_test_file_checks_it`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L181), [`test_a_new_test_file_is_checked`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L188), [`test_the_first_run_checks_every_tracked_file`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L137).
- Local fallbacks run the reduced set, while `CI` and the no-file-list cases still run `make typecheck-pyright`: [`test_a_change_reaching_most_of_the_project_checks_every_file_outside_tests`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L380), [`test_a_fallback_checks_the_test_files_that_changed`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L343) and the neighbouring `…checks_every_file_outside_tests` tests; `test_ci_checks_everything_and_records_nothing` is unchanged.
- Budget: [`test_a_run_over_the_time_budget_fails_and_records_nothing`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L492); [`test_a_failing_run_over_the_time_budget_reports_the_failure_not_the_time`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L504), where pyright's own exit code is the answer and no budget message is printed; [`test_ci_over_the_time_budget_fails_and_records_nothing`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L517), the `CI` path being the only one production measures; [`test_a_time_budget_that_is_not_finite_positive_seconds_runs_nothing`](https://github.com/pydantic/pydantic-ai/blob/8a1c20e11b9851abd202055565af8a978e572306/scripts/test_typecheck_changed.py#L548); plus the inside-budget and no-budget cases beside them.

### What changes for existing users

Nothing for library users; a contributor's pre-commit hook no longer type-checks `tests/` files they did not edit, and CI still does.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

