### PR TITLE
Make `thinking=False` disable thinking on Anthropic adaptive-thinking models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1114,10 +1114,14 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if anthropic_thinking := model_settings.get('anthropic_thinking'):
             return anthropic_thinking
         thinking = model_request_parameters.thinking
-        if thinking is None or thinking is False:
+        if thinking is None:
             return OMIT  # type: ignore[return-value]
         if self.profile.get('anthropic_supports_adaptive_thinking', False):
+            if thinking is False:
+                return {'type': 'disabled'}
             return {'type': 'adaptive'}
+        if thinking is False:
+            return OMIT  # type: ignore[return-value]
         return {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
 
     @overload

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -228,11 +228,18 @@ class TestAnthropicThinkingTranslation:
         result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
         assert result == snapshot({'type': 'enabled', 'budget_tokens': 2048})
 
-    def test_thinking_false_returns_omit(self, adaptive_model: FunctionModel):
-        """thinking=False -> OMIT (not sent to API)."""
+    def test_thinking_false_adaptive_returns_disabled(self, adaptive_model: FunctionModel):
+        """thinking=False with adaptive model -> {'type': 'disabled'}."""
         params = ModelRequestParameters(thinking=False)
         settings: ModelSettings = {}
         result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
+        assert result == snapshot({'type': 'disabled'})
+
+    def test_thinking_false_non_adaptive_returns_omit(self, non_adaptive_model: FunctionModel):
+        """thinking=False with non-adaptive model -> OMIT (silently ignored)."""
+        params = ModelRequestParameters(thinking=False)
+        settings: ModelSettings = {}
+        result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
         assert result is anthropic_omit
 
     def test_thinking_none_returns_omit(self, adaptive_model: FunctionModel):


### PR DESCRIPTION
Closes #8199

On adaptive-thinking Anthropic models (e.g. claude-sonnet-5), `thinking=False` was previously translated to `OMIT`, which leaves the provider default enabled. This change sends `{"type": "disabled"}` when `thinking=False` and the model profile reports `anthropic_supports_adaptive_thinking`, so the setting actually turns thinking off. Non-adaptive/always-on models keep returning `OMIT`, preserving the existing "silently ignored" behavior.

Changes:
- In `AnthropicModel._translate_thinking`, return `{"type": "disabled"}` for `thinking=False` on adaptive-thinking models.
- Updated the existing `thinking=False` test to expect `disabled` for adaptive models.
- Added a regression test asserting `thinking=False` still returns `OMIT` for non-adaptive models.

## Verification
- `uv run pytest tests/test_thinking.py::TestAnthropicThinkingTranslation -v` passes (15/15).
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/test_thinking.py` passes.
- `uv run ruff format --check` passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

