### PR TITLE
fix(google): forward WebSearchTool.blocked_domains as exclude_domains

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -773,7 +773,10 @@ class GoogleModel(Model[Client]):
 
             for tool in model_request_parameters.native_tools:
                 if isinstance(tool, WebSearchTool):
-                    tools.append(ToolDict(google_search=GoogleSearchDict()))
+                    google_search = GoogleSearchDict()
+                    if tool.blocked_domains:
+                        google_search['exclude_domains'] = list(tool.blocked_domains)
+                    tools.append(ToolDict(google_search=google_search))
                 elif isinstance(tool, WebFetchTool):
                     tools.append(ToolDict(url_context=UrlContextDict()))
                 elif isinstance(tool, CodeExecutionTool):

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4059,6 +4059,35 @@ def test_google_gemini_api_sets_include_server_side_tool_invocations(
     assert tool_config.get('include_server_side_tool_invocations') is True
 
 
+def test_google_web_search_tool_blocked_domains(
+    google_provider: GoogleProvider,
+) -> None:
+    """blocked_domains on WebSearchTool is forwarded as exclude_domains in the GoogleSearch config."""
+    model = GoogleModel('gemini-2.0-flash', provider=google_provider)
+    blocked = ['example.com', 'ads.example.org']
+    params = ModelRequestParameters(native_tools=[WebSearchTool(blocked_domains=blocked)])
+    tools, _tool_config, _image_config = model._get_tool_config(params, GoogleModelSettings())  # pyright: ignore[reportPrivateUsage]
+    assert tools is not None
+    assert len(tools) == 1
+    google_search = tools[0].get('google_search')
+    assert google_search is not None
+    assert google_search.get('exclude_domains') == blocked
+
+
+def test_google_web_search_tool_no_blocked_domains(
+    google_provider: GoogleProvider,
+) -> None:
+    """WebSearchTool without blocked_domains produces a GoogleSearch config without exclude_domains."""
+    model = GoogleModel('gemini-2.0-flash', provider=google_provider)
+    params = ModelRequestParameters(native_tools=[WebSearchTool()])
+    tools, _tool_config, _image_config = model._get_tool_config(params, GoogleModelSettings())  # pyright: ignore[reportPrivateUsage]
+    assert tools is not None
+    assert len(tools) == 1
+    google_search = tools[0].get('google_search')
+    assert google_search is not None
+    assert 'exclude_domains' not in google_search
+
+
 @pytest.mark.vcr()
 async def test_google_vertex_tool_combination_omits_include_server_side_tool_invocations(
     allow_model_requests: None, vertex_provider: GoogleProvider, vcr: Cassette


### PR DESCRIPTION
## Summary

Closes #8218.

`WebSearchTool.blocked_domains` was silently discarded when building the `GoogleSearch` tool config. The `google-genai` SDK exposes `GoogleSearch.exclude_domains` (added in v2.22.0) precisely for this use case, but it was never wired up.

**Before:** `blocked_domains` was ignored; any domain the caller wanted filtered still appeared in results.  
**After:** `blocked_domains` is forwarded as `exclude_domains` when non-empty, so the Gemini API respects the caller's exclusion list.

The Groq model already handles this correctly (`ss['exclude_domains'] = tool.blocked_domains`) — this brings the Google model to parity.

## Changes

- `pydantic_ai_slim/pydantic_ai/models/google.py`: wire `tool.blocked_domains` → `google_search['exclude_domains']` inside `_get_native_tools`
- `tests/models/test_google.py`: two new unit tests exercising `blocked_domains` (non-empty and empty/absent)

## Test plan

- [ ] `test_google_web_search_tool_blocked_domains` — asserts `exclude_domains` is set correctly from the list
- [ ] `test_google_web_search_tool_no_blocked_domains` — asserts `exclude_domains` is absent when not provided

Both new tests pass with `uv run pytest`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

