### PR TITLE
fix(temporal): allow tool opt-outs without MCP

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_durability.py
@@ -370,8 +370,6 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
         base_config = self._toolset_operation_config('function', toolset_id)
         config = resolve_tool_activity_config(cast(ToolsetTool[Any] | None, tool), name, {})
         if config is False:
-            from pydantic_ai.mcp import MCPToolset
-
             if (
                 isinstance(operation_id, (ToolsetCallToolId, ToolsetValidateToolArgumentsId))
                 and operation_id.toolset_kind == 'dynamic'
@@ -382,11 +380,17 @@ class TemporalDurability(BaseDurabilityCapability[AgentDepsT]):
                     'toolset and calling the tool may perform I/O. Remove the opt-out, or move the tool to a static '
                     '`FunctionToolset` (async tools there may opt out of activities).'
                 )
-            if isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
-                raise UserError(
-                    f'Temporal activity config for MCP tool {name!r} has been explicitly set to `False` (activity disabled), '
-                    'but MCP tools require the use of IO and so cannot be run outside of an activity.'
-                )
+            try:
+                from pydantic_ai.mcp import MCPToolset
+            except ImportError:  # pragma: no cover
+                pass
+            else:
+                if isinstance(cast(ToolsetTool[Any], tool).toolset, MCPToolset):
+                    raise UserError(
+                        f'Temporal activity config for MCP tool {name!r} has been explicitly set to `False` '
+                        '(activity disabled), but MCP tools require the use of IO and so cannot be run outside '
+                        'of an activity.'
+                    )
             assert isinstance(tool, FunctionToolsetTool)
             if not tool.is_async:
                 raise UserError(

--- a/tests/durable_exec/temporal/test_durability.py
+++ b/tests/durable_exec/temporal/test_durability.py
@@ -1521,6 +1521,49 @@ async def test_durability_resolves_supported_and_rejected_tool_activity_opt_outs
         )
 
 
+async def test_durability_resolves_function_tool_opt_outs_without_mcp(monkeypatch: pytest.MonkeyPatch):
+    """Function-tool activity opt-outs do not require the optional MCP extra."""
+
+    async def async_tool() -> str: ...  # pragma: no branch
+
+    def sync_tool() -> str: ...  # pragma: no branch
+
+    toolset = FunctionToolset[None](id='opt_out_without_mcp')
+    toolset.add_function(async_tool, metadata={'temporal': False})
+    toolset.add_function(sync_tool, metadata={'temporal': False})
+    agent = Agent(
+        TestModel(),
+        name='opt_out_without_mcp',
+        deps_type=type(None),
+        toolsets=[toolset],
+        capabilities=[TemporalDurability()],
+    )
+    durability = TemporalDurability.from_agent(agent)
+    assert durability is not None
+    ctx = RunContext[None](deps=None, model=TestModel(), usage=RunUsage())
+    tools = await toolset.get_tools(ctx)
+
+    class BlockMCP:
+        def find_spec(self, name: str, path: object = None, target: object = None) -> object:
+            if name == 'pydantic_ai.mcp':
+                raise ImportError(f'No module named {name!r}')
+            return None
+
+    monkeypatch.setattr(sys, 'meta_path', [BlockMCP(), *sys.meta_path])
+    monkeypatch.delitem(sys.modules, 'pydantic_ai.mcp', raising=False)
+
+    assert (
+        durability._resolve_temporal_tool_config(  # pyright: ignore[reportPrivateUsage]
+            ToolsetCallToolId('function', toolset_id='opt_out_without_mcp'), tools['async_tool'], 'async_tool'
+        )
+        is False
+    )
+    with pytest.raises(UserError, match='non-async tools are run in threads'):
+        durability._resolve_temporal_tool_config(  # pyright: ignore[reportPrivateUsage]
+            ToolsetCallToolId('function', toolset_id='opt_out_without_mcp'), tools['sync_tool'], 'sync_tool'
+        )
+
+
 async def test_durability_mcp_instructions_use_operation_activity_summary(monkeypatch: pytest.MonkeyPatch):
     """The common MCP instructions operation retains Temporal's legacy activity summary."""
     mcp_toolset = MCPToolset(


### PR DESCRIPTION
Closes #8249.

`TemporalDurability` imported `MCPToolset` unconditionally before resolving a function tool's `metadata={'temporal': False}` opt-out. That made the documented opt-out fail with an `ImportError` when `pydantic-ai-slim[temporal]` was installed without the optional MCP extra.

The import now follows the existing lazy optional-import guard used by `BaseDurabilityCapability._wrap_leaf_toolset`. If MCP is unavailable, the function-tool path continues and preserves the existing behavior: async tools can opt out, while sync tools still get the actionable `UserError`.

Tests mask `pydantic_ai.mcp` during resolution to cover both opt-out outcomes without requiring an actual no-MCP install.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

