### PR TITLE
Add pydantic-ai-governor to third-party capabilities

### DIFF
--- a/docs/capabilities/third-party.md
+++ b/docs/capabilities/third-party.md
@@ -27,6 +27,7 @@ Pydantic AI supports [multi-agent patterns](../multi-agent-applications.md) dire
 [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/guardrails/) provides input and output guardrails that validate or block requests and responses, and Pydantic AI enforces usage, token, and request limits via [`UsageLimits`](../agent.md#usage-limits). As a community alternative bundling several ready-made shields, including USD cost tracking:
 
 * [`pydantic-ai-shields`](https://github.com/vstorm-co/pydantic-ai-shields) - Ready-to-use guardrail capabilities: `CostTracking` (tracks token usage and USD cost per run, raises `BudgetExceededError` on budget overrun); `ToolGuard` (block or require approval for specific tools); `InputGuard` and `OutputGuard` (custom sync or async validation functions); `PromptInjection`, `PiiDetector`, `SecretRedaction`, `BlockedKeywords`, and `NoRefusals` content shields.
+* [`pydantic-ai-governor`](https://github.com/crescerelabs/sentience-governor/tree/main/integrations/pydantic-ai-governor) - `SentienceGovernor` records governance-oriented execution evidence against the objective and scope declared for a run: a session per run, a scope assertion before each dispatched tool call, a snapshot after each normal return, and per-turn token usage from `ModelResponse.usage`, joined on `tool_use_id`. Nothing is inferred from a tool's name. It observes and records rather than intervening in tool execution.
 
 ## File Operations & Sandboxing {#file-operations-sandboxing}
 


### PR DESCRIPTION
Adds `pydantic-ai-governor` to the **Guardrails & Safety** section of the
third-party capabilities page.

`SentienceGovernor` records governance-oriented execution evidence for
Pydantic AI runs, including declaration state, tool-dispatch assertions,
normal-return snapshots, and measured model-turn token usage. It observes and
records; it does not intervene in tool execution.

- Package: https://pypi.org/project/pydantic-ai-governor/
- Source: https://github.com/crescerelabs/sentience-governor/tree/main/integrations/pydantic-ai-governor
- License: Apache-2.0
- Released version: `0.1.0`

This is a documentation-only listing addition. Happy to shorten or adjust the
placement if preferred.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

