### PR TITLE
Say that excluding binary content drops documents too in the `instrumenting-pydantic-ai` skill

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/instrumenting-pydantic-ai/SKILL.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/instrumenting-pydantic-ai/SKILL.md
@@ -190,8 +190,9 @@ Two things that look like failure and aren't:
 - **Nothing appears until the process exits.** Spans are batched; a short script flushes on exit.
 - **Prompts, tool arguments and tool results are visible in the traces.** That is the point of the
   feature. Say so out loud, and if the agent touches anything sensitive, take the user back to the
-  content flags in step 4 — `instrument_pydantic_ai(include_binary_content=False)` drops images and
-  audio on its own — so they can decide before this reaches production.
+  content flags in step 4 — `instrument_pydantic_ai(include_binary_content=False)` drops binary file
+  data, images, audio and documents alike, on its own — so they can decide before this reaches
+  production.
 
 ## Offering more coverage
 


### PR DESCRIPTION
Follow-up to #8242, raised in review after it merged.

The skill told the user that `instrument_pydantic_ai(include_binary_content=False)` "drops images and audio on its own". The behaviour it points back at is broader — [Excluding binary content](https://pydantic.dev/docs/ai/logfire/#excluding-binary-content) says Pydantic AI excludes "binary file data, including images, audio, and documents".

An agent that handles PDFs is exactly the case where someone reading the skill to decide whether to flip the flag before production would have underestimated what flipping it drops, so the wording now names documents.

Verified against `docs/logfire.md`, which is the section the skill sends the reader to.

## Checklist

- [ ] I have added tests for the changes (documentation-only)
- [x] I have updated the documentation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

