### PR TITLE
Add DRY API errors helper in `CohereEmbeddingModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -35,9 +35,7 @@ def _map_api_errors(model_name: str) -> Generator[None]:
 
     except ApiError as e:  # pragma: no cover
         if (status_code := e.status_code) and status_code >= 400:
-            raise ModelHTTPError(
-                status_code=status_code, model_name=model_name, body=e.body, headers=e.headers
-            ) from e
+            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body, headers=e.headers) from e
 
         raise ModelAPIError(model_name=model_name, message=str(e)) from e
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -1,4 +1,5 @@
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
@@ -25,6 +26,21 @@ except ImportError as _import_error:
         'Please install `cohere` to use the Cohere embeddings model, '
         'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'
     ) from _import_error
+
+
+@contextmanager
+def _map_api_errors(model_name: str) -> Generator[None]:
+    try:
+        yield
+
+    except ApiError as e:  # pragma: no cover
+        if (status_code := e.status_code) and status_code >= 400:
+            raise ModelHTTPError(
+                status_code=status_code, model_name=model_name, body=e.body, headers=e.headers
+            ) from e
+
+        raise ModelAPIError(model_name=model_name, message=str(e)) from e
+
 
 LatestCohereEmbeddingModelNames = Literal[
     'embed-v4.0',
@@ -177,7 +193,7 @@ class CohereEmbeddingModel(EmbeddingModel):
         else:
             truncate = 'NONE'
 
-        try:
+        with _map_api_errors(self._model_name):
             response = await self._client.embed(
                 model=self.model_name,
                 texts=inputs,
@@ -186,14 +202,8 @@ class CohereEmbeddingModel(EmbeddingModel):
                 max_tokens=settings.get('cohere_max_tokens'),
                 truncate=truncate,
                 request_options=request_options,
-                embedding_types=['float'],  # Always request float embeddings to avoid Cohere SDK deserialization bug
+                embedding_types=['float'],  # Always request float embeddings to avoid Cohere SDK deserialization bug.
             )
-        except ApiError as e:
-            if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(
-                    status_code=status_code, model_name=self.model_name, body=e.body, headers=e.headers
-                ) from e
-            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e  # pragma: no cover
 
         embeddings = response.embeddings.float_
         if embeddings is None:
@@ -221,18 +231,13 @@ class CohereEmbeddingModel(EmbeddingModel):
         if self._v1_client is None:
             raise NotImplementedError('Counting tokens requires the Cohere v1 client')
         check_allow_model_requests()
-        try:
+
+        with _map_api_errors(self._model_name):
             result = await self._v1_client.tokenize(
                 model=self.model_name,
-                text=text,  # Has a max length of 65536 characters
+                text=text,  # Has a max length of 65536 characters.
                 offline=False,
             )
-        except ApiError as e:  # pragma: no cover
-            if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(
-                    status_code=status_code, model_name=self.model_name, body=e.body, headers=e.headers
-                ) from e
-            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
 
         return len(result.tokens)
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -202,7 +202,7 @@ class CohereEmbeddingModel(EmbeddingModel):
                 max_tokens=settings.get('cohere_max_tokens'),
                 truncate=truncate,
                 request_options=request_options,
-                embedding_types=['float'],  # Always request float embeddings to avoid Cohere SDK deserialization bug.
+                embedding_types=['float'],  # Always request float embeddings to avoid Cohere SDK deserialization bug
             )
 
         embeddings = response.embeddings.float_
@@ -235,7 +235,7 @@ class CohereEmbeddingModel(EmbeddingModel):
         with _map_api_errors(self._model_name):
             result = await self._v1_client.tokenize(
                 model=self.model_name,
-                text=text,  # Has a max length of 65536 characters.
+                text=text,  # Has a max length of 65536 characters
                 offline=False,
             )
 

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -33,11 +33,14 @@ def _map_api_errors(model_name: str) -> Generator[None]:
     try:
         yield
 
-    except ApiError as e:  # pragma: no cover
+    except ApiError as e:
         if (status_code := e.status_code) and status_code >= 400:
+            # For `CohereEmbeddingModel`, `count_tokens()` doesn't raise `ApiError` at all.
+            # However, `embed()` triggers such a branch.
             raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body, headers=e.headers) from e
 
-        raise ModelAPIError(model_name=model_name, message=str(e)) from e
+        # Neither `embed()` nor `count_tokens()` exercises this fallback.
+        raise ModelAPIError(model_name=model_name, message=str(e)) from e  # pragma: no cover
 
 
 LatestCohereEmbeddingModelNames = Literal[


### PR DESCRIPTION
Closes #8212.

---

### Changes

Added a module-level function called `_map_api_errors` to achieve DRY:

```
@contextmanager
def _map_api_errors(model_name: str) -> Generator[None]:
    try:
        yield

    except ApiError as e:
        if (status_code := e.status_code) and status_code >= 400:
            # For `CohereEmbeddingModel`, `count_tokens()` doesn't raise `ApiError` at all.
            # However, `embed()` triggers such a branch.
            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body, headers=e.headers) from e

        # Neither `embed()` nor `count_tokens()` exercises this fallback.
        raise ModelAPIError(model_name=model_name, message=str(e)) from e  # pragma: no cover
```

How `CohereEmbeddingModel.embed` calls it:

```
with _map_api_errors(self._model_name):
    response = await self._client.embed(...)
```

How `CohereEmbeddingModel.count_tokens` calls it:

```
with _map_api_errors(self._model_name):
    result = await self._v1_client.tokenize(...)
```

---

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

