### PR TITLE
Map WebSearchTool.blocked_domains to GoogleSearch.exclude_domains

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -773,7 +773,10 @@ class GoogleModel(Model[Client]):
 
             for tool in model_request_parameters.native_tools:
                 if isinstance(tool, WebSearchTool):
-                    tools.append(ToolDict(google_search=GoogleSearchDict()))
+                    google_search = GoogleSearchDict()
+                    if tool.blocked_domains:
+                        google_search['exclude_domains'] = tool.blocked_domains
+                    tools.append(ToolDict(google_search=google_search))
                 elif isinstance(tool, WebFetchTool):
                     tools.append(ToolDict(url_context=UrlContextDict()))
                 elif isinstance(tool, CodeExecutionTool):

--- a/pydantic_ai_slim/pydantic_ai/native_tools/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/native_tools/__init__.py
@@ -182,6 +182,7 @@ class WebSearchTool(AbstractNativeTool):
     Supported by:
 
     * Anthropic, see <https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool#domain-filtering>
+    * Google, see <https://ai.google.dev/gemini-api/docs/google-search>
     * Groq, see <https://console.groq.com/docs/agentic-tooling#search-settings>
     * xAI, see <https://docs.x.ai/docs/guides/tools/search-tools#web-search-parameters>
     * OpenRouter, see <https://openrouter.ai/docs/guides/features/server-tools/web-search#configuration>

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -2551,6 +2551,36 @@ async def test_google_timeout_zero_in_config():
     assert config_dict['http_options']['timeout'] == 0
 
 
+async def test_google_web_search_tool_blocked_domains_in_config():
+    """`WebSearchTool.blocked_domains` maps to `GoogleSearch.exclude_domains`."""
+    m = GoogleModel('gemini-1.5-flash', provider=GoogleProvider(api_key='test-key'))
+
+    _, config = await m._build_content_and_config(  # pyright: ignore[reportPrivateUsage]
+        messages=[ModelRequest(parts=[UserPromptPart(content='Hello')])],
+        model_settings=GoogleModelSettings(),
+        model_request_parameters=ModelRequestParameters(
+            native_tools=[WebSearchTool(blocked_domains=['example.com', 'spam.example'])]
+        ),
+    )
+
+    config_dict = cast(dict[str, Any], config)
+    assert config_dict['tools'] == [{'google_search': {'exclude_domains': ['example.com', 'spam.example']}}]
+
+
+async def test_google_web_search_tool_without_blocked_domains_in_config():
+    """Without domain filters the search tool is still sent, with no extra keys."""
+    m = GoogleModel('gemini-1.5-flash', provider=GoogleProvider(api_key='test-key'))
+
+    _, config = await m._build_content_and_config(  # pyright: ignore[reportPrivateUsage]
+        messages=[ModelRequest(parts=[UserPromptPart(content='Hello')])],
+        model_settings=GoogleModelSettings(),
+        model_request_parameters=ModelRequestParameters(native_tools=[WebSearchTool()]),
+    )
+
+    config_dict = cast(dict[str, Any], config)
+    assert config_dict['tools'] == [{'google_search': {}}]
+
+
 async def test_google_extra_headers(allow_model_requests: None, google_provider: GoogleProvider):
     m = GoogleModel('gemini-1.5-flash', provider=google_provider)
     agent = Agent(m, model_settings=GoogleModelSettings(extra_headers={'Extra-Header-Key': 'Extra-Header-Value'}))


### PR DESCRIPTION
Closes #8218

`GoogleModel` built an empty `GoogleSearchDict`, so `WebSearchTool.blocked_domains` was silently dropped:

```python
if isinstance(tool, WebSearchTool):
    tools.append(ToolDict(google_search=GoogleSearchDict()))
```

`google-genai` exposes `GoogleSearch.exclude_domains`, so the filter can be forwarded:

```python
if isinstance(tool, WebSearchTool):
    google_search = GoogleSearchDict()
    if tool.blocked_domains:
        google_search['exclude_domains'] = tool.blocked_domains
    tools.append(ToolDict(google_search=google_search))
```

This is the `GoogleModel` row of the matrix in #6156, which was closed once the Groq row landed — `GroqModel._get_native_tools` already builds `search_settings` this way.

## `allowed_domains` is deliberately left unmapped

`GoogleSearch` has no `include_domains` counterpart. On the installed `google-genai` its fields are:

```
['blocking_confidence', 'exclude_domains', 'search_types', 'time_range_filter']
```

So there is nothing to map `allowed_domains` onto, and it stays dropped for Google. I updated the `blocked_domains` docstring to list Google as supported, and left `allowed_domains` alone so the docs stay accurate about what actually reaches the API.

Happy to raise a `UserError` for `allowed_domains` on Google instead of dropping it silently, if you'd prefer that — it seemed like a behaviour change beyond this issue.

## Tests

Two tests, both network-free, calling `_build_content_and_config` directly in the style of the existing `test_google_*_in_config` tests:

- `test_google_web_search_tool_blocked_domains_in_config` — asserts the tool payload is `{'google_search': {'exclude_domains': [...]}}`
- `test_google_web_search_tool_without_blocked_domains_in_config` — asserts a plain `WebSearchTool()` still sends `{'google_search': {}}`, so the no-filter path is pinned too

`tests/models/test_google.py`: **158 passed**, up from 156, with the same 27 skips. One pre-existing failure (`test_google_model_receive_web_search_history_from_another_provider`, a `BlockingError` from a blocked outbound request in my environment) is present before and after this change.

Reverting only the `google.py` hunk fails the first test and leaves the second passing.

`ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

