### PR TITLE
Support round-tripping native tool search return parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2700,6 +2700,7 @@ ModelRequestPart = Annotated[
     | Annotated[UserPromptPart, pydantic.Tag('user-prompt')]
     | Annotated[SpeechPart, pydantic.Tag('speech')]
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
+    | Annotated[NativeToolSearchReturnPart, pydantic.Tag('builtin-tool-search-return')]
     | Annotated[LoadCapabilityReturnPart, pydantic.Tag('capability-load-return')]
     | Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
     | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -63,6 +63,7 @@ from pydantic_ai import (
 )
 from pydantic_ai._parts_manager import ModelResponsePartsManager
 from pydantic_ai.messages import (
+    NativeToolSearchReturnPart,
     _FILE_URL_KINDS,  # pyright: ignore[reportPrivateUsage]
     INVALID_JSON_KEY,
     MULTI_MODAL_CONTENT_TYPES,
@@ -879,6 +880,25 @@ def test_model_messages_type_adapter_preserves_run_id():
     deserialized = ModelMessagesTypeAdapter.validate_python(serialized)
 
     assert [message.run_id for message in deserialized] == snapshot(['run-123', 'run-123'])
+
+
+def test_model_messages_type_adapter_round_trips_native_tool_search_return_part():
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                NativeToolSearchReturnPart(
+                    tool_call_id='call-1',
+                    content={'discovered_tools': [{'name': 'weather'}]},
+                )
+            ]
+        )
+    ]
+
+    serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+
+    assert isinstance(deserialized[0].parts[0], NativeToolSearchReturnPart)
+    assert deserialized == messages
 
 
 def test_model_messages_type_adapter_preserves_conversation_id():


### PR DESCRIPTION
Fixes request-side JSON deserialization for NativeToolSearchReturnPart by registering it in ModelRequestPart. Adds a regression test for ModelMessagesTypeAdapter JSON round-tripping.\n\nCloses #8271\n\nValidation: targeted tests pass (5 passed).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

