### PR TITLE
Preserve text part boundaries after tool calls in `OpenAIChatModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3952,7 +3952,7 @@ class OpenAIStreamedResponse(StreamedResponse):
     _provider_timestamp: datetime | None = None
     _timestamp: datetime = field(default_factory=_now_utc)
     _model_settings: OpenAIChatModelSettings | None = None
-    _text_vendor_part_id: str = field(default='content', init=False)
+    _vendor_part_id: str = field(default='content', init=False)
     _has_refusal: bool = field(default=False, init=False)
     _refusal_text: str = field(default='', init=False)
     _has_finish_reason: bool = field(default=False, init=False)
@@ -4100,7 +4100,7 @@ class OpenAIStreamedResponse(StreamedResponse):
         content = choice.delta.content
         if content:
             for event in self._parts_manager.handle_text_delta(
-                vendor_part_id=self._text_vendor_part_id,
+                vendor_part_id=self._vendor_part_id,
                 content=content,
                 thinking_tags=self._model_profile.get('thinking_tags', DEFAULT_THINKING_TAGS),
                 ignore_leading_whitespace=self._model_profile.get('ignore_streamed_leading_whitespace', False),
@@ -4124,7 +4124,7 @@ class OpenAIStreamedResponse(StreamedResponse):
             )
             if maybe_event is not None:
                 if isinstance(maybe_event, PartStartEvent):
-                    self._text_vendor_part_id = f'content-after-tool-{maybe_event.index}'
+                    self._vendor_part_id = f'{self._vendor_part_id}-{maybe_event.index}'
                 yield maybe_event
 
     def _map_provider_details(self, chunk: ChatCompletionChunk) -> dict[str, Any] | None:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3952,6 +3952,7 @@ class OpenAIStreamedResponse(StreamedResponse):
     _provider_timestamp: datetime | None = None
     _timestamp: datetime = field(default_factory=_now_utc)
     _model_settings: OpenAIChatModelSettings | None = None
+    _text_vendor_part_id: str = field(default='content', init=False)
     _has_refusal: bool = field(default=False, init=False)
     _refusal_text: str = field(default='', init=False)
     _has_finish_reason: bool = field(default=False, init=False)
@@ -4099,7 +4100,7 @@ class OpenAIStreamedResponse(StreamedResponse):
         content = choice.delta.content
         if content:
             for event in self._parts_manager.handle_text_delta(
-                vendor_part_id='content',
+                vendor_part_id=self._text_vendor_part_id,
                 content=content,
                 thinking_tags=self._model_profile.get('thinking_tags', DEFAULT_THINKING_TAGS),
                 ignore_leading_whitespace=self._model_profile.get('ignore_streamed_leading_whitespace', False),
@@ -4122,6 +4123,8 @@ class OpenAIStreamedResponse(StreamedResponse):
                 tool_call_id=dtc.id,
             )
             if maybe_event is not None:
+                if isinstance(maybe_event, PartStartEvent):
+                    self._text_vendor_part_id = f'content-after-tool-{maybe_event.index}'
                 yield maybe_event
 
     def _map_provider_details(self, chunk: ChatCompletionChunk) -> dict[str, Any] | None:

--- a/tests/models/test_openai_text_after_tool.py
+++ b/tests/models/test_openai_text_after_tool.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai.ui.vercel_ai import VercelAIAdapter
+from pydantic_ai.ui.vercel_ai.request_types import SubmitMessage
+from pydantic_ai.ui.vercel_ai.response_types import (
+    ReasoningDeltaChunk,
+    TextDeltaChunk,
+    TextEndChunk,
+    TextStartChunk,
+)
+
+from ..conftest import try_import
+
+with try_import() as imports_successful:
+    from openai.types.chat import ChatCompletionChunk
+    from openai.types.chat.chat_completion_chunk import (
+        Choice,
+        ChoiceDelta,
+        ChoiceDeltaToolCall,
+        ChoiceDeltaToolCallFunction,
+    )
+
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.profiles.openai import OpenAIModelProfile
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    from .mock_openai import MockOpenAI
+
+pytestmark = [pytest.mark.anyio, pytest.mark.skipif(not imports_successful(), reason='openai not installed')]
+
+
+def chunk(delta: ChoiceDelta) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id='response', object='chat.completion.chunk', created=1, model='test', choices=[Choice(index=0, delta=delta)]
+    )
+
+
+@pytest.mark.parametrize('suffix', ['\n', 'More text.'])
+@pytest.mark.parametrize('thinking', [False, True])
+@pytest.mark.parametrize('ignore_whitespace', [False, True])
+async def test_text_after_tool_has_its_own_lifecycle(
+    allow_model_requests: None, suffix: str, thinking: bool, ignore_whitespace: bool
+):
+    # Mock the intermittent text/tool/text ordering observed with an OpenAI-compatible provider.
+    prefix = ['<think>', 'Checking', '</think>'] if thinking else []
+    stream = [chunk(ChoiceDelta(content=text)) for text in [*prefix, 'Checking ', 'now.']]
+    stream += [
+        chunk(
+            ChoiceDelta(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id='call-1',
+                        type='function',
+                        function=ChoiceDeltaToolCallFunction(name='lookup', arguments='{'),
+                    )
+                ]
+            )
+        ),
+        chunk(
+            ChoiceDelta(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        function=ChoiceDeltaToolCallFunction(arguments='}'),
+                    )
+                ]
+            )
+        ),
+    ]
+    if thinking:
+        stream.extend(chunk(ChoiceDelta(content=text)) for text in ['<think>', 'Considering', '</think>'])
+    stream.extend(chunk(ChoiceDelta(content=text)) for text in [suffix, ' Done.'])
+    client = MockOpenAI.create_mock_stream([stream, [chunk(ChoiceDelta(content='Finished.'))]])
+    model = OpenAIChatModel(
+        'test',
+        provider=OpenAIProvider(openai_client=client),
+        profile=OpenAIModelProfile(
+            thinking_tags=('<think>', '</think>'),
+            ignore_streamed_leading_whitespace=ignore_whitespace,
+        ),
+    )
+    agent = Agent(model)
+    calls: list[str] = []
+
+    @agent.tool_plain
+    def lookup() -> str:
+        calls.append('lookup')
+        return 'Found.'
+
+    request = SubmitMessage.model_validate(
+        {
+            'id': 'chat',
+            'messages': [{'id': 'user', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Look up.'}]}],
+        }
+    )
+    adapter = VercelAIAdapter(agent=agent, run_input=request, sdk_version=6)
+    reasoning = ''
+    active: set[str] = set()
+    text_parts: dict[str, str] = {}
+    async for event in adapter.transform_stream(adapter.run_stream_native()):
+        if isinstance(event, ReasoningDeltaChunk):
+            reasoning += event.delta
+        elif isinstance(event, TextStartChunk):
+            assert event.id not in text_parts
+            active.add(event.id)
+            text_parts[event.id] = ''
+        elif isinstance(event, TextDeltaChunk):
+            assert event.id in active
+            text_parts[event.id] += event.delta
+        elif isinstance(event, TextEndChunk):
+            assert event.id in active
+            active.remove(event.id)
+
+    expected_suffix = '' if ignore_whitespace and suffix.isspace() else suffix
+    assert list(text_parts.values()) == ['Checking now.', expected_suffix + ' Done.', 'Finished.']
+    assert not active
+    assert calls == ['lookup']
+    assert reasoning == ('CheckingConsidering' if thinking else '')


### PR DESCRIPTION
Fixes #8208.

OpenAI Chat streams can emit text after a tool call, which currently updates an already-ended text part and breaks Vercel AI SDK streams. Give that text a fresh internal part ID while preserving embedded thinking-tag tracking.

Tests cover repeated text/tool transitions, split tool arguments, ordinary text and newlines, whitespace filtering, and a closing thinking tag after a tool starts. All 8 cases pass; removing ID rotation fails all 8, and removing the thinking guard fails 4. Ruff and targeted Pyright pass.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
