### PR TITLE
fix(embeddings): write include_content vectors to attributes_to_set, not attributes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/instrumented.py
@@ -165,7 +165,7 @@ class InstrumentedEmbeddingModel(WrapperEmbeddingModel):
                     if embeddings:  # pragma: no branch
                         attributes_to_set['gen_ai.embeddings.dimension.count'] = len(embeddings[0])
                         if self.instrumentation_settings.include_content:
-                            attributes['embeddings'] = json.dumps(embeddings)
+                            attributes_to_set['embeddings'] = json.dumps(embeddings)
 
                     if result.provider_response_id is not None:
                         attributes_to_set['gen_ai.response.id'] = result.provider_response_id

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2291,6 +2291,32 @@ def test_result():
 
 
 @pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
+async def test_include_content_instrumentation(capfire: CaptureLogfire):
+    """include_content=True must export the embeddings vector on the span.
+
+    Regression test for #8293: the guarded write used `attributes` (consumed at span
+    creation) instead of `attributes_to_set` (passed to span.set_attributes), so the
+    `embeddings` key was always absent from the exported span even when include_content
+    was True.
+    """
+    model = TestEmbeddingModel(dimensions=3)
+    embedder = Embedder(model, instrument=InstrumentationSettings(include_content=True))
+    await embedder.embed_query('hello')
+
+    [span] = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    attrs = span['attributes']
+
+    # The vector must be present on the span under include_content=True.
+    assert attrs.get('embeddings') == [[1.0, 1.0, 1.0]]
+
+    # The input must also be present.
+    assert attrs.get('inputs') == ['hello']
+
+    # Dimension count must be wired up regardless of include_content.
+    assert attrs.get('gen_ai.embeddings.dimension.count') == 3
+
+
+@pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
 async def test_limited_instrumentation(capfire: CaptureLogfire):
     model = TestEmbeddingModel()
     embedder = Embedder(model, instrument=InstrumentationSettings(include_content=False))


### PR DESCRIPTION
## Summary

Fixes #8293.

Under `include_content=True`, `InstrumentedEmbeddingModel`'s completion callback wrote `result.embeddings` into the pre-span-creation closure dict (`attributes`) that `span.start_as_current_span` had already consumed — so the `embeddings` key was always absent from the exported span even though the module's own `logfire.json_schema` declared it there.

**Root cause** (`embeddings/instrumented.py:168` before this fix):
```python
# writes into the already-consumed creation dict — never appears on the span
attributes['embeddings'] = json.dumps(embeddings)
```

**Fix**: route the write into `attributes_to_set`, which is passed to `span.set_attributes` after the span is live — the same path used by every other post-response attribute in this callback.

## Changes

- `pydantic_ai_slim/pydantic_ai/embeddings/instrumented.py`: `attributes[...]` → `attributes_to_set[...]` (1 character)
- `tests/test_embeddings.py`: `test_include_content_instrumentation` — regression test using `TestEmbeddingModel` + `InMemorySpanExporter` (no network, no cassette) asserting that `embeddings`, `inputs`, and `gen_ai.embeddings.dimension.count` all appear on the exported span when `include_content=True`

The `test_limited_instrumentation` test (`include_content=False`) is unchanged and still passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

