### PR TITLE
docs: Add New Relic to OTel backend list

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -253,6 +253,7 @@ The following providers have dedicated documentation on Pydantic AI:
 - [Respan](https://respan.ai/docs/integrations/pydantic-ai)
 - [Raindrop](https://raindrop.ai/docs/integrations/pydantic-ai)
 - [Sentry](https://docs.sentry.io/platforms/python/integrations/pydantic-ai/)
+- [New Relic](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
 
 ## Advanced usage
 


### PR DESCRIPTION
Add New Relic as an OpenTelemetry-compatible backend option in the alternative observability backends section of the logfire documentation.

## Why

New Relic is an important observability platform that supports OpenTelemetry, but was missing from the list of alternative backends documented in the logfire.md file.

## Scope

- Added New Relic entry to the alternative observability backends list in docs/logfire.md with link to their OpenTelemetry best practices documentation

## Verification

The New Relic documentation link is accessible at https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

