### PR TITLE
docs: warn against registering tools from inside `prepare`

### DIFF
--- a/docs/tools-advanced.md
+++ b/docs/tools-advanced.md
@@ -236,6 +236,16 @@ A `prepare` method can be registered via the `prepare` kwarg to any of the tool 
 
 The `prepare` method has type [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc]. It receives [`RunContext`][pydantic_ai.tools.RunContext] and a pre-built [`ToolDefinition`][pydantic_ai.tools.ToolDefinition]. It can return that definition unchanged or modified, return a new definition, or return `None` to omit the tool for that step.
 
+!!! warning "Don't register tools from inside `prepare`"
+
+    A `prepare` method runs while the toolset is iterating its registered tools to build the step's tool
+    definitions, so registering a new tool on the same toolset from within a `prepare` callback (for
+    example via [`FunctionToolset.add_function`][pydantic_ai.toolsets.function.FunctionToolset.add_function])
+    is not supported and raises an error. To make tools available dynamically during a run, build a
+    [dynamic toolset](toolsets.md#dynamically-building-a-toolset), filter or extend the definitions with
+    the agent-wide `prepare_tools` hook (see [Agent-wide Dynamic Tools](#prepare-tools)), or mark tools
+    for [deferred loading](toolsets.md#deferred-loading).
+
 Here's a simple `prepare` method that only includes the tool if the value of the dependency is `42`.
 
 As with the previous example, we use [`TestModel`][pydantic_ai.models.test.TestModel] to demonstrate the behavior without calling a real model.


### PR DESCRIPTION
## Problem

`prepare` is documented as customize-or-omit a `ToolDefinition`, but nothing warns that registering a tool on the same toolset from inside a `prepare` callback is unsupported. A user hit exactly this in #8058: the toolset is iterating its tools while `prepare` runs, so calling `add_function()` from within the callback crashes with `RuntimeError: dictionary changed size during iteration` — with no hint pointing at the supported alternatives.

## Change

Adds a `!!! warning` admonition to the Dynamic Tools section (admonition style per `docs/CLAUDE.md`), stating the constraint and pointing at the supported dynamic paths: dynamic toolsets, the agent-wide `prepare_tools` hook, and deferred loading — the same trio a #8058 fix would point at.

The wording deliberately doesn't name the raised exception type, so it stays accurate regardless of whether #8058 lands as `UserError` or keeps the current `RuntimeError`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

