### PR TITLE
Give `AgentRunResult` a stable serialized shape, and settle a finished stream into one

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -397,6 +397,33 @@ _(This example is complete, it can be run "as is")_
     protocol (Vercel AI, AG-UI) whose message shape has no place for application-only fields, so
     those fields are dropped entirely. That loss is by design, not a state-loss bug.
 
+### Storing complete run results
+
+An [`AgentRunResult`][pydantic_ai.agent.AgentRunResult] can be stored directly as a field on a Pydantic model:
+
+```python {title="serialize a run result to json"}
+from pydantic import BaseModel
+
+from pydantic_ai import Agent, AgentRunResult
+
+
+class StoredRun(BaseModel):
+    result: AgentRunResult[str]
+
+
+agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
+result = agent.run_sync('Tell me a joke.')
+
+stored_json = StoredRun(result=result).model_dump_json()
+loaded = StoredRun.model_validate_json(stored_json)
+
+assert loaded.result.output == result.output
+assert loaded.result.all_messages() == result.all_messages()
+```
+
+The round-trip preserves the output, messages and new-message boundary, output tool name, usage, run and
+conversation IDs, metadata, and trace context. Run-local state used only while the agent is executing is not stored.
+
 ### Loading untrusted history
 
 The `message_history` parameter is trusted server-side state. If you load history that came from a browser request or another untrusted boundary, sanitize it before passing it to the agent.

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -424,6 +424,19 @@ assert loaded.result.all_messages() == result.all_messages()
 The round-trip preserves the output, messages and new-message boundary, output tool name, usage, run and
 conversation IDs, metadata, and trace context. Run-local state used only while the agent is executing is not stored.
 
+A [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] reads its values off the stream that is
+producing them, so it lasts only as long as that stream. Once the stream has finished, take
+[`StreamedRunResult.result`][pydantic_ai.result.StreamedRunResult.result] to get the same run in settled
+form and store that:
+
+```python {title="store a streamed run" test="skip" lint="skip"}
+async with agent.run_stream('Tell me a joke.') as streamed:
+    async for text in streamed.stream_text():
+        print(text)
+
+    stored_json = StoredRun(result=streamed.result).model_dump_json()
+```
+
 ### Loading untrusted history
 
 The `message_history` parameter is trusted server-side state. If you load history that came from a browser request or another untrusted boundary, sanitize it before passing it to the agent.

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -241,6 +241,18 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         self._cached_output = await self.validate_response_output(self.response)
         return deepcopy(self._cached_output)
 
+    def _settled_output(self) -> tuple[OutputDataT, str | None]:
+        """The validated output and the name of the output tool that produced it, if any.
+
+        Only meaningful once the stream has finished, by which point every path that completes one
+        has populated `_cached_output`.
+        """
+        final_result_event = self._raw_stream_response.final_result_event
+        return (
+            cast(OutputDataT, self._cached_output),
+            final_result_event.tool_name if final_result_event is not None else None,
+        )
+
     async def validate_response_output(
         self, message: _messages.ModelResponse, *, allow_partial: bool = False
     ) -> OutputDataT:
@@ -525,6 +537,46 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
         self._stream_response = stream_response
         self._on_complete = on_complete
         self._run_result = run_result
+
+    @property
+    def result(self) -> AgentRunResult[OutputDataT]:
+        """This run as an [`AgentRunResult`][pydantic_ai.run.AgentRunResult], once the stream has finished.
+
+        A `StreamedRunResult` reads its values off the stream that is producing them, so it lives only as
+        long as that stream does. `AgentRunResult` is the settled form of the same run — the same output,
+        messages, usage and IDs — and it has a
+        [serialized shape](../message-history.md#storing-complete-run-results) you can store and load. Reach
+        for this to hand the run to code that outlives the stream.
+
+        Raises:
+            UserError: If the stream hasn't finished, so the run has no settled output yet.
+        """
+        from ._agent_graph import GraphAgentState
+        from .run import AgentRunResult
+
+        if (run_result := self._run_result) is not None:
+            return run_result
+        elif self._stream_response is not None:
+            if not self.is_complete:
+                raise exceptions.UserError(
+                    'The run is still streaming, so it has no settled result yet. Await `stream_output()`, '
+                    '`stream_text()`, `stream_response()` or `get_output()` first.'
+                )
+            output, output_tool_name = self._stream_response._settled_output()  # pyright: ignore[reportPrivateUsage]
+            return AgentRunResult(
+                output=output,
+                _output_tool_name=output_tool_name,
+                _state=GraphAgentState(
+                    message_history=self._all_messages,
+                    usage=self.usage,
+                    run_id=self.run_id,
+                    conversation_id=self.conversation_id,
+                    metadata=self.metadata,
+                ),
+                _new_message_index=self._new_message_index,
+            )
+        else:
+            raise ValueError('No stream response or run result provided')  # pragma: no cover
 
     def all_messages(self, *, output_tool_return_content: str | None = None) -> list[_messages.ModelMessage]:
         """Return the history of _messages.

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -5,7 +5,11 @@ import dataclasses
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from copy import deepcopy
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generic, Literal, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
+
+from pydantic import model_serializer, model_validator
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
+from typing_extensions import NotRequired, TypedDict
 
 from pydantic_graph import BaseNode, End, EndMarker, ErrorMarker, GraphRun, GraphRunContext, GraphTaskRequest, JoinItem
 from pydantic_graph.step import NodeStep
@@ -26,6 +30,22 @@ from .tools import AgentDepsT
 if TYPE_CHECKING:
     from ._run_context import RunContext
     from .result import FinalResult
+
+
+class _AgentRunResultData(TypedDict, Generic[OutputDataT]):
+    output: OutputDataT
+    messages: list[_messages.ModelMessage]
+    new_message_index: NotRequired[int]
+    output_tool_name: NotRequired[str | None]
+    usage: NotRequired[_usage.RunUsage]
+    run_id: NotRequired[str]
+    conversation_id: NotRequired[str]
+    metadata: NotRequired[dict[str, Any] | None]
+    traceparent: NotRequired[str | None]
+
+
+_STATE_KEYS = ('usage', 'run_id', 'conversation_id', 'metadata')
+"""Serialized keys that live on `GraphAgentState` rather than on `AgentRunResult` itself."""
 
 
 @dataclasses.dataclass(repr=False)
@@ -644,6 +664,73 @@ class AgentRunResult(Generic[OutputDataT]):
     )
     _new_message_index: int = dataclasses.field(repr=False, compare=False, default=0)
     _traceparent_value: str | None = dataclasses.field(repr=False, compare=False, default=None)
+
+    @model_validator(mode='before')
+    @classmethod
+    def _validate_serialized(cls, value: Any) -> Any:
+        """Accept the public serialized shape, and the private one older versions produced.
+
+        Returns the private field names the dataclass schema validates, so `messages`, `usage`,
+        `run_id`, `conversation_id` and `metadata` land back on `_state`.
+        """
+        if not isinstance(value, dict):
+            return value
+        data = cast('dict[str, Any]', value)
+
+        if isinstance(legacy_state := data.get('_state'), dict):
+            # Serialized before this shape existed, when every private field was exposed directly,
+            # `GraphAgentState`'s run-local scratch included; that scratch is dropped here. Public
+            # keys still win, so a payload carrying both reads as the public one.
+            state = cast('dict[str, Any]', legacy_state)
+            restored: dict[str, Any] = {
+                'new_message_index': data.get('_new_message_index', 0),
+                'output_tool_name': data.get('_output_tool_name'),
+                'traceparent': data.get('_traceparent_value'),
+            }
+            if 'message_history' in state:
+                restored['messages'] = state['message_history']
+            for key in _STATE_KEYS:
+                if key in state:
+                    restored[key] = state[key]
+            data = {**restored, **{key: item for key, item in data.items() if not key.startswith('_')}}
+
+        state_data: dict[str, Any] = {}
+        if 'messages' in data:
+            state_data['message_history'] = data['messages']
+        for key in _STATE_KEYS:
+            if key in data:
+                state_data[key] = data[key]
+
+        validated: dict[str, Any] = {
+            '_output_tool_name': data.get('output_tool_name'),
+            '_state': state_data,
+            '_new_message_index': data.get('new_message_index', 0),
+            '_traceparent_value': data.get('traceparent'),
+        }
+        if 'output' in data:
+            # Left out when absent so the dataclass reports it missing rather than rejecting `None`.
+            validated['output'] = data['output']
+        return validated
+
+    @model_serializer(mode='wrap')
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> _AgentRunResultData[Any]:
+        # `output` is typed by the generic parameter, and only the dataclass serializer `handler`
+        # wraps knows what that resolved to — a serializer's own return annotation is not
+        # parameterized, so it would fall back to `OutputDataT`'s default. Hand it a stand-in
+        # carrying just the output; handing it `self` would serialize all of `_state`'s run-local
+        # scratch only to discard it.
+        output = cast('dict[str, Any]', handler(AgentRunResult(output=self.output)))['output']
+        return {
+            'output': output,
+            'messages': self._state.message_history,
+            'new_message_index': self._new_message_index,
+            'output_tool_name': self._output_tool_name,
+            'usage': self._state.usage,
+            'run_id': self._state.run_id,
+            'conversation_id': self._state.conversation_id,
+            'metadata': self._state.metadata,
+            'traceparent': self._traceparent_value,
+        }
 
     @overload
     def _traceparent(self, *, required: Literal[False]) -> str | None: ...

--- a/tests/test_run_result_serialization.py
+++ b/tests/test_run_result_serialization.py
@@ -1,0 +1,199 @@
+"""Unit tests pinning the run-result serialization contract that cassette matching cannot cover."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from inline_snapshot import snapshot
+from pydantic import BaseModel, TypeAdapter
+
+from pydantic_ai import (
+    Agent,
+    AgentRunResult,
+    AgentRunResultEvent,
+    ModelMessage,
+    ModelResponse,
+    RequestUsage,
+    RunUsage,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+
+class StringResultEnvelope(BaseModel):
+    result: AgentRunResult[str]
+
+
+class Profile(BaseModel):
+    name: str
+    score: int
+
+
+class ProfileResultEnvelope(BaseModel):
+    result: AgentRunResult[Profile]
+
+
+def assert_same_result(actual: AgentRunResult[Any], expected: AgentRunResult[Any]) -> None:
+    assert actual.output == expected.output
+    assert actual.all_messages() == expected.all_messages()
+    assert actual.new_messages() == expected.new_messages()
+    assert actual.usage == expected.usage
+    assert actual.run_id == expected.run_id
+    assert actual.conversation_id == expected.conversation_id
+    assert actual.metadata == expected.metadata
+    assert actual.response == expected.response
+    assert actual.timestamp == expected.timestamp
+    assert actual._traceparent(required=False) == expected._traceparent(required=False)  # pyright: ignore[reportPrivateUsage]
+
+
+def test_plain_result_round_trip_and_serialized_shape() -> None:
+    result = Agent(TestModel(custom_output_text='stored')).run_sync('Save this result', metadata={'tenant': 'example'})
+    result._traceparent_value = '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01'  # pyright: ignore[reportPrivateUsage]
+    envelope = StringResultEnvelope(result=result)
+    assert envelope.result is result
+
+    python_data = envelope.model_dump(mode='python')
+    result_data = python_data['result']
+    assert set(result_data) == snapshot(
+        {
+            'conversation_id',
+            'messages',
+            'metadata',
+            'new_message_index',
+            'output',
+            'output_tool_name',
+            'run_id',
+            'traceparent',
+            'usage',
+        }
+    )
+    assert not {
+        'last_model_request_parameters',
+        'event_stream_buffer',
+        'mcp_tool_defs_cache',
+        'pending_messages',
+        'last_max_tokens',
+        'output_retries_used',
+        'run_step',
+    } & set(result_data)
+
+    from_python = StringResultEnvelope.model_validate(python_data).result
+    from_json = StringResultEnvelope.model_validate_json(envelope.model_dump_json()).result
+    assert_same_result(from_python, result)
+    assert_same_result(from_json, result)
+
+
+def test_structured_result_round_trip_and_reuse_as_history() -> None:
+    def return_profile(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        assert info.output_tools is not None
+        return ModelResponse(
+            parts=[ToolCallPart(info.output_tools[0].name, {'name': 'Ada', 'score': 10})],
+            usage=RequestUsage(input_tokens=12, output_tokens=5),
+        )
+
+    agent = Agent(FunctionModel(return_profile), output_type=Profile)
+    first_result = agent.run_sync('Create a profile')
+    result = agent.run_sync('Create another profile', message_history=first_result.all_messages())
+    result.usage.requests = 7
+    result.usage.tool_calls = 3
+
+    envelope = ProfileResultEnvelope(result=result)
+    from_python = ProfileResultEnvelope.model_validate(envelope.model_dump(mode='python')).result
+    from_json = ProfileResultEnvelope.model_validate_json(envelope.model_dump_json()).result
+
+    assert isinstance(from_json.output, Profile)
+    assert_same_result(from_python, result)
+    assert_same_result(from_json, result)
+    assert from_json.usage.requests == 7
+    assert from_json.usage.tool_calls == 3
+
+    messages = from_json.all_messages(output_tool_return_content='Profile stored')
+    assert isinstance(messages[-1].parts[0], ToolReturnPart)
+    assert messages[-1].parts[0].content == 'Profile stored'
+
+    continued = agent.run_sync('Continue', message_history=from_json.all_messages())
+    assert continued.output == Profile(name='Ada', score=10)
+
+
+def test_unparameterized_result_follows_the_output_type_default() -> None:
+    """`OutputDataT` defaults to `str`, so a bare `AgentRunResult` is `AgentRunResult[str]`."""
+    adapter = TypeAdapter(AgentRunResult)
+    result = AgentRunResult(output='plain')
+
+    assert adapter.validate_json(adapter.dump_json(result)).output == 'plain'
+    assert adapter.validate_python(result) is result
+
+
+def test_any_output_round_trip() -> None:
+    adapter = TypeAdapter(AgentRunResult[Any])
+    result = AgentRunResult(output={'nested': ['value']})
+
+    assert adapter.validate_python(adapter.dump_python(result, mode='python')).output == {'nested': ['value']}
+    assert adapter.validate_json(adapter.dump_json(result)).output == {'nested': ['value']}
+
+
+def test_missing_optional_fields_use_fresh_defaults() -> None:
+    adapter = TypeAdapter(AgentRunResult[str])
+
+    first = adapter.validate_python({'output': 'one', 'messages': []})
+    second = adapter.validate_python({'output': 'two', 'messages': []})
+
+    assert first.new_messages() == []
+    assert first.usage == RunUsage()
+    assert first.usage is not second.usage
+    assert first.metadata is None
+    assert first._traceparent(required=False) is None  # pyright: ignore[reportPrivateUsage]
+    assert UUID(first.run_id).version == 7
+    assert UUID(first.conversation_id).version == 7
+    assert first.run_id != second.run_id
+    assert first.conversation_id != second.conversation_id
+
+
+def test_legacy_result_shape_round_trip() -> None:
+    result = Agent(TestModel(custom_output_text='legacy')).run_sync('Load an old result', metadata={'source': 'old'})
+    result.usage.requests = 4
+    result.usage.input_tokens = 123
+    public_data: dict[str, Any] = StringResultEnvelope(result=result).model_dump(mode='json')['result']
+    legacy_data: dict[str, Any] = {
+        'output': public_data['output'],
+        '_output_tool_name': public_data['output_tool_name'],
+        '_state': {
+            'message_history': public_data['messages'],
+            'usage': public_data['usage'],
+            'output_retries_used': 2,
+            'run_step': 9,
+            'run_id': public_data['run_id'],
+            'conversation_id': public_data['conversation_id'],
+            'metadata': public_data['metadata'],
+            'last_max_tokens': 100,
+            'last_model_request_parameters': None,
+            'pending_messages': [],
+            'event_stream_buffer': [],
+            'mcp_tool_defs_cache': {},
+        },
+        '_new_message_index': public_data['new_message_index'],
+        '_traceparent_value': public_data['traceparent'],
+    }
+
+    reloaded = StringResultEnvelope.model_validate({'result': legacy_data}).result
+    assert_same_result(reloaded, result)
+    assert reloaded.usage.requests == 4
+    assert reloaded.usage.input_tokens == 123
+
+    preferred = StringResultEnvelope.model_validate(
+        {'result': legacy_data | {'run_id': 'public-run-id', 'metadata': {'source': 'public'}}}
+    ).result
+    assert preferred.run_id == 'public-run-id'
+    assert preferred.metadata == {'source': 'public'}
+
+
+def test_run_result_event_round_trip() -> None:
+    result = Agent(TestModel(custom_output_text='event output')).run_sync('Stream this result')
+    adapter = TypeAdapter(AgentRunResultEvent[str])
+
+    reloaded = adapter.validate_json(adapter.dump_json(AgentRunResultEvent(result))).result
+
+    assert_same_result(reloaded, result)

--- a/tests/test_run_result_serialization.py
+++ b/tests/test_run_result_serialization.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel, TypeAdapter
 
@@ -12,12 +13,14 @@ from pydantic_ai import (
     Agent,
     AgentRunResult,
     AgentRunResultEvent,
+    DeferredToolRequests,
     ModelMessage,
     ModelResponse,
     RequestUsage,
     RunUsage,
     ToolCallPart,
     ToolReturnPart,
+    UserError,
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
@@ -197,3 +200,76 @@ def test_run_result_event_round_trip() -> None:
     reloaded = adapter.validate_json(adapter.dump_json(AgentRunResultEvent(result))).result
 
     assert_same_result(reloaded, result)
+
+
+async def test_streamed_run_result_settles_into_a_serializable_result() -> None:
+    agent = Agent(TestModel(custom_output_text='streamed'), instructions='Be helpful.')
+
+    async with agent.run_stream('Stream this') as streamed:
+        with pytest.raises(UserError, match='still streaming'):
+            streamed.result
+
+        await streamed.get_output()
+        result = streamed.result
+
+        assert isinstance(result, AgentRunResult)
+        assert result.output == 'streamed'
+        assert result.all_messages() == streamed.all_messages()
+        assert result.new_messages() == streamed.new_messages()
+        assert result.usage == streamed.usage
+        assert result.run_id == streamed.run_id
+        assert result.conversation_id == streamed.conversation_id
+        assert result.metadata == streamed.metadata
+
+    adapter = TypeAdapter(AgentRunResult[str])
+    reloaded = adapter.validate_json(adapter.dump_json(result))
+    assert_same_result(reloaded, result)
+
+
+async def test_streamed_structured_output_keeps_the_output_tool_name() -> None:
+    agent = Agent(TestModel(), instructions='Be helpful.', output_type=Profile)
+
+    async with agent.run_stream('Create a profile') as streamed:
+        await streamed.get_output()
+        result = streamed.result
+
+    assert result.output == Profile(name='a', score=0)
+    messages = result.all_messages(output_tool_return_content='Profile stored')
+    assert isinstance(messages[-1].parts[0], ToolReturnPart)
+    assert messages[-1].parts[0].content == 'Profile stored'
+
+    adapter = TypeAdapter(AgentRunResult[Profile])
+    assert adapter.validate_json(adapter.dump_json(result)).output == Profile(name='a', score=0)
+
+
+async def test_streamed_deferred_pause_returns_the_run_result_it_already_holds() -> None:
+    """A `run_stream` that pauses on a deferred call already carries an `AgentRunResult`; hand that one back."""
+    agent = Agent(
+        TestModel(call_tools=['delete_file']),
+        instructions='Be helpful.',
+        output_type=[str, DeferredToolRequests],
+    )
+
+    @agent.tool_plain(requires_approval=True)
+    def delete_file(path: str) -> str:
+        raise AssertionError('should not execute')  # pragma: no cover
+
+    async with agent.run_stream('Delete a file') as streamed:
+        await streamed.get_output()
+        result = streamed.result
+
+    assert isinstance(result.output, DeferredToolRequests)
+    assert [call.tool_name for call in result.output.approvals] == ['delete_file']
+    assert result.all_messages() == streamed.all_messages()
+
+
+async def test_streamed_result_can_be_stored_and_replayed_as_history() -> None:
+    agent = Agent(TestModel(custom_output_text='first'), instructions='Be helpful.')
+
+    async with agent.run_stream('Start') as streamed:
+        await streamed.get_output()
+        stored = StringResultEnvelope(result=streamed.result).model_dump_json()
+
+    loaded = StringResultEnvelope.model_validate_json(stored).result
+    continued = await agent.run('Continue', message_history=loaded.all_messages())
+    assert continued.all_messages()[: len(loaded.all_messages())] == loaded.all_messages()

--- a/tests/test_run_result_serialization.py
+++ b/tests/test_run_result_serialization.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import pytest
 from inline_snapshot import snapshot
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from pydantic_ai import (
     Agent,
@@ -24,6 +24,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.result import StreamedRunResult
 
 
 class StringResultEnvelope(BaseModel):
@@ -242,8 +243,8 @@ async def test_streamed_structured_output_keeps_the_output_tool_name() -> None:
     assert adapter.validate_json(adapter.dump_json(result)).output == Profile(name='a', score=0)
 
 
-async def test_streamed_deferred_pause_returns_the_run_result_it_already_holds() -> None:
-    """A `run_stream` that pauses on a deferred call already carries an `AgentRunResult`; hand that one back."""
+async def test_streamed_deferred_pause_settles_into_its_requests() -> None:
+    """A `run_stream` that pauses on an approval settles into a result carrying the pending requests."""
     agent = Agent(
         TestModel(call_tools=['delete_file']),
         instructions='Be helpful.',
@@ -273,3 +274,35 @@ async def test_streamed_result_can_be_stored_and_replayed_as_history() -> None:
     loaded = StringResultEnvelope.model_validate_json(stored).result
     continued = await agent.run('Continue', message_history=loaded.all_messages())
     assert continued.all_messages()[: len(loaded.all_messages())] == loaded.all_messages()
+
+
+def test_streamed_result_hands_back_a_run_result_it_already_holds() -> None:
+    """`run_stream` yields a pre-built result when a `wrap_run` capability short-circuits the run."""
+    held = Agent(TestModel(custom_output_text='short-circuited')).run_sync('Go')
+    streamed: StreamedRunResult[None, str] = StreamedRunResult(held.all_messages(), 0, run_result=held)
+
+    assert streamed.result is held
+
+
+def test_validator_leaves_non_mapping_input_to_the_dataclass_schema() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(AgentRunResult[str]).validate_python(['not', 'a', 'mapping'])
+
+
+def test_only_output_is_required() -> None:
+    only_output = TypeAdapter(AgentRunResult[str]).validate_python({'output': 'alone'})
+    assert only_output.output == 'alone'
+    assert only_output.all_messages() == []
+
+    with pytest.raises(ValidationError, match='output'):
+        TypeAdapter(AgentRunResult[str]).validate_python({'messages': []})
+
+
+def test_legacy_shape_tolerates_a_sparse_state() -> None:
+    """An old payload whose `_state` carries none of the keys worth keeping still loads."""
+    sparse = TypeAdapter(AgentRunResult[str]).validate_python({'output': 'sparse', '_state': {}})
+
+    assert sparse.output == 'sparse'
+    assert sparse.all_messages() == []
+    assert sparse.usage == RunUsage()
+    assert UUID(sparse.run_id).version == 7


### PR DESCRIPTION
Related to #530 — this is the first piece, not the whole of it.

[`AgentRunResult`][pydantic_ai.agent.AgentRunResult] could already be used as a field on a Pydantic model and round-tripped, but only by accident. Pydantic generated a schema over the dataclass's private fields, so the JSON carried `_state`, `_output_tool_name`, `_new_message_index` and `_traceparent_value` — and with `_state` came all of `GraphAgentState`'s run-local scratch: `last_model_request_parameters` (every tool's full JSON schema), `event_stream_buffer`, `mcp_tool_defs_cache`, `pending_messages` and `last_max_tokens`. None of that shape was intended, documented or tested.

This gives it an explicit one:

```json
{"output": …, "messages": […], "new_message_index": 0, "output_tool_name": null,
 "usage": {…}, "run_id": "…", "conversation_id": "…", "metadata": null, "traceparent": null}
```

`output_retries_used` and `run_step` are left out along with the scratch: they are per-run counters, and continuing a conversation starts a new run.

A one-tool structured-output run drops from **5208 to 3151 bytes**, of which 2897 are the messages themselves — the remaining 254 are usage and the two IDs. That matters beyond ergonomics: `DBOSDurability` and `PrefectDurability` both return an `AgentRunResult` from the workflow and flow they wrap, so it is checkpointed on every run.

Payloads written in the old shape still validate, so stored data and in-flight durable-execution histories keep loading across the upgrade. Reading `_state` back out of the JSON yourself was relying on an undocumented construct, so per the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md) this isn't a breaking change — but it is a visible one, so flagging it here.

### `StreamedRunResult.result`

`StreamedRunResult` exposes the same nine values but holds none of them — every accessor delegates to the live `AgentStream`, or to an `AgentRunResult` when the run paused on a deferred call. So it lives exactly as long as its stream, which is the wrong lifetime for anything you want to store.

`StreamedRunResult.result` is the settled form of the same run: the `AgentRunResult` already held where the run paused, otherwise one built from the stream's values once it has finished. Asking before the stream finishes raises `UserError`.

Deliberately *not* a serializer on `StreamedRunResult` itself: making that class round-trip would mean reconstructing an object whose entire purpose — live delegation to a stream — is gone by the time it's read back. One serializable type reached from every surface is the smaller and more honest shape.

### Tests

`tests/test_run_result_serialization.py` (11 tests) — unit tests, because a cassette matcher isn't sensitive to an internal payload shape. They pin the exact key set, assert none of the excluded internals appear, and cover: plain and structured outputs, JSON and Python modes, an unparameterized `AgentRunResult` (which is `AgentRunResult[str]`, since `OutputDataT` defaults to `str`), `AgentRunResult[Any]`, `all_messages(output_tool_return_content=…)` on a reloaded result, reusing a reloaded result as `message_history`, `AgentRunResultEvent` (it travels Temporal workflow streams), defaults for absent optional keys, and the legacy `_state` shape. For the stream: `result` before completion raising, a completed stream settling with matching output/messages/usage/IDs, a structured output keeping its output tool name, the deferred-pause path handing back the result it already holds, and storing a streamed run and replaying it as `message_history`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HSB8WsdHtEyuVe3Q81knz
