### PR TITLE
fix(temporal): guard mcp import in _resolve_temporal_tool_config against missing extra

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -370,7 +370,10 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         base_config = self._toolset_operation_config('function', toolset_id)
         config = resolve_tool_activity_config(cast(ToolsetTool[Any] | None, tool), name, {})
         if config is False:
-            from pydantic_ai.mcp import MCPToolset
+            try:
+                from pydantic_ai.mcp import MCPToolset
+            except ImportError:  # pragma: no cover
+                MCPToolset = None  # type: ignore[assignment,misc]
 
             if (
                 isinstance(operation_id, (ToolsetCallToolId, ToolsetValidateToolArgumentsId))
@@ -382,7 +385,7 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                     'toolset and calling the tool may perform I/O. Remove the opt-out, or move the tool to a static '
                     '`FunctionToolset` (async tools there may opt out of activities).'
                 )
-            if isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
+            if MCPToolset is not None and isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
                 raise UserError(
                     f'Temporal activity config for MCP tool {name!r} has been explicitly set to `False` (activity disabled), '
                     'but MCP tools require the use of IO and so cannot be run outside of an activity.'


### PR DESCRIPTION
## Summary

Using `TemporalDurability` with an async function tool configured to run directly in the workflow (`metadata={'temporal': False}`) raised an `ImportError` when the `mcp` extra was not installed — even though MCP wasn't involved at all.

### Root cause

`_resolve_temporal_tool_config` (`temporal/_durability.py:373`) has a bare unconditional import inside the `if config is False` branch:

```python
if config is False:
    from pydantic_ai.mcp import MCPToolset  # fails if mcp extra absent
    ...
    if isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
        raise UserError(...)
    # → only reaches here for non-MCP tools, but import already blew up
```

The import is hit for **every** tool opting out of a Temporal activity — including plain async function tools with nothing to do with MCP.

### Fix

Wrap the import in `try/except ImportError` (same pattern already used in `durable_exec/_base.py:967-970`) and guard the `isinstance` check with `MCPToolset is not None`:

```python
try:
    from pydantic_ai.mcp import MCPToolset
except ImportError:  # pragma: no cover
    MCPToolset = None  # type: ignore[assignment,misc]
...
if MCPToolset is not None and isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
    raise UserError(...)
```

When MCP isn't installed `MCPToolset` is `None`, the isinstance check is skipped (a non-MCP tool can never be an MCPToolset anyway), and the async function tool correctly returns `False` to run in-workflow.

Fixes #8249.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

