### PR TITLE
Improve CLI tool-call previews and spacing, and add `--no-tool-calls`

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -54,7 +54,7 @@ Either way, running `clai` will start an interactive session where you can chat 
 ## Help
 
 ```
-usage: clai [-h] [-l] [--version] [-m MODEL] [-a AGENT] [-t CODE_THEME] [--no-stream] [--mcp-config MCP_CONFIG] [prompt]
+usage: clai [-h] [-l] [--version] [-m MODEL] [-a AGENT] [-t CODE_THEME] [--no-stream] [--no-tool-calls] [--mcp-config MCP_CONFIG] [prompt]
 
 Pydantic AI CLI v...
 
@@ -76,6 +76,7 @@ options:
   -t CODE_THEME, --code-theme CODE_THEME
                         Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
   --no-stream           Disable streaming from the model
+  --no-tool-calls       Hide tool-call activity while streaming
   --mcp-config MCP_CONFIG
                         Path to MCP servers configuration file (JSON, using the same mcpServers shape as Claude Desktop, Claude Code, and Cursor).
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,22 +46,24 @@ Then running `clai` will start an interactive session where you can chat with th
 - `/cp`: Copy the last response to clipboard
 - `/usage`: Show cumulative token usage for the session (turns, input, output, requests, tool calls); add `--json` for a single-line JSON object
 
-When streaming (the default), function-tool calls show their name and a compact argument summary
-while running and when completed. Short arguments appear first; multiline strings show a line
-count, long single-line strings show a character count, and lists and dictionaries show item or
-key counts. For example, a tool receiving a script and a short description displays:
+When streaming (the default), function-tool calls show their name and bounded argument previews
+while running and when completed. Short arguments appear inline. Multiline strings display the
+first five lines, preserving indentation and blank lines, followed by the number of omitted lines:
 
 ```text
-Called tool run_code(description='Plot quarterly revenue', code=<22 lines>).
+Called tool run_code(code=<8 lines>).
+  code:
+    import json
+
+    values = [1, 2, 3]
+    for value in values:
+        print(value)
+    … 3 more lines
 ```
 
-The description in this example is an ordinary tool argument supplied by the model. To provide
-this context, your tool can accept a `description: str` argument and document that it should
-briefly explain the purpose of this call. The CLI does not infer a description from code. A call
-with only the script displays `Called tool run_code(code=<22 lines>).`.
-
-Each notice fits on one terminal line, with long summaries truncated. Consecutive calls appear
-together, separated from assistant text by a blank line.
+Each preview line is truncated to fit the terminal. Consecutive calls appear together, separated
+from assistant text by a blank line. Previews show actual argument contents, which may include
+sensitive data.
 
 Pass `--no-tool-calls` to hide these notices while keeping streamed responses, for example when
 Logfire already displays tool activity. This also hides argument previews if you do not want tool

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,10 +46,22 @@ Then running `clai` will start an interactive session where you can chat with th
 - `/cp`: Copy the last response to clipboard
 - `/usage`: Show cumulative token usage for the session (turns, input, output, requests, tool calls); add `--json` for a single-line JSON object
 
-When streaming (the default), function-tool calls show their name and an argument preview while
-running and when completed, for example `Called tool get_weather(city='Lisbon').`. Each call fits
-on one terminal line, with long previews truncated. Consecutive calls appear together, separated
-from assistant text by a blank line.
+When streaming (the default), function-tool calls show their name and a compact argument summary
+while running and when completed. Short arguments appear first; multiline strings show a line
+count, long single-line strings show a character count, and lists and dictionaries show item or
+key counts. For example, a tool receiving a script and a short description displays:
+
+```text
+Called tool run_code(description='Plot quarterly revenue', code=<22 lines>).
+```
+
+The description in this example is an ordinary tool argument supplied by the model. To provide
+this context, your tool can accept a `description: str` argument and document that it should
+briefly explain the purpose of this call. The CLI does not infer a description from code. A call
+with only the script displays `Called tool run_code(code=<22 lines>).`.
+
+Each notice fits on one terminal line, with long summaries truncated. Consecutive calls appear
+together, separated from assistant text by a blank line.
 
 Pass `--no-tool-calls` to hide these notices while keeping streamed responses, for example when
 Logfire already displays tool activity. This also hides argument previews if you do not want tool

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,9 +46,15 @@ Then running `clai` will start an interactive session where you can chat with th
 - `/cp`: Copy the last response to clipboard
 - `/usage`: Show cumulative token usage for the session (turns, input, output, requests, tool calls); add `--json` for a single-line JSON object
 
-When streaming (the default), any tool the agent calls is shown as it runs and marked done once its
-result arrives, so you can follow a tool-using agent without leaving the terminal. Pass `--no-stream`
-to print only the final answer.
+When streaming (the default), function-tool calls show their name and an argument preview while
+running and when completed, for example `Called tool get_weather(city='Lisbon').`. Each call fits
+on one terminal line, with long previews truncated. Consecutive calls appear together, separated
+from assistant text by a blank line.
+
+Pass `--no-tool-calls` to hide these notices while keeping streamed responses, for example when
+Logfire already displays tool activity. This also hides argument previews if you do not want tool
+inputs displayed in the terminal. It does not suppress errors, the working spinner, or output from
+tools and logging. Pass `--no-stream` to print only the final answer.
 
 ### CLI Options
 
@@ -59,6 +65,7 @@ to print only the final answer.
 | `-a`, `--agent` | Custom agent in `module:variable` format |
 | `-t`, `--code-theme` | Syntax highlighting theme (`dark`, `light`, or [pygments theme](https://pygments.org/styles/)) |
 | `--no-stream` | Disable streaming from the model |
+| `--no-tool-calls` | Hide tool-call activity while keeping streamed responses |
 | `--mcp-config` | Path to [MCP servers configuration file](mcp/client.md#loading-mcp-toolsets-from-configuration) (JSON, using the same `mcpServers` shape as Claude Desktop, Claude Code, and Cursor) |
 | `-l`, `--list-models` | List all available models and exit |
 | `--version` | Show version and exit |
@@ -143,6 +150,8 @@ _(To run this example, ensure `asyncio` is imported and add `asyncio.run(main())
 
 Both run the same chat interface as `clai`, so an agent with tools shows each call as it runs and
 marks it done when the result arrives, exactly as described under [CLI Usage](#cli-usage).
+Pass `show_tool_calls=False` to either method to hide tool-call activity, for example
+`agent.to_cli_sync(show_tool_calls=False)`.
 
 ### Message History
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -229,9 +229,8 @@ Need deterministic, fast tests?
 See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
 
 For an interactive terminal chat, use `agent.to_cli_sync()` or `await agent.to_cli()`.
-Both display function-tool calls with short arguments first and size summaries for multiline or
-large inputs. A tool can accept an ordinary short description argument to supply per-call context;
-the CLI does not infer purpose from code. Pass
+Both display function-tool calls with bounded argument previews. Multiline inputs show their first
+five lines and the number of omitted lines; individual lines are truncated to fit the terminal. Pass
 `show_tool_calls=False` to hide this activity, for example when using Logfire console output.
 The standalone `clai` command provides the equivalent `--no-tool-calls` flag.
 

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -228,6 +228,11 @@ Need deterministic, fast tests?
 
 See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
 
+For an interactive terminal chat, use `agent.to_cli_sync()` or `await agent.to_cli()`.
+Both display function-tool calls with compact argument previews by default. Pass
+`show_tool_calls=False` to hide this activity, for example when using Logfire console output.
+The standalone `clai` command provides the equivalent `--no-tool-calls` flag.
+
 ## Architecture Overview
 
 **Agent execution flow:**

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -229,7 +229,9 @@ Need deterministic, fast tests?
 See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
 
 For an interactive terminal chat, use `agent.to_cli_sync()` or `await agent.to_cli()`.
-Both display function-tool calls with compact argument previews by default. Pass
+Both display function-tool calls with short arguments first and size summaries for multiline or
+large inputs. A tool can accept an ordinary short description argument to supply per-call context;
+the CLI does not infer purpose from code. Pass
 `show_tool_calls=False` to hide this activity, for example when using Logfire console output.
 The standalone `clai` command provides the equivalent `--no-tool-calls` flag.
 

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations as _annotations
 import argparse
 import functools
 import json
+import re
 import sys
 from collections.abc import Sequence
 from contextlib import AsyncExitStack, ExitStack
@@ -268,6 +269,7 @@ subcommands:
         default='dark',
     )
     parser.add_argument('--no-stream', action='store_true', help='Disable streaming from the model')
+    parser.add_argument('--no-tool-calls', action='store_true', help='Hide tool-call activity while streaming')
     parser.add_argument(
         '--mcp-config',
         help='Path to MCP servers configuration file (JSON, using the same mcpServers shape as Claude Desktop, Claude Code, and Cursor).',
@@ -357,13 +359,35 @@ def _run_chat_command(
 
     if args.prompt:
         try:
-            anyio.run(functools.partial(ask_agent, agent, args.prompt, stream, console, code_theme, toolsets=toolsets))
+            anyio.run(
+                functools.partial(
+                    ask_agent,
+                    agent,
+                    args.prompt,
+                    stream,
+                    console,
+                    code_theme,
+                    toolsets=toolsets,
+                    show_tool_calls=not args.no_tool_calls,
+                )
+            )
         except KeyboardInterrupt:
             pass
         return 0
 
     try:
-        return anyio.run(functools.partial(run_chat, stream, agent, console, code_theme, prog_name, toolsets=toolsets))
+        return anyio.run(
+            functools.partial(
+                run_chat,
+                stream,
+                agent,
+                console,
+                code_theme,
+                prog_name,
+                toolsets=toolsets,
+                show_tool_calls=not args.no_tool_calls,
+            )
+        )
     except KeyboardInterrupt:  # pragma: no cover
         return 0
 
@@ -381,6 +405,8 @@ async def run_chat(
     model_settings: ModelSettings | None = None,
     usage_limits: _usage.UsageLimits | None = None,
     toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
+    *,
+    show_tool_calls: bool = True,
 ) -> int:
     prompt_history_path = (config_dir or PYDANTIC_AI_HOME) / PROMPT_HISTORY_FILENAME
     prompt_history_path.parent.mkdir(parents=True, exist_ok=True)
@@ -432,6 +458,7 @@ async def run_chat(
                         usage_limits=usage_limits,
                         toolsets=toolsets,
                         usage=session_usage,
+                        show_tool_calls=show_tool_calls,
                     )
                     session_turns += 1
                 except anyio.get_cancelled_exc_class():
@@ -457,6 +484,7 @@ async def ask_agent(
     toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
     *,
     usage: _usage.RunUsage | None = None,
+    show_tool_calls: bool = True,
 ) -> list[ModelMessage]:
     status = Status('[dim]Working on it…[/dim]', console=console)
 
@@ -492,7 +520,7 @@ async def ask_agent(
                 usage=turn_usage,
             ) as agent_run:
                 live = Live('', refresh_per_second=15, console=console, vertical_overflow='ellipsis')
-                content_pieces: list[str] = []
+                content_pieces: list[str | Text] = []
                 # Tool calls run concurrently and can return out of order, so in-flight calls are
                 # keyed by call id — rendering only the latest would erase the others' indicators.
                 pending_calls: dict[str, str] = {}
@@ -514,35 +542,67 @@ async def ask_agent(
 
                             async for content in handle_stream.stream_output(debounce_by=None):
                                 updated_content = str(content)
-                                display = '\n\n'.join([*content_pieces, updated_content])
-                                live.update(Markdown(display, code_theme=code_theme))
+                                pieces = list(content_pieces)
+                                if updated_content.strip():
+                                    pieces.append(updated_content)
+                                live.update(_cli_output(pieces, console.width, code_theme))
 
                     elif Agent.is_call_tools_node(node):
                         # Freeze the text streamed so far so tool-call lines append below it rather
                         # than overwriting it on the next model request node.
-                        if updated_content:
+                        if updated_content.strip():
                             content_pieces.append(updated_content)
-                            updated_content = ''
+                        updated_content = ''
 
                         async with node.stream(agent_run.ctx) as handle_stream:
                             async for event in handle_stream:
+                                if not show_tool_calls:
+                                    continue
                                 if isinstance(event, FunctionToolCallEvent):
-                                    pending_calls[event.tool_call_id] = event.part.tool_name
+                                    args = ', '.join(
+                                        f'{key if key.isidentifier() else repr(key)}={value!r}'
+                                        for key, value in event.part.args_as_dict().items()
+                                    )
+                                    pending_calls[event.tool_call_id] = f'{event.part.tool_name}({args})'
                                 elif isinstance(event, FunctionToolResultEvent):
                                     # Pop on any result, not just a `ToolReturnPart`: a call that
                                     # comes back as a `RetryPromptPart` would otherwise stay pending
                                     # and pin its indicator for the rest of the run.
-                                    pending_calls.pop(event.tool_call_id, None)
+                                    summary = pending_calls.pop(event.tool_call_id, event.part.tool_name)
                                     if isinstance(event.part, ToolReturnPart):
-                                        content_pieces.append(f'> Called tool `{event.part.tool_name}`.')
-                                calling = [f'> _Calling tool `{name}`…_' for name in pending_calls.values()]
-                                live.update(Markdown('\n\n'.join([*content_pieces, *calling]), code_theme=code_theme))
+                                        content_pieces.append(Text(f'Called tool {summary}.'))
+                                calling = [Text(f'Calling tool {summary}…') for summary in pending_calls.values()]
+                                live.update(_cli_output([*content_pieces, *calling], console.width, code_theme))
 
             assert agent_run.result is not None
             return agent_run.result.all_messages()
     finally:
         if usage is not None:
             usage.incr(turn_usage)
+
+
+_BACKTICK_RUN = re.compile(r'`+')
+
+
+def _cli_output(pieces: Sequence[str | Text], width: int, code_theme: str) -> Markdown:
+    """Keep one Markdown document, with literal tool rows separated by hard line breaks."""
+    markup: list[str] = []
+    previous_tool = False
+    for piece in pieces:
+        is_tool = isinstance(piece, Text)
+        if markup:
+            markup.append('  \n' if previous_tool and is_tool else '\n\n')
+        if isinstance(piece, Text):
+            preview = piece.copy()
+            # Leave room for the blockquote border and padding.
+            preview.truncate(max(1, width - 4), overflow='ellipsis')
+            # A delimiter longer than any backtick run keeps code and markup in arguments literal.
+            delimiter = '`' * (max((len(run) for run in _BACKTICK_RUN.findall(preview.plain)), default=0) + 1)
+            markup.append(f'> {delimiter} {preview.plain} {delimiter}')
+        else:
+            markup.append(piece)
+        previous_tool = is_tool
+    return Markdown(''.join(markup), code_theme=code_theme)
 
 
 class CustomAutoSuggest(AutoSuggestFromHistory):

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -5,12 +5,12 @@ import functools
 import json
 import re
 import sys
-from collections.abc import Sequence
+from collections.abc import Sequence, Sized
 from contextlib import AsyncExitStack, ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
 from reprlib import Repr
-from typing import Any
+from typing import Any, cast
 
 import anyio
 from pydantic import ImportString, TypeAdapter, ValidationError
@@ -594,19 +594,36 @@ async def ask_agent(
 
 _TOOL_ARG_REPR = Repr()
 _TOOL_ARG_REPR.maxstring = _TOOL_ARG_REPR.maxother = 80
-_TOOL_ARG_REPR.maxlevel = 2
-_TOOL_ARG_REPR.maxdict = _TOOL_ARG_REPR.maxlist = 3
 _TOOL_PREVIEW_WIDTH = 120
+_NEWLINE = re.compile(r'\r\n?|\n')
 
 
 def _tool_call_summary(part: ToolCallPart) -> str:
-    """Bound representations before retaining them or repeatedly rendering streamed output."""
+    """Show short arguments first, keeping large inputs recognizable without retaining their contents."""
+
+    def is_large(value: object) -> bool:
+        return isinstance(value, (dict, list)) or (
+            isinstance(value, str) and (len(value) > 80 or '\n' in value or '\r' in value)
+        )
+
     preview = Text(f'{part.tool_name}(')
-    for index, (key, value) in enumerate(part.args_as_dict().items()):
+    arguments = sorted(part.args_as_dict().items(), key=lambda item: is_large(item[1]))
+    for index, (key, value) in enumerate(arguments):
         if index:
             preview.append(', ')
         name = key if key.isidentifier() and len(key) <= 80 else _TOOL_ARG_REPR.repr(key)
-        preview.append(f'{name}={_TOOL_ARG_REPR.repr(value)}')
+        if isinstance(value, str) and ('\n' in value or '\r' in value):
+            lines = sum(1 for _ in _NEWLINE.finditer(value)) + (not value.endswith(('\n', '\r')))
+            summary = f'<{lines:,} line{"s" if lines != 1 else ""}>'
+        elif isinstance(value, str) and len(value) > 80:
+            summary = f'<{len(value):,} chars>'
+        elif isinstance(value, (dict, list)):
+            size = len(cast(Sized, value))
+            unit = 'key' if isinstance(value, dict) else 'item'
+            summary = f'<{size:,} {unit}{"s" if size != 1 else ""}>'
+        else:
+            summary = _TOOL_ARG_REPR.repr(value)
+        preview.append(f'{name}={summary}')
         if preview.cell_len >= _TOOL_PREVIEW_WIDTH:
             break
     preview.append(')')

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -5,12 +5,13 @@ import functools
 import json
 import re
 import sys
-from collections.abc import Sequence, Sized
+from collections.abc import Sequence
 from contextlib import AsyncExitStack, ExitStack
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from reprlib import Repr
-from typing import Any, cast
+from typing import Any
 
 import anyio
 from pydantic import ImportString, TypeAdapter, ValidationError
@@ -531,7 +532,7 @@ async def ask_agent(
                 content_pieces: list[str | Text] = []
                 # Tool calls run concurrently and can return out of order, so in-flight calls are
                 # keyed by call id — rendering only the latest would erase the others' indicators.
-                pending_calls: dict[str, str] = {}
+                pending_calls: dict[str, _ToolCallPreview] = {}
                 updated_content = ''
                 live_started = False
 
@@ -576,13 +577,14 @@ async def ask_agent(
                         async with node.stream(agent_run.ctx) as handle_stream:
                             async for event in handle_stream:
                                 if isinstance(event, FunctionToolCallEvent):
-                                    pending_calls[event.tool_call_id] = _tool_call_summary(event.part)
+                                    pending_calls[event.tool_call_id] = _tool_call_preview(event.part)
                                 elif isinstance(event, FunctionToolResultEvent):
                                     # Retry results must also clear the running indicator.
-                                    summary = pending_calls.pop(event.tool_call_id, event.part.tool_name)
+                                    preview = pending_calls.pop(event.tool_call_id, None)
                                     if isinstance(event.part, ToolReturnPart):
-                                        content_pieces.append(Text(f'Called tool {summary}.'))
-                                calling = [Text(f'Calling tool {summary}…') for summary in pending_calls.values()]
+                                        preview = preview or _ToolCallPreview(event.part.tool_name)
+                                        content_pieces.append(preview.render(completed=True))
+                                calling = [preview.render(completed=False) for preview in pending_calls.values()]
                                 live.update(_cli_output([*content_pieces, *calling], console.width, code_theme))
 
             assert agent_run.result is not None
@@ -594,41 +596,59 @@ async def ask_agent(
 
 _TOOL_ARG_REPR = Repr()
 _TOOL_ARG_REPR.maxstring = _TOOL_ARG_REPR.maxother = 80
+_TOOL_ARG_REPR.maxlevel = 2
+_TOOL_ARG_REPR.maxdict = _TOOL_ARG_REPR.maxlist = 3
 _TOOL_PREVIEW_WIDTH = 120
 _NEWLINE = re.compile(r'\r\n?|\n')
+_CONTROL_CHARACTERS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
 
 
-def _tool_call_summary(part: ToolCallPart) -> str:
-    """Show short arguments first, keeping large inputs recognizable without retaining their contents."""
+@dataclass
+class _ToolCallPreview:
+    signature: str
+    details: str = ''
 
-    def is_large(value: object) -> bool:
-        return isinstance(value, (dict, list)) or (
-            isinstance(value, str) and (len(value) > 80 or '\n' in value or '\r' in value)
-        )
+    def render(self, *, completed: bool) -> Text:
+        heading = f'Called tool {self.signature}.' if completed else f'Calling tool {self.signature}…'
+        return Text(f'{heading}\n{self.details}' if self.details else heading)
 
-    preview = Text(f'{part.tool_name}(')
-    arguments = sorted(part.args_as_dict().items(), key=lambda item: is_large(item[1]))
-    for index, (key, value) in enumerate(arguments):
+
+def _tool_call_preview(part: ToolCallPart) -> _ToolCallPreview:
+    """Retain bounded argument previews, including the first five lines of multiline strings."""
+    signature = Text(f'{part.tool_name}(')
+    details: list[str] = []
+    for index, (key, value) in enumerate(part.args_as_dict().items()):
         if index:
-            preview.append(', ')
+            signature.append(', ')
         name = key if key.isidentifier() and len(key) <= 80 else _TOOL_ARG_REPR.repr(key)
         if isinstance(value, str) and ('\n' in value or '\r' in value):
             lines = sum(1 for _ in _NEWLINE.finditer(value)) + (not value.endswith(('\n', '\r')))
             summary = f'<{lines:,} line{"s" if lines != 1 else ""}>'
+            details.append(f'  {name}:')
+            start = 0
+            for _ in range(min(lines, 5)):
+                ending = _NEWLINE.search(value, start)
+                end = ending.start() if ending else len(value)
+                # Slice before constructing Text so long source lines are never retained in full.
+                source = value[start : min(end, start + _TOOL_PREVIEW_WIDTH)].expandtabs(4)
+                if end - start > _TOOL_PREVIEW_WIDTH:
+                    source += '…'
+                line = Text(_CONTROL_CHARACTERS.sub(lambda match: repr(match[0])[1:-1], source))
+                line.truncate(_TOOL_PREVIEW_WIDTH, overflow='ellipsis')
+                details.append(f'    {line.plain}')
+                start = ending.end() if ending else end
+            if lines > 5:
+                details.append(f'    … {lines - 5:,} more line{"s" if lines != 6 else ""}')
         elif isinstance(value, str) and len(value) > 80:
-            summary = f'<{len(value):,} chars>'
-        elif isinstance(value, (dict, list)):
-            size = len(cast(Sized, value))
-            unit = 'key' if isinstance(value, dict) else 'item'
-            summary = f'<{size:,} {unit}{"s" if size != 1 else ""}>'
+            summary = f'{value[:80]!r}…'
         else:
             summary = _TOOL_ARG_REPR.repr(value)
-        preview.append(f'{name}={summary}')
-        if preview.cell_len >= _TOOL_PREVIEW_WIDTH:
+        signature.append(f'{name}={summary}')
+        if signature.cell_len >= _TOOL_PREVIEW_WIDTH:
             break
-    preview.append(')')
-    preview.truncate(_TOOL_PREVIEW_WIDTH, overflow='ellipsis')
-    return preview.plain
+    signature.append(')')
+    signature.truncate(_TOOL_PREVIEW_WIDTH, overflow='ellipsis')
+    return _ToolCallPreview(signature.plain, '\n'.join(details))
 
 
 _BACKTICK_RUN = re.compile(r'`+')
@@ -643,12 +663,14 @@ def _cli_output(pieces: Sequence[str | Text], width: int, code_theme: str) -> Ma
         if markup:
             markup.append('  \n' if previous_tool and is_tool else '\n\n')
         if isinstance(piece, Text):
-            preview = piece.copy()
-            # Leave room for the blockquote border and padding.
-            preview.truncate(max(1, width - 4), overflow='ellipsis')
-            # A delimiter longer than any backtick run keeps code and markup in arguments literal.
-            delimiter = '`' * (max((len(run) for run in _BACKTICK_RUN.findall(preview.plain)), default=0) + 1)
-            markup.append(f'> {delimiter} {preview.plain} {delimiter}')
+            lines: list[str] = []
+            for preview in piece.split('\n', allow_blank=True):
+                # Leave room for the blockquote border and padding.
+                preview.truncate(max(1, width - 4), overflow='ellipsis')
+                # A delimiter longer than any backtick run keeps source code and arguments literal.
+                delimiter = '`' * (max((len(run) for run in _BACKTICK_RUN.findall(preview.plain)), default=0) + 1)
+                lines.append(f'> {delimiter} {preview.plain} {delimiter}')
+            markup.append('  \n'.join(lines))
         else:
             markup.append(piece)
         previous_tool = is_tool

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from contextlib import AsyncExitStack, ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
+from reprlib import Repr
 from typing import Any
 
 import anyio
@@ -18,7 +19,14 @@ from .. import __version__, models, usage as _usage
 from .._run_context import AgentDepsT
 from ..agent import AbstractAgent, Agent
 from ..exceptions import UserError
-from ..messages import FunctionToolCallEvent, FunctionToolResultEvent, ModelMessage, ModelResponse, ToolReturnPart
+from ..messages import (
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    ModelMessage,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
 from ..models import infer_model, known_model_names
 from ..native_tools import NATIVE_TOOLS_REQUIRING_CONFIG, SUPPORTED_NATIVE_TOOLS
 from ..output import OutputDataT
@@ -33,7 +41,7 @@ try:
     from prompt_toolkit.buffer import Buffer
     from prompt_toolkit.document import Document
     from prompt_toolkit.history import FileHistory
-    from rich.console import Console, ConsoleOptions, RenderResult
+    from rich.console import Console, ConsoleOptions, Group, RenderResult
     from rich.live import Live
     from rich.markdown import CodeBlock, Heading, Markdown
     from rich.status import Status
@@ -554,20 +562,23 @@ async def ask_agent(
                             content_pieces.append(updated_content)
                         updated_content = ''
 
+                        if not show_tool_calls:
+                            output = _cli_output(content_pieces, console.width, code_theme)
+                            live.update(Group(status.renderable, output))
+                            try:
+                                # Exiting the stream context drains its events and executes the tools.
+                                async with node.stream(agent_run.ctx):
+                                    pass
+                            finally:
+                                live.update(output)
+                            continue
+
                         async with node.stream(agent_run.ctx) as handle_stream:
                             async for event in handle_stream:
-                                if not show_tool_calls:
-                                    continue
                                 if isinstance(event, FunctionToolCallEvent):
-                                    args = ', '.join(
-                                        f'{key if key.isidentifier() else repr(key)}={value!r}'
-                                        for key, value in event.part.args_as_dict().items()
-                                    )
-                                    pending_calls[event.tool_call_id] = f'{event.part.tool_name}({args})'
+                                    pending_calls[event.tool_call_id] = _tool_call_summary(event.part)
                                 elif isinstance(event, FunctionToolResultEvent):
-                                    # Pop on any result, not just a `ToolReturnPart`: a call that
-                                    # comes back as a `RetryPromptPart` would otherwise stay pending
-                                    # and pin its indicator for the rest of the run.
+                                    # Retry results must also clear the running indicator.
                                     summary = pending_calls.pop(event.tool_call_id, event.part.tool_name)
                                     if isinstance(event.part, ToolReturnPart):
                                         content_pieces.append(Text(f'Called tool {summary}.'))
@@ -579,6 +590,28 @@ async def ask_agent(
     finally:
         if usage is not None:
             usage.incr(turn_usage)
+
+
+_TOOL_ARG_REPR = Repr()
+_TOOL_ARG_REPR.maxstring = _TOOL_ARG_REPR.maxother = 80
+_TOOL_ARG_REPR.maxlevel = 2
+_TOOL_ARG_REPR.maxdict = _TOOL_ARG_REPR.maxlist = 3
+_TOOL_PREVIEW_WIDTH = 120
+
+
+def _tool_call_summary(part: ToolCallPart) -> str:
+    """Bound representations before retaining them or repeatedly rendering streamed output."""
+    preview = Text(f'{part.tool_name}(')
+    for index, (key, value) in enumerate(part.args_as_dict().items()):
+        if index:
+            preview.append(', ')
+        name = key if key.isidentifier() and len(key) <= 80 else _TOOL_ARG_REPR.repr(key)
+        preview.append(f'{name}={_TOOL_ARG_REPR.repr(value)}')
+        if preview.cell_len >= _TOOL_PREVIEW_WIDTH:
+            break
+    preview.append(')')
+    preview.truncate(_TOOL_PREVIEW_WIDTH, overflow='ellipsis')
+    return preview.plain
 
 
 _BACKTICK_RUN = re.compile(r'`+')

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -2005,6 +2005,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
+        *,
+        show_tool_calls: bool = True,
     ) -> None:
         """Run the agent in a CLI chat interface.
 
@@ -2015,6 +2017,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
             model: Optional model to use for the agent run.
+            show_tool_calls: Show tool-call activity with argument previews. Set to `False` to hide it,
+                for example when Logfire already displays tool activity.
 
         Example:
         ```python {title="agent_to_cli.py" test="skip"}
@@ -2041,6 +2045,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             model=model,
             model_settings=model_settings,
             usage_limits=usage_limits,
+            show_tool_calls=show_tool_calls,
         )
 
     def to_cli_sync(
@@ -2051,6 +2056,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
+        *,
+        show_tool_calls: bool = True,
     ) -> None:
         """Run the agent in a CLI chat interface with the non-async interface.
 
@@ -2061,6 +2068,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
             model: Optional model to use for the agent run.
+            show_tool_calls: Show tool-call activity with argument previews. Set to `False` to hide it,
+                for example when Logfire already displays tool activity.
 
         ```python {title="agent_to_cli_sync.py" test="skip"}
         from pydantic_ai import Agent
@@ -2078,6 +2087,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                 model=model,
                 model_settings=model_settings,
                 usage_limits=usage_limits,
+                show_tool_calls=show_tool_calls,
             )
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import json
 import sys
 import types
 from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import nullcontext
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
@@ -16,6 +17,7 @@ from pytest import CaptureFixture
 from pytest_mock import MockerFixture
 from rich.console import Console, RenderableType
 from rich.live import Live
+from rich.live_render import LiveRender
 
 from pydantic_ai import Agent, ModelMessage, ModelResponse, ModelRetry, TextPart, ToolCallPart
 from pydantic_ai.capabilities import NativeTool
@@ -435,7 +437,9 @@ def live_frames(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
     def capture_update(self: Live, renderable: RenderableType, *, refresh: bool = False) -> None:
         output = StringIO()
-        Console(file=output, width=100).print(renderable)
+        Console(file=output, width=self.console.width, height=self.console.height).print(
+            LiveRender(renderable, vertical_overflow='ellipsis')
+        )
         frames.append('\n'.join(line.rstrip() for line in output.getvalue().splitlines()).rstrip())
         return original_update(self, renderable, refresh=refresh)
 
@@ -1587,19 +1591,40 @@ def test_cli_no_tool_calls(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize('width', [40, 1000])
 @pytest.mark.parametrize(
-    ('argument_name', 'code'),
-    [('code', "print(`[red]hello[/red]`)\nprint('  spaced  ')"), ('code', 'x' * 1000), ('bad\nkey', 'hello')],
-    ids=['literal-code', 'long-code', 'multiline-key'],
+    ('arguments', 'expected'),
+    [
+        pytest.param(
+            {'code': "print(`[red]hello[/red]`)\nprint('  spaced  ')"},
+            snapshot('▌ Called tool run_code(code="print(`[red]hello[/red]`)\\nprint(\'  spaced  \')").'),
+            id='literal-code',
+        ),
+        pytest.param(
+            {'code': 'x' * 1000},
+            snapshot(
+                "▌ Called tool run_code(code='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')."
+            ),
+            id='long-code',
+        ),
+        pytest.param(
+            {'bad\nkey': 'hello'}, snapshot("▌ Called tool run_code('bad\\nkey'='hello')."), id='multiline-key'
+        ),
+        pytest.param(
+            {'first': 'x' * 1000, 'second': 'y' * 1000, 'third': 'not shown'},
+            snapshot(
+                "▌ Called tool run_code(first='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', second='yyyyyyyyyyyyyy…."
+            ),
+            id='many-arguments',
+        ),
+    ],
 )
-async def test_tool_argument_preview(argument_name: str, code: str, live_frames: list[str]):
+async def test_tool_argument_preview(arguments: dict[str, str], expected: str, width: int, live_frames: list[str]):
     async def code_stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
         if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
             yield 'Done.'
         else:
-            yield {
-                0: DeltaToolCall(name='run_code', json_args=json.dumps({argument_name: code}), tool_call_id='call_1')
-            }
+            yield {0: DeltaToolCall(name='run_code', json_args=json.dumps(arguments), tool_call_id='call_1')}
 
     agent = Agent(FunctionModel(stream_function=code_stream))
     executed: list[dict[str, str]] = []
@@ -1610,19 +1635,18 @@ async def test_tool_argument_preview(argument_name: str, code: str, live_frames:
         return 'ok'
 
     output = StringIO()
-    await ask_agent(agent, 'go', True, Console(file=output, width=100), 'monokai')
+    await ask_agent(agent, 'go', True, Console(file=output, width=width), 'monokai')
     lines = [line.rstrip() for line in output.getvalue().splitlines()]
-    assert executed == [{argument_name: code}]
+    assert executed == [arguments]
     assert lines[0] == ''
     assert lines[2:] == ['', 'Done.']
-    if len(code) > 100:
-        assert lines[1].startswith("▌ Called tool run_code(code='")
-        assert lines[1].endswith('…')
-        assert len(lines[1]) <= 100
+    if width == 1000:
+        assert lines[1] == expected
+        assert len(lines[1]) <= 135
     else:
-        key = argument_name if argument_name.isidentifier() else repr(argument_name)
-        assert lines[1] == f'▌ Called tool run_code({key}={code!r}).'
-        assert any(f'Calling tool run_code({key}={code!r})…' in frame for frame in live_frames)
+        assert lines[1].startswith('▌ Called tool run_code(')
+        assert len(lines[1]) <= width
+    assert any('Calling tool run_code(' in frame for frame in live_frames)
 
 
 @pytest.mark.anyio
@@ -1647,3 +1671,33 @@ async def test_streaming_preserves_markdown_references(show_tool_calls: bool):
     assert 'Checking the docs.' in rendered
     assert '[the docs][docs]' not in rendered
     assert 'Confirmed.' in rendered
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('fail', [False, True])
+async def test_hidden_tool_calls_keep_working_indicator(live_frames: list[str], fail: bool):
+    async def stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            yield 'Done.'
+        else:
+            yield '\n\n'.join(f'Checking item {index}.' for index in range(10))
+            yield {0: DeltaToolCall(name='slow_tool', json_args='{}', tool_call_id='call_1')}
+
+    agent = Agent(FunctionModel(stream_function=stream))
+    during_tool: list[str] = []
+
+    @agent.tool_plain
+    async def slow_tool() -> str:
+        during_tool.append(live_frames[-1] if live_frames else '')
+        if fail:
+            raise RuntimeError('tool failed')
+        return 'ok'
+
+    output = StringIO()
+    with pytest.raises(RuntimeError, match='tool failed') if fail else nullcontext():
+        await ask_agent(agent, 'go', True, Console(file=output, width=80, height=5), 'monokai', show_tool_calls=False)
+    assert len(during_tool[0].splitlines()) == 5
+    assert 'Working on it' in during_tool[0]
+    assert 'slow_tool' not in during_tool[0]
+    assert 'Working on it' not in output.getvalue()
+    assert ('Done.' in output.getvalue()) is not fail

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,16 +7,15 @@ from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import anyio
 import pytest
 import sniffio
 from pytest import CaptureFixture
 from pytest_mock import MockerFixture
-from rich.console import Console
+from rich.console import Console, RenderableType
 from rich.live import Live
-from rich.markdown import Markdown
 
 from pydantic_ai import Agent, ModelMessage, ModelResponse, ModelRetry, TextPart, ToolCallPart
 from pydantic_ai.capabilities import NativeTool
@@ -348,7 +347,8 @@ def test_cli_prompt(capfd: CaptureFixture[str], env: TestEnv):
 
 
 @pytest.mark.anyio
-async def test_streaming_with_tool_calls():
+@pytest.mark.parametrize('show_tool_calls', [True, False])
+async def test_streaming_with_tool_calls(show_tool_calls: bool, live_frames: list[str]):
     """The streaming CLI render loop interleaves streamed model text with tool-call indicators.
 
     Uses a `FunctionModel` stream so the agent emits real text deltas and a tool call, exercising
@@ -372,17 +372,54 @@ async def test_streaming_with_tool_calls():
 
     output = StringIO()
     console = Console(file=output, force_terminal=False, width=80)
-    messages = await ask_agent(agent, 'weather?', stream=True, console=console, code_theme='monokai')
+    messages = await ask_agent(
+        agent, 'weather?', stream=True, console=console, code_theme='monokai', show_tool_calls=show_tool_calls
+    )
 
-    assert output.getvalue() == snapshot("""\
-Let me check the weather.                                                       \n\
-
-▌ Called tool get_weather.                                                    \n\
-
-It is sunny in Mexico City.                                                     \
-""")
+    expected_lines = ['Let me check the weather.', '']
+    if show_tool_calls:
+        expected_lines.extend(["▌ Called tool get_weather(city='Mexico City').", ''])
+    expected_lines.append('It is sunny in Mexico City.')
+    assert [line.rstrip() for line in output.getvalue().splitlines()] == expected_lines
+    assert any('Calling tool' in frame for frame in live_frames) is show_tool_calls
     assert isinstance(messages[-1], ModelResponse)
     assert messages[-1].parts[-1] == TextPart(content='It is sunny in Mexico City.')
+
+
+@pytest.mark.anyio
+async def test_tool_call_spacing_across_model_requests():
+    async def run_code_stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
+        count = sum(isinstance(part, ToolReturnPart) for message in messages for part in message.parts)
+        if count == 3:
+            yield 'Done.'
+        else:
+            if count == 0:
+                yield 'Checking.'
+            elif count == 1:
+                yield '   '
+            yield {
+                0: DeltaToolCall(
+                    name='run_code', json_args=json.dumps({'code': f'print({count})'}), tool_call_id=f'call_{count}'
+                )
+            }
+
+    agent = Agent(FunctionModel(stream_function=run_code_stream))
+
+    @agent.tool_plain
+    def run_code(code: str) -> str:
+        return code
+
+    output = StringIO()
+    await ask_agent(agent, 'go', stream=True, console=Console(file=output, width=80), code_theme='monokai')
+    assert [line.rstrip() for line in output.getvalue().splitlines()] == [
+        'Checking.',
+        '',
+        "▌ Called tool run_code(code='print(0)').",
+        "▌ Called tool run_code(code='print(1)').",
+        "▌ Called tool run_code(code='print(2)').",
+        '',
+        'Done.',
+    ]
 
 
 def _distinct_frames(frames: list[str]) -> list[str]:
@@ -392,16 +429,14 @@ def _distinct_frames(frames: list[str]) -> list[str]:
 
 @pytest.fixture
 def live_frames(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Record the markdown of every `Live.update`, so intermediate render frames can be asserted.
-
-    `ask_agent` only ever updates the display with a `Markdown`, and the final console output shows
-    just the last frame — these tests are about what the display showed along the way.
-    """
+    """Capture rendered intermediate frames, including calls that finish before the final frame."""
     frames: list[str] = []
     original_update = Live.update
 
-    def capture_update(self: Live, renderable: Markdown, *, refresh: bool = False) -> None:
-        frames.append(renderable.markup)
+    def capture_update(self: Live, renderable: RenderableType, *, refresh: bool = False) -> None:
+        output = StringIO()
+        Console(file=output, width=100).print(renderable)
+        frames.append('\n'.join(line.rstrip() for line in output.getvalue().splitlines()).rstrip())
         return original_update(self, renderable, refresh=refresh)
 
     monkeypatch.setattr(Live, 'update', capture_update)
@@ -451,17 +486,20 @@ async def test_streaming_with_concurrent_tool_calls(live_frames: list[str]):
     distinct = _distinct_frames(live_frames)
 
     # The regression: the second call's indicator replaced the first's, so this frame never existed.
-    assert any('_Calling tool `get_weather`…_' in frame and '_Calling tool `get_temp`…_' in frame for frame in distinct)
+    assert any(
+        "Calling tool get_weather(city='Lisbon')…" in frame and "Calling tool get_temp(city='Porto')…" in frame
+        for frame in distinct
+    )
     # And once one call finished, the other was left with no indicator at all.
-    assert any('Called tool `' in frame and '_Calling tool `' in frame for frame in distinct)
+    assert any('Called tool ' in frame and 'Calling tool ' in frame for frame in distinct)
 
     # The final frame holds both completions; their order follows task completion, so assert
     # membership rather than a sequence.
     final = distinct[-1]
     assert final.startswith('Checking two cities.')
-    assert '> Called tool `get_weather`.' in final
-    assert '> Called tool `get_temp`.' in final
-    assert '_Calling tool' not in final
+    assert "Called tool get_weather(city='Lisbon')." in final
+    assert "Called tool get_temp(city='Porto')." in final
+    assert 'Calling tool' not in final
     assert final.endswith('Both cities checked.')
 
 
@@ -523,7 +561,7 @@ async def test_streaming_clears_indicator_for_retried_tool(live_frames: list[str
             """\
 Trying a tool.
 
-> _Calling tool `flaky`…_\
+▌ Calling tool flaky()…\
 """,
             'Trying a tool.',
             """\
@@ -876,7 +914,7 @@ def test_code_theme_unset(mocker: MockerFixture, env: TestEnv):
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
     cli([])
     mock_run_chat.assert_awaited_once_with(
-        True, IsInstance(Agent), IsInstance(Console), 'monokai', 'clai', toolsets=None
+        True, IsInstance(Agent), IsInstance(Console), 'monokai', 'clai', toolsets=None, show_tool_calls=True
     )
 
 
@@ -885,7 +923,7 @@ def test_code_theme_light(mocker: MockerFixture, env: TestEnv):
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
     cli(['--code-theme=light'])
     mock_run_chat.assert_awaited_once_with(
-        True, IsInstance(Agent), IsInstance(Console), 'default', 'clai', toolsets=None
+        True, IsInstance(Agent), IsInstance(Console), 'default', 'clai', toolsets=None, show_tool_calls=True
     )
 
 
@@ -894,14 +932,15 @@ def test_code_theme_dark(mocker: MockerFixture, env: TestEnv):
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
     cli(['--code-theme=dark'])
     mock_run_chat.assert_awaited_once_with(
-        True, IsInstance(Agent), IsInstance(Console), 'monokai', 'clai', toolsets=None
+        True, IsInstance(Agent), IsInstance(Console), 'monokai', 'clai', toolsets=None, show_tool_calls=True
     )
 
 
-def test_agent_to_cli_sync(mocker: MockerFixture, env: TestEnv):
+@pytest.mark.parametrize('show_tool_calls', [True, False])
+def test_agent_to_cli_sync(mocker: MockerFixture, env: TestEnv, show_tool_calls: bool):
     env.set('OPENAI_API_KEY', 'test')
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
-    cli_agent.to_cli_sync()
+    cli_agent.to_cli_sync(show_tool_calls=show_tool_calls)
     mock_run_chat.assert_awaited_once_with(
         stream=True,
         agent=IsInstance(Agent),
@@ -913,14 +952,16 @@ def test_agent_to_cli_sync(mocker: MockerFixture, env: TestEnv):
         model=None,
         model_settings=None,
         usage_limits=None,
+        show_tool_calls=show_tool_calls,
     )
 
 
 @pytest.mark.anyio
-async def test_agent_to_cli_async(mocker: MockerFixture, env: TestEnv):
+@pytest.mark.parametrize('show_tool_calls', [True, False])
+async def test_agent_to_cli_async(mocker: MockerFixture, env: TestEnv, show_tool_calls: bool):
     env.set('OPENAI_API_KEY', 'test')
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
-    await cli_agent.to_cli()
+    await cli_agent.to_cli(show_tool_calls=show_tool_calls)
     mock_run_chat.assert_awaited_once_with(
         stream=True,
         agent=IsInstance(Agent),
@@ -932,6 +973,7 @@ async def test_agent_to_cli_async(mocker: MockerFixture, env: TestEnv):
         model=None,
         model_settings=None,
         usage_limits=None,
+        show_tool_calls=show_tool_calls,
     )
 
 
@@ -955,6 +997,7 @@ async def test_agent_to_cli_with_message_history(mocker: MockerFixture, env: Tes
         model=None,
         model_settings=None,
         usage_limits=None,
+        show_tool_calls=True,
     )
 
 
@@ -977,6 +1020,7 @@ def test_agent_to_cli_sync_with_message_history(mocker: MockerFixture, env: Test
         model=None,
         model_settings=None,
         usage_limits=None,
+        show_tool_calls=True,
     )
 
 
@@ -1338,6 +1382,7 @@ def test_agent_to_cli_sync_with_args(mocker: MockerFixture, env: TestEnv):
         model=None,
         model_settings=model_settings,
         usage_limits=usage_limits,
+        show_tool_calls=True,
     )
 
 
@@ -1358,6 +1403,7 @@ def test_agent_to_cli_sync_with_model(mocker: MockerFixture, env: TestEnv):
         model='test',
         model_settings=None,
         usage_limits=None,
+        show_tool_calls=True,
     )
 
 
@@ -1382,6 +1428,7 @@ async def test_agent_to_cli_async_with_args(mocker: MockerFixture, env: TestEnv)
         model=None,
         model_settings=model_settings,
         usage_limits=usage_limits,
+        show_tool_calls=True,
     )
 
 
@@ -1403,6 +1450,7 @@ async def test_agent_to_cli_async_with_model(mocker: MockerFixture, env: TestEnv
         model='test',
         model_settings=None,
         usage_limits=None,
+        show_tool_calls=True,
     )
 
 
@@ -1500,3 +1548,102 @@ def test_clai_web_answers_to_the_host_it_binds_to(mocker: MockerFixture, env: Te
 
     assert mock_create.call_args.kwargs['allowed_hosts'] == ['devbox.example']
     assert mock_uvicorn.call_args.kwargs['host'] == 'devbox.example'
+
+
+@pytest.mark.parametrize('mode', ['one-shot', 'interactive', 'non-streaming'])
+def test_cli_no_tool_calls(
+    mode: str,
+    capfd: CaptureFixture[str],
+    mocker: MockerFixture,
+    create_test_module: Callable[..., None],
+):
+    agent = Agent(TestModel(custom_output_text='Finished.'))
+    calls: list[str] = []
+
+    @agent.tool_plain
+    def run_code(token: Literal['private-preview-marker']) -> str:
+        calls.append(token)
+        print('Saved chart.')
+        return 'saved'
+
+    create_test_module(agent=agent)
+    args = ['--agent', 'test_module:agent', '--no-tool-calls']
+    with create_pipe_input() as inp:
+        inp.send_text('go\n/exit\n')
+        mocker.patch('pydantic_ai._cli.PromptSession', return_value=PromptSession[Any](input=inp, output=DummyOutput()))
+        if mode != 'interactive':
+            args.append('go')
+        if mode == 'non-streaming':
+            args.append('--no-stream')
+        assert cli(args) == 0
+
+    output = capfd.readouterr().out
+    assert calls == ['private-preview-marker']
+    assert 'private-preview-marker' not in output
+    assert 'Saved chart.' in output
+    assert 'Finished.' in output
+    assert 'Calling tool' not in output
+    assert 'Called tool' not in output
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ('argument_name', 'code'),
+    [('code', "print(`[red]hello[/red]`)\nprint('  spaced  ')"), ('code', 'x' * 1000), ('bad\nkey', 'hello')],
+    ids=['literal-code', 'long-code', 'multiline-key'],
+)
+async def test_tool_argument_preview(argument_name: str, code: str, live_frames: list[str]):
+    async def code_stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            yield 'Done.'
+        else:
+            yield {
+                0: DeltaToolCall(name='run_code', json_args=json.dumps({argument_name: code}), tool_call_id='call_1')
+            }
+
+    agent = Agent(FunctionModel(stream_function=code_stream))
+    executed: list[dict[str, str]] = []
+
+    @agent.tool_plain
+    def run_code(**kwargs: str) -> str:
+        executed.append(kwargs)
+        return 'ok'
+
+    output = StringIO()
+    await ask_agent(agent, 'go', True, Console(file=output, width=100), 'monokai')
+    lines = [line.rstrip() for line in output.getvalue().splitlines()]
+    assert executed == [{argument_name: code}]
+    assert lines[0] == ''
+    assert lines[2:] == ['', 'Done.']
+    if len(code) > 100:
+        assert lines[1].startswith("▌ Called tool run_code(code='")
+        assert lines[1].endswith('…')
+        assert len(lines[1]) <= 100
+    else:
+        key = argument_name if argument_name.isidentifier() else repr(argument_name)
+        assert lines[1] == f'▌ Called tool run_code({key}={code!r}).'
+        assert any(f'Calling tool run_code({key}={code!r})…' in frame for frame in live_frames)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('show_tool_calls', [True, False])
+async def test_streaming_preserves_markdown_references(show_tool_calls: bool):
+    async def reference_stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            yield 'Confirmed.\n\n[docs]: https://example.com'
+        else:
+            yield 'Checking [the docs][docs].'
+            yield {0: DeltaToolCall(name='lookup', json_args='{}', tool_call_id='call_1')}
+
+    agent = Agent(FunctionModel(stream_function=reference_stream))
+
+    @agent.tool_plain
+    def lookup() -> str:
+        return 'ok'
+
+    output = StringIO()
+    await ask_agent(agent, 'go', True, Console(file=output, width=80), 'monokai', show_tool_calls=show_tool_calls)
+    rendered = output.getvalue()
+    assert 'Checking the docs.' in rendered
+    assert '[the docs][docs]' not in rendered
+    assert 'Confirmed.' in rendered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ import sniffio
 from pydantic import JsonValue
 from pytest import CaptureFixture
 from pytest_mock import MockerFixture
+from rich.cells import cell_len
 from rich.console import Console, RenderableType
 from rich.live import Live
 from rich.live_render import LiveRender
@@ -390,7 +391,8 @@ async def test_streaming_with_tool_calls(show_tool_calls: bool, live_frames: lis
 
 
 @pytest.mark.anyio
-async def test_tool_call_spacing_across_model_requests():
+@pytest.mark.parametrize('multiline', [False, True])
+async def test_tool_call_spacing_across_model_requests(multiline: bool):
     async def run_code_stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
         count = sum(isinstance(part, ToolReturnPart) for message in messages for part in message.parts)
         if count == 3:
@@ -402,7 +404,9 @@ async def test_tool_call_spacing_across_model_requests():
                 yield '   '
             yield {
                 0: DeltaToolCall(
-                    name='run_code', json_args=json.dumps({'code': f'print({count})'}), tool_call_id=f'call_{count}'
+                    name='run_code',
+                    json_args=json.dumps({'code': f'print({count})' + ('\n# end' if multiline else '')}),
+                    tool_call_id=f'call_{count}',
                 )
             }
 
@@ -414,15 +418,16 @@ async def test_tool_call_spacing_across_model_requests():
 
     output = StringIO()
     await ask_agent(agent, 'go', stream=True, console=Console(file=output, width=80), code_theme='monokai')
-    assert [line.rstrip() for line in output.getvalue().splitlines()] == [
-        'Checking.',
-        '',
-        "▌ Called tool run_code(code='print(0)').",
-        "▌ Called tool run_code(code='print(1)').",
-        "▌ Called tool run_code(code='print(2)').",
-        '',
-        'Done.',
-    ]
+    expected = ['Checking.', '']
+    for count in range(3):
+        if multiline:
+            expected.extend(
+                ['▌ Called tool run_code(code=<2 lines>).', '▌   code:', f'▌     print({count})', '▌     # end']
+            )
+        else:
+            expected.append(f"▌ Called tool run_code(code='print({count})').")
+    expected.extend(['', 'Done.'])
+    assert [line.rstrip() for line in output.getvalue().splitlines()] == expected
 
 
 def _distinct_frames(frames: list[str]) -> list[str]:
@@ -1566,7 +1571,7 @@ def test_cli_no_tool_calls(
     calls: list[str] = []
 
     @agent.tool_plain
-    def run_code(token: Literal['private-preview-marker']) -> str:
+    def run_code(token: Literal['private-preview-marker\nline 2\nline 3\nline 4\nline 5\nline 6']) -> str:
         calls.append(token)
         print('Saved chart.')
         return 'saved'
@@ -1583,7 +1588,7 @@ def test_cli_no_tool_calls(
         assert cli(args) == 0
 
     output = capfd.readouterr().out
-    assert calls == ['private-preview-marker']
+    assert calls == ['private-preview-marker\nline 2\nline 3\nline 4\nline 5\nline 6']
     assert 'private-preview-marker' not in output
     assert 'Saved chart.' in output
     assert 'Finished.' in output
@@ -1598,12 +1603,19 @@ def test_cli_no_tool_calls(
     [
         pytest.param(
             {'code': "print(`[red]hello[/red]`)\nprint('  spaced  ')"},
-            snapshot('▌ Called tool run_code(code=<2 lines>).'),
+            snapshot("""\
+▌ Called tool run_code(code=<2 lines>).
+▌   code:
+▌     print(`[red]hello[/red]`)
+▌     print('  spaced  ')\
+"""),
             id='literal-code',
         ),
         pytest.param(
             {'code': 'x' * 1000},
-            snapshot('▌ Called tool run_code(code=<1,000 chars>).'),
+            snapshot(
+                "▌ Called tool run_code(code='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'…)."
+            ),
             id='long-code',
         ),
         pytest.param(
@@ -1611,13 +1623,94 @@ def test_cli_no_tool_calls(
         ),
         pytest.param(
             {'first': 'x' * 1000, 'second': 'y' * 1000, 'third': 'useful'},
-            snapshot("▌ Called tool run_code(third='useful', first=<1,000 chars>, second=<1,000 chars>)."),
+            snapshot(
+                "▌ Called tool run_code(first='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'…, second='yyyyyyyyyyy…."
+            ),
             id='many-arguments',
         ),
         pytest.param(
-            {'code': 'import pandas as pd\n' + 'print("data")\n' * 21, 'description': 'Plot quarterly revenue'},
-            snapshot("▌ Called tool run_code(description='Plot quarterly revenue', code=<22 lines>)."),
-            id='script-with-purpose',
+            {'code': 'import json\n\nvalues = [1, 2, 3]\nfor value in values:\n    print(value)'},
+            snapshot("""\
+▌ Called tool run_code(code=<5 lines>).
+▌   code:
+▌     import json
+▌
+▌     values = [1, 2, 3]
+▌     for value in values:
+▌         print(value)\
+"""),
+            id='5-line-script',
+        ),
+        pytest.param(
+            {'code': 'import json\n\nvalues = [1, 2, 3]\nfor value in values:\n    print(value)\nprint("done")'},
+            snapshot("""\
+▌ Called tool run_code(code=<6 lines>).
+▌   code:
+▌     import json
+▌
+▌     values = [1, 2, 3]
+▌     for value in values:
+▌         print(value)
+▌     … 1 more line\
+"""),
+            id='6-line-script',
+        ),
+        pytest.param(
+            {'code': 'import json\n' + 'print("data")\n' * 21},
+            snapshot("""\
+▌ Called tool run_code(code=<22 lines>).
+▌   code:
+▌     import json
+▌     print("data")
+▌     print("data")
+▌     print("data")
+▌     print("data")
+▌     … 17 more lines\
+"""),
+            id='large-script',
+        ),
+        pytest.param(
+            {'first': 'one\ntwo', 'second': 'three\nfour'},
+            snapshot("""\
+▌ Called tool run_code(first=<2 lines>, second=<2 lines>).
+▌   first:
+▌     one
+▌     two
+▌   second:
+▌     three
+▌     four\
+"""),
+            id='multiple-multiline-arguments',
+        ),
+        pytest.param(
+            {'code': 'x' * 300 + '\nlast line'},
+            snapshot("""\
+▌ Called tool run_code(code=<2 lines>).
+▌   code:
+▌     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…
+▌     last line\
+"""),
+            id='wide-source-line',
+        ),
+        pytest.param(
+            {'code': "if True:\n\tprint('\x1b[2J')"},
+            snapshot("""\
+▌ Called tool run_code(code=<2 lines>).
+▌   code:
+▌     if True:
+▌         print('\\x1b[2J')\
+"""),
+            id='tabs-and-terminal-escapes',
+        ),
+        pytest.param(
+            {'code': 'e\u0301' * 100 + '\nend'},
+            snapshot("""\
+▌ Called tool run_code(code=<2 lines>).
+▌   code:
+▌     éééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé…
+▌     end\
+"""),
+            id='combining-characters',
         ),
         pytest.param(
             {'code': 'print(`[red]hello[/red]`)'},
@@ -1626,12 +1719,16 @@ def test_cli_no_tool_calls(
         ),
         pytest.param(
             {'code': 'print(1)\r\n'},
-            snapshot('▌ Called tool run_code(code=<1 line>).'),
+            snapshot("""\
+▌ Called tool run_code(code=<1 line>).
+▌   code:
+▌     print(1)\
+"""),
             id='one-line-with-ending',
         ),
         pytest.param(
             {'data': [1, 2, 3], 'options': {'private': 'hidden'}, 'limit': 5},
-            snapshot('▌ Called tool run_code(limit=5, data=<3 items>, options=<1 key>).'),
+            snapshot("▌ Called tool run_code(data=[1, 2, 3], options={'private': 'hidden'}, limit=5)."),
             id='collections',
         ),
         pytest.param(
@@ -1665,13 +1762,14 @@ async def test_tool_argument_preview(
     lines = [line.rstrip() for line in output.getvalue().splitlines()]
     assert executed == [arguments]
     assert lines[0] == ''
-    assert lines[2:] == ['', 'Done.']
+    assert lines[-2:] == ['', 'Done.']
+    notice = '\n'.join(lines[1:-2])
     if width == 1000:
-        assert lines[1] == expected
-        assert len(lines[1]) <= 135
+        assert notice == expected
+        assert all(cell_len(line) <= 135 for line in lines[1:-2])
     else:
         assert lines[1].startswith('▌ Called tool run_code(')
-        assert len(lines[1]) <= width
+        assert all(cell_len(line) <= width for line in lines[1:-2])
     assert any('Calling tool run_code(' in frame for frame in live_frames)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 import anyio
 import pytest
 import sniffio
+from pydantic import JsonValue
 from pytest import CaptureFixture
 from pytest_mock import MockerFixture
 from rich.console import Console, RenderableType
@@ -1597,29 +1598,54 @@ def test_cli_no_tool_calls(
     [
         pytest.param(
             {'code': "print(`[red]hello[/red]`)\nprint('  spaced  ')"},
-            snapshot('▌ Called tool run_code(code="print(`[red]hello[/red]`)\\nprint(\'  spaced  \')").'),
+            snapshot('▌ Called tool run_code(code=<2 lines>).'),
             id='literal-code',
         ),
         pytest.param(
             {'code': 'x' * 1000},
-            snapshot(
-                "▌ Called tool run_code(code='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')."
-            ),
+            snapshot('▌ Called tool run_code(code=<1,000 chars>).'),
             id='long-code',
         ),
         pytest.param(
             {'bad\nkey': 'hello'}, snapshot("▌ Called tool run_code('bad\\nkey'='hello')."), id='multiline-key'
         ),
         pytest.param(
-            {'first': 'x' * 1000, 'second': 'y' * 1000, 'third': 'not shown'},
-            snapshot(
-                "▌ Called tool run_code(first='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', second='yyyyyyyyyyyyyy…."
-            ),
+            {'first': 'x' * 1000, 'second': 'y' * 1000, 'third': 'useful'},
+            snapshot("▌ Called tool run_code(third='useful', first=<1,000 chars>, second=<1,000 chars>)."),
             id='many-arguments',
+        ),
+        pytest.param(
+            {'code': 'import pandas as pd\n' + 'print("data")\n' * 21, 'description': 'Plot quarterly revenue'},
+            snapshot("▌ Called tool run_code(description='Plot quarterly revenue', code=<22 lines>)."),
+            id='script-with-purpose',
+        ),
+        pytest.param(
+            {'code': 'print(`[red]hello[/red]`)'},
+            snapshot("▌ Called tool run_code(code='print(`[red]hello[/red]`)')."),
+            id='literal-short-code',
+        ),
+        pytest.param(
+            {'code': 'print(1)\r\n'},
+            snapshot('▌ Called tool run_code(code=<1 line>).'),
+            id='one-line-with-ending',
+        ),
+        pytest.param(
+            {'data': [1, 2, 3], 'options': {'private': 'hidden'}, 'limit': 5},
+            snapshot('▌ Called tool run_code(limit=5, data=<3 items>, options=<1 key>).'),
+            id='collections',
+        ),
+        pytest.param(
+            {'first': 'a' * 60, 'second': 'b' * 60, 'third': 'c' * 60},
+            snapshot(
+                "▌ Called tool run_code(first='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', second='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb…."
+            ),
+            id='bounded-many-short-arguments',
         ),
     ],
 )
-async def test_tool_argument_preview(arguments: dict[str, str], expected: str, width: int, live_frames: list[str]):
+async def test_tool_argument_preview(
+    arguments: dict[str, JsonValue], expected: str, width: int, live_frames: list[str]
+):
     async def code_stream(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str | DeltaToolCalls]:
         if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
             yield 'Done.'
@@ -1627,10 +1653,10 @@ async def test_tool_argument_preview(arguments: dict[str, str], expected: str, w
             yield {0: DeltaToolCall(name='run_code', json_args=json.dumps(arguments), tool_call_id='call_1')}
 
     agent = Agent(FunctionModel(stream_function=code_stream))
-    executed: list[dict[str, str]] = []
+    executed: list[dict[str, JsonValue]] = []
 
     @agent.tool_plain
-    def run_code(**kwargs: str) -> str:
+    def run_code(**kwargs: JsonValue) -> str:
         executed.append(kwargs)
         return 'ok'
 


### PR DESCRIPTION
### Why we make these changes

Samuel's feedback on #1374: repeated tool names do not distinguish calls, blank lines are inconsistent, and notices need an off switch alongside Logfire. Related historical issue: #4416.

### New public surface

- `show_tool_calls: bool = True` on `Agent.to_cli()` and `Agent.to_cli_sync()`.
- `clai --no-tool-calls` for interactive and one-shot sessions.

### User-visible behavior

Previously, each completed call printed only `Called tool run_code.` Now short arguments appear inline. Multiline arguments show their actual first five lines, including indentation and blank lines, followed by the omitted-line count:

```text
Called tool run_code(code=<8 lines>).
  code:
    import json

    values = [1, 2, 3]
    for value in values:
        print(value)
    … 3 more lines
```

Individual lines are truncated to fit the terminal. Consecutive notices stay together, with one blank line separating assistant text. `--no-tool-calls` / `show_tool_calls=False` hides the entire preview while retaining responses, errors, the generic working spinner, tool stdout, and Logfire output.

### Verification

- 126 CLI tests pass; CLI line and branch coverage is 100%. Focused Ruff/Pyright and CLI docs examples pass.
- [Argument previews](https://github.com/pydantic/pydantic-ai/blob/2c9d29c62/tests/test_cli.py#L1743), [spacing](https://github.com/pydantic/pydantic-ai/blob/2c9d29c62/tests/test_cli.py#L395), [CLI opt-out](https://github.com/pydantic/pydantic-ai/blob/2c9d29c62/tests/test_cli.py#L1564), [Markdown references](https://github.com/pydantic/pydantic-ai/blob/2c9d29c62/tests/test_cli.py#L1778), and [hidden-tool progress](https://github.com/pydantic/pydantic-ai/blob/2c9d29c62/tests/test_cli.py#L1802) exercise rendering and execution.
- Real terminal smoke: a code-only tool executes an eight-line script, shows five lines plus the omission count, and preserves stdout and the answer with notices disabled. Uses `FunctionModel`, without provider requests.
- Earlier Logfire terminal smoke, API compatibility, and Python 3.12 README help checks passed. Optional Trio probe fails in unchanged agent lifecycle code before rendering. Full-repository type checks are CI-only.

### What changes for existing users

Tool notices remain enabled by default and now show argument contents, which may include sensitive data. Use the off switch to suppress them. This default-visibility tradeoff remains highlighted for maintainer review. Non-streaming behavior is unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (None.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
