### PR TITLE
Correct which tools can opt out of Temporal activities

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -490,8 +490,10 @@ agent = Agent(
 2. Set `'temporal': False` to skip activity wrapping entirely (only valid for `async` tools — sync tools always need an activity since threads aren't deterministic).
 3. Selector-based: [`SetToolMetadata`][pydantic_ai.capabilities.SetToolMetadata] applies the same metadata across a selection of tools (`'all'`, a name list, a dict, or a callable).
 
-The opt-out applies to function and dynamic tools only. MCP tools perform I/O and always run in
-their Temporal activity, so `metadata={'temporal': False}` on an MCP tool raises a `UserError`.
+The opt-out applies to [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset] tools only. MCP tools
+perform I/O and always run in their Temporal activity, and a dynamic toolset has to be resolved before
+its tool can be called, which may perform I/O as well, so `metadata={'temporal': False}` on either
+raises a `UserError`. Move the tool to a static `FunctionToolset` to opt it out.
 
 !!! tip "Configuring third-party tools"
     [`SetToolMetadata`][pydantic_ai.capabilities.SetToolMetadata] is the recommended path when the activity config doesn't belong on the tool definition — for example, tools defined in third-party packages, or a group of tools that share the same timeout profile but live in different files.


### PR DESCRIPTION
`docs/durable_execution/temporal.md` says the activity opt-out "applies to function and dynamic tools only", but a dynamic-toolset tool cannot opt out under Temporal. `_durability.py:378` raises a `UserError` for it, and that error's own text tells you to "move the tool to a static `FunctionToolset`". I reproduced it on current main by calling `_resolve_temporal_tool_config` with one async tool carrying `metadata={'temporal': False}` under all three toolset kinds: `function` falls through both guards, while `dynamic` and `mcp` each raise. The repo's own `test_durability.py:1507` asserts the dynamic case too.

The sentence looks like it was carried over from the Prefect page, where it is correct. Prefect honours the opt-out for dynamic tools: `DurableDynamicToolset.call_tool` in `durable_exec/_toolset.py` sees `config is False` and resolves a fresh copy to call the tool inline in flow code. Temporal cannot do that, because workflow code has to stay deterministic and I/O free, which is exactly what the dynamic guard says. So this changes the Temporal page only. `docs/durable_execution/prefect.md` stays as it is, and the DBOS page never made the claim.

I ran `uv run pytest tests/test_examples.py -k temporal` (5 passed) and checked that the new `FunctionToolset` reference resolves. The Temporal test module skips on my machine because it is Python 3.14 and the temporalio sandbox is incompatible, which is why I reproduced the behaviour directly rather than by running that file.

I am a college freshman contributing in good faith. I sanity-checked the reasoning with Claude Code and ran the repro myself. Happy to reword or close if you would rather state it differently.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

