### PR TITLE
Document using a Nebius Serverless Endpoint with `VLLMProvider`

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -1057,6 +1057,33 @@ print(result.output)
 !!! note "Multiple system messages are merged by default"
     Some vLLM chat templates reject multiple leading system messages, so `VLLMProvider` merges them by default. To opt out, pass an [`OpenAIModelProfile`][pydantic_ai.profiles.openai.OpenAIModelProfile] with `openai_chat_supports_multiple_system_messages=True`. See [Models that accept only one leading system message](#models-that-accept-only-one-leading-system-message).
 
+#### Nebius Serverless Endpoints
+
+To connect to vLLM deployed on a [Nebius Serverless Endpoint](https://docs.vllm.ai/en/latest/deployment/frameworks/nebius/),
+use the Endpoint's managed HTTPS URL followed by `/v1` as `base_url`, and its authentication token as `api_key`:
+
+```python {test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.vllm import VLLMProvider
+
+model = OpenAIChatModel(
+    'Qwen/Qwen3-0.6B',  # Use the model ID served by your Endpoint.
+    provider=VLLMProvider(
+        base_url=os.environ['VLLM_BASE_URL'],  # https://<endpoint-url>/v1
+        api_key=os.environ['VLLM_API_KEY'],  # The Endpoint authentication token.
+    ),
+)
+agent = Agent(model)
+```
+
+Enable token authentication when creating the Endpoint, and wait for the model to be ready before making requests.
+The Endpoint token is separate from your Nebius CLI credentials and managed model API key.
+Tool calling requires the vLLM server configuration described above; support depends on the model and server version.
+Stop or delete the Endpoint when it is no longer needed; closing the agent does not stop it.
+
 ### Nebius AI Studio
 
 Go to [Nebius AI Studio](https://studio.nebius.com/) and create an API key.


### PR DESCRIPTION
Document how to connect `VLLMProvider` to a user-deployed Nebius Serverless Endpoint using its managed HTTPS URL and Endpoint token. Add a configuration example under the existing vLLM section, link the published deployment guide, and explain readiness, tool configuration and resource shutdown.

This changes only `docs/models/openai.md`. It adds no provider, dependency or runtime behavior. The managed-model API update in #7435 is separate. No linked issue: this is a small documentation improvement.

Validation:

- Applicable pre-commit hooks passed; affected-page example checks: **53 passed, 9 skipped**.
- The exact configuration was exercised live with Pydantic AI 2.43.0, OpenAI SDK 3.13.0, vLLM 0.19.1 and Qwen3-0.6B on an L40S. The invocation used non-thinking mode and bounded output/timeouts. Chat, actual tool execution, native output, authentication and stop/start checks passed.
- Expanded streaming revalidation with separate, unreleased SDK/httpx2 cleanup patches passed **101 checks**, including **52 early cancellations**, without shutdown errors. Those dependency patches are not included here. All test resources were deleted.

The credential-dependent example uses `test="skip"`. Human author review and a unified-docs preview remain pending before merge.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] Any permitted **compatibility impact** has a label, warning, migration, release note, and exact API-check waiver. (Not applicable: no compatibility impact.)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

