### PR TITLE
fix(messages): preserve extra keys on load_capability args/return con…

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py
+++ b/pydantic_ai_slim/pydantic_ai/_deferred_capabilities.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 class LoadCapabilityArgs(TypedDict):
     """Typed arguments for a `load_capability` tool call."""
 
+    __pydantic_config__ = pydantic.ConfigDict(extra='allow')
+
     id: Annotated[
         str,
         pydantic.Field(
@@ -39,6 +41,8 @@ class LoadCapabilityArgs(TypedDict):
 
 class LoadCapabilityReturn(TypedDict):
     """Typed return value for the `load_capability` tool."""
+
+    __pydantic_config__ = pydantic.ConfigDict(extra='allow')
 
     instructions: NotRequired[str]
     """Instructions for the loaded capability."""

--- a/tests/test_capability_deferred_loading.py
+++ b/tests/test_capability_deferred_loading.py
@@ -1006,6 +1006,55 @@ def test_load_capability_parts_round_trip_through_message_history() -> None:
     assert isinstance(rebuilt[1].parts[0], LoadCapabilityReturnPart)
 
 
+def test_load_capability_parts_round_trip_preserves_content_extras() -> None:
+    """Unknown keys on `load_capability` args/return content survive a history round trip.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/8002: the
+    `LoadCapabilityReturn` narrower silently dropped unknown content keys on
+    dump and validate, so extras written by capabilities (e.g. version markers)
+    were lost when persisting message history.
+    """
+    import json
+
+    from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelRequest, ModelResponse
+
+    messages: Any = [
+        ModelResponse(
+            parts=[
+                LoadCapabilityCallPart(
+                    tool_call_id='c1',
+                    args={'id': 'refunds', 'requested_by': 'policy-v2'},
+                ),
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                LoadCapabilityReturnPart(
+                    tool_name='load_capability',
+                    tool_call_id='c1',
+                    content={'instructions': 'Confirm the order id.', 'version': 2, 'deprecated': True},
+                ),
+            ]
+        ),
+    ]
+
+    dumped = json.loads(ModelMessagesTypeAdapter.dump_json(messages))
+    assert dumped[0]['parts'][0]['args'] == {'id': 'refunds', 'requested_by': 'policy-v2'}
+    assert dumped[1]['parts'][0]['content'] == {
+        'instructions': 'Confirm the order id.',
+        'version': 2,
+        'deprecated': True,
+    }
+
+    rebuilt = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages))
+    assert rebuilt[0].parts[0].args == {'id': 'refunds', 'requested_by': 'policy-v2'}
+    assert rebuilt[1].parts[0].content == {
+        'instructions': 'Confirm the order id.',
+        'version': 2,
+        'deprecated': True,
+    }
+
+
 async def test_deferred_capability_loads_instructions_and_tools_e2e() -> None:
     """A deferred capability starts as a catalog entry and becomes usable after `load_capability`."""
     toolset = FunctionToolset()


### PR DESCRIPTION
## Description

`ModelMessagesTypeAdapter` silently drops unknown keys on `load_capability` tool call **args** and tool **return** `content` — both on dump and on validate — because `LoadCapabilityArgs` and `LoadCapabilityReturn` validate with pydantic's default `extra='ignore'`.

Capabilities can attach extra fields to return payloads (version markers, deprecation flags, tool hints), and those are lost whenever message history is persisted through the documented `ModelMessagesTypeAdapter` boundary. #7933 fixed this class of bug for the call side; the current typed-part narrower path drops extras on both sides again.

This allows extras on both TypedDicts so unknown keys survive the round trip, symmetric with the earlier fix.

Fixes #8002

## Tests

- Added `test_load_capability_parts_round_trip_preserves_content_extras`: dumps and round-trips a call part with an extra arg key and a return part with extra content keys, asserting both survive on the wire JSON and after `validate_json`. It fails on `main` (extras dropped) and passes with this change.
- `uv run pytest tests/test_capability_deferred_loading.py`: 62 passed. (`tests/test_messages.py` shows 2 pre-existing failures on unmodified `main` on this Windows machine — verified by stashing this change; unrelated to it.)
- `ruff check` and `ruff format --check` clean on the touched files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

