### PR TITLE
Default `clai` to `openai:gpt-5.6-terra`

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -70,7 +70,7 @@ options:
   -l, --list-models     List all available models and exit
   --version             Show version and exit
   -m MODEL, --model MODEL
-                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-5" or "anthropic:claude-sonnet-4-6". Defaults to "openai:gpt-5".
+                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-5.6-terra" or "anthropic:claude-sonnet-4-6". Defaults to "openai:gpt-5.6-terra".
   -a AGENT, --agent AGENT
                         Custom Agent to use: a module path like "module:variable" or a YAML/JSON spec file like "agent.yml"
   -t CODE_THEME, --code-theme CODE_THEME

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -139,7 +139,9 @@ def cli_exit(prog_name: str = 'clai'):  # pragma: no cover
     sys.exit(cli(prog_name=prog_name))
 
 
-def cli(args_list: Sequence[str] | None = None, *, prog_name: str = 'clai', default_model: str = 'openai:gpt-5') -> int:
+def cli(
+    args_list: Sequence[str] | None = None, *, prog_name: str = 'clai', default_model: str = 'openai:gpt-5.6-terra'
+) -> int:
     """Run the CLI and return the exit code for the process."""
     # we don't want to autocomplete or list models that don't include the provider,
     # e.g. we want to show `openai:gpt-5.2` but not `gpt-5.2`
@@ -171,7 +173,7 @@ def _cli_web(args_list: list[str], prog_name: str, default_model: str, qualified
         '--model',
         action='append',
         dest='models',
-        help='Model to make available (can be repeated, e.g., -m openai:gpt-5 -m anthropic:claude-sonnet-4-6). '
+        help='Model to make available (can be repeated, e.g., -m openai:gpt-5.6-terra -m anthropic:claude-sonnet-4-6). '
         'Format: "provider:model_name". First model is preselected in UI; additional models appear as options.',
     )
     model_arg.completer = argcomplete.ChoicesCompleter(qualified_model_names)  # type: ignore[reportPrivateUsage]
@@ -253,7 +255,7 @@ subcommands:
     model_arg = parser.add_argument(
         '-m',
         '--model',
-        help=f'Model to use, in format "<provider>:<model>" e.g. "openai:gpt-5" or "anthropic:claude-sonnet-4-6". Defaults to "{default_model}".',
+        help=f'Model to use, in format "<provider>:<model>" e.g. "openai:gpt-5.6-terra" or "anthropic:claude-sonnet-4-6". Defaults to "{default_model}".',
     )
     model_arg.completer = argcomplete.ChoicesCompleter(qualified_model_names)  # type: ignore[reportPrivateUsage]
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1017,7 +1017,7 @@ def test_clai_web_generic_agent(mocker: MockerFixture, env: TestEnv):
         models=['openai:gpt-5'],
         tools=['web_search'],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=[],
     )
@@ -1040,7 +1040,7 @@ def test_clai_web_success(mocker: MockerFixture, create_test_module: Callable[..
         models=[],
         tools=[],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=[],
     )
@@ -1078,7 +1078,7 @@ def test_clai_web_with_models(mocker: MockerFixture, create_test_module: Callabl
         models=['openai:gpt-5', 'anthropic:claude-sonnet-4-6'],
         tools=[],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=[],
     )
@@ -1107,7 +1107,7 @@ def test_clai_web_with_tools(mocker: MockerFixture, create_test_module: Callable
         models=[],
         tools=['web_search', 'code_execution'],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=[],
     )
@@ -1128,7 +1128,7 @@ def test_clai_web_generic_with_instructions(mocker: MockerFixture, env: TestEnv)
         models=['openai:gpt-5'],
         tools=[],
         instructions='You are a helpful coding assistant',
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=[],
     )
@@ -1155,7 +1155,7 @@ def test_clai_web_with_custom_port(mocker: MockerFixture, create_test_module: Ca
         models=[],
         tools=[],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=[],
     )
@@ -1459,7 +1459,7 @@ def test_clai_web_with_html_source(mocker: MockerFixture, env: TestEnv):
         models=['openai:gpt-5'],
         tools=[],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=custom_url,
         allowed_hosts=[],
     )
@@ -1480,7 +1480,7 @@ def test_clai_web_with_allowed_hosts(mocker: MockerFixture, env: TestEnv):
         models=['openai:gpt-5'],
         tools=[],
         instructions=None,
-        default_model='openai:gpt-5',
+        default_model='openai:gpt-5.6-terra',
         html_source=None,
         allowed_hosts=['ui.example.com', '*.corp.example'],
     )


### PR DESCRIPTION
`clai` has defaulted to `openai:gpt-5` since it was written. The docs around it moved on — `docs/cli.md` and `clai/README.md` both use `openai:gpt-5.2` in their examples — but the default itself never did. Nothing surfaced the drift until the first-run banner (#7447) started printing the model a session resolved, which put `model: openai:gpt-5` in front of everyone.

## What changes

- `cli(..., default_model=...)` → `openai:gpt-5.6-terra`
- The `-m` help text named `openai:gpt-5` as its example in two places, independently of the default, so a reader would have seen the old model even after the default moved. Both now name the new one.
- `clai/README.md` regenerated from `clai --help`.
- Eight assertions in `tests/test_cli.py` pinned the default flowing through to `run_web_command`. Only those moved; the `-m openai:gpt-5` cases are explicit user choices and are left alone.

## The cost, since it is a real increase

| model | input $/M | output $/M |
| --- | --- | --- |
| `gpt-5` (today's default) | 1.25 | 10.00 |
| **`gpt-5.6-terra`** | **4.00** | **18.00** |
| `gpt-5.6-sol` | 8.00 | 30.00 |
| `gpt-5.6-luna` | 0.40 | 1.80 |

Taken from `genai-prices`. So this is roughly 3.2× the input and 1.8× the output cost of the current default — deliberate, on the grounds that a CLI's default should be a good general-purpose model rather than the cheapest thing that runs.

Worth naming the alternative rather than burying it: `gpt-5.6-luna` is both newer than the current default *and* cheaper than it, so it's the option that improves the model without any cost conversation. `terra` is the call here; `luna` is there if the cost matters more than the capability for a CLI people leave running.

## Verification

`tests/test_cli.py` passes (84). `clai/update_readme.py` passes — note it is `skipif(sys.version_info >= (3, 13))`, so it silently skips on a 3.13+ interpreter and has to be run on 3.12 to actually regenerate the README; that's how the stale help text survived the first pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

