### PR TITLE
Raise the JSON call budget above the noise it flakes on

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2002,11 +2002,13 @@ def test_tool_return_content_json_paths_make_no_per_node_python_calls():
     thousands of Rust→Python crossings, paid on every message-history load, UI adapter round-trip, and
     Temporal activity resolution and replay.
 
-    Counting Python calls rather than timing is what makes this pin usable in CI: the count is
-    deterministic and machine-independent, where a wall-clock threshold would either flake on a noisy
-    runner or be loose enough to catch nothing. The bound is generous on purpose — the regression it
-    guards adds tens of thousands of calls, so a handful of tolerance costs no signal and removes any
-    dependence on ambient interpreter activity. `cProfile` rather than a `sys.setprofile` callback
+    Counting Python calls rather than timing is what makes this pin usable in CI: the count is far
+    steadier than a wall-clock threshold, which would either flake on a noisy runner or be loose
+    enough to catch nothing. It is not perfectly machine-independent, though — the delta is 0 on a
+    developer machine but around 110 on some CI runners, from something ambient that has never been
+    tracked down — so the bound has to clear that. The gap it separates is enormous: a per-node
+    Python call costs ~2,770 extra calls here, one per JSON value node in the larger payload, so a
+    bound of 1,000 sits an order of magnitude above the noise and well under the regression. `cProfile` rather than a `sys.setprofile` callback
     because the interpreter does not trace the callback's own body, leaving it unmeasurable by
     coverage.
 
@@ -2047,7 +2049,7 @@ def test_tool_return_content_json_paths_make_no_per_node_python_calls():
     for dump in (False, True):
         small, large = python_calls(payload(2), dump), python_calls(payload(200), dump)
         direction = 'dump_json' if dump else 'validate_json'
-        assert large - small < 100, f'{direction} cost {large - small} extra Python calls for a 100x larger payload'
+        assert large - small < 1_000, f'{direction} cost {large - small} extra Python calls for a 100x larger payload'
 
 
 def test_multimodal_nested_in_kind_colliding_mapping_rehydrates():


### PR DESCRIPTION
`test_tool_return_content_json_paths_make_no_per_node_python_calls`, added in #7823, bounds the extra Python calls a 100× larger payload may cost at `< 100`. CI runners measure **107–110**, so it passes only when a run happens to come in under the line.

It has gone red on `main` twice (`8e3f21d41`, `96d7e907d`) and blocked four unrelated PRs. Observed values across six runs: 107, 107, 109, 110, 110, 110 — a tight cluster above the threshold, not noise straddling it.

## What I checked before touching the number

The delta is **0 locally** — on Python 3.12, 3.13 and 3.14, with and without `coverage`, inside pytest and standalone. So this isn't the JSON path drifting; the CI runners add something the measurement picks up.

It is not garbage collection: forcing far more collections (`gc.set_threshold(50, 2, 2)`) and disabling GC entirely both leave the delta at 0. I could not reproduce the CI number locally at all, and I haven't tracked down what produces it. The bound therefore has to clear that noise rather than sit inside it.

## Why 1,000

The gap this test separates is enormous, which is what makes a loose bound free:

| | delta |
| --- | --- |
| observed locally | 0 |
| observed on CI runners | 107–110 |
| **the regression it guards** | **~2,770** |

The regression is one Python call per JSON value node, and the larger payload has 2,809 nodes against the smaller one's 37. So `1,000` sits an order of magnitude above the worst observed noise and still nearly 3× below a per-node cost. The test's own docstring already argued for this — *"The bound is generous on purpose — the regression it guards adds tens of thousands of calls, so a handful of tolerance costs no signal"* — 100 simply landed below the real baseline.

## Docstring

It claimed the count is "deterministic and machine-independent", which is the thing the flake disproves. It now says what's actually true: far steadier than wall-clock, but not machine-independent, with the observed CI delta and the reason the bound is where it is — so the next person doesn't tighten it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

