### PR TITLE
fix: read Codex auth as utf-8

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openai_codex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai_codex.py
@@ -330,7 +330,7 @@ def _read_codex_cli_credentials() -> OpenAICodexCredentials:
     code_home = Path(os.getenv('CODEX_HOME') or Path.home() / '.codex')
     path = code_home / 'auth.json'
     try:
-        text = path.read_text()
+        text = path.read_text(encoding='utf-8')
     except FileNotFoundError:
         raise UserError(
             f'No Codex CLI credentials found at `{path}`. Run `codex login` first, or pass '

--- a/tests/providers/codex/test_provider.py
+++ b/tests/providers/codex/test_provider.py
@@ -153,6 +153,30 @@ def test_from_codex_cli_honors_code_home(env: TestEnv, tmp_path: Path):
     assert auth_json.read_text(encoding='utf-8') == original
 
 
+def test_from_codex_cli_reads_auth_json_as_utf8(env: TestEnv, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The Codex CLI auth file is JSON text, so its decoding must not depend on the locale."""
+    auth_json = tmp_path / 'auth.json'
+    auth_json.write_text(
+        json.dumps(
+            {
+                'OPENAI_API_KEY': None,
+                'tokens': {'access_token': 'a', 'refresh_token': 'r', 'account_id': 'acc'},
+            }
+        ),
+        encoding='utf-8',
+    )
+    read_text = Path.read_text
+
+    def read_text_requires_utf8(path: Path, *args: Any, **kwargs: Any) -> str:
+        assert kwargs.get('encoding') == 'utf-8'
+        return read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, 'read_text', read_text_requires_utf8)
+    env.set('CODEX_HOME', str(tmp_path))
+
+    assert OpenAICodexProvider().credentials.account_id == 'acc'
+
+
 def test_from_codex_cli_missing_file(env: TestEnv, tmp_path: Path):
     env.set('CODEX_HOME', str(tmp_path))
     with pytest.raises(UserError, match=r'codex login'):
@@ -927,7 +951,8 @@ def test_provider_class_inference():
 
 def test_openai_codex_prefix_infers_responses_model(env: TestEnv, tmp_path: Path):
     (tmp_path / 'auth.json').write_text(
-        json.dumps({'tokens': {'access_token': 'a', 'refresh_token': 'r', 'account_id': 'acc'}})
+        json.dumps({'tokens': {'access_token': 'a', 'refresh_token': 'r', 'account_id': 'acc'}}),
+        encoding='utf-8',
     )
     env.set('CODEX_HOME', str(tmp_path))
     model = infer_model('openai-codex:gpt-5.6-luna')

--- a/tests/providers/codex/test_provider.py
+++ b/tests/providers/codex/test_provider.py
@@ -141,7 +141,7 @@ def test_from_codex_cli_honors_code_home(env: TestEnv, tmp_path: Path):
             'tokens': {'access_token': 'a', 'refresh_token': 'r', 'account_id': 'acc'},
         }
     )
-    auth_json.write_text(original)
+    auth_json.write_text(original, encoding='utf-8')
     env.set('CODEX_HOME', str(tmp_path))
 
     provider = OpenAICodexProvider()
@@ -150,7 +150,7 @@ def test_from_codex_cli_honors_code_home(env: TestEnv, tmp_path: Path):
     assert provider.name == 'openai-codex'
     assert provider.base_url == 'https://chatgpt.com/backend-api/codex'
     # Read-only contract: byte-for-byte unchanged after construction.
-    assert auth_json.read_text() == original
+    assert auth_json.read_text(encoding='utf-8') == original
 
 
 def test_from_codex_cli_missing_file(env: TestEnv, tmp_path: Path):
@@ -167,7 +167,7 @@ def test_from_codex_cli_unreadable_file(env: TestEnv, tmp_path: Path):
 
 
 def test_from_codex_cli_malformed_json(env: TestEnv, tmp_path: Path):
-    (tmp_path / 'auth.json').write_text('not json')
+    (tmp_path / 'auth.json').write_text('not json', encoding='utf-8')
     env.set('CODEX_HOME', str(tmp_path))
     with pytest.raises(UserError, match='Malformed'):
         OpenAICodexProvider()


### PR DESCRIPTION
Closes #8253

Supersedes #8252, which was closed by the issue-link guard before #8253 was created and confirmed.

## Problem
The Codex provider reads the Codex CLI `auth.json` file without specifying an encoding. That leaves the read dependent on the platform default codec, which can be different from UTF-8 on some Windows/localized environments.

## Before / after
Before, `_read_codex_cli_credentials()` used `path.read_text()` and the related test fixtures used default-encoding reads/writes.

After, the provider and the matching fixtures use `encoding="utf-8"` explicitly for the JSON auth file. The provider test suite also includes a regression check that fails if the auth JSON read stops passing `encoding="utf-8"`.

## Verification
- `python -m py_compile pydantic_ai_slim\pydantic_ai\providers\openai_codex.py tests\providers\codex\test_provider.py`
- `uv run pytest tests\providers\codex\test_provider.py -q` (`57 passed`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

