### PR TITLE
Add `Model._prepare_model_settings` hook

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -614,17 +614,11 @@ class Model(AbstractModel, Generic[InterfaceClient]):
 
         return model_request_parameters
 
-    @staticmethod
-    def _apply_model_settings_filter(
-        model_settings: ModelSettings | None, filter_settings: Callable[[ModelSettings], None]
+    def _prepare_model_settings(
+        self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
     ) -> ModelSettings | None:
-        """Apply an in-place filter to a copy of model settings, preserving the caller's input."""
-        if not model_settings:
-            return model_settings
-
-        filtered: ModelSettings = {**model_settings}
-        filter_settings(filtered)
-        return filtered or None
+        """Customize merged model settings after generic request preparation."""
+        return model_settings
 
     def prepare_request(
         self,
@@ -719,6 +713,7 @@ class Model(AbstractModel, Generic[InterfaceClient]):
                 tool_visibility={t.name: 'visible' for t in params.function_tools},
             )
 
+        model_settings = self._prepare_model_settings(model_settings, params)
         return model_settings, params
 
     def prepare_messages(

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -614,6 +614,18 @@ class Model(AbstractModel, Generic[InterfaceClient]):
 
         return model_request_parameters
 
+    @staticmethod
+    def _apply_model_settings_filter(
+        model_settings: ModelSettings | None, filter_settings: Callable[[ModelSettings], None]
+    ) -> ModelSettings | None:
+        """Apply an in-place filter to a copy of model settings, preserving the caller's input."""
+        if not model_settings:
+            return model_settings
+
+        filtered: ModelSettings = {**model_settings}
+        filter_settings(filtered)
+        return filtered or None
+
     def prepare_request(
         self,
         model_settings: ModelSettings | None,

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1079,10 +1079,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             )
 
         prepared_settings, model_request_parameters = super().prepare_request(model_settings, model_request_parameters)
-        if profile.get('anthropic_disallows_sampling_settings', False) and prepared_settings:
-            filtered: ModelSettings = {**prepared_settings}
-            self._drop_unsupported_sampling_settings(filtered)
-            prepared_settings = filtered or None
+        if profile.get('anthropic_disallows_sampling_settings', False):
+            prepared_settings = self._apply_model_settings_filter(
+                prepared_settings, self._drop_unsupported_sampling_settings
+            )
         return prepared_settings, model_request_parameters
 
     def _drop_unsupported_sampling_settings(self, model_settings: ModelSettings) -> None:
@@ -1102,7 +1102,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             warnings.warn(
                 f'Sampling parameters {ordered} are not supported by {self.model_name!r}. These settings will be ignored.',
                 UserWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
     def _translate_thinking(

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -12,7 +12,7 @@ from typing import Any, Literal, TypeAlias, TypeGuard, cast, overload
 import pydantic_core
 from opentelemetry.trace import get_current_span
 from pydantic import TypeAdapter
-from typing_extensions import assert_never
+from typing_extensions import assert_never, override
 
 from .. import ModelHTTPError, UnexpectedModelBehavior, _utils, usage
 from .._http import to_httpx2_timeout
@@ -1080,10 +1080,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         return super().prepare_request(model_settings, model_request_parameters)
 
+    @override
     def _prepare_model_settings(
         self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
     ) -> ModelSettings | None:
-        del model_request_parameters
         if self.profile.get('anthropic_disallows_sampling_settings', False) and model_settings:
             filtered: ModelSettings = {**model_settings}
             self._drop_unsupported_sampling_settings(filtered)

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1078,12 +1078,17 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                 model_request_parameters, output_object=replace(model_request_parameters.output_object, strict=True)
             )
 
-        prepared_settings, model_request_parameters = super().prepare_request(model_settings, model_request_parameters)
-        if profile.get('anthropic_disallows_sampling_settings', False):
-            prepared_settings = self._apply_model_settings_filter(
-                prepared_settings, self._drop_unsupported_sampling_settings
-            )
-        return prepared_settings, model_request_parameters
+        return super().prepare_request(model_settings, model_request_parameters)
+
+    def _prepare_model_settings(
+        self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
+    ) -> ModelSettings | None:
+        del model_request_parameters
+        if self.profile.get('anthropic_disallows_sampling_settings', False) and model_settings:
+            filtered: ModelSettings = {**model_settings}
+            self._drop_unsupported_sampling_settings(filtered)
+            return filtered or None
+        return model_settings
 
     def _drop_unsupported_sampling_settings(self, model_settings: ModelSettings) -> None:
         dropped = {setting for setting in ANTHROPIC_SAMPLING_PARAMS if setting in model_settings}
@@ -1102,7 +1107,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             warnings.warn(
                 f'Sampling parameters {ordered} are not supported by {self.model_name!r}. These settings will be ignored.',
                 UserWarning,
-                stacklevel=3,
+                stacklevel=4,
             )
 
     def _translate_thinking(

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -719,10 +719,10 @@ class BedrockConverseModel(Model[BaseClient]):
             )
         # Pass unmerged model_settings; base class does its own merge
         prepared_settings, model_request_parameters = super().prepare_request(model_settings, model_request_parameters)
-        if self.profile.get('anthropic_disallows_sampling_settings', False) and prepared_settings:
-            filtered: ModelSettings = {**prepared_settings}
-            self._drop_unsupported_sampling_settings(filtered)
-            prepared_settings = filtered or None
+        if self.profile.get('anthropic_disallows_sampling_settings', False):
+            prepared_settings = self._apply_model_settings_filter(
+                prepared_settings, self._drop_unsupported_sampling_settings
+            )
         return prepared_settings, model_request_parameters
 
     def _drop_unsupported_sampling_settings(self, model_settings: ModelSettings) -> None:
@@ -742,7 +742,7 @@ class BedrockConverseModel(Model[BaseClient]):
             warnings.warn(
                 f'Sampling parameters {dropped} are not supported by {self.model_name!r}. These settings will be ignored.',
                 UserWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qs, urlparse
 
 import anyio.to_thread
 from pydantic_core import to_json
-from typing_extensions import ParamSpec, TypedDict, assert_never
+from typing_extensions import ParamSpec, TypedDict, assert_never, override
 
 try:
     from botocore.client import BaseClient
@@ -720,10 +720,10 @@ class BedrockConverseModel(Model[BaseClient]):
         # Pass unmerged model_settings; base class does its own merge
         return super().prepare_request(model_settings, model_request_parameters)
 
+    @override
     def _prepare_model_settings(
         self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
     ) -> ModelSettings | None:
-        del model_request_parameters
         if self.profile.get('anthropic_disallows_sampling_settings', False) and model_settings:
             filtered: ModelSettings = {**model_settings}
             self._drop_unsupported_sampling_settings(filtered)

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -718,12 +718,17 @@ class BedrockConverseModel(Model[BaseClient]):
                 model_request_parameters, output_object=replace(model_request_parameters.output_object, strict=True)
             )
         # Pass unmerged model_settings; base class does its own merge
-        prepared_settings, model_request_parameters = super().prepare_request(model_settings, model_request_parameters)
-        if self.profile.get('anthropic_disallows_sampling_settings', False):
-            prepared_settings = self._apply_model_settings_filter(
-                prepared_settings, self._drop_unsupported_sampling_settings
-            )
-        return prepared_settings, model_request_parameters
+        return super().prepare_request(model_settings, model_request_parameters)
+
+    def _prepare_model_settings(
+        self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
+    ) -> ModelSettings | None:
+        del model_request_parameters
+        if self.profile.get('anthropic_disallows_sampling_settings', False) and model_settings:
+            filtered: ModelSettings = {**model_settings}
+            self._drop_unsupported_sampling_settings(filtered)
+            return filtered or None
+        return model_settings
 
     def _drop_unsupported_sampling_settings(self, model_settings: ModelSettings) -> None:
         """Drop the sampling settings a flagged model rejects, warning like `AnthropicModel` does.
@@ -742,7 +747,7 @@ class BedrockConverseModel(Model[BaseClient]):
             warnings.warn(
                 f'Sampling parameters {dropped} are not supported by {self.model_name!r}. These settings will be ignored.',
                 UserWarning,
-                stacklevel=3,
+                stacklevel=4,
             )
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -108,21 +108,19 @@ class CerebrasModel(OpenAIChatModel):
         return omit
 
     @override
-    def prepare_request(
+    def _prepare_model_settings(
         self,
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-    ) -> tuple[ModelSettings | None, ModelRequestParameters]:
-        merged_settings, customized_parameters = super().prepare_request(model_settings, model_request_parameters)
+    ) -> ModelSettings:
         # `'tags'` means we replay prior reasoning as `<think>` content (zai/GLM); Cerebras strips that
         # by default, so the transform preserves it. See `_cerebras_settings_to_openai_settings`.
         replays_thinking_as_tags = self.profile.get('openai_chat_send_back_thinking_parts') == 'tags'
-        new_settings = _cerebras_settings_to_openai_settings(
-            cast(CerebrasModelSettings, merged_settings or {}),
-            customized_parameters,
+        return _cerebras_settings_to_openai_settings(
+            cast(CerebrasModelSettings, model_settings or {}),
+            model_request_parameters,
             replays_thinking_as_tags=replays_thinking_as_tags,
         )
-        return new_settings, customized_parameters
 
 
 def _cerebras_settings_to_openai_settings(

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -871,16 +871,14 @@ class OpenRouterModel(OpenAIChatModel):
         return frozenset({WebSearchTool, AdvisorTool})
 
     @override
-    def prepare_request(
+    def _prepare_model_settings(
         self,
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-    ) -> tuple[ModelSettings | None, ModelRequestParameters]:
-        merged_settings, customized_parameters = super().prepare_request(model_settings, model_request_parameters)
-        new_settings = _openrouter_settings_to_openai_settings(
-            cast(OpenRouterModelSettings, merged_settings or {}), customized_parameters
+    ) -> ModelSettings:
+        return _openrouter_settings_to_openai_settings(
+            cast(OpenRouterModelSettings, model_settings or {}), model_request_parameters
         )
-        return new_settings, customized_parameters
 
     @override
     def _translate_thinking(

--- a/pydantic_ai_slim/pydantic_ai/models/snowflake.py
+++ b/pydantic_ai_slim/pydantic_ai/models/snowflake.py
@@ -185,16 +185,16 @@ class SnowflakeModel(OpenAIChatModel):
         return cast(SnowflakeModelProfile, self.profile)
 
     @override
-    def prepare_request(
+    def _prepare_model_settings(
         self,
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-    ) -> tuple[ModelSettings | None, ModelRequestParameters]:
-        merged_settings, customized_parameters = super().prepare_request(model_settings, model_request_parameters)
-        new_settings = _snowflake_settings_to_openai_settings(
-            cast(SnowflakeModelSettings, merged_settings or {}), customized_parameters, profile=self._resolved_profile
+    ) -> ModelSettings:
+        return _snowflake_settings_to_openai_settings(
+            cast(SnowflakeModelSettings, model_settings or {}),
+            model_request_parameters,
+            profile=self._resolved_profile,
         )
-        return new_settings, customized_parameters
 
     @override
     def _translate_thinking(

--- a/pydantic_ai_slim/pydantic_ai/models/zai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/zai.py
@@ -161,21 +161,19 @@ class ZaiModel(OpenAIChatModel):
         super().__init__(model_name, provider=provider, profile=profile, settings=settings)
 
     @override
-    def prepare_request(
+    def _prepare_model_settings(
         self,
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-    ) -> tuple[ModelSettings | None, ModelRequestParameters]:
-        merged_settings, customized_parameters = super().prepare_request(model_settings, model_request_parameters)
+    ) -> ModelSettings:
         profile = cast(ZaiModelProfile, self.profile)
-        new_settings = _zai_settings_to_openai_settings(
-            cast(ZaiModelSettings, merged_settings or {}),
-            customized_parameters,
+        return _zai_settings_to_openai_settings(
+            cast(ZaiModelSettings, model_settings or {}),
+            model_request_parameters,
             supports_thinking=profile.get('supports_thinking', False),
             supports_reasoning_effort=profile.get('zai_supports_reasoning_effort', False),
             reasoning_effort_mapping=profile.get('zai_reasoning_effort_mapping', {}),
         )
-        return new_settings, customized_parameters
 
     @override
     def _translate_thinking(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4723,10 +4723,11 @@ async def test_anthropic_opus_47_dedups_sampling_warning_across_settings_and_ext
     with pytest.warns(UserWarning) as recorded:
         await agent.run('What is 2+2?')
 
-    sampling_warnings = [str(w.message) for w in recorded if 'Sampling parameters' in str(w.message)]
-    assert sampling_warnings == [
+    sampling_warnings = [w for w in recorded if 'Sampling parameters' in str(w.message)]
+    assert [str(w.message) for w in sampling_warnings] == [
         f"Sampling parameters ['temperature', 'top_k'] are not supported by '{model_name}'. These settings will be ignored."
     ]
+    assert all(w.filename.endswith('/pydantic_ai/models/anthropic.py') for w in sampling_warnings)
 
 
 @pytest.mark.parametrize('model_name', ['claude-opus-4-7', 'claude-opus-4-8'])

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -6969,13 +6969,14 @@ async def test_bedrock_anthropic_5_drops_sampling_settings(
         result = await agent.run('What is 2+2? Answer with the number only.')
 
     assert result.output.strip() == snapshot('4')
-    sampling_warnings = [str(w.message) for w in recorded if 'Sampling parameters' in str(w.message)]
-    assert sampling_warnings == snapshot(
+    sampling_warnings = [w for w in recorded if 'Sampling parameters' in str(w.message)]
+    assert [str(w.message) for w in sampling_warnings] == snapshot(
         [
             "Sampling parameters ['temperature', 'top_p', 'top_k'] are not supported by "
             "'eu.anthropic.claude-opus-5'. These settings will be ignored."
         ]
     )
+    assert all(w.filename.endswith('/pydantic_ai/models/bedrock.py') for w in sampling_warnings)
 
     sent = single_request_body(vcr)
     assert sent['inferenceConfig'] == snapshot({'maxTokens': 16})

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -17,9 +17,18 @@ from pydantic_ai.messages import (
     TextPart,
     UserPromptPart,
 )
-from pydantic_ai.models import DEFAULT_PROFILE, AbstractModel, Model, infer_model, infer_model_profile, parse_model_id
+from pydantic_ai.models import (
+    DEFAULT_PROFILE,
+    AbstractModel,
+    Model,
+    ModelRequestParameters,
+    infer_model,
+    infer_model_profile,
+    parse_model_id,
+)
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.profiles import ModelProfile
+from pydantic_ai.settings import ModelSettings
 
 from ..conftest import try_import
 
@@ -36,6 +45,26 @@ with try_import() as imports_successful:
 
 if not imports_successful():
     pytest.skip('model packages were not installed', allow_module_level=True)  # pragma: lax no cover
+
+
+def test_prepare_model_settings_hook() -> None:
+    """The internal hook runs after generic preparation without changing no-op model behavior."""
+
+    class CustomModel(TestModel):
+        def _prepare_model_settings(
+            self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
+        ) -> ModelSettings | None:
+            assert model_request_parameters.output_mode == 'tool'
+            return {**(model_settings or {}), 'max_tokens': 42}
+
+    settings: ModelSettings = {'temperature': 0.2}
+    unchanged, _ = TestModel().prepare_request(settings, ModelRequestParameters(output_mode='auto'))
+    prepared, parameters = CustomModel().prepare_request(settings, ModelRequestParameters(output_mode='auto'))
+
+    assert unchanged is settings
+    assert prepared == {'temperature': 0.2, 'max_tokens': 42}
+    assert settings == {'temperature': 0.2}
+    assert parameters.output_mode == 'tool'
 
 
 # TODO(Marcelo): We need to add Vertex AI to the test cases.


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

- Follow-up to [this review discussion](https://github.com/pydantic/pydantic-ai/pull/7961#discussion_r3959096664).

### Why we make these changes

The duplicated post-preparation settings work in `AnthropicModel` and `BedrockConverseModel` suggested a reusable adapter seam. This change adds the internal `Model._prepare_model_settings` hook so adapters can convert or filter merged settings without returning unchanged request parameters.

### New public surface

None. `Model._prepare_model_settings` is an internal adapter hook.

### User-visible behavior

```diff
pydantic_ai_slim/pydantic_ai/models/__init__.py :: Model.prepare_request()
└─ generic request preparation
+  └─ pydantic_ai_slim/pydantic_ai/models/__init__.py :: Model._prepare_model_settings()
+     └─ merged settings after adapter conversion or filtering
```

### Verification

- [`test_prepare_model_settings_hook`](https://github.com/pydantic/pydantic-ai/blob/ad86a7818ba22d250e74d19a851a124d73a29c67/tests/models/test_model.py#L50-L67)
- [`test_anthropic_opus_47_dedups_sampling_warning_across_settings_and_extra_body`](https://github.com/pydantic/pydantic-ai/blob/ad86a7818ba22d250e74d19a851a124d73a29c67/tests/models/test_anthropic.py#L4706-L4730)
- [`test_bedrock_anthropic_5_drops_sampling_settings`](https://github.com/pydantic/pydantic-ai/blob/ad86a7818ba22d250e74d19a851a124d73a29c67/tests/models/test_bedrock.py#L6953-L6985)

### What changes for existing users

Nothing. Settings object identity, converter ordering, and provider warning attribution remain unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (Not applicable.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).