### PR TITLE
fix(ui): keep retried tool outcome on the Vercel AI stream

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -573,14 +573,33 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             # subclasses only ever wrap successful, shape-valid content, and readers
                             # like `parse_loaded_capabilities` treat their presence as proof of success.
                             elif part.state == 'output-error':
-                                builder.add(
-                                    ToolReturnPart(
-                                        tool_name=tool_name,
-                                        tool_call_id=tool_call_id,
-                                        content=part.error_text,
-                                        outcome='failed',
-                                    )
+                                # A tool-bound `RetryPromptPart` shares `output-error` with
+                                # `'failed'`. The dump path stores the claim on
+                                # `call_provider_metadata`; a live-stream echo stores the same
+                                # claim on `result_provider_metadata` (AI SDK copies
+                                # `ToolOutputErrorChunk.provider_metadata` there). Without
+                                # either, the return reloads as a definitive failure.
+                                result_meta = load_provider_metadata(part.result_provider_metadata)
+                                retried = (
+                                    provider_meta.get('outcome') == 'retried' or result_meta.get('outcome') == 'retried'
                                 )
+                                if retried:
+                                    builder.add(
+                                        RetryPromptPart(
+                                            content=part.error_text,
+                                            tool_name=tool_name,
+                                            tool_call_id=tool_call_id,
+                                        )
+                                    )
+                                else:
+                                    builder.add(
+                                        ToolReturnPart(
+                                            tool_name=tool_name,
+                                            tool_call_id=tool_call_id,
+                                            content=part.error_text,
+                                            outcome='failed',
+                                        )
+                                    )
                             elif part.state == 'output-denied':
                                 builder.add(
                                     ToolReturnPart(
@@ -860,15 +879,18 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         """Convert a ToolCallPart (with optional result) into UIMessageParts."""
         tool_result = tool_results.get(part.tool_call_id)
         interrupted = isinstance(tool_result, ToolReturnPart) and tool_result.outcome == 'interrupted'
+        retried = isinstance(tool_result, RetryPromptPart)
+        # The two claims the UI part state can't represent on its own: `'interrupted'` dumps as
+        # neutral `output-available` below, and a `RetryPromptPart` shares `output-error` with
+        # `'failed'`. Both ride the metadata channel so a dump/load (or stream echo) round-trip
+        # doesn't degrade them to `'success'` / `'failed'`.
+        carried_outcome = 'interrupted' if interrupted else 'retried' if retried else None
         call_provider_metadata = dump_provider_metadata(
             id=part.id,
             provider_name=part.provider_name,
             provider_details=part.provider_details,
             tool_kind=part.tool_kind,
-            # `'interrupted'` is the one outcome the UI part state can't represent (it dumps as
-            # neutral `output-available` below), so it rides the metadata channel instead of
-            # degrading to `'success'` on a dump/load round-trip.
-            outcome='interrupted' if interrupted else None,
+            outcome=carried_outcome,
         )
         tool_type = f'tool-{part.tool_name}'
         ui_parts: list[UIMessagePart] = []
@@ -970,13 +992,13 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
 
         Note: The round-trip `dump_messages` -> `load_messages` is not fully lossless for tool
         results. Successful, failed, and denied results each round-trip via their own part type
-        (`ToolOutputAvailablePart` / `ToolOutputErrorPart` / `ToolOutputDeniedPart`), but a
-        `RetryPromptPart` becomes a `ToolReturnPart` with `outcome='failed'` on reload (or a user
-        text part when it has no `tool_name`), since the protocol has no separate retry concept —
-        both a retry prompt and a `ToolFailed` result map to `ToolOutputErrorPart`. A reloaded retry
-        is therefore presented to the model as a definitive failure rather than a request to correct
-        and retry; keep the conversation in-process rather than persisting through the Vercel AI wire
-        format if you need retry semantics to survive a round-trip.
+        (`ToolOutputAvailablePart` / `ToolOutputErrorPart` / `ToolOutputDeniedPart`). A tool-bound
+        `RetryPromptPart` shares `ToolOutputErrorPart` with a failed result — the protocol has no
+        separate retry concept — so its outcome rides the `providerMetadata` channel that already
+        carries `'interrupted'`, and is restored from there on reload. The live stream emits the
+        same claim on `ToolOutputErrorChunk.provider_metadata`; a v6 frontend that echoes the
+        conversation stores that on `resultProviderMetadata`, which `load_messages` also reads.
+        A `RetryPromptPart` with no `tool_name` still becomes a user text part.
 
         Tool calls lose one thing too: `ToolCallPart.args` that don't parse as a JSON object are
         rewritten to `{'INVALID_JSON': '<raw args>'}` (see

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -467,7 +467,14 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
                 else part.model_response_str(wrap_if_error=False),
             )
         elif isinstance(part, RetryPromptPart):
-            yield ToolOutputErrorChunk(tool_call_id=tool_call_id, error_text=part.model_response())
+            # `'retried'` shares `tool-output-error` with `'failed'`. The claim rides
+            # `provider_metadata` so a frontend echo can restore a `RetryPromptPart`
+            # instead of a definitive `ToolReturnPart(outcome='failed')`.
+            yield ToolOutputErrorChunk(
+                tool_call_id=tool_call_id,
+                error_text=part.model_response(),
+                provider_metadata=dump_provider_metadata(outcome='retried'),
+            )
         elif isinstance(part, ToolReturnPart) and part.outcome == 'failed':
             yield ToolOutputErrorChunk(
                 tool_call_id=tool_call_id, error_text=part.model_response_str(wrap_if_error=False)

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -204,6 +204,12 @@ class ToolOutputErrorPart(BaseUIPart):
     error_text: str
     provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
+    result_provider_metadata: ProviderMetadata | None = Field(default=None, exclude_if=lambda value: value is None)
+    """Metadata the AI SDK copies from a streamed `tool-output-error` chunk.
+
+    A v6 frontend that echoes a live turn stores `ToolOutputErrorChunk.provider_metadata`
+    here, not on `call_provider_metadata`. `VercelAIAdapter.load_messages` reads both.
+    """
     approval: ToolApproval | None = None
 
 
@@ -315,6 +321,12 @@ class DynamicToolOutputErrorPart(BaseUIPart):
     error_text: str
     provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
+    result_provider_metadata: ProviderMetadata | None = Field(default=None, exclude_if=lambda value: value is None)
+    """Metadata the AI SDK copies from a streamed `tool-output-error` chunk.
+
+    A v6 frontend that echoes a live turn stores `ToolOutputErrorChunk.provider_metadata`
+    here, not on `call_provider_metadata`. `VercelAIAdapter.load_messages` reads both.
+    """
     approval: ToolApproval | None = None
 
 

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/response_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/response_types.py
@@ -149,12 +149,21 @@ class ToolInputErrorChunk(BaseChunk):
 
 
 class ToolOutputErrorChunk(BaseChunk):
-    """Tool output error chunk."""
+    """Tool output error chunk.
+
+    `provider_metadata` is the live-stream carrier for an outcome the UI part state
+    cannot represent on its own: a tool-bound `RetryPromptPart` shares `tool-output-error`
+    with `ToolReturnPart(outcome='failed')`. A v6 frontend that builds
+    `ToolUIPart(state='output-error')` from this chunk stores the field on
+    `resultProviderMetadata`, which `VercelAIAdapter.load_messages` reads so a later
+    echo reloads as a retry rather than a definitive failure.
+    """
 
     type: Literal['tool-output-error'] = 'tool-output-error'
     tool_call_id: str
     error_text: str
     provider_executed: bool | None = None
+    provider_metadata: ProviderMetadata | None = None
     dynamic: bool | None = None
 
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -2953,6 +2953,7 @@ Unknown tool name: 'unknown_tool'. No tools available.
 
 Fix the errors and try again.\
 """,
+                'providerMetadata': {'pydantic_ai': {'outcome': 'retried'}},
             },
             {'type': 'finish-step'},
             {'type': 'start-step'},
@@ -6213,7 +6214,7 @@ Tool failed with error
 
 Fix the errors and try again.\
 """,
-                        'call_provider_metadata': None,
+                        'call_provider_metadata': {'pydantic_ai': {'outcome': 'retried'}},
                         'approval': None,
                     }
                 ],
@@ -6221,17 +6222,16 @@ Fix the errors and try again.\
         ]
     )
 
-    # Verify roundtrip — load_messages now produces ToolReturnPart(outcome='failed')
-    # instead of RetryPromptPart for tool errors from the Vercel AI format
+    # The outcome claim on the metadata channel restores a RetryPromptPart instead of
+    # degrading the retry to ToolReturnPart(outcome='failed').
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
-    tool_error_part = message_part(reloaded_messages, ToolReturnPart, message_index=2)
+    tool_error_part = message_part(reloaded_messages, RetryPromptPart, message_index=2)
     assert tool_error_part == snapshot(
-        ToolReturnPart(
-            tool_name='my_tool',
+        RetryPromptPart(
             content='Tool failed with error\n\nFix the errors and try again.',
+            tool_name='my_tool',
             tool_call_id='tool_789',
             timestamp=IsDatetime(),
-            outcome='failed',
         )
     )
 
@@ -8672,6 +8672,7 @@ Fix the errors and try again.\
                                 'id': 'call_fail_id',
                                 'provider_name': 'google',
                                 'provider_details': {'attempt': 1},
+                                'outcome': 'retried',
                             }
                         },
                         'approval': None,
@@ -8681,10 +8682,8 @@ Fix the errors and try again.\
         ]
     )
 
-    # Verify roundtrip — load_messages now produces ToolReturnPart(outcome='failed')
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
-    tool_error_part = message_part(reloaded_messages, ToolReturnPart, message_index=2)
-    assert tool_error_part.outcome == 'failed'
+    tool_error_part = message_part(reloaded_messages, RetryPromptPart, message_index=2)
     assert tool_error_part.content == 'Tool execution failed\n\nFix the errors and try again.'
 
 
@@ -9694,6 +9693,33 @@ async def test_adapter_dump_messages_builtin_tool_error_backward_compat():
     )
 
 
+async def test_adapter_load_output_error_without_retried_claim_stays_failed():
+    """A persisted `output-error` part with no outcome claim still reloads as `failed`.
+
+    Not VCR-backed: this pins the pre-#8185 dump shape so adding the stream carrier
+    does not change how existing histories without the claim load.
+    """
+    reloaded = VercelAIAdapter.load_messages(
+        [
+            UIMessage(
+                id='hist',
+                role='assistant',
+                parts=[
+                    ToolOutputErrorPart(
+                        type='tool-my_tool',
+                        tool_call_id='tc_old',
+                        input={'x': 1},
+                        error_text='Something went wrong',
+                    ),
+                ],
+            ),
+        ]
+    )
+    error_part = message_part(reloaded, ToolReturnPart, message_index=1)
+    assert error_part.outcome == 'failed'
+    assert error_part.content == 'Something went wrong'
+
+
 async def test_event_stream_function_tool_return_error():
     """Test that ToolOutputErrorChunk is emitted for ToolReturnPart(outcome='failed')."""
 
@@ -9841,6 +9867,118 @@ async def test_event_stream_function_tool_return_interrupted_is_neutral():
             '[DONE]',
         ]
     )
+
+
+async def test_event_stream_retry_prompt_carries_retried_outcome():
+    """A `RetryPromptPart` streams as `tool-output-error` with an `'retried'` outcome claim.
+
+    Not VCR-backed: this pins a local event-stream transformation and makes no model request.
+    """
+
+    async def event_generator():
+        yield FunctionToolResultEvent(
+            part=RetryPromptPart(
+                content='Service unavailable',
+                tool_name='my_tool',
+                tool_call_id='tc_retry',
+            )
+        )
+
+    request = SubmitMessage(
+        id='foo',
+        messages=[
+            UIMessage(
+                id='bar',
+                role='user',
+                parts=[TextUIPart(text='Do something')],
+            ),
+        ],
+    )
+    event_stream = VercelAIEventStream(run_input=request, sdk_version=6)
+    events = [
+        '[DONE]' if '[DONE]' in event else json.loads(event.removeprefix('data: '))
+        async for event in event_stream.encode_stream(event_stream.transform_stream(event_generator()))
+    ]
+
+    assert events == snapshot(
+        [
+            {'type': 'start'},
+            {
+                'type': 'tool-output-error',
+                'toolCallId': 'tc_retry',
+                'errorText': """\
+Service unavailable
+
+Fix the errors and try again.\
+""",
+                'providerMetadata': {'pydantic_ai': {'outcome': 'retried'}},
+            },
+            {'type': 'finish-step'},
+            {'type': 'finish'},
+            '[DONE]',
+        ]
+    )
+
+
+async def test_stream_retry_echo_reloads_as_retry_prompt():
+    """A live retry streamed to a v6 frontend reloads as a `RetryPromptPart`, not `failed`.
+
+    The AI SDK copies `tool-output-error.providerMetadata` onto `resultProviderMetadata`
+    (not `callProviderMetadata`) when it builds `ToolUIPart(state='output-error')`. Echoing
+    that part back through `load_messages` must keep the retry.
+
+    Not VCR-backed: FunctionModel drives the retry; there is no provider HTTP.
+    """
+
+    async def stream_function(
+        messages: list[ModelMessage], agent_info: AgentInfo
+    ) -> AsyncIterator[DeltaToolCalls | str]:
+        if any(isinstance(part, RetryPromptPart) for message in messages for part in message.parts):
+            yield 'gave up'
+        else:
+            yield {0: DeltaToolCall(name='flaky', json_args='{}', tool_call_id='tc_live')}
+
+    agent = Agent(model=FunctionModel(stream_function=stream_function))
+
+    @agent.tool_plain
+    async def flaky() -> str:
+        raise ModelRetry('Service unavailable')
+
+    request = SubmitMessage(id='foo', messages=[UIMessage(id='bar', role='user', parts=[TextUIPart(text='Call it')])])
+    adapter = VercelAIAdapter(agent, request, sdk_version=6)
+    events: list[str | dict[str, Any]] = [
+        '[DONE]' if '[DONE]' in event else json.loads(event.removeprefix('data: '))
+        async for event in adapter.encode_stream(adapter.run_stream())
+    ]
+    retry_chunk = next(
+        e
+        for e in events
+        if isinstance(e, dict) and e.get('type') == 'tool-output-error' and e.get('toolCallId') == 'tc_live'
+    )
+    assert retry_chunk['providerMetadata'] == {'pydantic_ai': {'outcome': 'retried'}}
+
+    # Replay the way processUIMessageStream does: chunk.providerMetadata → resultProviderMetadata.
+    reloaded = VercelAIAdapter.load_messages(
+        [
+            UIMessage(
+                id='echo',
+                role='assistant',
+                parts=[
+                    ToolOutputErrorPart(
+                        type='tool-flaky',
+                        tool_call_id='tc_live',
+                        input={},
+                        error_text=retry_chunk['errorText'],
+                        result_provider_metadata=retry_chunk['providerMetadata'],
+                    ),
+                ],
+            ),
+        ]
+    )
+    retry_part = message_part(reloaded, RetryPromptPart, message_index=1)
+    assert retry_part.tool_name == 'flaky'
+    assert retry_part.tool_call_id == 'tc_live'
+    assert retry_part.content == retry_chunk['errorText']
 
 
 def _sync_timestamps(original: list[ModelMessage], new: list[ModelMessage]) -> None:


### PR DESCRIPTION
Fixes #8185

### Why we make these changes

`VercelAIAdapter.load_messages` rebuilds a tool error from `output-error` as `ToolReturnPart(outcome='failed')` unless an `'retried'` claim is on the metadata channel. History dump can carry that claim on `callProviderMetadata`. The live stream emitted `ToolOutputErrorChunk` with no metadata field, so a v6 frontend that echoes the turn reloaded a retry as a definitive failure.

Discovered during #8094; this PR only adds the stream/load carrier. It does not rewrite that deprecation.

### New public surface

- `ToolOutputErrorChunk.provider_metadata`
- `ToolOutputErrorPart.result_provider_metadata` and `DynamicToolOutputErrorPart.result_provider_metadata` (AI SDK field; optional)

### User-visible behavior

```diff
pydantic_ai/ui/vercel_ai/_event_stream.py :: VercelAIEventStream._handle_tool_result()
└─ RetryPromptPart
-    └─ ToolOutputErrorChunk(tool_call_id, error_text)
+    └─ ToolOutputErrorChunk(..., provider_metadata={pydantic_ai: {outcome: 'retried'}})
pydantic_ai/ui/vercel_ai/_adapter.py :: VercelAIAdapter.load_messages()
└─ ToolUIPart(state='output-error')
-    └─ ToolReturnPart(outcome='failed')
+    └─ RetryPromptPart  if call or result metadata says outcome='retried'
+    └─ ToolReturnPart(outcome='failed')  otherwise
```

### Verification

- [`test_stream_retry_echo_reloads_as_retry_prompt`](tests/test_vercel_ai.py) — live `ModelRetry` stream, echo via `resultProviderMetadata`, reload stays a `RetryPromptPart`
- [`test_event_stream_retry_prompt_carries_retried_outcome`](tests/test_vercel_ai.py) — chunk shape
- [`test_adapter_load_output_error_without_retried_claim_stays_failed`](tests/test_vercel_ai.py) — old dumps without the claim still load as `failed`

### What changes for existing users

Nothing for persisted histories that lack the claim. New dumps of a tool-bound `RetryPromptPart` and new live retries now round-trip as a retry instead of `failed`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

