### PR TITLE
docs: use 'an AG-UI tool' in shared-state example

### DIFF
--- a/docs/examples/ag-ui.md
+++ b/docs/examples/ag-ui.md
@@ -174,7 +174,7 @@ Demonstrates how to use the shared state between the UI and the agent.
 
 State sent to the agent is detected by a function based instruction. This then
 validates the data using a custom pydantic model before using to create the
-instructions for the agent to follow and send to the client using a AG-UI tool.
+instructions for the agent to follow and send to the client using an AG-UI tool.
 
 If you've [run the example](#running-the-example), you can view it at <http://localhost:3000/pydantic-ai/feature/shared_state>.
 


### PR DESCRIPTION
## Summary
- Fix a/an grammar in `docs/examples/ag-ui.md`: "a AG-UI tool" → "an AG-UI tool"

Trivial docs fix; no issue per CONTRIBUTING.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

