### PR TITLE
Preserve `strict=False` in `OpenAIChatModel` tool definitions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1724,7 +1724,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                 'parameters': f.parameters_json_schema,
             },
         }
-        if f.strict and self.profile.get('openai_supports_strict_tool_definition', True):
+        if f.strict is not None and self.profile.get('openai_supports_strict_tool_definition', True):
             tool_param['function']['strict'] = f.strict
         return tool_param
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -2901,7 +2901,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_default,
@@ -2913,7 +2913,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_datetime,
@@ -2949,7 +2949,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_decimal,
@@ -2985,7 +2985,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_url,
@@ -3036,7 +3036,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_recursion,
@@ -3124,7 +3124,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_typed_dict,
@@ -3150,7 +3150,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_partial_typed_dict,
@@ -3162,7 +3162,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_model_with_extras,
@@ -3174,7 +3174,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_model_with_extras,
@@ -3200,7 +3200,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_kwargs,
@@ -3226,7 +3226,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_union,
@@ -3246,7 +3246,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_union,
@@ -3287,7 +3287,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_discriminated_union,
@@ -3331,7 +3331,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_lists,
@@ -3377,7 +3377,7 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                     'type': 'object',
                 }
             ),
-            snapshot(None),
+            snapshot(False),
         ),
         (
             tool_with_tuples,
@@ -4024,17 +4024,22 @@ def test_openai_model_profile_from_provider():
     assert m.profile.get('json_schema_transformer', None) is None
 
 
-def test_model_profile_strict_not_supported():
+@pytest.mark.parametrize('strict', [True, False, None])
+def test_model_profile_strict_not_supported(strict: bool | None):
+    # Pin serialization directly: cassette matching does not compare tool definitions.
     model_settings = ModelSettings()
     my_tool = ToolDefinition(
         name='my_tool',
         description='This is my tool',
         parameters_json_schema={'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
-        strict=True,
+        strict=strict,
     )
 
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='foobar'))
     tool_param = m._map_tool_definition(my_tool, model_settings)  # type: ignore[reportPrivateUsage]
+
+    if strict is not None:
+        assert tool_param['function'].pop('strict') is strict
 
     assert tool_param == snapshot(
         {
@@ -4043,7 +4048,6 @@ def test_model_profile_strict_not_supported():
                 'name': 'my_tool',
                 'description': 'This is my tool',
                 'parameters': {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
-                'strict': True,
             },
         }
     )

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1135,6 +1135,7 @@ async def test_openrouter_web_search_tool_is_after_tool_cache_and_advisor(allow_
                     'name': 'get_weather',
                     'description': '',
                     'parameters': {'additionalProperties': False, 'properties': {}, 'type': 'object'},
+                    'strict': False,
                 },
                 'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
             },


### PR DESCRIPTION
`OpenAIChatModel` drops a tool definition's `strict=False` because its serializer tests truthiness. Preserve both boolean values while continuing to omit `None` and suppress the field when the profile disables strict tool definitions. `OpenRouterModel` inherits the fix.

This also preserves `False` produced by existing schema inference. Schema transformation and strictness inference are unchanged; no public API is added.

Verification: all 317 tests in `tests/models/test_openai.py` and `tests/models/test_openrouter.py` pass. The existing agent-level strict-mode test checks the tool schema and `strict` value passed to the SDK. The parameterized mapping test covers `True`, `False`, `None`, and unsupported profiles. An existing OpenRouter request snapshot also reflects the preserved `False` value.

No linked issue: [the contribution guide](https://github.com/pydantic/pydantic-ai/blob/main/docs/contributing.md#trivial-fixes) allows obvious one-line fixes without one. Searches found no issue or PR covering the dropped boolean.

<details>
<summary>Minimal reproducible example (no API key or network request)</summary>

Install with `pip install "pydantic-ai-slim[openai]"`, then run:

```python
from pydantic_ai.models.openrouter import OpenRouterModel
from pydantic_ai.providers.openrouter import OpenRouterProvider
from pydantic_ai.tools import ToolDefinition

model = OpenRouterModel(
    'openai/gpt-4o', provider=OpenRouterProvider(api_key='unused')
)
tool = ToolDefinition(
    name='greet',
    parameters_json_schema={
        'type': 'object',
        'properties': {'name': {'type': 'string'}},
        'additionalProperties': False,
    },
    strict=False,
)

# Inspect serialization directly; no request is sent.
function = model._map_tool_definition(tool, {})['function']
print('strict:', function.get('strict', '<omitted>'))
assert function.get('strict') is False
assert function['parameters'] == tool.parameters_json_schema
```

Before this fix: prints `strict: <omitted>` and raises `AssertionError`.
After this fix: prints `strict: False` and both assertions pass.

This isolates the adapter's serialization boundary; it makes no claim about model output or downstream OpenRouter routing.

</details>

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://pydantic.dev/docs/ai/project/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- For a version-policy-permitted compatibility impact, add the `compatibility impact` label -->
<!-- and place this warning immediately after the PR's opening explanation: -->
<!-- > [!WARNING] -->
<!-- > **Compatibility impact:** Existing code that ... may ... -->
<!-- > -->
<!-- > **Why this can ship in a minor release:** ... -->
<!-- > -->
<!-- > **Migration:** ... -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#when-do-you-need-the-harness -->

<!-- No issue to close: trivial one-line bug fix. -->

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. — Not applicable: no public API changes or migration required.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
