### PR TITLE
test: cover background evaluation thread cleanup

### DIFF
--- a/tests/evals/test_online.py
+++ b/tests/evals/test_online.py
@@ -5,6 +5,7 @@ from __future__ import annotations as _annotations
 import asyncio
 import inspect
 import random
+import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -44,6 +45,43 @@ needs_logfire = pytest.mark.skipif(not logfire_import_successful(), reason='logf
 
 
 if TYPE_CHECKING or imports_successful():
+
+    async def test_wait_for_evaluations_joins_background_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+        joined: list[float] = []
+
+        class CompletedThread:
+            def join(self, *, timeout: float) -> None:
+                joined.append(timeout)
+
+            def is_alive(self) -> bool:
+                return False
+
+        monkeypatch.setattr(_online, '_background_tasks', set())
+        monkeypatch.setattr(_online, '_background_events', set())
+        monkeypatch.setattr(_online, '_background_threads', {CompletedThread()})
+
+        await wait_for_evaluations(timeout=1.25)
+
+        assert joined == [1.25]
+
+    async def test_wait_for_evaluations_warns_for_live_background_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+        class LiveThread:
+            def join(self, *, timeout: float) -> None:
+                pass
+
+            def is_alive(self) -> bool:
+                return True
+
+        monkeypatch.setattr(_online, '_background_tasks', set())
+        monkeypatch.setattr(_online, '_background_events', set())
+        monkeypatch.setattr(_online, '_background_threads', {LiveThread()})
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            await wait_for_evaluations(timeout=0.5)
+
+        monkeypatch.setattr(_online, '_background_threads', set())
+        assert [str(item.message) for item in caught] == ['Background evaluation thread did not complete within 0.5s timeout']
 
     @dataclass
     class AlwaysTrue(Evaluator):


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://pydantic.dev/docs/ai/project/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- For a version-policy-permitted compatibility impact, add the `compatibility impact` label -->
<!-- and place this warning immediately after the PR's opening explanation: -->
<!-- > [!WARNING] -->
<!-- > **Compatibility impact:** Existing code that ... may ... -->
<!-- > -->
<!-- > **Why this can ship in a minor release:** ... -->
<!-- > -->
<!-- > **Migration:** ... -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#when-do-you-need-the-harness -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

