### PR TITLE
Render `pydantic_ai.output`'s public type aliases on its API reference page

### DIFF
--- a/docs/api/output.md
+++ b/docs/api/output.md
@@ -12,3 +12,8 @@
             - StructuredDict
             - DeferredToolRequests
             - OutputObjectDefinition
+            - OutputMode
+            - StructuredOutputMode
+            - OutputSpec
+            - OutputTypeOrFunction
+            - TextOutputFunc


### PR DESCRIPTION
`pydantic_ai.output.__all__` groups its exports as `# classes` and `# types`. `docs/api/output.md` lists 6 of the 7 classes but only 1 of the 6 types, so these five render nowhere under `docs/api/`:

`OutputMode`, `StructuredOutputMode`, `OutputSpec`, `OutputTypeOrFunction`, `TextOutputFunc`

Each is the declared type of a public member the site already renders, so those signatures show a type name with nothing to resolve to — the same gap #8036 closed on `docs/api/settings.md`:

| alias | declared on | already rendered by |
|---|---|---|
| `OutputTypeOrFunction` | `ToolOutput.output`, `NativeOutput.outputs`, `PromptedOutput.outputs` | `docs/api/output.md` |
| `TextOutputFunc` | `TextOutput.output_function` | `docs/api/output.md` |
| `OutputSpec` | `Agent(output_type=...)` | `docs/api/agent.md` |
| `StructuredOutputMode` | `ModelProfile.default_structured_output_mode` | `docs/api/profiles.md` |
| `OutputMode` | `OutputContext.mode`, `ModelRequestParameters.output_mode` | `docs/api/capabilities.md`, `docs/api/models/base.md` |

This reads as a slip rather than a decision. #7483 swept this page for `__all__` entries missing from the `members:` filter and added `OutputObjectDefinition`; `__all__` at that commit was already identical to today's, so the five types were left behind by the same criterion that pulled `OutputObjectDefinition` in. All five already carry docstrings, so they render with no other change.

Both alias kinds have precedent on rendered pages: `Literal` aliases via `ServiceTier` and `ToolChoice` on `docs/api/settings.md`, and `TypeAliasType` via `KnownModelName` on `docs/api/models/base.md`.

**Deliberately left out:** `OutputContext`, the sixth `__all__` entry absent from this page. `docs/api/capabilities.md` renders `pydantic_ai.capabilities` with no `members:` filter and that module's `__all__` re-exports `OutputContext`, so it already renders and the three `[...][pydantic_ai.output.OutputContext]` cross-references resolve. Adding it here would make it the only symbol in `docs/api/` rendered on two pages. Happy to add it if you'd rather it live on its own module's page.

No issue, per the PR template's note on small doc improvements — same as #8036 and #7483.

### Verification

Checked each added entry against `pydantic_ai.output.__all__`, and confirmed none of the five appears on any other page under `docs/api/` — including the pages with no `members:` filter, which render their module's entire `__all__`. `tests/test_examples.py` doesn't cover this page (it has no code examples). Per `docs/AGENTS.md` this still wants a unified-docs preview before merge, which I can't run from a fork.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

