### PR TITLE
fix(mcp): include port in derived MCP capability ids

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/mcp.py
@@ -136,11 +136,16 @@ class MCP(NativeOrLocalTool[AgentDepsT]):
             return self.native.id
         if url is None:
             return None
-        # Include hostname to avoid collisions (e.g. two /sse URLs on different hosts)
+        # Include hostname (and port when present) to avoid collisions — e.g. two /sse
+        # URLs on different hosts, or the same path on localhost:8000 vs localhost:9000 (#8207).
         parsed = urlparse(url)
         path = parsed.path.rstrip('/')
         slug = path.split('/')[-1] if path else ''
-        host = parsed.hostname or ''
+        if parsed.port is not None:
+            # Prefer netloc (minus userinfo) so IPv6 brackets and the port stay intact.
+            host = parsed.netloc.rsplit('@', 1)[-1]
+        else:
+            host = parsed.hostname or ''
         return f'{host}-{slug}' if slug else host or url
 
     @cached_property

--- a/tests/test_capability_native_or_local.py
+++ b/tests/test_capability_native_or_local.py
@@ -646,6 +646,13 @@ class TestMCPCapability:
         assert isinstance(native_sse, MCPServerTool)
         assert native_sse.id == 'server1.example.com-sse'
 
+        # Same host/path on different ports must not collide (#8207)
+        cap_a = MCP(url='http://localhost:8000/mcp', native=True)
+        cap_b = MCP(url='http://localhost:9000/mcp', native=True)
+        assert cap_a.id == 'localhost:8000-mcp'
+        assert cap_b.id == 'localhost:9000-mcp'
+        assert cap_a.id != cap_b.id
+
     def test_mcp_local_toolset_id_derived(self):
         """MCP stamps a derived id on the local `MCPToolset` so it can be used with durable
         execution. Precedence: explicit `id` → native `MCPServerTool` id → host+slug from the URL,


### PR DESCRIPTION
﻿## Summary
- Include the URL port in derived MCP capability ids when present (`localhost:8000-mcp` vs `localhost:9000-mcp`)
- Keep host-only ids when no port is specified (unchanged for `https://mcp.example.com/api`)
- Use netloc (minus userinfo) when a port is set so IPv6 bracket form stays valid

## Test plan
- [x] Extended `test_mcp_id_from_url` with same-host different-port collision case

## Note
Happy to wait for maintainer assignment per CONTRIBUTING if preferred — approach is the minimal port-in-authority change described on #8207.

Fixes #8207


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

