### PR TITLE
fix(openai): read Codex auth.json as UTF-8

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openai_codex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai_codex.py
@@ -330,7 +330,7 @@ def _read_codex_cli_credentials() -> OpenAICodexCredentials:
     code_home = Path(os.getenv('CODEX_HOME') or Path.home() / '.codex')
     path = code_home / 'auth.json'
     try:
-        text = path.read_text()
+        text = path.read_text(encoding='utf-8')
     except FileNotFoundError:
         raise UserError(
             f'No Codex CLI credentials found at `{path}`. Run `codex login` first, or pass '

--- a/tests/providers/codex/test_provider.py
+++ b/tests/providers/codex/test_provider.py
@@ -153,6 +153,33 @@ def test_from_codex_cli_honors_code_home(env: TestEnv, tmp_path: Path):
     assert auth_json.read_text() == original
 
 
+def test_read_codex_cli_credentials_decodes_as_utf8(env: TestEnv, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """`_read_codex_cli_credentials()` must decode `auth.json` as UTF-8, not the locale default.
+
+    Unit test, not VCR: the defect is a `Path.read_text()` encoding argument. It only
+    surfaces when the platform default is not UTF-8 (Windows/localized CPython ≤ 3.14),
+    which no cassette can force. The monkeypatch simulates that locale so this fails
+    before the fix (`UnicodeDecodeError`) and passes after it.
+    """
+    (tmp_path / 'auth.json').write_bytes(
+        json.dumps(
+            {'tokens': {'access_token': 'a', 'refresh_token': 'r', 'account_id': 'acc-é-123'}},
+            ensure_ascii=False,
+        ).encode('utf-8')
+    )
+    env.set('CODEX_HOME', str(tmp_path))
+
+    original = Path.read_text
+
+    def read_text_as_locale_ascii(self: Path, encoding: str | None = None, **kwargs: Any) -> str:
+        return original(self, encoding=encoding or 'ascii', **kwargs)
+
+    monkeypatch.setattr(Path, 'read_text', read_text_as_locale_ascii)
+
+    provider = OpenAICodexProvider()
+    assert provider.credentials.account_id == 'acc-é-123'
+
+
 def test_from_codex_cli_missing_file(env: TestEnv, tmp_path: Path):
     env.set('CODEX_HOME', str(tmp_path))
     with pytest.raises(UserError, match=r'codex login'):


### PR DESCRIPTION
Fixes #8253

`OpenAICodexProvider` loaded `CODEX_HOME/auth.json` with bare `Path.read_text()`, so decoding used the platform default codec. On Windows/localized CPython ≤ 3.14 that raises a raw `UnicodeDecodeError` for valid UTF-8 credentials.

### New public surface

none

### User-visible behavior

```diff
pydantic_ai/providers/openai_codex.py :: OpenAICodexProvider.__init__()
└─ pydantic_ai/providers/openai_codex.py :: _read_codex_cli_credentials()
   - path.read_text()
   + path.read_text(encoding='utf-8')
```

### Verification

- `tests/providers/codex/test_provider.py::test_read_codex_cli_credentials_decodes_as_utf8` — forces a non-UTF-8 `Path.read_text()` default and asserts construction still loads a non-ASCII `auth.json`.

### What changes for existing users

Nothing on UTF-8 locales. Valid UTF-8 `auth.json` files now load under non-UTF-8 platform defaults.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

