### PR TITLE
fix(temporal): key tool opt-out checks on operation kind, not an MCP import

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -370,19 +370,19 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         base_config = self._toolset_operation_config('function', toolset_id)
         config = resolve_tool_activity_config(cast(ToolsetTool[Any] | None, tool), name, {})
         if config is False:
-            from pydantic_ai.mcp import MCPToolset
-
-            if (
-                isinstance(operation_id, (ToolsetCallToolId, ToolsetValidateToolArgumentsId))
-                and operation_id.toolset_kind == 'dynamic'
-            ):
+            # The tool-kind checks read `operation_id.toolset_kind` rather than the type of `tool.toolset`: the
+            # toolset that provided the tool is not always the durable leaf (wrappers like `PrefixedToolset` rewrite
+            # `ToolsetTool.toolset`), and reading the kind here keeps the optional `mcp` import out of this path
+            # entirely, so opting a plain tool out of activities works without the `mcp` extra (#8249).
+            is_tool_operation = isinstance(operation_id, (ToolsetCallToolId, ToolsetValidateToolArgumentsId))
+            if is_tool_operation and operation_id.toolset_kind == 'dynamic':
                 raise UserError(
                     f'Temporal activity config for dynamic toolset tool {name!r} has been explicitly set to `False` '
                     '(activity disabled), but dynamic-toolset tools cannot run inside the workflow: resolving the '
                     'toolset and calling the tool may perform I/O. Remove the opt-out, or move the tool to a static '
                     '`FunctionToolset` (async tools there may opt out of activities).'
                 )
-            if isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
+            if is_tool_operation and operation_id.toolset_kind == 'mcp':
                 raise UserError(
                     f'Temporal activity config for MCP tool {name!r} has been explicitly set to `False` (activity disabled), '
                     'but MCP tools require the use of IO and so cannot be run outside of an activity.'

--- a/tests/durable_exec/temporal/test_durability.py
+++ b/tests/durable_exec/temporal/test_durability.py
@@ -30,6 +30,7 @@ from pydantic_ai import (
     MultiModalContent,
     PartDeltaEvent,
     PartStartEvent,
+    PrefixedToolset,
     RequestUsage,
     RetryPromptPart,
     RunContext,
@@ -1518,6 +1519,71 @@ async def test_durability_resolves_supported_and_rejected_tool_activity_opt_outs
     with pytest.raises(UserError, match='MCP tools require the use of IO'):
         durability._resolve_temporal_tool_config(  # pyright: ignore[reportPrivateUsage]
             ToolsetCallToolId('mcp', toolset_id='mcp_opt_out'), mcp_tool, 'mcp_tool'
+        )
+
+
+async def test_durability_tool_opt_out_without_mcp_extra(monkeypatch: pytest.MonkeyPatch):
+    """A plain tool opting out of activities must not import `pydantic_ai.mcp`.
+
+    Regression test for #8249: the opt-out branch used an unguarded `from pydantic_ai.mcp import
+    MCPToolset`, which raised `ImportError` for every tool with `metadata={'temporal': False}` -- even
+    non-MCP function tools -- when the optional `mcp` extra was not installed. Simulate that install by
+    making `pydantic_ai.mcp` unimportable.
+    """
+
+    async def async_tool() -> str: ...  # pragma: no branch
+
+    toolset = FunctionToolset[None](id='opt_out_without_mcp')
+    toolset.add_function(async_tool, metadata={'temporal': False})
+    agent = Agent(
+        TestModel(),
+        name='opt_out_without_mcp',
+        deps_type=type(None),
+        toolsets=[toolset],
+        capabilities=[TemporalDurability()],
+    )
+    durability = TemporalDurability.from_agent(agent)
+    assert durability is not None
+    ctx = RunContext[None](deps=None, model=TestModel(), usage=RunUsage())
+    tools = await toolset.get_tools(ctx)
+
+    monkeypatch.setitem(sys.modules, 'pydantic_ai.mcp', None)
+    assert (
+        durability._resolve_temporal_tool_config(  # pyright: ignore[reportPrivateUsage]
+            ToolsetCallToolId('function', toolset_id='opt_out_without_mcp'), tools['async_tool'], 'async_tool'
+        )
+        is False
+    )
+
+
+async def test_durability_mcp_opt_out_identified_by_operation_kind():
+    """An MCP tool's opt-out is rejected via the operation kind, not `tool.toolset` identity.
+
+    `PrefixedToolset` rewrites `ToolsetTool.toolset` to the wrapper, so an `isinstance(tool.toolset,
+    MCPToolset)` check cannot identify an MCP tool once wrapped; the durable operation's `toolset_kind`
+    can, and it also avoids importing the optional `mcp` package in this path (#8249).
+    """
+
+    mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='mcp_wrapped')
+    prefixed = PrefixedToolset[Any](mcp_toolset, prefix='wrapped')
+    prefixed_tool = ToolsetTool(
+        toolset=prefixed,
+        tool_def=ToolDefinition(name='wrapped_mcp_tool', metadata={'temporal': False}),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+    agent = Agent(
+        TestModel(),
+        name='mcp_wrapped',
+        deps_type=type(None),
+        toolsets=[prefixed],
+        capabilities=[TemporalDurability()],
+    )
+    durability = TemporalDurability.from_agent(agent)
+    assert durability is not None
+    with pytest.raises(UserError, match='MCP tools require the use of IO'):
+        durability._resolve_temporal_tool_config(  # pyright: ignore[reportPrivateUsage]
+            ToolsetCallToolId('mcp', toolset_id='mcp_wrapped'), prefixed_tool, 'wrapped_mcp_tool'
         )
 
 


### PR DESCRIPTION
Closes #8249

## Summary

A plain tool with `metadata={'temporal': False}` — which opts it out of Temporal activities so it runs directly in the workflow — crashed with an `ImportError` when the optional `mcp` extra was **not** installed, even though MCP was not involved at all.

### Root cause

`_resolve_temporal_tool_config` (`durable_exec/temporal/_durability.py`) decides, inside the workflow, whether an opted-out tool may run inline. To reject MCP tools (which require I/O and cannot run inline), it checked `isinstance(tool.toolset, MCPToolset)` — and got `MCPToolset` via an **unguarded** `from pydantic_ai.mcp import MCPToolset` at the top of the opt-out branch:

```python
if config is False:
    from pydantic_ai.mcp import MCPToolset  # ImportError if the `mcp` extra is absent
    ...
```

`pydantic_ai.mcp` raises `ImportError` at import time when the `mcp` package isn't installed (the rest of the codebase guards this import, e.g. `durable_exec/_base.py`). Because the import ran for **every** opted-out tool — including plain function tools — users with only `pydantic-ai-slim[temporal]` hit a raw `ImportError` inside the workflow instead of the tool running inline (async) or the actionable `UserError` (sync).

### The fix

Discriminate on the durable operation's `toolset_kind` instead of importing `MCPToolset` at all — the same pattern the neighboring dynamic-toolset check already uses:

```python
is_tool_operation = isinstance(operation_id, (ToolsetCallToolId, ToolsetValidateToolArgumentsId))
...
if is_tool_operation and operation_id.toolset_kind == 'mcp':
    raise UserError(...)
```

Why this is strictly better than guarding the import:

- The `ImportError` path is gone by construction — no optional dependency is ever imported here.
- `toolset_kind` is assigned when the durable operation is built (`ToolsetCallToolId('mcp', ...)`), so it identifies the call boundary reliably. A type check on `tool.toolset` is fragile: wrappers such as `PrefixedToolset` rewrite `ToolsetTool.toolset` to themselves, so an MCP tool wrapped that way previously fell through to the `assert isinstance(tool, FunctionToolsetTool)` and crashed with an `AssertionError`.

### Tests

- `test_durability_tool_opt_out_without_mcp_extra` — makes `pydantic_ai.mcp` unimportable (simulating an install without the extra) and asserts a plain async tool's opt-out resolves to `False` instead of raising. Fails on `main` with `ModuleNotFoundError`.
- `test_durability_mcp_opt_out_identified_by_operation_kind` — a `PrefixedToolset`-wrapped MCP tool (whose `tool.toolset` is the wrapper, not the `MCPToolset`) is still rejected via `toolset_kind`. Fails on `main` with `AssertionError`.

Verified: full `tests/durable_exec/temporal/test_durability.py` (99 passed, 2 pre-existing skips), related `test_toolsets.py` opt-out tests (5 passed), ruff lint + format clean, pyright clean on both changed files.

Note: a previous attempt (#8255) guarded the import with `try/except ImportError`; this PR instead removes the import from this path entirely.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

