### PR TITLE
Add an enterprise support guide

### DIFF
--- a/docs/enterprise-support.md
+++ b/docs/enterprise-support.md
@@ -1,0 +1,73 @@
+---
+title: Enterprise support for Pydantic AI
+description: Get direct support from Pydantic AI engineers for production incidents, architecture reviews, provider changes, and upgrades.
+---
+
+# Enterprise support for Pydantic AI
+
+Pydantic AI is open source under the MIT license. When it becomes part of a critical agent system, a public issue tracker is not the escalation path you want during an incident, provider change, or major rollout.
+
+Commercial support gives your team direct access to Pydantic AI engineers for production incidents, architecture, provider changes, and upgrades. Enterprise plans include 24/7 priority support, setup assistance, and an SLA matched to your operating model.
+
+<EnterpriseSupportCta
+  product="ai"
+  href="https://pydantic.dev/contact"
+  label="Discuss Pydantic AI support"
+/>
+
+<EnterpriseSupportPlan product="ai" />
+
+## Where Pydantic AI engineers can help
+
+Use the public documentation, issue tracker, and community channels for ordinary questions. Enterprise support covers production incidents, agent architecture reviews, and framework or provider rollouts.
+
+<EnterpriseSupportAreas product="ai" />
+
+## How support works
+
+<Steps>
+
+1. **Agree the support boundary**
+
+   Define the framework and provider integrations, release lines, environments, contacts, and initial response targets covered by your agreement.
+
+2. **Prepare useful context**
+
+   Map critical agent paths and decide how to capture a reproducible example, model inputs and outputs, traces, configuration, and recent changes.
+
+3. **Escalate directly**
+
+   Bring production-impacting issues to Pydantic AI engineers, who work with your team to isolate the failing boundary and determine the next action.
+
+</Steps>
+
+## Open source remains the foundation
+
+Pydantic AI's license, documentation, releases, issue tracker, and community support remain open to everyone. Enterprise support adds a direct escalation path and contractual commitments for teams that depend on the framework in production.
+
+## Questions teams ask
+
+<Collapsible title="Is Logfire required?">
+
+No. Commercial support is available for the open-source Pydantic AI framework itself. Logfire traces can make an investigation faster, but Logfire is not required.
+
+</Collapsible>
+
+<Collapsible title="What can Pydantic AI engineers help investigate?">
+
+We work with your engineers to reproduce the issue, isolate Pydantic AI behavior, explain the relevant implementation details, and determine the next action. Your team and provider retain ownership of the surrounding application and model service.
+
+</Collapsible>
+
+<Collapsible title="Can we agree specific versions and initial response targets?">
+
+Yes. Supported versions, severity levels, initial response targets, and other commitments are defined in your commercial agreement. [Contact us](https://pydantic.dev/contact) to discuss your requirements.
+
+</Collapsible>
+
+## Continue reading
+
+- Review the [agent documentation](agent.md).
+- Design [function tools](tools.md) and [structured output](output.md).
+- Read about [Logfire instrumentation](logfire.md) for Pydantic AI.
+- Use the [community help channels](help.md) for questions that do not require a commercial support relationship.

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -25,6 +25,11 @@ navigation:
         slug: "overview/help"
         aliases:
           - "help"
+      - page: "Enterprise Support"
+        path: "enterprise-support.md"
+        slug: "overview/enterprise-support"
+        aliases:
+          - "enterprise-support"
       - page: "Troubleshooting"
         path: "troubleshooting.md"
         slug: "overview/troubleshooting"


### PR DESCRIPTION
## Summary

- Add an enterprise-support guide for teams running Pydantic AI in production.
- Cover incident escalation, architecture reviews, provider changes, and agreed support boundaries.
- Add the guide to the Overview navigation.

Requires [pydantic/unified-docs#266](https://github.com/pydantic/unified-docs/pull/266) for the shared page components.

## Verification

- `make format`
- `make lint`
- `uv run pre-commit run --files docs/enterprise-support.md docs/navigation.yml`
- Exact unified-docs AI build and responsive browser review at 390x844, 768x1024, and 1440x900

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/8306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

