### PR TITLE
Drop the `AbstractToolDefinition` entry from the `pydantic_ai.models` API page

### DIFF
--- a/docs/api/models/base.md
+++ b/docs/api/models/base.md
@@ -12,7 +12,6 @@
         - ModelResolutionContext
         - ModelSelectionContext
         - Model
-        - AbstractToolDefinition
         - StreamedResponse
         - ALLOW_MODEL_REQUESTS
         - check_allow_model_requests


### PR DESCRIPTION
`docs/api/models/base.md` lists `AbstractToolDefinition` in its mkdocstrings `members:` block, but that name does not exist anywhere in the repository. It used to be a Protocol in `pydantic_ai/models/__init__.py` and #157 (Dynamic tools, 2024-12-08) deleted it along with the `function_tools` and `result_tools` signatures that used it. Griffe cannot resolve the entry, so the page renders nothing for it and the members list has been claiming a symbol that is not there for about twenty-one months.

Dropping the one line is the whole change. I checked that the other fourteen members on that page still resolve, and I ran the same check over every `::: target` and `members:` list under `docs/api/`, where the only other unresolved names are the `voyageai` and `sentence-transformers` modules that fail to import because those optional dependencies are not installed locally.

I am a college freshman contributing in good faith. I sanity-checked the reasoning with Claude Code, and confirmed the symbol is really gone myself with `git log -S "class AbstractToolDefinition"` and a repo-wide grep that returns only this docs line. Happy to adjust or close if you would rather keep the entry.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

