### PR TITLE
Apply model concurrency limits to `compact_messages()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/concurrency.py
+++ b/pydantic_ai_slim/pydantic_ai/models/concurrency.py
@@ -19,7 +19,7 @@ from ..concurrency import (
 from ..messages import ModelMessage, ModelResponse
 from ..settings import ModelSettings
 from ..usage import RequestUsage
-from . import KnownModelName, Model, ModelRequestParameters, StreamedResponse
+from . import KnownModelName, Model, ModelRequestContext, ModelRequestParameters, StreamedResponse
 from .wrapper import WrapperModel
 
 
@@ -94,6 +94,13 @@ class ConcurrencyLimitedModel(WrapperModel):
         """Count tokens with concurrency limiting."""
         async with get_concurrency_context(self._limiter, f'model:{self.model_name}'):
             return await self.wrapped.count_tokens(messages, model_settings, model_request_parameters)
+
+    async def compact_messages(
+        self, request_context: ModelRequestContext, *, instructions: str | None = None
+    ) -> ModelResponse:
+        """Compact messages with concurrency limiting."""
+        async with get_concurrency_context(self._limiter, f'model:{self.model_name}'):
+            return await self.wrapped.compact_messages(request_context, instructions=instructions)
 
     @asynccontextmanager
     async def request_stream(

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -12,6 +12,9 @@ import pytest
 from pydantic_ai import Agent, ConcurrencyLimit, ConcurrencyLimiter, ConcurrencyLimitExceeded
 from pydantic_ai.concurrency import get_concurrency_context, normalize_to_limiter
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
 from pydantic_ai.models.test import TestModel
 
 if TYPE_CHECKING:
@@ -347,8 +350,6 @@ class TestConcurrencyLimitedModel:
 
     async def test_basic_concurrency_limit(self):
         """Test that ConcurrencyLimitedModel limits concurrent requests."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         request_count = 0
         max_concurrent = 0
         lock = anyio.Lock()
@@ -381,24 +382,18 @@ class TestConcurrencyLimitedModel:
 
     async def test_with_int_limiter(self):
         """Test ConcurrencyLimitedModel with int limiter."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         model = ConcurrencyLimitedModel(TestModel(), limiter=5)
         assert model._limiter.max_running == 5
         assert model._limiter._max_queued is None
 
     async def test_with_concurrency_limit(self):
         """Test ConcurrencyLimitedModel with ConcurrencyLimit."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         model = ConcurrencyLimitedModel(TestModel(), limiter=ConcurrencyLimit(max_running=5, max_queued=10))
         assert model._limiter.max_running == 5
         assert model._limiter._max_queued == 10
 
     async def test_with_shared_limiter(self):
         """Test ConcurrencyLimitedModel with shared ConcurrencyLimiter."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         shared_limiter = ConcurrencyLimiter(max_running=3, name='shared-pool')
         model1 = ConcurrencyLimitedModel(TestModel(), limiter=shared_limiter)
         model2 = ConcurrencyLimitedModel(TestModel(), limiter=shared_limiter)
@@ -409,8 +404,6 @@ class TestConcurrencyLimitedModel:
 
     async def test_shared_limiter_limits_across_models(self):
         """Test that shared limiter limits concurrent requests across multiple models."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         request_count = 0
         max_concurrent = 0
         lock = anyio.Lock()
@@ -454,7 +447,7 @@ class TestConcurrencyLimitedModel:
 
     async def test_limit_model_concurrency_helper(self):
         """Test the limit_model_concurrency helper function."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel, limit_model_concurrency
+        from pydantic_ai.models.concurrency import limit_model_concurrency
 
         # With limiter
         model = limit_model_concurrency(TestModel(), limiter=5)
@@ -471,8 +464,6 @@ class TestConcurrencyLimitedModel:
 
     async def test_model_properties_delegated(self):
         """Test that model properties are properly delegated to wrapped model."""
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         base_model = TestModel(model_name='custom-test')
         model = ConcurrencyLimitedModel(base_model, limiter=5)
 
@@ -650,14 +641,60 @@ class TestConcurrencyLimiterWithTracer:
 
 
 class TestConcurrencyLimitedModelMethods:
-    """Tests for ConcurrencyLimitedModel count_tokens and request_stream methods."""
+    """Tests for concurrency limiting across model methods."""
+
+    @pytest.mark.parametrize('raise_error', [False, True])
+    async def test_compact_messages(self, raise_error: bool):
+        """Use a local model to deterministically hold a compaction slot, without provider timing."""
+        entered = anyio.Event()
+        release = anyio.Event()
+        response = ModelResponse(parts=[TextPart('compacted')])
+
+        class CompactionModel(TestModel):
+            async def compact_messages(
+                self, request_context: ModelRequestContext, *, instructions: str | None = None
+            ) -> ModelResponse:
+                assert request_context is context
+                assert instructions == 'Preserve tool results'
+                entered.set()
+                await release.wait()
+                if raise_error:
+                    raise ValueError('compaction failed')
+                return response
+
+        limiter = ConcurrencyLimiter(max_running=1, max_queued=0)
+        model = ConcurrencyLimitedModel(CompactionModel(), limiter=limiter)
+        other_model = ConcurrencyLimitedModel(TestModel(), limiter=limiter)
+        parameters = ModelRequestParameters()
+        context = ModelRequestContext(
+            model=model, messages=[], model_settings=None, model_request_parameters=parameters
+        )
+
+        async def compact():
+            if raise_error:
+                with pytest.raises(ValueError, match='compaction failed'):
+                    await model.compact_messages(context, instructions='Preserve tool results')
+            else:
+                assert await model.compact_messages(context, instructions='Preserve tool results') is response
+
+        with anyio.fail_after(5):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(compact)
+                await entered.wait()
+                assert limiter.running_count == 1
+                with pytest.raises(ConcurrencyLimitExceeded):
+                    await other_model.request([], None, parameters)
+                with pytest.raises(ConcurrencyLimitExceeded):
+                    await model.compact_messages(context)
+                release.set()
+
+        assert limiter.running_count == 0
+        await other_model.request([], None, parameters)
 
     async def test_count_tokens(self):
         """Test that count_tokens delegates to wrapped model with concurrency limiting."""
         from unittest.mock import AsyncMock
 
-        from pydantic_ai.models import ModelRequestParameters
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
         from pydantic_ai.usage import RequestUsage
 
         base_model = TestModel()
@@ -672,9 +709,6 @@ class TestConcurrencyLimitedModelMethods:
 
     async def test_request_stream(self):
         """Test that request_stream is called with concurrency limiting."""
-        from pydantic_ai.models import ModelRequestParameters
-        from pydantic_ai.models.concurrency import ConcurrencyLimitedModel
-
         base_model = TestModel()
         model = ConcurrencyLimitedModel(base_model, limiter=5)
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -26,6 +26,8 @@ logfire_installed = importlib.util.find_spec('logfire') is not None
 
 pytestmark = pytest.mark.anyio
 
+READINESS_WAIT_TIMEOUT = 5
+
 
 class AsyncBarrier:
     """A simple asyncio.Barrier-like implementation compatible with Python 3.10 using anyio."""
@@ -677,7 +679,7 @@ class TestConcurrencyLimitedModelMethods:
             else:
                 assert await model.compact_messages(context, instructions='Preserve tool results') is response
 
-        with anyio.fail_after(5):
+        with anyio.fail_after(READINESS_WAIT_TIMEOUT):
             async with anyio.create_task_group() as tg:
                 tg.start_soon(compact)
                 await entered.wait()


### PR DESCRIPTION
`ConcurrencyLimitedModel` currently delegates `compact_messages()` without acquiring its limiter, allowing stateless compaction to exceed the configured concurrency and queue limits.

Override `compact_messages()` using the same concurrency context as `request()` and `count_tokens()`. The regression test covers slot accounting, shared-pool backpressure, argument forwarding, and slot release after success or failure. Stateful compaction and models without a concurrency wrapper are unchanged.

### Verification

- `tests/test_concurrency.py`: 49 passed on asyncio; the new regression cases fail before the fix.
- Existing OpenAI compaction and direct-compaction tests: 2 passed with offline cassette playback.
- `make lint` and Pyright on both changed files: passed.
- The issue's reproduction now reports `Compaction: rejected` when the limiter is full.
- Local tests used `BLOCKBUSTER_ENABLED=false` because the environment lacks `clai` package metadata. Trio was also attempted; it raises `trio.WouldBlock` in the existing limiter, reproduced with the unmodified baseline's `test_backpressure_raises`.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://pydantic.dev/docs/ai/project/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- For a version-policy-permitted compatibility impact, add the `compatibility impact` label -->
<!-- and place this warning immediately after the PR's opening explanation: -->
<!-- > [!WARNING] -->
<!-- > **Compatibility impact:** Existing code that ... may ... -->
<!-- > -->
<!-- > **Why this can ship in a minor release:** ... -->
<!-- > -->
<!-- > **Migration:** ... -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#when-do-you-need-the-harness -->

- Closes #8240

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

