### PR TITLE
Preserve history after empty `CompactionPart` summaries

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -3070,7 +3070,7 @@ def _compaction_part_is_wire_boundary(
         return False
     if part.provider_details and 'encrypted_content' in part.provider_details:
         return True
-    return not requires_encrypted_content and part.content is not None
+    return not requires_encrypted_content and bool(part.content)
 
 
 def _post_compaction_window_for_response(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -72,6 +72,7 @@ from pydantic_ai.messages import (
     LoadCapabilityReturnPart,
     RealtimeSessionErrorEvent,
     ToolReturnContent,
+    _post_compaction_window_for_response,  # pyright: ignore[reportPrivateUsage]
     is_multi_modal_content,
     narrow_message_parts,
     post_compaction_window,
@@ -3281,3 +3282,21 @@ def test_post_compaction_window_accepts_a_minimal_sequence():
     assert len(window) == 2
     assert isinstance(window[0], ModelResponse)
     assert isinstance(window[1], ModelRequest)
+
+
+def test_empty_compaction_part_does_not_reset_provider_evidence_window():
+    """An empty summary cannot replace the history before it."""
+    empty_compaction = ModelResponse(
+        parts=[CompactionPart(content='', provider_name='anthropic')], provider_name='anthropic'
+    )
+    serving_response = ModelResponse(parts=[TextPart(content='answer')], provider_name='anthropic')
+    messages: list[ModelMessage] = [
+        ModelRequest.user_text_prompt('tool context'),
+        empty_compaction,
+        ModelRequest.user_text_prompt('continue'),
+        serving_response,
+    ]
+
+    window = _post_compaction_window_for_response(messages, serving_response)
+
+    assert window == messages


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

- Closes #7773

### Summary

- Do not treat an empty `CompactionPart` summary as a provider wire boundary.
- Preserve the prior conversation history when the compaction summary is empty.
- Add a regression test for the provider evidence window.

### Testing

- `uv run --with pytest pytest tests/test_messages.py -k "empty_compaction_part_does_not_reset_provider_evidence_window"`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

