### PR TITLE
Publish the harness `TrajectoryJudge` page

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -402,6 +402,10 @@ navigation:
             path: "system-reminders.md"
             source: "harness"
             slug: "harness/system-reminders"
+          - page: "Trajectory Judge"
+            path: "trajectory-judge.md"
+            source: "harness"
+            slug: "harness/trajectory-judge"
       - section: "Self-Extension"
         slug: ""
         contents:


### PR DESCRIPTION
`pydantic-ai-harness` added `docs/trajectory-judge.md` ([harness #724](https://github.com/pydantic/pydantic-ai-harness/pull/724), 2026-09-08 14:45Z) and links it from its capability index under Control & safety. But the harness section is published through *this* repo's `docs/navigation.yml`, so a harness page with no entry here is never built — `mutation-testing.md` is in the same state today.

The result is a dead link in the built docs, and because unified-docs tracks the harness at `ref: main` rather than a pin, **every unified-docs pull request built since that commit fails its link check**:

```
### Errors in dist/ai/harness/index.html
* [ERROR] .../dist/ai/harness/trajectory-judge (at 458:1262) | File not found.
```

This adds the entry, after System Reminders, matching the Control & Safety grouping the harness index puts the page in.

Found while a unified-docs PR of mine went red; it is unrelated to that change and blocks any other one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EkyQrAYWj3qzZBvB7YHUR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

