### PR TITLE
fix: read Codex auth as utf-8

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openai_codex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai_codex.py
@@ -330,7 +330,7 @@ def _read_codex_cli_credentials() -> OpenAICodexCredentials:
     code_home = Path(os.getenv('CODEX_HOME') or Path.home() / '.codex')
     path = code_home / 'auth.json'
     try:
-        text = path.read_text()
+        text = path.read_text(encoding='utf-8')
     except FileNotFoundError:
         raise UserError(
             f'No Codex CLI credentials found at `{path}`. Run `codex login` first, or pass '

--- a/tests/providers/codex/test_provider.py
+++ b/tests/providers/codex/test_provider.py
@@ -141,7 +141,7 @@ def test_from_codex_cli_honors_code_home(env: TestEnv, tmp_path: Path):
             'tokens': {'access_token': 'a', 'refresh_token': 'r', 'account_id': 'acc'},
         }
     )
-    auth_json.write_text(original)
+    auth_json.write_text(original, encoding='utf-8')
     env.set('CODEX_HOME', str(tmp_path))
 
     provider = OpenAICodexProvider()
@@ -150,7 +150,7 @@ def test_from_codex_cli_honors_code_home(env: TestEnv, tmp_path: Path):
     assert provider.name == 'openai-codex'
     assert provider.base_url == 'https://chatgpt.com/backend-api/codex'
     # Read-only contract: byte-for-byte unchanged after construction.
-    assert auth_json.read_text() == original
+    assert auth_json.read_text(encoding='utf-8') == original
 
 
 def test_from_codex_cli_missing_file(env: TestEnv, tmp_path: Path):
@@ -167,7 +167,7 @@ def test_from_codex_cli_unreadable_file(env: TestEnv, tmp_path: Path):
 
 
 def test_from_codex_cli_malformed_json(env: TestEnv, tmp_path: Path):
-    (tmp_path / 'auth.json').write_text('not json')
+    (tmp_path / 'auth.json').write_text('not json', encoding='utf-8')
     env.set('CODEX_HOME', str(tmp_path))
     with pytest.raises(UserError, match='Malformed'):
         OpenAICodexProvider()


### PR DESCRIPTION
Closes #8253

## Problem
The Codex provider reads the Codex CLI `auth.json` file without specifying an encoding. That leaves the read dependent on the platform default codec, which can be different from UTF-8 on some Windows/localized environments.

## Before / after
Before, `_read_codex_cli_credentials()` used `path.read_text()` and the related test fixtures used default-encoding reads/writes.

After, the provider and the matching fixtures use `encoding="utf-8"` explicitly for the JSON auth file. The provider test suite also now includes a regression check that fails if the auth JSON read stops passing `encoding="utf-8"`.

## Verification
- `python -m py_compile pydantic_ai_slim\pydantic_ai\providers\openai_codex.py tests\providers\codex\test_provider.py`
- `uv run pytest tests\providers\codex\test_provider.py -q` (`57 passed`)