### PR TITLE
Fix deferred tool metadata aliasing

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deferred.py
+++ b/pydantic_ai_slim/pydantic_ai/_deferred.py
@@ -83,7 +83,7 @@ class DeferredToolRequests:
             for tool_call_id in approval_ids - set(approvals):
                 approvals[tool_call_id] = ToolApproved()
 
-        return DeferredToolResults(approvals=approvals, calls=calls, metadata=metadata or {})
+        return DeferredToolResults(approvals=approvals, calls=calls, metadata=_copy_deferred_metadata(metadata))
 
     def remaining(self, results: DeferredToolResults) -> DeferredToolRequests | None:
         """Return unresolved requests after applying results, or `None` if all resolved."""
@@ -94,9 +94,13 @@ class DeferredToolRequests:
         remaining = DeferredToolRequests(
             calls=[c for c in self.calls if c.tool_call_id not in call_result_ids],
             approvals=[c for c in self.approvals if c.tool_call_id not in approval_result_ids],
-            metadata={k: v for k, v in self.metadata.items() if k not in resolved_ids},
+            metadata={k: dict(v) for k, v in self.metadata.items() if k not in resolved_ids},
         )
         return remaining if remaining.calls or remaining.approvals else None
+
+
+def _copy_deferred_metadata(metadata: dict[str, dict[str, Any]] | None) -> dict[str, dict[str, Any]]:
+    return {tool_call_id: dict(tool_call_metadata) for tool_call_id, tool_call_metadata in (metadata or {}).items()}
 
 
 @dataclass(kw_only=True)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2906,6 +2906,24 @@ def test_deferred_tool_results_serializable():
     )
 
 
+def test_deferred_tool_metadata_copied_at_continuation_boundaries():
+    requests = DeferredToolRequests(
+        calls=[ToolCallPart('tool', {}, tool_call_id='call-1')],
+        metadata={'call-1': {'scope': 'before'}},
+    )
+    caller_metadata = {'call-1': {'scope': 'before'}}
+
+    results = requests.build_results(metadata=caller_metadata)
+    caller_metadata['call-1']['scope'] = 'after-build-results'
+
+    remaining = requests.remaining(results)
+    assert remaining is not None
+    requests.metadata['call-1']['scope'] = 'after-remaining'
+
+    assert results.metadata == {'call-1': {'scope': 'before'}}
+    assert remaining.metadata == {'call-1': {'scope': 'before'}}
+
+
 def test_deferred_tool_call_result_tool_failed():
     """A `ToolFailed` in `DeferredToolResults.calls` reaches the model as a failed tool return, not a retry or a success."""
 


### PR DESCRIPTION
## Summary

- copy per-call deferred tool metadata when `DeferredToolRequests.build_results()` captures caller-provided metadata
- copy remaining request metadata when deriving unresolved `DeferredToolRequests`
- add a regression test covering the continuation-state aliasing reported in #7637

Fixes #7637.

## Tests

- `.venv\Scripts\pytest.exe tests/test_tools.py::test_deferred_tool_metadata_copied_at_continuation_boundaries tests/test_tools.py::test_deferred_tool_results_serializable -q` (`2 passed`; local Windows venv printed an unrelated `pywin32.pth` warning)
- `.venv\Scripts\ruff.exe check pydantic_ai_slim/pydantic_ai/_deferred.py tests/test_tools.py`
- `.venv\Scripts\ruff.exe format --check pydantic_ai_slim/pydantic_ai/_deferred.py tests/test_tools.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

