### PR TITLE
docs: fix grammar in dependencies intro

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,7 +6,7 @@ Pydantic AI's dependency system follows established Python practices, making dep
 
 ## Defining Dependencies
 
-Dependencies can be any python type. While in simple cases you might be able to pass a single object as a dependency (e.g. an HTTP connection), [dataclasses][] are generally a convenient container when your dependencies included multiple objects.
+Dependencies can be any python type. While in simple cases you might be able to pass a single object as a dependency (e.g. an HTTP connection), [dataclasses][] are generally a convenient container when your dependencies include multiple objects.
 
 Here's an example of defining an agent that requires dependencies.
 


### PR DESCRIPTION
## Summary
- Fix tense: "when your dependencies included multiple objects" → "include".

Tiny unsolicited docs grammar fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

