### PR TITLE
Include explicit ports in MCP capability IDs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/mcp.py
@@ -136,11 +136,14 @@ class MCP(NativeOrLocalTool[AgentDepsT]):
             return self.native.id
         if url is None:
             return None
-        # Include hostname to avoid collisions (e.g. two /sse URLs on different hosts)
+        # Include hostname and an explicit port to avoid endpoint collisions (e.g. two /mcp
+        # servers on localhost). Keep the existing format when no port is specified.
         parsed = urlparse(url)
         path = parsed.path.rstrip('/')
         slug = path.split('/')[-1] if path else ''
         host = parsed.hostname or ''
+        if parsed.port is not None:
+            host = f'{host}:{parsed.port}'
         return f'{host}-{slug}' if slug else host or url
 
     @cached_property

--- a/tests/test_capability_native_or_local.py
+++ b/tests/test_capability_native_or_local.py
@@ -646,6 +646,12 @@ class TestMCPCapability:
         assert isinstance(native_sse, MCPServerTool)
         assert native_sse.id == 'server1.example.com-sse'
 
+        # Explicit ports distinguish multiple MCP servers on the same host and path.
+        cap_port_8000 = MCP(url='http://localhost:8000/mcp', native=True)
+        cap_port_9000 = MCP(url='http://localhost:9000/mcp', native=True)
+        assert cap_port_8000.get_native_tools()[0].id == 'localhost:8000-mcp'
+        assert cap_port_9000.get_native_tools()[0].id == 'localhost:9000-mcp'
+
     def test_mcp_local_toolset_id_derived(self):
         """MCP stamps a derived id on the local `MCPToolset` so it can be used with durable
         execution. Precedence: explicit `id` → native `MCPServerTool` id → host+slug from the URL,


### PR DESCRIPTION
Fixes #8207

MCP capability IDs derived from URLs omitted explicit ports, causing collisions when multiple servers share the same host and path. Include the port when present while preserving the existing format for URLs without an explicit port.

Tests: `uv run pytest tests/test_capability_native_or_local.py -k "derived or port" -q` (8 passed).

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No breaking changes in accordance with the version policy.
- [x] PR title is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

