### PR TITLE
fix: validate a list tool_choice against function tools only

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/_tool_choice.py
+++ b/pydantic_ai_slim/pydantic_ai/models/_tool_choice.py
@@ -146,12 +146,17 @@ def resolve_tool_choice(  # noqa: C901
     # list[str]: required, restricted to these tools
     elif isinstance(function_tool_choice, list):
         chosen_set = set(function_tool_choice)
-        _check_invalid_tools(chosen_set, known_tool_names, known_label='Known tools')
+        # A list choice excludes output tools, so it is validated against the function tools alone
+        # -- same basis as `ToolOrOutput.function_tools` below. Validating against every known name
+        # would accept an output tool name here and force the model toward a tool this choice does
+        # not actually make available.
+        known_function_tool_names = {t.name for t in model_request_parameters.function_tools}
+        _check_invalid_tools(chosen_set, known_function_tool_names, known_label='Known tools')
         # A deferred declaration or a tool-addition definition is already on the wire and remains
         # callable; only tools absent from the wire cannot be forced by name.
         chosen_set = _filter_withheld_tools(chosen_set)
 
-        if chosen_set == known_tool_names:
+        if chosen_set == known_function_tool_names:
             return 'required'
 
         return ('required', chosen_set)

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -261,6 +261,18 @@ RAISES_CASES = [
         match=r'Invalid tool names in `tool_choice`:.*Known tools:',
     ),
     dict(
+        id='list_names_only_an_output_tool',
+        # A list choice excludes output tools, so an output tool name in one is a typo, not a
+        # selection -- and must be rejected the same way `ToolOrOutput(function_tools=...)` does.
+        tool_choice=['final_result'],
+        params_kwargs={
+            'function_tools': [make_tool('a')],
+            'output_tools': [make_tool('final_result')],
+            'allow_text_output': True,
+        },
+        match=r"Invalid tool names in `tool_choice`: \{'final_result'\}",
+    ),
+    dict(
         id='list_invalid_no_function_tools',
         tool_choice=['x'],
         params_kwargs={'function_tools': [], 'allow_text_output': True},
@@ -397,6 +409,21 @@ WARNS_CASES = [
         match=r"Some tools.*'typo'.*Known tools: \['a', 'b'\]",
         expected_mode='required',
         expected_tools={'a', 'typo'},
+    ),
+    dict(
+        id='list_function_tool_plus_output_tool_name',
+        # Before the output tool name was counted as known, `chosen_set == known_tool_names` held
+        # and the choice collapsed to a bare `'required'` -- silently dropping the restriction the
+        # caller asked for, with no warning. It must warn and keep the restriction instead.
+        tool_choice=['a', 'final_result'],
+        params_kwargs={
+            'function_tools': [make_tool('a'), make_tool('b')],
+            'output_tools': [make_tool('final_result')],
+            'allow_text_output': True,
+        },
+        match=r"Some tools.*'final_result'",
+        expected_mode='required',
+        expected_tools={'a', 'final_result'},
     ),
     dict(
         id='tool_or_output_partial_invalid',


### PR DESCRIPTION
## Problem

A `list[str]` `tool_choice` excludes output tools. The docs state it directly:

> `tool_choice='required'` and `['tool_a', ...]` exclude output tools

and the sibling `ToolOrOutput.function_tools` branch validates accordingly:

```python
known_function_tool_names = {t.name for t in model_request_parameters.function_tools}
_check_invalid_tools(chosen_function_set, known_function_tool_names, known_label='Known function tools')
```

The list branch instead validated against `known_tool_names`, which is built from `tool_defs` and therefore **includes output tools**. Two consequences, measured on `main` with one function tool `search` and one output tool `final_result`:

| `tool_choice` | on `main` | expected |
|---|---|---|
| `['final_result']` | `('required', {'final_result'})` | rejected — not a function tool |
| `['search', 'final_result']` | `'required'` (bare, no warning) | `('required', …)` + warning |
| `ToolOrOutput(['search', 'final_result'])` | `'auto'` + warning | — (reference behaviour) |

The second row is the damaging one. `chosen_set == known_tool_names` became true — the chosen names happened to equal *all* known names once output tools were counted — so the branch concluded "everything is selected" and returned a bare `'required'`. The caller asked to restrict the model to one specific tool and silently got **"any tool will do"**, with no error and no warning. The same names passed through `ToolOrOutput` do warn.

This is reachable by an ordinary typo: output tool names like `final_result` are framework-generated, so a user writing `tool_choice=['final_result']` gets no signal that they named the wrong kind of tool.

## Fix

Validate the list against the function tools alone, and compare against that same set when deciding whether the choice covers everything.

After the change, an output tool name raises for a fully invalid list and warns for a partial one — matching `ToolOrOutput`. The `Known tools:` label in the error message is deliberately left unchanged, so no existing error text shifts.

## Tests

Two cases added to the existing tables in `tests/models/test_tool_choice_unit.py`:

- `list_names_only_an_output_tool` — an output tool name alone now raises
- `list_function_tool_plus_output_tool_name` — the silent-collapse case now warns and keeps the restriction

## Verification

- 101 tests pass in `test_tool_choice_unit.py` (99 pre-existing + 2 new); 263 pass together with `tests/test_tools.py`.
- **Rollback counter-proof**: reverting only the validation basis while keeping the new tests makes exactly the 2 new cases fail, with all 99 pre-existing ones still passing — the tests pin this defect and nothing else.
- **No new breakage**: across `test_tools.py`, `test_agent.py`, `test_tool_choice_unit.py` and `test_model_settings_support.py` the failure set is empty both before and after; passing count goes 715 → 717, exactly the 2 added tests.
- `ruff check` and `ruff format --check` clean on both files.
- Checked the 254 open PRs for any that touch `_tool_choice.py` or its tests: only #7967 (Bedrock/Anthropic adaptive thinking) overlaps, and it changes only test files in a different area — no conflict with this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

